### PR TITLE
avoid panic when contentOf block hasn't been set

### DIFF
--- a/content_helper.go
+++ b/content_helper.go
@@ -36,6 +36,9 @@ func contentForHelper(name string, help HelperContext) {
 	<%= contentOf("buttons", {"label": "Click me"}) %>
 */
 func contentOfHelper(name string, data map[string]interface{}, help HelperContext) (template.HTML, error) {
-	fn := help.Value("contentFor:" + name).(func(data map[string]interface{}) (template.HTML, error))
+	fn, ok := help.Value("contentFor:" + name).(func(data map[string]interface{}) (template.HTML, error))
+	if !ok {
+		return template.HTML(""), errors.WithStack(errors.New("missing contentOf block: " + name))
+	}
 	return fn(data)
 }

--- a/content_helper_test.go
+++ b/content_helper_test.go
@@ -37,3 +37,13 @@ func Test_ContentForOfWithData(t *testing.T) {
 	r.Contains(s, "<b2><button>Button Two</button></b2>")
 	r.Contains(s, "<b3>Outer label</b3>", "the outer label shouldn't be affected by the map passed in")
 }
+
+func Test_ContentForOf_MissingBlock(t *testing.T) {
+	r := require.New(t)
+	input := `
+	<b1><%= contentOf("buttons") %></b1>
+	<b2><%= contentOf("buttons") %></b2>
+	`
+	_, err := Render(input, NewContext())
+	r.EqualError(err, "line 2: missing contentOf block: buttons")
+}


### PR DESCRIPTION
This change uses the magic ok to ensure we get a non-nil value (with the appropriate type) and if we don't, we return a nice error message.