### PR TITLE
Add index assignment

### DIFF
--- a/ast/index_expression.go
+++ b/ast/index_expression.go
@@ -8,6 +8,7 @@ type IndexExpression struct {
 	TokenAble
 	Left  Expression
 	Index Expression
+	Value Expression
 }
 
 func (ie *IndexExpression) expressionNode() {}
@@ -20,6 +21,10 @@ func (ie *IndexExpression) String() string {
 	out.WriteString("[")
 	out.WriteString(ie.Index.String())
 	out.WriteString("])")
+	if ie.Value != nil {
+		out.WriteString("=")
+		out.WriteString(ie.Value.String())
+	}
 
 	return out.String()
 }

--- a/compiler.go
+++ b/compiler.go
@@ -254,16 +254,42 @@ func (c *compiler) evalIndexExpression(node *ast.IndexExpression) (interface{}, 
 	if err != nil {
 		return nil, err
 	}
+	var value interface{}
+
+	if node.Value != nil {
+
+		value, err = c.evalExpression(node.Value)
+		if err != nil {
+			return nil, err
+		}
+
+	}
 	rv := reflect.ValueOf(left)
 	switch rv.Kind() {
 	case reflect.Map:
 		val := rv.MapIndex(reflect.ValueOf(index))
-		if !val.IsValid() {
+		if !val.IsValid() && node.Value == nil {
 			return nil, nil
 		}
+		if node.Value != nil {
+			rv.SetMapIndex(reflect.ValueOf(index), reflect.ValueOf(value))
+			return nil, nil
+		}
+
 		return val.Interface(), nil
 	case reflect.Array, reflect.Slice:
 		if i, ok := index.(int); ok {
+
+			if node.Value != nil {
+
+				if rv.Len()-1 < i {
+
+					return nil, fmt.Errorf("array index out of bounds, got index %d, while array size is %v", i, rv.Len())
+
+				}
+				rv.Index(i).Set(reflect.ValueOf(value))
+				return nil, nil
+			}
 			return rv.Index(i).Interface(), nil
 		}
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -667,6 +667,13 @@ func (p *parser) parseIndexExpression(left ast.Expression) ast.Expression {
 		return nil
 	}
 
+	if p.peekTokenIs(token.ASSIGN) {
+		p.nextToken()
+		p.nextToken()
+
+		exp.Value = p.parseExpression(LOWEST)
+	}
+
 	return exp
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -694,6 +694,22 @@ func Test_ArrayLiterals(t *testing.T) {
 	r.True(testInfixExpression(t, array.Elements[2], 3, "+", 3))
 }
 
+func Test_IndexExpressionsAssign(t *testing.T) {
+	r := require.New(t)
+	input := "<% myArray[2] = 1 %>"
+
+	program, err := Parse(input)
+	r.NoError(err)
+
+	stmt := program.Statements[0].(*ast.ExpressionStatement)
+	indexExp := stmt.Expression.(*ast.IndexExpression)
+
+	r.True(testIdentifier(t, indexExp.Left, "myArray"))
+	r.True(testIntegerLiteral(t, indexExp.Index, 2))
+	r.True(testIntegerLiteral(t, indexExp.Value, 1))
+	//r.True(testInfixExpression(t, indexExp.Index, 2, "=", 1))
+}
+
 func Test_IndexExpressions(t *testing.T) {
 	r := require.New(t)
 	input := "<% myArray[1 + 1] %>"

--- a/variables_test.go
+++ b/variables_test.go
@@ -78,3 +78,78 @@ func Test_Render_Let_Hash(t *testing.T) {
 	r.NoError(err)
 	r.Equal("<p>A</p>", s)
 }
+
+func Test_Render_Let_HashAssign(t *testing.T) {
+	r := require.New(t)
+
+	input := `<p><% let h = {"a": "A"} %><% h["a"] = "C"%><%= h["a"] %></p>`
+	s, err := Render(input, NewContext())
+	r.NoError(err)
+	r.Equal("<p>C</p>", s)
+}
+
+func Test_Render_Let_HashAssign_NewKey(t *testing.T) {
+	r := require.New(t)
+
+	input := `<p><% let h = {"a": "A"} %><% h["b"] = "d" %><%= h["b"] %></p>`
+	s, err := Render(input, NewContext())
+	r.NoError(err)
+	r.Equal("<p>d</p>", s)
+}
+
+func Test_Render_Let_HashAssign_Int(t *testing.T) {
+	r := require.New(t)
+
+	input := `<p><% let h = {"a": "A"} %><% h["b"] = 3 %><%= h["b"] %></p>`
+	s, err := Render(input, NewContext())
+	r.NoError(err)
+	r.Equal("<p>3</p>", s)
+}
+
+func Test_Render_Let_HashAssign_InvalidKey(t *testing.T) {
+	r := require.New(t)
+
+	input := `<p><% let h = {"a": "A"} %><% h["b"] = 3 %><%= h["c"] %></p>`
+	s, err := Render(input, NewContext())
+	r.NoError(err)
+	r.Equal("<p></p>", s)
+}
+
+func Test_Render_Let_ArrayAssign_InvalidKey(t *testing.T) {
+	r := require.New(t)
+
+	input := `<p><% let a = [1, 2, "three", "four", 3.75] %><% a["b"] = 3 %><%= a["c"] %></p>`
+	_, err := Render(input, NewContext())
+	r.Error(err)
+	//r.NoError(err)
+	//r.Equal("<p></p>", s)
+}
+
+func Test_Render_Let_ArrayAssign_ValidIndex(t *testing.T) {
+	r := require.New(t)
+
+	input := `<p><% let a = [1, 2, "three", "four", 3.75] %><% a[0] = 3 %><%= a[0] %></p>`
+	s, err := Render(input, NewContext())
+	//r.Error(err)
+	r.NoError(err)
+	r.Equal("<p>3</p>", s)
+}
+
+func Test_Render_Let_ArrayAssign_Resultaddition(t *testing.T) {
+	r := require.New(t)
+
+	input := `<p><% let a = [1, 2, "three", "four", 3.75] %><% a[4] = 3 %><%= a[4] + 2 %></p>`
+	s, err := Render(input, NewContext())
+	//r.Error(err)
+	r.NoError(err)
+	r.Equal("<p>5</p>", s)
+}
+
+func Test_Render_Let_ArrayAssign_OutofBoundsIndex(t *testing.T) {
+	r := require.New(t)
+
+	input := `<p><% let a = [1, 2, "three", "four", 3.75] %><% a[5] = 3 %><%= a[4] + 2 %></p>`
+	_, err := Render(input, NewContext())
+	r.Error(err)
+
+}


### PR DESCRIPTION
Add index assignment to both Arrays and Maps. For arrays, the size will not grow, and the evaluator will throw an out-of-bounds error. I thought about expanding the array if the user sends an index out of bounds, but I don't think it should be allowed. The memory cost will be high. 