### PR TITLE
Line comments

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -173,6 +173,14 @@ func (l *Lexer) nextInsideToken() token.Token {
 	case '`':
 		tok.Type = token.B_STRING
 		tok.Literal = l.readBString()
+	case '#':
+		for l.ch != 0 {
+			l.readChar()
+			if l.ch == '\n' || l.ch == '\r' {
+				break
+			}
+		}
+		tok = l.nextInsideToken()
 	case '[':
 		tok = l.newToken(token.LBRACKET)
 	case ']':

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -28,6 +28,30 @@ func Test_NextToken_Simple(t *testing.T) {
 	}
 }
 
+func Test_NextToken_SkipLineComments(t *testing.T) {
+	r := require.New(t)
+	input := `<%= 
+		# comment
+		1
+		# another line comment
+		 %>`
+	tests := []struct {
+		tokenType    token.Type
+		tokenLiteral string
+	}{
+		{token.E_START, "<%="},
+		{token.INT, "1"},
+		{token.E_END, "%>"},
+	}
+
+	l := New(input)
+	for _, tt := range tests {
+		tok := l.NextToken()
+		r.Equal(tt.tokenType, tok.Type)
+		r.Equal(tt.tokenLiteral, tok.Literal)
+	}
+}
+
 func Test_EscapeStringQuote(t *testing.T) {
 	r := require.New(t)
 	input := `<%= "mark \"cool\" bates" %>`


### PR DESCRIPTION
Adds line comments by skipping them in the lexer.

I chose `#` because it matches up with the block comments `<%#`. 