### PR TITLE
Variadic function allows 0 to n params, so must Plush

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -495,11 +495,14 @@ func (c *compiler) evalCallExpression(node *ast.CallExpression) (interface{}, er
 		if len(args) > rtNumIn {
 			return nil, errors.WithStack(errors.Errorf("%s too many arguments (%d for %d) - %+v", node.String(), len(args), rtNumIn, args))
 		}
+		if len(args) < rtNumIn {
+			return nil, errors.WithStack(errors.Errorf("%s too few arguments (%d for %d) - %+v", node.String(), len(args), rtNumIn, args))
+		}
 	} else {
 		// Variadic func
 		nodeArgs := node.Arguments
 		nodeArgsLen := len(nodeArgs)
-		if nodeArgsLen < rtNumIn {
+		if nodeArgsLen < rtNumIn-1 {
 			return nil, errors.WithStack(errors.Errorf("%s too few arguments (%d for %d) - %+v", node.String(), len(args), rtNumIn, args))
 		}
 		var pos int
@@ -549,10 +552,6 @@ func (c *compiler) evalCallExpression(node *ast.CallExpression) (interface{}, er
 
 			args = append(args, ar)
 		}
-	}
-
-	if len(args) < rtNumIn {
-		return nil, errors.WithStack(errors.Errorf("%s too few arguments (%d for %d) - %+v", node.String(), len(args), rtNumIn, args))
 	}
 
 	res := rv.Call(args)

--- a/plush_test.go
+++ b/plush_test.go
@@ -358,6 +358,32 @@ func Test_VariadicHelper(t *testing.T) {
 	r.Equal("3", s)
 }
 
+func Test_VariadicHelperNoParam(t *testing.T) {
+	r := require.New(t)
+	input := `<%= foo() %>`
+	ctx := NewContext()
+	ctx.Set("foo", func(args ...int) int {
+		return len(args)
+	})
+
+	s, err := Render(input, ctx)
+	r.NoError(err)
+	r.Equal("0", s)
+}
+
+func Test_VariadicHelperNoVariadicParam(t *testing.T) {
+	r := require.New(t)
+	input := `<%= foo(1) %>`
+	ctx := NewContext()
+	ctx.Set("foo", func(a int, args ...int) int {
+		return a + len(args)
+	})
+
+	s, err := Render(input, ctx)
+	r.NoError(err)
+	r.Equal("1", s)
+}
+
 func Test_VariadicHelperWithWrongParam(t *testing.T) {
 	r := require.New(t)
 	input := `<%= foo(1, 2, "test") %>`


### PR DESCRIPTION
- Allow variadic args to be omitted in helper call