### PR TITLE
Added optional data map to contentFor/contentOf helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ fmt.Print(s)
 
 Use the `contentFor` and `contentOf` helpers to dry up your templates with reusable components.
 
-For example:
+For example, we can define a snippet that generates a fancy title using `contentFor`:
 
 ```
 <% contentFor("fancy-title") { %>
@@ -296,17 +296,20 @@ For example:
 <% } %>
 ```
 
-Elsewhere...
+The `fancy-title` name is how we will invoke this with `contentOf` elsewhere 
+in our template:
 
 ```
 <%= contentOf("fancy-title", {"title":"Welcome to Plush"}) %>
 ```
 
-Would generate:
+Rendering this would generate this output:
 
 ```
 <h1 class='fancy'>Welcome to Plush</h1>
 ```
+
+As you can see, the `<%= title %>` has been replaced with the `Welcome to Plush` string.
 
 #### truncate
 

--- a/README.md
+++ b/README.md
@@ -303,6 +303,8 @@ in our template:
 <%= contentOf("fancy-title", {"title":"Welcome to Plush"}) %>
 ```
 
+* The second map argument is optional, for static content just use `<%= contentOf("fancy-title") %>`
+
 Rendering this would generate this output:
 
 ```

--- a/README.md
+++ b/README.md
@@ -284,6 +284,30 @@ fmt.Print(s)
 * `form` - support for the [github.com/gobuffalo/tags/form](https://github.com/gobuffalo/tags/tree/master/form) package (Bootstrap version)
 * `form_for` - support for the [github.com/gobuffalo/tags/form](https://github.com/gobuffalo/tags/tree/master/form) package (Bootstrap version) to build a form for a model
 
+#### contentFor and contentOf
+
+Use the `contentFor` and `contentOf` helpers to dry up your templates with reusable components.
+
+For example:
+
+```
+<% contentFor("fancy-title") { %>
+  <h1 class='fancy'><%= title %></h1>
+<% } %>
+```
+
+Elsewhere...
+
+```
+<%= contentOf("fancy-title", {"title":"Welcome to Plush"}) %>
+```
+
+Would generate:
+
+```
+<h1 class='fancy'>Welcome to Plush</h1>
+```
+
 #### truncate
 
 `truncate` takes two optional parameters:

--- a/ast/assign_expression.go
+++ b/ast/assign_expression.go
@@ -11,5 +11,12 @@ type AssignExpression struct {
 func (ae *AssignExpression) expressionNode() {}
 
 func (ae *AssignExpression) String() string {
-	return fmt.Sprintf("%s = %s", ae.Name.String(), ae.Value.String())
+	n, v := "?", "?"
+	if ae.Name != nil {
+		n = ae.Name.String()
+	}
+	if ae.Value != nil {
+		v = ae.Value.String()
+	}
+	return fmt.Sprintf("%s = %s", n, v)
 }

--- a/content_helper.go
+++ b/content_helper.go
@@ -6,29 +6,35 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ContentFor stores a block of templating code to be re-used later in the template.
+// ContentFor stores a block of templating code to be re-used later in the template
+// via the contentOf helper.
+// An optional map of values can be passed to contentOf,
+// which are made available to the contentFor block.
 /*
 	<% contentFor("buttons") { %>
 		<button>hi</button>
 	<% } %>
 */
-func contentForHelper(name string, help HelperContext) (template.HTML, error) {
-	body, err := help.Block()
-	if err != nil {
-		return "", errors.WithStack(err)
-	}
-	b := template.HTML(body)
-	help.Set(name, b)
-	return b, nil
+func contentForHelper(name string, help HelperContext) {
+	help.Set("contentFor:"+name, func(data map[string]interface{}) (template.HTML, error) {
+		for k, v := range data {
+			help.Set(k, v)
+		}
+		body, err := help.Block()
+		if err != nil {
+			return "", errors.WithStack(err)
+		}
+		return template.HTML(body), nil
+	})
 }
 
 // ContentOf retrieves a stored block for templating and renders it.
+// You can pass an optional map of fields that will be set.
 /*
 	<%= contentOf("buttons") %>
+	<%= contentOf("buttons", {"label": "Click me"}) %>
 */
-func contentOfHelper(name string, help HelperContext) template.HTML {
-	if s := help.Value(name); s != nil {
-		return s.(template.HTML)
-	}
-	return ""
+func contentOfHelper(name string, data map[string]interface{}, help HelperContext) (template.HTML, error) {
+	fn := help.Value("contentFor:" + name).(func(data map[string]interface{}) (template.HTML, error))
+	return fn(data)
 }

--- a/content_helper.go
+++ b/content_helper.go
@@ -17,10 +17,15 @@ import (
 */
 func contentForHelper(name string, help HelperContext) {
 	help.Set("contentFor:"+name, func(data map[string]interface{}) (template.HTML, error) {
-		for k, v := range data {
-			help.Set(k, v)
+		subhelp := &HelperContext{
+			Context:  help.New(),
+			compiler: help.compiler,
+			block:    help.block,
 		}
-		body, err := help.Block()
+		for k, v := range data {
+			subhelp.Set(k, v)
+		}
+		body, err := subhelp.Block()
 		if err != nil {
 			return "", errors.WithStack(err)
 		}

--- a/content_helper.go
+++ b/content_helper.go
@@ -17,15 +17,11 @@ import (
 */
 func contentForHelper(name string, help HelperContext) {
 	help.Set("contentFor:"+name, func(data map[string]interface{}) (template.HTML, error) {
-		subhelp := &HelperContext{
-			Context:  help.New(),
-			compiler: help.compiler,
-			block:    help.block,
-		}
+		ctx := help.New()
 		for k, v := range data {
-			subhelp.Set(k, v)
+			ctx.Set(k, v)
 		}
-		body, err := subhelp.Block()
+		body, err := help.BlockWith(ctx)
 		if err != nil {
 			return "", errors.WithStack(err)
 		}

--- a/content_helper_test.go
+++ b/content_helper_test.go
@@ -35,5 +35,5 @@ func Test_ContentForOfWithData(t *testing.T) {
 	r.Contains(s, "<b0></b0>")
 	r.Contains(s, "<b1><button>Button One</button></b1>")
 	r.Contains(s, "<b2><button>Button Two</button></b2>")
-	r.Contains(s, "<b3>Outer label</b3>")
+	r.Contains(s, "<b3>Outer label</b3>", "the outer label shouldn't be affected by the map passed in")
 }

--- a/content_helper_test.go
+++ b/content_helper_test.go
@@ -19,3 +19,17 @@ func Test_ContentForOf(t *testing.T) {
 	r.Contains(s, "<b1><button>hi</button></b1>")
 	r.Contains(s, "<b2><button>hi</button></b2>")
 }
+
+func Test_ContentForOfWithData(t *testing.T) {
+	r := require.New(t)
+	input := `
+	<b0><% contentFor("buttons") { %><button><%= label %></button><% } %></b0>
+	<b1><%= contentOf("buttons", {"label": "Button One"}) %></b1>
+	<b2><%= contentOf("buttons", {"label": "Button Two"}) %></b2>
+	`
+	s, err := Render(input, NewContext())
+	r.NoError(err)
+	r.Contains(s, "<b0></b0>")
+	r.Contains(s, "<b1><button>Button One</button></b1>")
+	r.Contains(s, "<b2><button>Button Two</button></b2>")
+}

--- a/content_helper_test.go
+++ b/content_helper_test.go
@@ -26,10 +26,14 @@ func Test_ContentForOfWithData(t *testing.T) {
 	<b0><% contentFor("buttons") { %><button><%= label %></button><% } %></b0>
 	<b1><%= contentOf("buttons", {"label": "Button One"}) %></b1>
 	<b2><%= contentOf("buttons", {"label": "Button Two"}) %></b2>
+	<b3><%= label %></b3>
 	`
-	s, err := Render(input, NewContext())
+	ctx := NewContext()
+	ctx.Set("label", "Outer label")
+	s, err := Render(input, ctx)
 	r.NoError(err)
 	r.Contains(s, "<b0></b0>")
 	r.Contains(s, "<b1><button>Button One</button></b1>")
 	r.Contains(s, "<b2><button>Button Two</button></b2>")
+	r.Contains(s, "<b3>Outer label</b3>")
 }


### PR DESCRIPTION
addresses https://github.com/gobuffalo/plush/issues/54

* Added support for a data map being passed to `contentOf`
* `contentFor` now stores a function, instead of the rendered string output (since it needs to call that function each time)
* The function is stored as `"contentFor:name"` instead of just `"name"` to avoid clashes with other data fields (I could easily have a block of content called `person` and an item in the data with the same name)
* Added a test which includes a check on the scope of the data (so passing data doesn't affect global scope)

This now works:

```
<% contentFor("greeting") { %>
    Hello, <%= person.Name %>.
<% } %>

<%=  for (person) in people { %>
    <%= contentOf("greeting", {"person":person}) %>
<% } %>
```

* Question: I am setting the value in the `help` inside the helper function, does this get set for everything outside of that context too? I.e. will `person` be set globally, or just for the `contentFor` block?

NOTE: The helper function is set as `contentFor:name` where `name` is the name of the block of content. This is to ensure it doesn't clash with other data fields.