### PR TITLE
Fixes: unable to operate (==) on int64 and int64

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -270,8 +270,8 @@ func (c *compiler) evalInfixExpression(node *ast.InfixExpression) (interface{}, 
 	case string:
 		return c.stringsOperator(t, rres, node.Operator)
 	case int64:
-		if r, ok := rres.(int); ok {
-			return c.intsOperator(int(t), r, node.Operator)
+		if r, ok := rres.(int64); ok {
+			return c.intsOperator(int(t), int(r), node.Operator)
 		}
 	case int:
 		if r, ok := rres.(int); ok {


### PR DESCRIPTION
Currently when you try to compare two int64's, you will get the following message:

`unable to operate (==) on int64 and int64`

This tests `rres` on the correct type (int64), and casts it properly to an `int`.