### PR TITLE
Fix markdown partials in markdown partials

### DIFF
--- a/partial_helper.go
+++ b/partial_helper.go
@@ -39,6 +39,7 @@ func partialHelper(name string, data map[string]interface{}, help HelperContext)
 
 	if strings.HasSuffix(name, ".md") {
 		part = string(github_flavored_markdown.Markdown([]byte(part)))
+		part = strings.TrimSuffix(part, "\n")
 	}
 
 	if ct, ok := help.Value("contentType").(string); ok {

--- a/partial_helper_test.go
+++ b/partial_helper_test.go
@@ -280,7 +280,7 @@ func Test_PartialHelper_Markdown_With_Layout(t *testing.T) {
 
 	html, err := partialHelper(name, data, help)
 	r.NoError(err)
-	r.Equal("<html>This <em>is</em> a <p><strong>test</strong></p>\n</html>", string(html))
+	r.Equal("<html>This <em>is</em> a <p><strong>test</strong></p></html>", string(html))
 }
 
 func Test_PartialHelper_Markdown_With_Layout_Reversed(t *testing.T) {
@@ -301,4 +301,36 @@ func Test_PartialHelper_Markdown_With_Layout_Reversed(t *testing.T) {
 	html, err := partialHelper(name, data, help)
 	r.NoError(err)
 	r.Equal(`<p>This <em>is</em> a <strong>test</strong></p>`, strings.TrimSpace(string(html)))
+}
+
+func Test_PartialHelpers_With_Indentatio(t *testing.T) {
+	r := require.New(t)
+
+	main := `<div>
+    <div>
+        <%= partial("dummy.md") %>
+    </div>
+</div>`
+	partial := "```go\n" +
+		"if true {\n" +
+		"    fmt.Println()\n" +
+		"}\n" +
+		"```"
+
+	ctx := NewContext()
+	ctx.Set("partialFeeder", func(string) (string, error) {
+		return partial, nil
+	})
+
+	html, err := Render(main, ctx)
+	r.NoError(err)
+	r.Equal(`<div>
+    <div>
+        <div class="highlight highlight-go"><pre>if true {
+    fmt.Println()
+}
+</pre></div>
+    </div>
+</div>`,
+		string(html))
 }

--- a/partial_helper_test.go
+++ b/partial_helper_test.go
@@ -303,7 +303,7 @@ func Test_PartialHelper_Markdown_With_Layout_Reversed(t *testing.T) {
 	r.Equal(`<p>This <em>is</em> a <strong>test</strong></p>`, strings.TrimSpace(string(html)))
 }
 
-func Test_PartialHelpers_With_Indentatio(t *testing.T) {
+func Test_PartialHelpers_With_Indentation(t *testing.T) {
 	r := require.New(t)
 
 	main := `<div>


### PR DESCRIPTION
Fix for gobuffalo/gobuffalo#412

The markdown parser adds an empty line at the end of the generated html.
If the lines after the `<%= partial(...) %>` are indented by at least 4 spaces, they get interpreted as code (which is following https://guides.github.com/features/mastering-markdown/).

This PR strips the empty line at the end to change this behavior.