### PR TITLE
Don't return block content from contentFor helper

### DIFF
--- a/content_helper.go
+++ b/content_helper.go
@@ -8,7 +8,7 @@ import (
 
 // ContentFor stores a block of templating code to be re-used later in the template.
 /*
-	<%= contentFor("buttons") { %>
+	<% contentFor("buttons") { %>
 		<button>hi</button>
 	<% } %>
 */
@@ -19,7 +19,7 @@ func contentForHelper(name string, help HelperContext) (template.HTML, error) {
 	}
 	b := template.HTML(body)
 	help.Set(name, b)
-	return b, nil
+	return "", nil
 }
 
 // ContentOf retrieves a stored block for templating and renders it.


### PR DESCRIPTION
I noticed that no matter which open tag I used (`<%` or `<%=`) the `contentFor` block content was being rendered immediately--in addition to being stored for later use via `contentOf`. While I believe there's another bug where `<%` prints the content returned from helpers; which I think should be ignored when using `<%` without the `=`, I'm still researching this. At this time it seems like returning empty content from the `contentFor` helper is the lightest-touch fix.

The test still passes. Perhaps I can make it better though. It uses this template:

```
<%= contentFor("buttons") { %><button>hi</button><% } %>
<b1><%= contentOf("buttons") %></b1>
<b2><%= contentOf("buttons") %></b2>
```

And the rendered result is:

```
<button>hi</button>
<b1><button>hi</button></b1>
<b2><button>hi</button></b2>
```

The test checks for the existence of the second two lines. I think the first line of output shouldn't be there. Anyway, this small PR fixes my problem. I can't see there being any harm in this new behavior; unless some people chain, or otherwise use, the return from `contentFor`.