### PR TITLE
Add markdown file support in partials

### DIFF
--- a/partial_helper.go
+++ b/partial_helper.go
@@ -1,10 +1,11 @@
 package plush
 
 import (
-	"github.com/gobuffalo/github_flavored_markdown"
 	"html/template"
+	"path/filepath"
 	"strings"
 
+	"github.com/gobuffalo/github_flavored_markdown"
 	"github.com/pkg/errors"
 )
 
@@ -40,6 +41,13 @@ func partialHelper(name string, data map[string]interface{}, help HelperContext)
 		part = string(github_flavored_markdown.Markdown([]byte(part)))
 	}
 
+	if ct, ok := help.Value("contentType").(string); ok {
+		ext := filepath.Ext(name)
+		if strings.Contains(ct, "javascript") && ext != ".js" && ext != "" {
+			part = template.JSEscapeString(string(part))
+		}
+	}
+
 	if layout, ok := data["layout"].(string); ok {
 		return partialHelper(
 			layout,
@@ -47,10 +55,5 @@ func partialHelper(name string, data map[string]interface{}, help HelperContext)
 			help)
 	}
 
-	if ct, ok := help.Value("contentType").(string); ok {
-		if strings.Contains(ct, "javascript") && !strings.HasSuffix(name, ".js") {
-			part = template.JSEscapeString(string(part))
-		}
-	}
 	return template.HTML(part), err
 }

--- a/partial_helper.go
+++ b/partial_helper.go
@@ -36,15 +36,15 @@ func partialHelper(name string, data map[string]interface{}, help HelperContext)
 		return "", err
 	}
 
+	if strings.HasSuffix(name, ".md") {
+		part = string(github_flavored_markdown.Markdown([]byte(part)))
+	}
+
 	if layout, ok := data["layout"].(string); ok {
 		return partialHelper(
 			layout,
 			map[string]interface{}{"yield": template.HTML(part)},
 			help)
-	}
-
-	if strings.HasSuffix(name, ".md") {
-		part = string(github_flavored_markdown.Markdown([]byte(part)))
 	}
 
 	if ct, ok := help.Value("contentType").(string); ok {

--- a/partial_helper.go
+++ b/partial_helper.go
@@ -1,6 +1,7 @@
 package plush
 
 import (
+	"github.com/gobuffalo/github_flavored_markdown"
 	"html/template"
 	"strings"
 
@@ -45,6 +46,9 @@ func partialHelper(name string, data map[string]interface{}, help HelperContext)
 	if ct, ok := help.Value("contentType").(string); ok {
 		if strings.Contains(ct, "javascript") && strings.HasSuffix(name, ".html") {
 			part = template.JSEscapeString(string(part))
+		}
+		if strings.Contains(ct, "markdown") || strings.HasSuffix(name, ".md") {
+			part = string(github_flavored_markdown.Markdown([]byte(part)))
 		}
 	}
 	return template.HTML(part), err

--- a/partial_helper.go
+++ b/partial_helper.go
@@ -43,12 +43,13 @@ func partialHelper(name string, data map[string]interface{}, help HelperContext)
 			help)
 	}
 
+	if strings.HasSuffix(name, ".md") {
+		part = string(github_flavored_markdown.Markdown([]byte(part)))
+	}
+
 	if ct, ok := help.Value("contentType").(string); ok {
 		if strings.Contains(ct, "javascript") && strings.HasSuffix(name, ".html") {
 			part = template.JSEscapeString(string(part))
-		}
-		if strings.Contains(ct, "markdown") || strings.HasSuffix(name, ".md") {
-			part = string(github_flavored_markdown.Markdown([]byte(part)))
 		}
 	}
 	return template.HTML(part), err

