### PR TITLE
truncate helper: handle case where size is less than len(trail)

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -150,5 +150,8 @@ func truncateHelper(s string, opts map[string]interface{}) string {
 		return s
 	}
 	trail := opts["trail"].(string)
+	if len(trail) >= size {
+		return trail
+	}
 	return s[:size-len(trail)] + trail
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -26,6 +26,14 @@ func Test_truncateHelper(t *testing.T) {
 	})
 	r.Len(s, 10)
 	r.Equal("more", s[6:])
+
+	// Case size < len(trail)
+	s = truncateHelper(x, map[string]interface{}{
+		"size":  3,
+		"trail": "more",
+	})
+	r.Len(s, 4)
+	r.Equal("more", s)
 }
 
 func Test_inspectHelper(t *testing.T) {


### PR DESCRIPTION
Mark,

Whilst using the truncate helper with some dynamic data, I experienced a slice size error.

Update the truncate helper to handle this case, and update the test.

Best wishes,

Alex 