### PR TITLE
forms using GET method ignore authenticity_token

### DIFF
--- a/forms.go
+++ b/forms.go
@@ -57,7 +57,7 @@ func helper(opts tags.Options, help HelperContext, fn func(opts tags.Options) he
 		opts["errors"] = help.Context.Value("errors")
 	}
 	form := fn(opts)
-	if help.Value("authenticity_token") != nil {
+	if help.Value("authenticity_token") != nil && opts["method"] != "GET" {
 		form.SetAuthenticityToken(fmt.Sprint(help.Value("authenticity_token")))
 	}
 	ctx := help.Context.New()


### PR DESCRIPTION
When a form with a GET `method` is used, the `authenticity_token` value used for CSRF protection on POST requests is provided and becomes part of the query string of the URL once the form is submitted. The length of the token causes _really_ long URLs and obscures the other form values.

This PR excludes the `authenticity_token` from GET requests.