### PR TITLE
Update test cases to account for nested comments.

### DIFF
--- a/comments_test.go
+++ b/comments_test.go
@@ -8,26 +8,43 @@ import (
 
 func Test_Comment(t *testing.T) {
 	r := require.New(t)
-	input := `
-	<%# This is a comment %>
-	Hi
-	`
-	s, err := Render(input, NewContext())
-	r.NoError(err)
-	r.Contains(s, "Hi")
-	r.NotContains(s, "This is a comment")
+	input := map[string]string{
+		"test1": `
+		<%# this is a comment %>
+		Hi
+		`,
+		"test2": `
+		<% <%# this is a comment %> %>
+		Hi
+		`,
+	}
+
+	for _, test := range input {
+		s, err := Render(test, NewContext())
+		r.NoError(err)
+		r.Contains(s, "Hi")
+		r.NotContains(s, "this is a comment")
+	}
 }
 
 func Test_BlockComment(t *testing.T) {
 	r := require.New(t)
-	input := `
-	<%# This is a 
-	block comment %>
-	Hi
-	`
-	s, err := Render(input, NewContext())
-	r.NoError(err)
-	r.Contains(s, "Hi")
-	r.NotContains(s, "This is a")
-	r.NotContains(s, "block comment")
+	input := map[string]string{
+		"test1": `
+		<%# this is 
+		a block comment %>
+		Hi
+		`,
+		"test2": `
+		<% <%# this is 
+		a block comment %> %>
+		Hi`,
+	}
+
+	for _, test := range input {
+		s, err := Render(test, NewContext())
+		r.NoError(err)
+		r.Contains(s, "Hi")
+		r.NotContains(s, []string{"this is", "a block comment"})
+	}
 }


### PR DESCRIPTION
  - Comments can be nested inside of a plush code block.
  - Perhaps this should be changed to allow commenting with only a '#'.