### PR TITLE
moved recursion to e-o-f, handling omitted extension

### DIFF
--- a/partial_helper.go
+++ b/partial_helper.go
@@ -1,10 +1,11 @@
 package plush
 
 import (
-	"github.com/gobuffalo/github_flavored_markdown"
 	"html/template"
+	"path/filepath"
 	"strings"
 
+	"github.com/gobuffalo/github_flavored_markdown"
 	"github.com/pkg/errors"
 )
 
@@ -40,6 +41,13 @@ func partialHelper(name string, data map[string]interface{}, help HelperContext)
 		part = string(github_flavored_markdown.Markdown([]byte(part)))
 	}
 
+	if ct, ok := help.Value("contentType").(string); ok {
+		ext := filepath.Ext(name)
+		if strings.Contains(ct, "javascript") && ext != ".js" && ext != "" {
+			part = template.JSEscapeString(string(part))
+		}
+	}
+
 	if layout, ok := data["layout"].(string); ok {
 		return partialHelper(
 			layout,
@@ -47,10 +55,5 @@ func partialHelper(name string, data map[string]interface{}, help HelperContext)
 			help)
 	}
 
-	if ct, ok := help.Value("contentType").(string); ok {
-		if strings.Contains(ct, "javascript") && !strings.HasSuffix(name, ".js") {
-			part = template.JSEscapeString(string(part))
-		}
-	}
 	return template.HTML(part), err
 }

--- a/partial_helper_test.go
+++ b/partial_helper_test.go
@@ -215,6 +215,22 @@ func Test_PartialHelper_JavaScript(t *testing.T) {
 	r.Equal(`alert('\'Hello\'');`, string(html))
 }
 
+func Test_PartialHelper_JavaScript_Without_Extension(t *testing.T) {
+	r := require.New(t)
+
+	name := "index"
+	data := map[string]interface{}{}
+	help := HelperContext{Context: NewContext()}
+	help.Set("contentType", "application/javascript")
+	help.Set("partialFeeder", func(string) (string, error) {
+		return `alert('\'Hello\'');`, nil
+	})
+
+	html, err := partialHelper(name, data, help)
+	r.NoError(err)
+	r.Equal(`alert('\'Hello\'');`, string(html))
+}
+
 func Test_PartialHelper_Javascript_With_HTML(t *testing.T) {
 	r := require.New(t)
 


### PR DESCRIPTION
I just added two changes to #77:
* moved recursion for layout so all possible manipulations can be handled correctly.
* added extension check for partial so omitted extension inside of javascript can be treated as javascript.