### PR TITLE
fixed to handle pointer method

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -462,6 +462,11 @@ func (c *compiler) evalCallExpression(node *ast.CallExpression) (interface{}, er
 			mname = i.Value
 		}
 		rv = rc.MethodByName(mname)
+		if !rv.IsValid() && rc.Type().Kind() != reflect.Ptr {
+			ptr := reflect.New(reflect.TypeOf(c))
+			ptr.Elem().Set(rc)
+			rv = ptr.MethodByName(mname)
+		}
 		if !rv.IsValid() {
 			if rv.Kind() == reflect.Slice {
 				rv = rc.FieldByName(mname)

--- a/struct_test.go
+++ b/struct_test.go
@@ -32,12 +32,17 @@ func Test_Render_UnknownAttribute_on_Callee(t *testing.T) {
 
 type Robot struct {
 	Avatar Avatar
+	name   string
 }
 
 type Avatar string
 
 func (a Avatar) URL() string {
 	return strings.ToUpper(string(a))
+}
+
+func (r *Robot) Name() string {
+	return r.name
 }
 
 func Test_Render_Function_on_sub_Struct(t *testing.T) {
@@ -51,4 +56,25 @@ func Test_Render_Function_on_sub_Struct(t *testing.T) {
 	s, err := Render(input, ctx)
 	r.NoError(err)
 	r.Equal("BENDER.JPG", s)
+}
+
+func Test_Render_Struct_PointerMethod(t *testing.T) {
+	r := require.New(t)
+	ctx := NewContext()
+	robot := Robot{name: "robot"}
+
+	t.Run("ByValue", func(t *testing.T) {
+		ctx.Set("robot", robot)
+		input := `<%= robot.Name() %>`
+		s, err := Render(input, ctx)
+		r.NoError(err)
+		r.Equal("robot", s)
+	})
+	t.Run("ByPointer", func(t *testing.T) {
+		ctx.Set("robot", &robot)
+		input := `<%= robot.Name() %>`
+		s, err := Render(input, ctx)
+		r.NoError(err)
+		r.Equal("robot", s)
+	})
 }


### PR DESCRIPTION
Hi @markbates and @stanislas-m,
I open a PR to fix the behavior of plush when we call a method of structure which has pointer receiver.
(related to https://github.com/gobuffalo/buffalo/issues/1479)

When the model looks like 

```go
type Robot struct {
    name string
}

func (r *Robot) Name() string {
    return r.name
}
```

and we wrote templates like

```
<%= robot.Name() %>
```

in `show.html` which is `robot` is already a pointer or

```
<%= for (robot) in robots { %>
<%= robot.Name() %>
<% } %>
```

in `index.html` which is `robot` in the loop is not a pointer.

Currently, the first template works fine as user expected but the code was translated into the same result of `robot.String()` in second template. If this is not a designed behavior(I think so), this PR makes the same results from these two cases.