### PR TITLE
Better Float Support

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -223,7 +223,7 @@ func (l *Lexer) peekChar() byte {
 
 func (l *Lexer) readIdentifier() string {
 	position := l.position
-	for isLetter(l.ch) {
+	for isLetter(l.ch) || isDigit(l.ch) {
 		l.readChar()
 	}
 	return l.input[position:l.position]

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -196,8 +196,6 @@ func (l *Lexer) nextInsideToken() token.Token {
 	return tok
 }
 
-var floatX = regexp.MustCompile(`\d*\.\d*`)
-
 func (l *Lexer) skipWhitespace() {
 	for l.ch == ' ' || l.ch == '\t' || l.ch == '\n' || l.ch == '\r' {
 		l.readChar()

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -1,7 +1,6 @@
 package lexer
 
 import (
-	"regexp"
 	"strings"
 
 	"github.com/gobuffalo/plush/token"

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -99,6 +99,9 @@ let add = fn(x, y) {
 let result = add(five, ten);
 !-/*5;
 5 < 10 > 5;
+.23
+23.2343
+23.23.23
 
 if (5 < 10) {
 	return true;
@@ -179,6 +182,9 @@ my-helper()
 		{token.GT, ">"},
 		{token.INT, "5"},
 		{token.SEMICOLON, ";"},
+		{token.FLOAT, ".23"},
+		{token.FLOAT, "23.2343"},
+		{token.ILLEGAL, "23.23.23"},
 		{token.IF, "if"},
 		{token.LPAREN, "("},
 		{token.INT, "5"},

--- a/token/const.go
+++ b/token/const.go
@@ -10,6 +10,7 @@ const (
 	FLOAT  = "FLOAT"  // 12.34
 	STRING = "STRING" // "foobar"
 	HTML   = "HTML"   // <p>adf</p>
+	DOT    = "DOT" // .23
 
 	// Operators
 	ASSIGN   = "="

--- a/token/const.go
+++ b/token/const.go
@@ -10,7 +10,7 @@ const (
 	FLOAT  = "FLOAT"  // 12.34
 	STRING = "STRING" // "foobar"
 	HTML   = "HTML"   // <p>adf</p>
-	DOT    = "DOT" // .23
+	DOT    = "DOT"    // .23
 
 	// Operators
 	ASSIGN   = "="


### PR DESCRIPTION
The pull request you maybe didn't know you needed.

I added the following to the current input:

```
.23
23.23
23.23.23
23.23.23
```

I also added the following to the current test:

```
		{token.FLOAT, ".23"}, // passes
		{token.FLOAT, "23.23"}, // passes
		{token.FLOAT, "23.23.23"}, // passes -- This is bad.
                {token.ILLEGAL, "23.23.23"}, // fails -- This is bad.
```

It fails on the last two. I then proceeded to fix it. This does change your `readIdentifier` and `readNumber` slightly. It also reduces the dependency on the regular expression pattern.

You may not want this fix. Feel free to discard if you don't, I won't be offended.