### PR TITLE
Allow to change _START _END tokens

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -3,7 +3,7 @@ package lexer
 import (
 	"strings"
 
-	"github.com/gobuffalo/plush/token"
+	"github.com/bart84ek/plush/token"
 )
 
 // Lexer moves through the source input and tokenizes its content

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -3,7 +3,7 @@ package lexer
 import (
 	"strings"
 
-	"github.com/bart84ek/plush/token"
+	"github.com/gobuffalo/plush/token"
 )
 
 // Lexer moves through the source input and tokenizes its content
@@ -307,10 +307,10 @@ func (l *Lexer) readBString() string {
 
 func (l *Lexer) readHTML() string {
 	position := l.position
-
+	start := get(token.S_START)
 	for l.ch != 0 {
 
-		if l.ch == '\\' && l.prevChar() == '\\' && l.peekChar() == '<' {
+		if l.ch == '\\' && l.prevChar() == '\\' && l.peekChar() == start[0] {
 			// escape escaping
 			l.readChar()
 			x := l.input[position : l.position-1]
@@ -318,17 +318,17 @@ func (l *Lexer) readHTML() string {
 		}
 
 		// allow for expression escaping using \<% foo %>
-		if l.ch == '\\' && l.peekChar() == '<' {
+		if l.ch == '\\' && l.peekChar() == start[0] {
 			l.readChar()
 			l.readChar()
 		}
-		if l.ch == '<' && l.peekChar() == '%' {
+		if l.ch == start[0] && l.peekChar() == start[1] {
 			l.inside = true
 			break
 		}
 		l.readChar()
 	}
-	return strings.Replace(l.input[position:l.position], "\\<%", "<%", -1)
+	return strings.Replace(l.input[position:l.position], "\\"+string(start), string(start), -1)
 }
 
 func isLetter(ch byte) bool {

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -51,7 +51,6 @@ func (l *Lexer) NextToken() token.Token {
 }
 
 func (l *Lexer) nextOutsideToken() (token.Token, bool) {
-	var tok token.Token
 	switch l.ch {
 	case resolve(token.E_END)[0]:
 		if l.peekChar() == resolve(token.E_END)[1] {
@@ -76,7 +75,7 @@ func (l *Lexer) nextOutsideToken() (token.Token, bool) {
 			return token.Token{Type: tt, Literal: string(tt), LineNumber: l.curLine}, true
 		}
 	}
-	return tok, false
+	return token.Token{}, false
 }
 
 func (l *Lexer) nextInsideToken() token.Token {

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -38,7 +38,7 @@ func (l *Lexer) NextToken() token.Token {
 		return tok
 	}
 
-	start := get(token.S_START)
+	start := resolve(token.S_START)
 	if l.ch == start[0] && l.peekChar() == start[1] {
 		l.inside = true
 		return l.nextInsideToken()
@@ -53,25 +53,25 @@ func (l *Lexer) NextToken() token.Token {
 func (l *Lexer) nextOutsideToken() (token.Token, bool) {
 	var tok token.Token
 	switch l.ch {
-	case get(token.E_END)[0]:
-		if l.peekChar() == get(token.E_END)[1] {
+	case resolve(token.E_END)[0]:
+		if l.peekChar() == resolve(token.E_END)[1] {
 			l.inside = false
 			l.readChar()
-			tt := get(token.E_END)
+			tt := resolve(token.E_END)
 			return token.Token{Type: tt, Literal: string(tt), LineNumber: l.curLine}, true
 		}
-	case get(token.S_START)[0]:
-		if l.peekChar() == get(token.S_START)[1] {
+	case resolve(token.S_START)[0]:
+		if l.peekChar() == resolve(token.S_START)[1] {
 			l.inside = true
 			l.readChar()
-			tt := get(token.S_START)
+			tt := resolve(token.S_START)
 			switch l.peekChar() {
 			case '#':
 				l.readChar()
-				tt = get(token.C_START)
+				tt = resolve(token.C_START)
 			case '=':
 				l.readChar()
-				tt = get(token.E_START)
+				tt = resolve(token.E_START)
 			}
 			return token.Token{Type: tt, Literal: string(tt), LineNumber: l.curLine}, true
 		}
@@ -307,7 +307,7 @@ func (l *Lexer) readBString() string {
 
 func (l *Lexer) readHTML() string {
 	position := l.position
-	start := get(token.S_START)
+	start := resolve(token.S_START)
 	for l.ch != 0 {
 
 		if l.ch == '\\' && l.prevChar() == '\\' && l.peekChar() == start[0] {
@@ -351,6 +351,6 @@ func (l *Lexer) newIllegalTokenLiteral(tokenType token.Type, literal string) tok
 	return token.Token{Type: tokenType, Literal: literal, LineNumber: l.curLine}
 }
 
-func get(tokenType token.Type) token.Type {
+func resolve(tokenType token.Type) token.Type {
 	return token.Resolve(tokenType)
 }

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -2,7 +2,6 @@ package lexer
 
 import (
 	"strings"
-	// "fmt"
 
 	"github.com/gobuffalo/plush/token"
 )

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -4,8 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/gobuffalo/plush/token"
+	"github.com/bart84ek/plush/token"
 )
 
 func Test_NextToken_Simple(t *testing.T) {
@@ -311,5 +310,28 @@ my-helper()
 
 		r.Equal(tt.expectedLiteral, tok.Literal)
 		r.Equal(tt.expectedType, tok.Type)
+	}
+}
+
+func Test_CustomOutsideTokens(t *testing.T) {
+	r := require.New(t)
+	input := `{{= 1 }}`
+
+	token.SetTemplateDelimeters("{{", "}}")
+
+	tests := []struct {
+		tokenType    token.Type
+		tokenLiteral string
+	}{
+		{token.Resolve(token.E_START), "{{="},
+		{token.INT, "1"},
+		{token.Resolve(token.E_END), "}}"},
+	}
+
+	l := New(input)
+	for _, tt := range tests {
+		tok := l.NextToken()
+		r.Equal(tt.tokenType, tok.Type)
+		r.Equal(tt.tokenLiteral, tok.Literal)
 	}
 }

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/bart84ek/plush/token"
+	"github.com/gobuffalo/plush/token"
 )
 
 func Test_NextToken_Simple(t *testing.T) {

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -339,9 +339,7 @@ func Test_DynamicTokensComplete(t *testing.T) {
 	token.SetTemplatingDelimiters("{{", "}}")
 	input := `{{= 1 }}
 {{# 2 }}
-{{ 3 }}
-<%= "AAAA" %>
-`
+{{ 3 }}`
 	tests := []struct {
 		expectedType    token.Type
 		expectedLiteral string
@@ -350,10 +348,13 @@ func Test_DynamicTokensComplete(t *testing.T) {
 		{token.INT, "1"},
 		{token.Resolve(token.E_END), "}}"},
 		{token.HTML, "\n"},
-		{token.Resolve(token.C_START), "{{="},
+		{token.Resolve(token.C_START), "{{#"},
 		{token.INT, "2"},
 		{token.Resolve(token.E_END), "}}"},
 		{token.HTML, "\n"},
+		{token.Resolve(token.S_START), "{{"},
+		{token.INT, "3"},
+		{token.Resolve(token.E_END), "}}"},
 	}
 
 	l := New(input)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/gobuffalo/plush/ast"
-	"github.com/bart84ek/plush/lexer"
-	"github.com/bart84ek/plush/token"
+	"github.com/gobuffalo/plush/lexer"
+	"github.com/gobuffalo/plush/token"
 )
 
 type (

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/gobuffalo/plush/ast"
-	"github.com/gobuffalo/plush/lexer"
-	"github.com/gobuffalo/plush/token"
+	"github.com/bart84ek/plush/lexer"
+	"github.com/bart84ek/plush/token"
 )
 
 type (

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -48,8 +48,8 @@ func newParser(l *lexer.Lexer) *parser {
 	p.registerPrefix(token.LBRACKET, p.parseArrayLiteral)
 	p.registerPrefix(token.LBRACE, p.parseHashLiteral)
 	p.registerPrefix(token.HTML, p.parseHTMLLiteral)
-	p.registerPrefix(token.Resolve(token.C_START), p.parseCommentLiteral)
-	p.registerPrefix(token.Resolve(token.E_END), func() ast.Expression { return nil })
+	p.registerPrefix(get(token.C_START), p.parseCommentLiteral)
+	p.registerPrefix(get(token.E_END), func() ast.Expression { return nil })
 
 	p.infixParseFns = make(map[token.Type]infixParseFn)
 	p.registerInfix(token.PLUS, p.parseInfixExpression)
@@ -147,13 +147,13 @@ func (p *parser) parseStatement() ast.Statement {
 	case token.LET:
 		l := p.parseLetStatement()
 		return l
-	case token.Resolve(token.S_START):
+	case get(token.S_START):
 		p.nextToken()
 		return p.parseStatement()
 	case token.RETURN:
 		return p.parseReturnStatement(token.RETURN)
-	case token.Resolve(token.E_START):
-		return p.parseReturnStatement(string(token.Resolve(token.E_START)))
+	case get(token.E_START):
+		return p.parseReturnStatement(string(get(token.E_START)))
 	case token.RBRACE:
 		return nil
 	case token.EOF:
@@ -335,7 +335,7 @@ func (p *parser) parseStringLiteral() ast.Expression {
 
 func (p *parser) parseCommentLiteral() ast.Expression {
 	// fmt.Println("parseCommentLiteral")
-	for p.curToken.Type != token.Resolve(token.E_END) {
+	for p.curToken.Type != get(token.E_END) {
 		p.nextToken()
 	}
 	return &ast.StringLiteral{TokenAble: ast.TokenAble{p.curToken}, Value: ""}
@@ -531,7 +531,7 @@ func (p *parser) parseBlockStatement() *ast.BlockStatement {
 	p.nextToken()
 
 	for !p.curTokenIs(token.RBRACE) && !p.curTokenIs(token.EOF) {
-		if p.curTokenIs(token.Resolve(token.S_START)) || p.curTokenIs(token.Resolve(token.E_END)) {
+		if p.curTokenIs(get(token.S_START)) || p.curTokenIs(get(token.E_END)) {
 			p.nextToken()
 			continue
 		}
@@ -714,4 +714,8 @@ func (p *parser) registerPrefix(tokenType token.Type, fn prefixParseFn) {
 
 func (p *parser) registerInfix(tokenType token.Type, fn infixParseFn) {
 	p.infixParseFns[tokenType] = fn
+}
+
+func get(tokenType token.Type) token.Type {
+	return token.Resolve(tokenType)
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -48,8 +48,8 @@ func newParser(l *lexer.Lexer) *parser {
 	p.registerPrefix(token.LBRACKET, p.parseArrayLiteral)
 	p.registerPrefix(token.LBRACE, p.parseHashLiteral)
 	p.registerPrefix(token.HTML, p.parseHTMLLiteral)
-	p.registerPrefix(token.C_START, p.parseCommentLiteral)
-	p.registerPrefix(token.E_END, func() ast.Expression { return nil })
+	p.registerPrefix(token.Resolve(token.C_START), p.parseCommentLiteral)
+	p.registerPrefix(token.Resolve(token.E_END), func() ast.Expression { return nil })
 
 	p.infixParseFns = make(map[token.Type]infixParseFn)
 	p.registerInfix(token.PLUS, p.parseInfixExpression)
@@ -147,13 +147,13 @@ func (p *parser) parseStatement() ast.Statement {
 	case token.LET:
 		l := p.parseLetStatement()
 		return l
-	case token.S_START:
+	case token.Resolve(token.S_START):
 		p.nextToken()
 		return p.parseStatement()
 	case token.RETURN:
 		return p.parseReturnStatement(token.RETURN)
-	case token.E_START:
-		return p.parseReturnStatement(token.E_START)
+	case token.Resolve(token.E_START):
+		return p.parseReturnStatement(string(token.Resolve(token.E_START)))
 	case token.RBRACE:
 		return nil
 	case token.EOF:
@@ -335,7 +335,7 @@ func (p *parser) parseStringLiteral() ast.Expression {
 
 func (p *parser) parseCommentLiteral() ast.Expression {
 	// fmt.Println("parseCommentLiteral")
-	for p.curToken.Type != token.E_END {
+	for p.curToken.Type != token.Resolve(token.E_END) {
 		p.nextToken()
 	}
 	return &ast.StringLiteral{TokenAble: ast.TokenAble{p.curToken}, Value: ""}
@@ -531,7 +531,7 @@ func (p *parser) parseBlockStatement() *ast.BlockStatement {
 	p.nextToken()
 
 	for !p.curTokenIs(token.RBRACE) && !p.curTokenIs(token.EOF) {
-		if p.curTokenIs(token.S_START) || p.curTokenIs(token.E_END) {
+		if p.curTokenIs(token.Resolve(token.S_START)) || p.curTokenIs(token.Resolve(token.E_END)) {
 			p.nextToken()
 			continue
 		}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -48,8 +48,8 @@ func newParser(l *lexer.Lexer) *parser {
 	p.registerPrefix(token.LBRACKET, p.parseArrayLiteral)
 	p.registerPrefix(token.LBRACE, p.parseHashLiteral)
 	p.registerPrefix(token.HTML, p.parseHTMLLiteral)
-	p.registerPrefix(get(token.C_START), p.parseCommentLiteral)
-	p.registerPrefix(get(token.E_END), func() ast.Expression { return nil })
+	p.registerPrefix(resolve(token.C_START), p.parseCommentLiteral)
+	p.registerPrefix(resolve(token.E_END), func() ast.Expression { return nil })
 
 	p.infixParseFns = make(map[token.Type]infixParseFn)
 	p.registerInfix(token.PLUS, p.parseInfixExpression)
@@ -147,13 +147,13 @@ func (p *parser) parseStatement() ast.Statement {
 	case token.LET:
 		l := p.parseLetStatement()
 		return l
-	case get(token.S_START):
+	case resolve(token.S_START):
 		p.nextToken()
 		return p.parseStatement()
 	case token.RETURN:
 		return p.parseReturnStatement(token.RETURN)
-	case get(token.E_START):
-		return p.parseReturnStatement(string(get(token.E_START)))
+	case resolve(token.E_START):
+		return p.parseReturnStatement(string(resolve(token.E_START)))
 	case token.RBRACE:
 		return nil
 	case token.EOF:
@@ -335,7 +335,7 @@ func (p *parser) parseStringLiteral() ast.Expression {
 
 func (p *parser) parseCommentLiteral() ast.Expression {
 	// fmt.Println("parseCommentLiteral")
-	for p.curToken.Type != get(token.E_END) {
+	for p.curToken.Type != resolve(token.E_END) {
 		p.nextToken()
 	}
 	return &ast.StringLiteral{TokenAble: ast.TokenAble{p.curToken}, Value: ""}
@@ -531,7 +531,7 @@ func (p *parser) parseBlockStatement() *ast.BlockStatement {
 	p.nextToken()
 
 	for !p.curTokenIs(token.RBRACE) && !p.curTokenIs(token.EOF) {
-		if p.curTokenIs(get(token.S_START)) || p.curTokenIs(get(token.E_END)) {
+		if p.curTokenIs(resolve(token.S_START)) || p.curTokenIs(resolve(token.E_END)) {
 			p.nextToken()
 			continue
 		}
@@ -716,6 +716,6 @@ func (p *parser) registerInfix(tokenType token.Type, fn infixParseFn) {
 	p.infixParseFns[tokenType] = fn
 }
 
-func get(tokenType token.Type) token.Type {
+func resolve(tokenType token.Type) token.Type {
 	return token.Resolve(tokenType)
 }

--- a/token/const.go
+++ b/token/const.go
@@ -36,8 +36,8 @@ const (
 	// Delimiters
 
 	S_START = "<%"
-	C_START = "<%#"
-	E_START = "<%="
+	C_START = S_START + "#"
+	E_START = S_START + "="
 	E_END   = "%>"
 
 	COMMA     = ","

--- a/token/token.go
+++ b/token/token.go
@@ -12,14 +12,14 @@ type Token struct {
 	LineNumber int
 }
 
-const TEMPLATE_DELIMITERS_LEN = 2
+const templateDelimitersLen = 2
 
-type DelimitersLengthError struct {
+type delimitersLengthError struct {
 	Delimiters []string
 	Length     int
 }
 
-func (e *DelimitersLengthError) Error() string {
+func (e *delimitersLengthError) Error() string {
 	return fmt.Sprintf("Incorrect delimiters \"%s\" length. %v chars allowed", e.Delimiters, e.Length)
 }
 var keywords = map[string]Type{
@@ -45,10 +45,11 @@ func LookupIdent(ident string) Type {
 	return IDENT
 }
 
+// SetTemplatingDelimiters to start and end, or return delimitersLengthError if delimiters length is incorrect
 func SetTemplatingDelimiters(start, end string) error {
-	if len(start) != TEMPLATE_DELIMITERS_LEN ||
-		len(end) != TEMPLATE_DELIMITERS_LEN {
-		return &DelimitersLengthError{[]string{start, end}, TEMPLATE_DELIMITERS_LEN}
+	if len(start) != templateDelimitersLen ||
+		len(end) != templateDelimitersLen {
+		return &delimitersLengthError{[]string{start, end}, templateDelimitersLen}
 	}
 	replace(S_START, Type(start))
 	replace(C_START, Type(fmt.Sprintf("%v#", start)))
@@ -58,9 +59,10 @@ func SetTemplatingDelimiters(start, end string) error {
 }
 
 func replace(token Type, replacement Type) {
-      dynamic[token] = replacement
+	dynamic[token] = replacement
 }
 
+// Resolve token.Type, return dynamic replacement if found or default Type
 func Resolve(token Type) Type {
 	if tok, ok := dynamic[token]; ok {
 		return tok

--- a/token/token.go
+++ b/token/token.go
@@ -35,7 +35,7 @@ func LookupIdent(ident string) Type {
 	return IDENT
 }
 
-func SetTemplatingDelimiters(start, end rune) {
+func SetTemplatingDelimiters(start, end string) {
 	replace(S_START, Type(start))
 	replace(C_START, Type(fmt.Sprintf("%v#", start)))
 	replace(E_START, Type(fmt.Sprintf("%v=", start)))

--- a/token/token.go
+++ b/token/token.go
@@ -12,6 +12,16 @@ type Token struct {
 	LineNumber int
 }
 
+const TEMPLATE_DELIMITERS_LEN = 2
+
+type DelimitersLengthError struct {
+	Delimiters []string
+	Length     int
+}
+
+func (e *DelimitersLengthError) Error() string {
+	return fmt.Sprintf("Incorrect delimiters \"%s\" length. %v chars allowed", e.Delimiters, e.Length)
+}
 var keywords = map[string]Type{
 	"fn":     FUNCTION,
 	"func":   FUNCTION,
@@ -35,11 +45,16 @@ func LookupIdent(ident string) Type {
 	return IDENT
 }
 
-func SetTemplatingDelimiters(start, end string) {
+func SetTemplatingDelimiters(start, end string) error {
+	if len(start) != TEMPLATE_DELIMITERS_LEN ||
+		len(end) != TEMPLATE_DELIMITERS_LEN {
+		return &DelimitersLengthError{[]string{start, end}, TEMPLATE_DELIMITERS_LEN}
+	}
 	replace(S_START, Type(start))
 	replace(C_START, Type(fmt.Sprintf("%v#", start)))
 	replace(E_START, Type(fmt.Sprintf("%v=", start)))
 	replace(E_END, Type(end))
+	return nil
 }
 
 func replace(token Type, replacement Type) {

--- a/token/token.go
+++ b/token/token.go
@@ -52,15 +52,11 @@ func SetTemplatingDelimiters(start, end string) error {
 		len(end) != templateDelimitersLen {
 		return &delimitersLengthError{[]string{start, end}, templateDelimitersLen}
 	}
-	replace(S_START, Type(start))
-	replace(C_START, Type(fmt.Sprintf("%v#", start)))
-	replace(E_START, Type(fmt.Sprintf("%v=", start)))
-	replace(E_END, Type(end))
+	dynamic[S_START] = Type(start)
+	dynamic[C_START] = Type(fmt.Sprintf("%v#", start))
+	dynamic[E_START] = Type(fmt.Sprintf("%v=", start))
+	dynamic[E_END] = Type(end)
 	return nil
-}
-
-func replace(token, replacement Type) {
-	dynamic[token] = replacement
 }
 
 // Resolve token.Type, return dynamic replacement if found or default Type

--- a/token/token.go
+++ b/token/token.go
@@ -22,6 +22,7 @@ type delimitersLengthError struct {
 func (e *delimitersLengthError) Error() string {
 	return fmt.Sprintf("Incorrect delimiters \"%s\" length. %v chars allowed", e.Delimiters, e.Length)
 }
+
 var keywords = map[string]Type{
 	"fn":     FUNCTION,
 	"func":   FUNCTION,

--- a/token/token.go
+++ b/token/token.go
@@ -80,8 +80,12 @@ func (t *Type) BeginsWith(ch byte) bool {
 	return (*t)[0] == ch
 }
 
+func (t *Type) endsWith(ch byte) bool {
+	return (*t)[1] == ch
+}
+
 // MatchAhead returns true if token matches firstChar and nextChar
-func MatchAhead(token Type, firstChar, nextChar byte) bool {
+func MatchAhead(token Type, firstChar, lastChar byte) bool {
 	token = Resolve(token)
-	return token.BeginsWith(firstChar) && token[1] == nextChar
+	return token.BeginsWith(firstChar) && token.endsWith(lastChar)
 }

--- a/token/token.go
+++ b/token/token.go
@@ -58,7 +58,7 @@ func SetTemplatingDelimiters(start, end string) error {
 	return nil
 }
 
-func replace(token Type, replacement Type) {
+func replace(token, replacement Type) {
 	dynamic[token] = replacement
 }
 

--- a/token/token.go
+++ b/token/token.go
@@ -1,5 +1,7 @@
 package token
 
+import "fmt"
+
 // Type represents each type of token.
 type Type string
 
@@ -23,10 +25,30 @@ var keywords = map[string]Type{
 	"in":     IN,
 }
 
+var dynamic = map[Type]Type{}
+
 // LookupIdent an ident and return a keyword type, or a plain ident
 func LookupIdent(ident string) Type {
 	if tok, ok := keywords[ident]; ok {
 		return tok
 	}
 	return IDENT
+}
+
+func SetTemplatingDelimiters(start, end rune) {
+	replace(S_START, Type(start))
+	replace(C_START, Type(fmt.Sprintf("%v#", start)))
+	replace(E_START, Type(fmt.Sprintf("%v=", start)))
+	replace(E_END, Type(end))
+}
+
+func replace(token Type, replacement Type) {
+      dynamic[token] = replacement
+}
+
+func Resolve(token Type) Type {
+	if tok, ok := dynamic[token]; ok {
+		return tok
+	}
+	return token
 }

--- a/token/token.go
+++ b/token/token.go
@@ -75,7 +75,7 @@ func checkDelimitersLength(arr []string) error {
 	return nil
 }
 
-// BeginsWith returns true if char of type matches input
+// BeginsWith returns true if first char of type matches input
 func (t *Type) BeginsWith(ch byte) bool {
 	return (*t)[0] == ch
 }

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -52,10 +52,10 @@ func Test_SetTemplatingDelimiters_LengthErrors(t *testing.T) {
 		end   string
 		error error
 	}{
-		{"{", "}", &delimitersLengthError{[]string{"{", "}"}, templateDelimitersLen}},
-		{"###", "###", &delimitersLengthError{[]string{"###", "###"}, templateDelimitersLen}},
-		{"{%", "}", &delimitersLengthError{[]string{"{%", "}"}, templateDelimitersLen}},
-		{"{{{", "%}", &delimitersLengthError{[]string{"{{{", "%}"}, templateDelimitersLen}},
+		{"{", "}", &delimiterLengthError{"{", templateDelimitersLen}},
+		{"###", "###", &delimiterLengthError{"###", templateDelimitersLen}},
+		{"{%", "}", &delimiterLengthError{"}", templateDelimitersLen}},
+		{"{{{", "%}", &delimiterLengthError{"{{{", templateDelimitersLen}},
 		{"{%", "%}", nil},
 	}
 	for _, tt := range tests {

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -1,0 +1,66 @@
+package token
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/gobuffalo/plush/token"
+)
+
+func Test_Resolve_Default(t *testing.T) {
+	r := require.New(t)
+	tests := []struct {
+		tokenType    Type
+		tokenLiteral string
+	}{
+		{token.S_START, "<%"},
+		{token.C_START, "<%#"},
+		{token.E_START, "<%="},
+		{token.E_END, "%>"},
+	}
+
+	for _, tt := range tests {
+		tok := Resolve(tt.tokenType)
+		r.Equal(tt.tokenType, tok)
+		r.Equal(tt.tokenLiteral, string(tok))
+	}
+}
+
+func Test_SetTemplatingDelimiters(t *testing.T) {
+	r := require.New(t)
+	SetTemplatingDelimiters("{{", "}}")
+
+	tests := []struct {
+		tokenType    Type
+		tokenLiteral string
+	}{
+		{token.S_START, "{{"},
+		{token.C_START, "{{#"},
+		{token.E_START, "{{="},
+		{token.E_END, "}}"},
+	}
+
+	for _, tt := range tests {
+		tok := Resolve(tt.tokenType)
+		r.Equal(tt.tokenLiteral, string(tok))
+	}
+}
+
+func Test_SetTemplatingDelimiters_LengthErrors(t *testing.T) {
+	r := require.New(t)
+	tests := []struct {
+		start string
+		end   string
+		error error
+	}{
+		{"{", "}", &DelimitersLengthError{[]string{"{", "}"}, TEMPLATE_DELIMITERS_LEN}},
+		{"###", "###", &DelimitersLengthError{[]string{"###", "###"}, TEMPLATE_DELIMITERS_LEN}},
+		{"{%", "}", &DelimitersLengthError{[]string{"{%", "}"}, TEMPLATE_DELIMITERS_LEN}},
+		{"{{{", "%}", &DelimitersLengthError{[]string{"{{{", "%}"}, TEMPLATE_DELIMITERS_LEN}},
+		{"{%", "%}", nil},
+	}
+	for _, tt := range tests {
+		err := SetTemplatingDelimiters(tt.start, tt.end)
+		r.Equal(tt.error, err)
+	}
+}

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -53,10 +53,10 @@ func Test_SetTemplatingDelimiters_LengthErrors(t *testing.T) {
 		end   string
 		error error
 	}{
-		{"{", "}", &DelimitersLengthError{[]string{"{", "}"}, TEMPLATE_DELIMITERS_LEN}},
-		{"###", "###", &DelimitersLengthError{[]string{"###", "###"}, TEMPLATE_DELIMITERS_LEN}},
-		{"{%", "}", &DelimitersLengthError{[]string{"{%", "}"}, TEMPLATE_DELIMITERS_LEN}},
-		{"{{{", "%}", &DelimitersLengthError{[]string{"{{{", "%}"}, TEMPLATE_DELIMITERS_LEN}},
+		{"{", "}", &delimitersLengthError{[]string{"{", "}"}, templateDelimitersLen}},
+		{"###", "###", &delimitersLengthError{[]string{"###", "###"}, templateDelimitersLen}},
+		{"{%", "}", &delimitersLengthError{[]string{"{%", "}"}, templateDelimitersLen}},
+		{"{{{", "%}", &delimitersLengthError{[]string{"{{{", "%}"}, templateDelimitersLen}},
 		{"{%", "%}", nil},
 	}
 	for _, tt := range tests {

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -3,8 +3,8 @@ package token
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/gobuffalo/plush/token"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_Resolve_Default(t *testing.T) {

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -3,7 +3,6 @@ package token
 import (
 	"testing"
 
-	"github.com/gobuffalo/plush/token"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,10 +12,10 @@ func Test_Resolve_Default(t *testing.T) {
 		tokenType    Type
 		tokenLiteral string
 	}{
-		{token.S_START, "<%"},
-		{token.C_START, "<%#"},
-		{token.E_START, "<%="},
-		{token.E_END, "%>"},
+		{S_START, "<%"},
+		{C_START, "<%#"},
+		{E_START, "<%="},
+		{E_END, "%>"},
 	}
 
 	for _, tt := range tests {
@@ -34,10 +33,10 @@ func Test_SetTemplatingDelimiters(t *testing.T) {
 		tokenType    Type
 		tokenLiteral string
 	}{
-		{token.S_START, "{{"},
-		{token.C_START, "{{#"},
-		{token.E_START, "{{="},
-		{token.E_END, "}}"},
+		{S_START, "{{"},
+		{C_START, "{{#"},
+		{E_START, "{{="},
+		{E_END, "}}"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Hi,
we love Plush very much, we use it in our open source project https://oya.sh/ as a engine for rendering.
It would very helpful to be able to change starting(S_START, C_START, E_START) and ending(E_END) tokens to something else. 
I came up with something like this allowing user to change those tokens with `token.SetTemplatingDelimiters(start, end)` and fetch them with `token.Resolve`.
 I had quite a problem with naming convention in lexer so feel free to point out everything you see. thanks