### PR TITLE
Fix incorrect line number when token is a keyword/digit

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -184,6 +184,7 @@ func (l *Lexer) nextInsideToken() token.Token {
 		if isLetter(l.ch) {
 			tok.Literal = l.readIdentifier()
 			tok.Type = token.LookupIdent(tok.Literal)
+			tok.LineNumber = l.curLine
 			return tok
 		} else if isDigit(l.ch) {
 			tok.Literal = l.readNumber()
@@ -196,7 +197,7 @@ func (l *Lexer) nextInsideToken() token.Token {
 			default:
 				tok.Type = "INT"
 			}
-
+			tok.LineNumber = l.curLine
 			return tok
 		} else {
 			tok = l.newToken(token.ILLEGAL)

--- a/line_number_test.go
+++ b/line_number_test.go
@@ -59,7 +59,7 @@ func Test_LineNumberErrors_InsideForLoop(t *testing.T) {
 	r.Contains(err.Error(), "line 3:")
 }
 
-func Test_LineNumber_MissingkeyWord(t *testing.T) {
+func Test_LineNumberErrors_MissingKeyword(t *testing.T) {
 	r := require.New(t)
 	input := `
 	

--- a/line_number_test.go
+++ b/line_number_test.go
@@ -58,3 +58,21 @@ func Test_LineNumberErrors_InsideForLoop(t *testing.T) {
 	r.Error(err)
 	r.Contains(err.Error(), "line 3:")
 }
+
+func Test_LineNumber_MissingkeyWord(t *testing.T) {
+	r := require.New(t)
+	input := `
+	
+	
+	
+	
+	<%=  (n) in numbers { %>
+		<%= n %>
+	<% } %>
+	`
+	ctx := NewContext()
+	ctx.Set("numbers", []int{1, 2})
+	_, err := Render(input, ctx)
+	r.Error(err)
+	r.Contains(err.Error(), "line 6:")
+}


### PR DESCRIPTION
The tokens for the keywords/numbers were missing the line numbers.  

Fixes [issue 124](https://github.com/gobuffalo/plush/issues/124)