### PR TITLE
evalPrefixExpression now handles unknown identifiers

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -162,7 +162,9 @@ func (c *compiler) evalFunctionLiteral(node *ast.FunctionLiteral) (interface{}, 
 func (c *compiler) evalPrefixExpression(node *ast.PrefixExpression) (interface{}, error) {
 	res, err := c.evalExpression(node.Right)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		if errors.Cause(err) != ErrUnknownIdentifier {
+			return nil, errors.WithStack(err)
+		}
 	}
 	switch node.Operator {
 	case "!":

--- a/if_test.go
+++ b/if_test.go
@@ -70,6 +70,14 @@ func Test_Render_If_Nil(t *testing.T) {
 	r.Equal("", s)
 }
 
+func Test_Render_If_NotNil(t *testing.T) {
+	r := require.New(t)
+	input := `<%= if (!names) { %>hi<%} %>`
+	s, err := Render(input, NewContext())
+	r.NoError(err)
+	r.Equal("hi", s)
+}
+
 func Test_Render_If_Nil_Else(t *testing.T) {
 	r := require.New(t)
 	input := `<%= if (names && len(names) >= 1) { %>hi<%} else { %>something else<% } %>`


### PR DESCRIPTION
Previously evalIfExpression was updated to handle unknown identifiers,
so the following would go down the else case.

`
if (unknownIdentifier) {
} else {
}
`

evalPrefixExpression did not not handle unknown identifiers the same
way, so the following would also go down the else case.

`
if (!unknownIdentifier) {
} else {
}
`

evalPrefixExpression will now properly return !isTruthy.