### PR TITLE
Pretty print String()

### DIFF
--- a/ast/block_statement.go
+++ b/ast/block_statement.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 )
 
+// BlockStatement is a list of statements grouped in a context surrounded by braces.
 type BlockStatement struct {
 	TokenAble
 	Statements []Statement
@@ -11,7 +12,8 @@ type BlockStatement struct {
 
 func (bs *BlockStatement) statementNode() {}
 
-func (bs *BlockStatement) Value() string {
+// InnerText gets the raw string representation of the block's contents.
+func (bs *BlockStatement) InnerText() string {
 	var out bytes.Buffer
 	for _, s := range bs.Statements {
 		out.WriteString(s.String())

--- a/ast/block_statement.go
+++ b/ast/block_statement.go
@@ -11,12 +11,18 @@ type BlockStatement struct {
 
 func (bs *BlockStatement) statementNode() {}
 
-func (bs *BlockStatement) String() string {
+func (bs *BlockStatement) Value() string {
 	var out bytes.Buffer
-
 	for _, s := range bs.Statements {
 		out.WriteString(s.String())
 	}
+	return out.String()
+}
 
+func (bs *BlockStatement) String() string {
+	var out bytes.Buffer
+	for _, s := range bs.Statements {
+		out.WriteString("\t" + s.String() + "\n")
+	}
 	return out.String()
 }

--- a/ast/call_expression.go
+++ b/ast/call_expression.go
@@ -29,14 +29,17 @@ func (ce *CallExpression) String() string {
 	out.WriteString(strings.Join(args, ", "))
 	out.WriteString(")")
 	if ce.Block != nil {
-		out.WriteString(" { ")
+		out.WriteString(" {\n")
 		out.WriteString(ce.Block.String())
-		out.WriteString(" } ")
+		out.WriteString("}")
 	}
 	if ce.ElseBlock != nil {
 		out.WriteString(" else { ")
 		out.WriteString(ce.ElseBlock.String())
-		out.WriteString(" } ")
+		out.WriteString(" }")
+	}
+	if ce.Block != nil || ce.ElseBlock != nil {
+		out.WriteString("\n")
 	}
 
 	return out.String()

--- a/ast/call_expression.go
+++ b/ast/call_expression.go
@@ -24,10 +24,6 @@ func (ce *CallExpression) String() string {
 		args = append(args, a.String())
 	}
 
-	if ce.Callee != nil {
-		out.WriteString(ce.Callee.String())
-		out.WriteString(".")
-	}
 	out.WriteString(ce.Function.String())
 	out.WriteString("(")
 	out.WriteString(strings.Join(args, ", "))

--- a/ast/hash_literal.go
+++ b/ast/hash_literal.go
@@ -7,6 +7,7 @@ import (
 
 type HashLiteral struct {
 	TokenAble
+	Order []Expression
 	Pairs map[Expression]Expression
 }
 
@@ -16,8 +17,9 @@ func (hl *HashLiteral) String() string {
 	var out bytes.Buffer
 
 	pairs := []string{}
-	for key, value := range hl.Pairs {
-		pairs = append(pairs, key.String()+": "+value.String())
+	for _, key := range hl.Order {
+		p := hl.Pairs[key]
+		pairs = append(pairs, key.String()+": "+p.String())
 	}
 
 	out.WriteString("{")

--- a/ast/hash_literal.go
+++ b/ast/hash_literal.go
@@ -17,7 +17,7 @@ func (hl *HashLiteral) String() string {
 
 	pairs := []string{}
 	for key, value := range hl.Pairs {
-		pairs = append(pairs, key.String()+":"+value.String())
+		pairs = append(pairs, key.String()+": "+value.String())
 	}
 
 	out.WriteString("{")

--- a/ast/return_statement.go
+++ b/ast/return_statement.go
@@ -2,9 +2,12 @@ package ast
 
 import (
 	"bytes"
+
+	"github.com/gobuffalo/plush/token"
 )
 
 type ReturnStatement struct {
+	Type string
 	TokenAble
 	ReturnValue Expression
 }
@@ -18,13 +21,21 @@ func (rs *ReturnStatement) statementNode() {}
 func (rs *ReturnStatement) String() string {
 	var out bytes.Buffer
 
-	out.WriteString("return ")
+	if rs.Type == token.E_START {
+		out.WriteString("<%= ")
+	} else {
+		out.WriteString("return ")
+	}
 
 	if rs.ReturnValue != nil {
 		out.WriteString(rs.ReturnValue.String())
 	}
 
-	out.WriteString(";")
+	if rs.Type == token.E_START {
+		out.WriteString("; %>")
+	} else {
+		out.WriteString(";")
+	}
 
 	return out.String()
 }

--- a/ast/string_literal.go
+++ b/ast/string_literal.go
@@ -8,5 +8,5 @@ type StringLiteral struct {
 func (sl *StringLiteral) expressionNode() {}
 
 func (sl *StringLiteral) String() string {
-	return sl.Token.Literal
+	return "\"" + sl.Token.Literal + "\""
 }

--- a/compiler.go
+++ b/compiler.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/gobuffalo/plush/ast"
-
 	"github.com/pkg/errors"
 )
 
@@ -260,7 +259,7 @@ func (c *compiler) evalHashLiteral(node *ast.HashLiteral) (interface{}, error) {
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
-		m[ke.String()] = v
+		m[ke.TokenLiteral()] = v
 	}
 	return m, nil
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -151,9 +151,9 @@ func (p *parser) parseStatement() ast.Statement {
 		p.nextToken()
 		return p.parseStatement()
 	case token.RETURN:
-		return p.parseReturnStatement()
+		return p.parseReturnStatement(token.RETURN)
 	case token.E_START:
-		return p.parseReturnStatement()
+		return p.parseReturnStatement(token.E_START)
 	case token.RBRACE:
 		return nil
 	case token.EOF:
@@ -163,9 +163,9 @@ func (p *parser) parseStatement() ast.Statement {
 	}
 }
 
-func (p *parser) parseReturnStatement() *ast.ReturnStatement {
+func (p *parser) parseReturnStatement(t string) *ast.ReturnStatement {
 	// fmt.Println("parseReturnStatement")
-	stmt := &ast.ReturnStatement{TokenAble: ast.TokenAble{p.curToken}}
+	stmt := &ast.ReturnStatement{Type: t, TokenAble: ast.TokenAble{p.curToken}}
 
 	p.nextToken()
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -680,6 +680,7 @@ func (p *parser) parseHashLiteral() ast.Expression {
 	// fmt.Println("parseHashLiteral")
 	hash := &ast.HashLiteral{TokenAble: ast.TokenAble{p.curToken}}
 	hash.Pairs = make(map[ast.Expression]ast.Expression)
+	hash.Order = make([]ast.Expression, 0)
 
 	for !p.peekTokenIs(token.RBRACE) {
 		p.nextToken()
@@ -693,6 +694,7 @@ func (p *parser) parseHashLiteral() ast.Expression {
 		value := p.parseExpression(LOWEST)
 
 		hash.Pairs[key] = value
+		hash.Order = append(hash.Order, key)
 
 		if !p.peekTokenIs(token.RBRACE) && !p.expectPeek(token.COMMA) {
 			return nil

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/gobuffalo/plush/ast"
-
 	"github.com/stretchr/testify/require"
 )
 
@@ -590,7 +589,7 @@ func Test_CallExpressionParsing_WithCallee(t *testing.T) {
 	r.Equal("Greet", ident.Value)
 
 	r.Len(exp.Arguments, 1)
-	r.Equal(exp.Arguments[0].String(), "mark")
+	r.Equal(exp.Arguments[0].String(), "\"mark\"")
 }
 
 func Test_CallExpressionParsing_WithMultipleCallees(t *testing.T) {
@@ -611,7 +610,7 @@ func Test_CallExpressionParsing_WithMultipleCallees(t *testing.T) {
 	r.Equal("Greet", ident.Value)
 
 	r.Len(exp.Arguments, 1)
-	r.Equal(exp.Arguments[0].String(), "mark")
+	r.Equal(exp.Arguments[0].String(), "\"mark\"")
 }
 
 func Test_CallExpressionParsing_WithBlock(t *testing.T) {
@@ -744,7 +743,7 @@ func Test_HashLiteralsStringKeys(t *testing.T) {
 	for key, value := range hash.Pairs {
 		literal := key.(*ast.StringLiteral)
 
-		expectedValue := expected[literal.String()]
+		expectedValue := expected[literal.Value]
 		r.True(testIntegerLiteral(t, value, expectedValue))
 	}
 }
@@ -828,7 +827,7 @@ func Test_HashLiteralsWithExpressions(t *testing.T) {
 	for key, value := range hash.Pairs {
 		literal := key.(*ast.StringLiteral)
 
-		testFunc := tests[literal.String()]
+		testFunc := tests[literal.Value]
 		testFunc(value)
 	}
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -581,6 +581,7 @@ func Test_CallExpressionParsing_WithCallee(t *testing.T) {
 
 	r.Len(program.Statements, 1)
 
+	r.Equal(input, program.String())
 	stmt := program.Statements[0].(*ast.ReturnStatement)
 
 	exp := stmt.ReturnValue.(*ast.CallExpression)
@@ -601,6 +602,7 @@ func Test_CallExpressionParsing_WithMultipleCallees(t *testing.T) {
 
 	r.Len(program.Statements, 1)
 
+	r.Equal(input, program.String())
 	stmt := program.Statements[0].(*ast.ReturnStatement)
 
 	exp := stmt.ReturnValue.(*ast.CallExpression)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -634,7 +634,7 @@ func Test_CallExpressionParsing_WithBlock(t *testing.T) {
 
 	r.Len(exp.Arguments, 0)
 	r.NotNil(exp.Block)
-	r.Equal("hi", exp.Block.String())
+	r.Equal("hi", exp.Block.Value())
 	r.Nil(exp.Callee)
 }
 
@@ -978,4 +978,32 @@ func Test_AndOrInfixExpressions(t *testing.T) {
 		ins := stmt.Expression.(*ast.InfixExpression)
 		r.Equal(ins.Right.String(), tt.rightValue)
 	}
+}
+
+func Test_String_Function(t *testing.T) {
+	r := require.New(t)
+	input := `create_table("users") {
+	t.Column("id", "int", {primary: true})
+	t.Column("name", "string", {})
+	t.Column("user_name", "string", {"size": 100})
+	t.Column("alive", "boolean", {"null": true})
+	t.Column("birth_date", "timestamp", {"null": true})
+	t.Column("bio", "text", {"null": true})
+	t.Column("price", "numeric", {"null": true, "default": "1.00"})
+	t.Column("email", "string", {"default": "foo@example.com", "size": 50})
+}
+create_table("users_2", {"timestamps": false}) {
+	t.Column("id", "int", {primary: true})
+	t.Column("name", "string", {})
+	t.Column("user_name", "string", {"size": 100})
+	t.Column("alive", "boolean", {"null": true})
+	t.Column("birth_date", "timestamp", {"null": true})
+	t.Column("bio", "text", {"null": true})
+	t.Column("price", "numeric", {"null": true, "default": "1.00"})
+	t.Column("email", "string", {"default": "foo@example.com", "size": 50})
+}
+`
+	p, err := Parse("<%" + input + "%>")
+	r.NoError(err)
+	r.Equal(input, p.String())
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -634,7 +634,7 @@ func Test_CallExpressionParsing_WithBlock(t *testing.T) {
 
 	r.Len(exp.Arguments, 0)
 	r.NotNil(exp.Block)
-	r.Equal("hi", exp.Block.Value())
+	r.Equal("hi", exp.Block.InnerText())
 	r.Nil(exp.Callee)
 }
 


### PR DESCRIPTION
In order to use the plush AST to fix fizz files, I needed to change the way String() is handled so it pretty print the AST. Some functions were using String() to get the raw value of a node, I had to adapt them a bit.

This allows to modify some nodes and generate the new string representation of the AST without having an hard to read fixed fizz migration.