### PR TITLE
Improve func call error

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -628,7 +628,7 @@ func (c *compiler) evalCallExpression(node *ast.CallExpression) (interface{}, er
 	res := rv.Call(args)
 	if len(res) > 0 {
 		if e, ok := res[len(res)-1].Interface().(error); ok {
-			return nil, e
+			return nil, errors.Wrap(e, fmt.Sprintf("could not call %s function", node.Function.String()))
 		}
 		return res[0].Interface(), nil
 	}


### PR DESCRIPTION
Instead of "line 1: could not convert struct { Name string } to Ident"
it will now say "line 1: could not call form_for function: could not
convert struct { Name string } to Ident".

This will give more context to the plush user and improve debugging.