### PR TITLE
Fix invalid if condition parameter 

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -36,3 +36,7 @@ type Expression interface {
 	Node
 	expressionNode()
 }
+
+type Comparable interface {
+	validIfCondition() bool
+}

--- a/ast/boolean.go
+++ b/ast/boolean.go
@@ -5,6 +5,8 @@ type Boolean struct {
 	Value bool
 }
 
+func (b *Boolean) validIfCondition() bool { return true }
+
 func (b *Boolean) expressionNode() {}
 
 func (b *Boolean) String() string {

--- a/ast/call_expression.go
+++ b/ast/call_expression.go
@@ -14,6 +14,8 @@ type CallExpression struct {
 	ElseBlock *BlockStatement
 }
 
+func (ce *CallExpression) validIfCondition() bool { return true }
+
 func (ce *CallExpression) expressionNode() {}
 
 func (ce *CallExpression) String() string {

--- a/ast/float_literal.go
+++ b/ast/float_literal.go
@@ -5,6 +5,8 @@ type FloatLiteral struct {
 	Value float64
 }
 
+func (il *FloatLiteral) validIfCondition() bool { return true }
+
 func (il *FloatLiteral) expressionNode() {}
 
 func (il *FloatLiteral) String() string {

--- a/ast/identifier.go
+++ b/ast/identifier.go
@@ -10,6 +10,8 @@ type Identifier struct {
 	Value  string
 }
 
+func (il *Identifier) validIfCondition() bool { return true }
+
 func (i *Identifier) expressionNode() {}
 
 func (i *Identifier) String() string {

--- a/ast/infix_expression.go
+++ b/ast/infix_expression.go
@@ -11,6 +11,8 @@ type InfixExpression struct {
 	Right    Expression
 }
 
+func (oe *InfixExpression) validIfCondition() bool { return true }
+
 func (oe *InfixExpression) expressionNode() {}
 
 func (oe *InfixExpression) String() string {

--- a/ast/integer_literal.go
+++ b/ast/integer_literal.go
@@ -5,6 +5,8 @@ type IntegerLiteral struct {
 	Value int
 }
 
+func (il *IntegerLiteral) validIfCondition() bool { return true }
+
 func (il *IntegerLiteral) expressionNode() {}
 
 func (il *IntegerLiteral) String() string {

--- a/ast/prefix_expression.go
+++ b/ast/prefix_expression.go
@@ -10,6 +10,8 @@ type PrefixExpression struct {
 	Right    Expression
 }
 
+func (ce *PrefixExpression) validIfCondition() bool { return true }
+
 func (pe *PrefixExpression) expressionNode() {}
 
 func (pe *PrefixExpression) String() string {

--- a/ast/string_literal.go
+++ b/ast/string_literal.go
@@ -5,6 +5,8 @@ type StringLiteral struct {
 	Value string
 }
 
+func (sl *StringLiteral) validIfCondition() bool { return true }
+
 func (sl *StringLiteral) expressionNode() {}
 
 func (sl *StringLiteral) String() string {

--- a/compiler.go
+++ b/compiler.go
@@ -200,6 +200,9 @@ func (c *compiler) evalIfExpression(node *ast.IfExpression) (interface{}, error)
 		}
 	}
 
+	if !c.isValidIfCondtionValue(con) {
+		return nil, fmt.Errorf("non-bool %s (type %T) used as if condition", node.Condition.String(), con)
+	}
 	if c.isTruthy(con) {
 		return c.evalBlockStatement(node.Block)
 	}
@@ -228,7 +231,16 @@ func (c *compiler) evalElseAndElseIfExpressions(node *ast.IfExpression) (interfa
 
 	return r, nil
 }
+func (c *compiler) isValidIfCondtionValue(i interface{}) bool {
 
+	switch i.(type) {
+	case bool, nil:
+		return true
+
+	default:
+		return false
+	}
+}
 func (c *compiler) isTruthy(i interface{}) bool {
 	if i == nil {
 		return false

--- a/go.sum
+++ b/go.sum
@@ -40,9 +40,7 @@ golang.org/x/net v0.0.0-20190613194153-d28f0bde5980 h1:dfGZHvZk057jK2MCeWus/TowK
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/if_test.go
+++ b/if_test.go
@@ -6,6 +6,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func Test_Render_If_Condition_Not_Valid(t *testing.T) {
+	r := require.New(t)
+	input := `<% 
+	
+		if (x - 4) { 
+			return "hi"
+		} %>`
+	ctx := NewContext()
+	ctx.Set("x", 4)
+
+	s, err := Render(input, ctx)
+	r.Error(err)
+	r.Equal("", s)
+}
 func Test_Render_If(t *testing.T) {
 	r := require.New(t)
 	input := `<% if (true) { return "hi"} %>`

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -736,6 +736,10 @@ func (p *parser) confrimIfCondition(v ast.Expression) bool {
 		if !p.confrimIfCondition(val.Right) {
 			return false
 		}
+	case *ast.PrefixExpression:
+		if !p.confrimIfCondition(val.Right) {
+			return false
+		}
 	}
 	return true
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -720,26 +720,28 @@ func (p *parser) registerInfix(tokenType token.Type, fn infixParseFn) {
 	p.infixParseFns[tokenType] = fn
 }
 
-func (p *parser) confrimIfCondition(v ast.Expression) bool {
+func (p *parser) confrimIfCondition(v ast.Expression) (returnData bool) {
 	_, ok := v.(ast.Comparable)
 	if !ok {
 		p.invalidIfCondition(v.String())
-		return false
+		return
 	}
+
+	returnData = true
+
 	switch val := v.(type) {
 
 	case *ast.InfixExpression:
 		if !p.confrimIfCondition(val.Left) {
-			return false
-		}
-
-		if !p.confrimIfCondition(val.Right) {
-			return false
+			returnData = false
+		} else if !p.confrimIfCondition(val.Right) {
+			returnData = false
 		}
 	case *ast.PrefixExpression:
 		if !p.confrimIfCondition(val.Right) {
-			return false
+			returnData = false
 		}
 	}
-	return true
+
+	return
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -389,6 +389,14 @@ func Test_IfExpression_ComapreWithFunction(t *testing.T) {
 	r.True(testIdentifier(t, consequence.Expression, "x"))
 	r.Nil(exp.ElseBlock)
 }
+func Test_IfExpression_PrefixExpressions_InvalidCompar(t *testing.T) {
+	r := require.New(t)
+	input := `<% if (!(x = 1)) { x } %>`
+
+	_, err := Parse(input)
+
+	r.Error(err, "syntax error: invalid if condition, got x = 1")
+}
 func Test_IfExpression_InfixExpressions_InvalidCompare(t *testing.T) {
 	r := require.New(t)
 	input := `<% if ( y == 1 && x = 1) { x } %>`

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -357,6 +357,84 @@ func Test_IfExpression(t *testing.T) {
 	r.Nil(exp.ElseBlock)
 }
 
+func Test_IfExpression_ComapreWithFunction(t *testing.T) {
+	r := require.New(t)
+	input := `<% if (f() != "yes") { x } %>`
+
+	program, err := Parse(input)
+	r.NoError(err)
+
+	r.Len(program.Statements, 1)
+
+	stmt := program.Statements[0].(*ast.ExpressionStatement)
+
+	exp := stmt.Expression.(*ast.IfExpression)
+
+	cond := exp.Condition.(*ast.InfixExpression)
+
+	isCall := cond.Left.(*ast.CallExpression)
+
+	r.True(testIdentifier(t, isCall.Function, "f"))
+
+	r.Equal("!=", cond.Operator)
+
+	right := cond.Right.(*ast.StringLiteral)
+
+	r.Equal("yes", right.Value)
+
+	r.Len(exp.Block.Statements, 1)
+
+	consequence := exp.Block.Statements[0].(*ast.ExpressionStatement)
+
+	r.True(testIdentifier(t, consequence.Expression, "x"))
+	r.Nil(exp.ElseBlock)
+}
+func Test_IfExpression_InfixExpressions_InvalidCompare(t *testing.T) {
+	r := require.New(t)
+	input := `<% if ( y == 1 && x = 1) { x } %>`
+
+	_, err := Parse(input)
+
+	r.Error(err, "syntax error: invalid if condition, got x = 1")
+}
+
+func Test_IfExpression_Boolean(t *testing.T) {
+	r := require.New(t)
+	input := `<% if (true) { x } %>`
+
+	_, err := Parse(input)
+
+	r.NoError(err)
+
+}
+
+func Test_IfExpression_Condition_CompareToString(t *testing.T) {
+	r := require.New(t)
+	input := `<% if (x == "yes") { x } %>`
+
+	_, err := Parse(input)
+
+	r.NoError(err, "syntax error: invalid if condition, got x = y")
+
+}
+func Test_IfExpression_Condition_Assign(t *testing.T) {
+	r := require.New(t)
+	input := `<% if (x = y) { x } %>`
+
+	_, err := Parse(input)
+
+	r.Error(err, "syntax error: invalid if condition, got x = y")
+
+}
+
+func Test_IfExpression_Condition_EmptyHash(t *testing.T) {
+	r := require.New(t)
+	input := `<% if ({}}) { x } %>`
+
+	_, err := Parse(input)
+	r.Error(err, "syntax error: invalid if statment, got {}")
+}
+
 func Test_IfExpression_HTML(t *testing.T) {
 	r := require.New(t)
 	input := `<p><% if (x < y) { %><%= x %><% } %></p>`


### PR DESCRIPTION
Fixes issue [115](https://github.com/gobuffalo/plush/issues/115)

The new pull requests confirm the validity of the If condition parameter during parsing and compiling. It checks for syntax error and if the evaluated `If condition` is of a type `Bool` or `nil`

### During Parsing:
We check if the  `expression. Condition` implements `ast.Comparable`. If not, then a syntax error is returned. If the type of `expression. Condition` is of type `ast.InflixExpression` then we also check the Left and Right expressions do implement   `ast.Comparable` recursively.

### During Compilation:
We confirm the evaluated type return of the if condition to be either `bool` or `nil`.