--- a/partial_helper.go
+++ b/partial_helper.go
@@ -48,7 +48,7 @@ func partialHelper(name string, data map[string]interface{}, help HelperContext)
 	}
 
 	if ct, ok := help.Value("contentType").(string); ok {
-		if strings.Contains(ct, "javascript") && strings.HasSuffix(name, ".html") {
+		if strings.Contains(ct, "javascript") && !strings.HasSuffix(name, ".js") {
 			part = template.JSEscapeString(string(part))
 		}
 	}

--- a/partial_helper_test.go
+++ b/partial_helper_test.go
@@ -246,3 +246,43 @@ func Test_PartialHelper_Markdown(t *testing.T) {
 	r.NoError(err)
 	r.Equal(`<p><code>test</code></p>`, strings.TrimSpace(string(md)))
 }
+
+func Test_PartialHelper_Markdown_With_Layout(t *testing.T) {
+	r := require.New(t)
+
+	name := "index.md"
+	data := map[string]interface{}{
+		"layout": "container.html",
+	}
+	help := HelperContext{Context: NewContext()}
+	help.Set("partialFeeder", func(name string) (string, error) {
+		if name == data["layout"] {
+			return `<html>This <em>is</em> a <%= yield %></html>`, nil
+		}
+		return `**test**`, nil
+	})
+
+	html, err := partialHelper(name, data, help)
+	r.NoError(err)
+	r.Equal("<html>This <em>is</em> a <p><strong>test</strong></p>\n</html>", string(html))
+}
+
+func Test_PartialHelper_Markdown_With_Layout_Reversed(t *testing.T) {
+	r := require.New(t)
+
+	name := "index.html"
+	data := map[string]interface{}{
+		"layout": "container.md",
+	}
+	help := HelperContext{Context: NewContext()}
+	help.Set("partialFeeder", func(name string) (string, error) {
+		if name == data["layout"] {
+			return `This *is* a <%= yield %>`, nil
+		}
+		return `<strong>test</strong>`, nil
+	})
+
+	html, err := partialHelper(name, data, help)
+	r.NoError(err)
+	r.Equal(`<p>This <em>is</em> a <strong>test</strong></p>`, strings.TrimSpace(string(html)))
+}

--- a/partial_helper_test.go
+++ b/partial_helper_test.go
@@ -215,6 +215,22 @@ func Test_PartialHelper_JavaScript(t *testing.T) {
 	r.Equal(`alert('\'Hello\'');`, string(html))
 }
 
+func Test_PartialHelper_JavaScript_Without_Extension(t *testing.T) {
+	r := require.New(t)
+
+	name := "index"
+	data := map[string]interface{}{}
+	help := HelperContext{Context: NewContext()}
+	help.Set("contentType", "application/javascript")
+	help.Set("partialFeeder", func(string) (string, error) {
+		return `alert('\'Hello\'');`, nil
+	})
+
+	html, err := partialHelper(name, data, help)
+	r.NoError(err)
+	r.Equal(`alert('\'Hello\'');`, string(html))
+}
+
 func Test_PartialHelper_Javascript_With_HTML(t *testing.T) {
 	r := require.New(t)
 

--- a/partial_helper_test.go
+++ b/partial_helper_test.go
@@ -1,6 +1,7 @@
 package plush
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -228,4 +229,20 @@ func Test_PartialHelper_Javascript_With_HTML(t *testing.T) {
 	html, err := partialHelper(name, data, help)
 	r.NoError(err)
 	r.Equal(`alert(\'\\\'Hello\\\'\');`, string(html))
+}
+
+func Test_PartialHelper_Markdown(t *testing.T) {
+	r := require.New(t)
+
+	name := "index.md"
+	data := map[string]interface{}{}
+	help := HelperContext{Context: NewContext()}
+	help.Set("contentType", "text/markdown")
+	help.Set("partialFeeder", func(string) (string, error) {
+		return "`test`", nil
+	})
+
+	md, err := partialHelper(name, data, help)
+	r.NoError(err)
+	r.Equal(`<p><code>test</code></p>`, strings.TrimSpace(string(md)))
 }


### PR DESCRIPTION
This is a fix for https://github.com/gobuffalo/gobuffalo/issues/404, but not necessarily a good one:

### What is bad?
In contrast to the js support in `partial_helper.go#47`, the markdown support activates if the content type includes `markdown` or if the file ends in `.md` (JS support requires both to be true). This is inconsistent and might lead to confusion.

### Why did I still do it this way?
Concluding from my tests, buffalo doesn't set a `markdown` content type but uses `text/html`. I could not yet find the place to change this in buffalo. I'm not sure if buffalo can change the content type for markdown files as r.HTML seems to define it on initialization where the file type might not yet be clear: https://gobuffalo.io/en/docs/rendering#automatic-extensions

### Solution
To be honest, I don't think this really is a big deal. If someone can give me some pointers on how to fix it in buffalo though, I'd be happy to give it a try and make this fix a bit better.
