### PR TITLE
Render additional numeric types.

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -60,7 +60,7 @@ func (c *compiler) write(bb *bytes.Buffer, i interface{}) {
 		bb.WriteString(string(t))
 	case HTMLer:
 		bb.WriteString(string(t.HTML()))
-	case int64, int, float64:
+	case uint, uint8, uint16, uint32, uint64, int, int8, int16, int32, int64, float32, float64:
 		bb.WriteString(fmt.Sprint(t))
 	case fmt.Stringer:
 		bb.WriteString(t.String())

--- a/plush_test.go
+++ b/plush_test.go
@@ -503,6 +503,20 @@ func Test_RunScript(t *testing.T) {
 	r.Equal("3hiasdfasdf", bb.String())
 }
 
+func Test_Render_AllowsManyNumericTypes(t *testing.T) {
+	r := require.New(t)
+	input := `<%= i32 %> <%= u32 %> <%= i8 %>`
+
+	ctx := NewContext()
+	ctx.Set("i32", int32(1))
+	ctx.Set("u32", uint32(2))
+	ctx.Set("i8", int8(3))
+
+	s, err := Render(input, ctx)
+	r.NoError(err)
+	r.Equal("1 2 3", s)
+}
+
 const script = `let x = "foo"
 
 let a = 1


### PR DESCRIPTION
I had an issue where some numbers were not rendering in my templates, which I eventually tracked down to their type being `int32`. It looks like Plush has a pretty short list of types it considers numbers.

I attempted some fancy reflection code after [reading some stackoverflow](https://stackoverflow.com/questions/17220764/go-cast-any-int-value-to-int64-in-type-switch), but I'm not sure it's worth the time and potential performance hit. The [list of numeric types in Go](https://golang.org/ref/spec#Numeric_types) seems pretty well set, and it's not that long. I omitted complex numbers because I don't even want to guess how they ought to render.

I wasn't sure exactly where to put my test for this change. Let me know if that doesn't work.

Thanks for all your work on Buffalo. It's been very fast to pick up and accomplish things.