### PR TITLE
Merge global exported context with local variables

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -521,7 +521,7 @@ func (c *compiler) evalCallExpression(node *ast.CallExpression) (interface{}, er
 			}
 		}
 
-		if len(args) == rtNumIn {
+		if (len(args) == rtNumIn) && rtNumIn > 0 {
 			// Merge local and global Data from exported context
 			// TODO: does this apply only to the last argument, or can it be in any position?
 			last := rt.In(rtNumIn - 1)

--- a/compiler.go
+++ b/compiler.go
@@ -521,6 +521,23 @@ func (c *compiler) evalCallExpression(node *ast.CallExpression) (interface{}, er
 			}
 		}
 
+		if len(args) == rtNumIn {
+			// Merge local and global Data from exported context
+			// TODO: does this apply only to the last argument, or can it be in any position?
+			last := rt.In(rtNumIn - 1)
+			if last.Name() == "Data" {
+				i := args[rtNumIn-1].Interface()
+				data := i.(map[string]interface{}) // TODO: Can we use reflect.TypeOf(c.ctx.export())?
+
+				for k, v := range c.ctx.export() {
+					_, ok := data[k]
+					if !ok {
+						data[k] = v
+					}
+				}
+			}
+		}
+
 		if len(args) < rtNumIn {
 			// missing some args, let's see if we can figure out what they are.
 			diff := rtNumIn - len(args)


### PR DESCRIPTION
Hi Mark,

This enables buffalo's partial(...) rendering to use locals in addition to global rendering context, rather than instead of global rendering context.

This is for consideration, and I've left a couple of TODOs for review as I'm unsure whether this is:
- The intended or desired behaviour;
- What the best approach for those TODOs is without further review.

A test case is covered by https://github.com/gobuffalo/buffalo/pull/1006
