### PR TITLE
Expose template program to allow node manipulation.

### DIFF
--- a/template.go
+++ b/template.go
@@ -2,9 +2,7 @@ package plush
 
 import (
 	"github.com/gobuffalo/plush/ast"
-
 	"github.com/gobuffalo/plush/parser"
-
 	"github.com/pkg/errors"
 )
 
@@ -67,4 +65,9 @@ func (t *Template) Clone() *Template {
 		program: t.program,
 	}
 	return t2
+}
+
+// Program exposes the template AST to allow node manipulation.
+func (t *Template) Program() *ast.Program {
+	return t.program
 }


### PR DESCRIPTION
This can be used in fizz case to rewrite fizz migrations using the program nodes directly
instead of raw string manipulation.