### PR TITLE
Support identifiers containing digits, but not starting with a digit

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -200,7 +200,7 @@ func (l *Lexer) peekChar() byte {
 
 func (l *Lexer) readIdentifier() string {
 	position := l.position
-	for isLetter(l.ch) || l.ch == '.' {
+	for isLetter(l.ch) || isDigit(l.ch) || l.ch == '.' {
 		l.readChar()
 	}
 	return l.input[position:l.position]

--- a/plush_test.go
+++ b/plush_test.go
@@ -30,6 +30,20 @@ func Test_Render_Keeps_Spacing(t *testing.T) {
 	r.Equal("hi mark", s)
 }
 
+// support identifiers containing digits, but not starting with a digits
+func Test_Identifiers_With_Digits(t *testing.T) {
+	r := require.New(t)
+	input := `<%= my123greet %> <%= name3 %>`
+
+	ctx := NewContext()
+	ctx.Set("my123greet", "hi")
+	ctx.Set("name3", "mark")
+
+	s, err := Render(input, ctx)
+	r.NoError(err)
+	r.Equal("hi mark", s)
+}
+
 func Test_Render_HTML_InjectedString(t *testing.T) {
 	r := require.New(t)
 


### PR DESCRIPTION
This fix addresses [issue 2](https://github.com/gobuffalo/plush/issues/2)