### PR TITLE
add continue to for loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,16 @@ There are three different types that can be looped over: maps, arrays/slices, an
 <% } %>
 ```
 
+You can also  `continue` to the next iteration of the loop:
+```erb
+ for (i,v) in [1, 2, 3,4,5,6,7,8,9,10] {
+ 	if (i > 0) {
+    continue
+  }
+ 	return v   
+ } 
+```
+
 The values inside the `()` part of the statement are the names you wish to give to the key (or index) and the value of the expression. The `expression` can be an array, map, or iterator type.
 
 ### Arrays

--- a/ast/continue_expression.go
+++ b/ast/continue_expression.go
@@ -1,0 +1,11 @@
+package ast
+
+type ContinueExpression struct {
+	TokenAble
+}
+
+func (ce *ContinueExpression) expressionNode() {}
+
+func (ce *ContinueExpression) String() string {
+	return ce.Token.Literal
+}

--- a/compiler.go
+++ b/compiler.go
@@ -16,6 +16,9 @@ import (
 type returnValue struct {
 	Value []interface{}
 }
+type continueV struct {
+	Value []interface{}
+}
 type ErrUnknownIdentifier struct {
 	ID  string
 	Err error
@@ -135,6 +138,8 @@ func (c *compiler) evalExpression(node ast.Expression) (interface{}, error) {
 		return c.evalFunctionLiteral(s)
 	case *ast.AssignExpression:
 		return c.evalAssignExpression(s)
+	case *ast.ContinueExpression:
+		return continueV{}, nil
 	case nil:
 		return nil, nil
 	}
@@ -539,6 +544,7 @@ func (c *compiler) evalCallExpression(node *ast.CallExpression) (interface{}, er
 		}
 		rv = reflect.ValueOf(f)
 	}
+
 	if rv.Kind() == reflect.Ptr {
 		rv = rv.Elem()
 	}
@@ -720,22 +726,36 @@ func (c *compiler) evalForExpression(node *ast.ForExpression) (interface{}, erro
 			if err != nil {
 				return nil, err
 			}
+
+			if val, ok := res.(continueV); ok {
+				res = val.Value
+			}
+
 			ret = append(ret, res)
 		}
 	case reflect.Slice, reflect.Array:
+
 		for i := 0; i < riter.Len(); i++ {
 			v := riter.Index(i)
 			c.ctx.Set(node.KeyName, i)
 			c.ctx.Set(node.ValueName, v.Interface())
+
 			res, err := c.evalBlockStatement(node.Block)
 			if err != nil {
 				return nil, err
 			}
+
+			if val, ok := res.(continueV); ok {
+				res = val.Value
+			}
 			if res != nil {
+
 				ret = append(ret, res)
 			}
 		}
+
 	default:
+
 		if iter == nil {
 			return nil, nil
 		}
@@ -748,6 +768,9 @@ func (c *compiler) evalForExpression(node *ast.ForExpression) (interface{}, erro
 				res, err := c.evalBlockStatement(node.Block)
 				if err != nil {
 					return nil, err
+				}
+				if val, ok := res.(continueV); ok {
+					res = val.Value
 				}
 				if res != nil {
 					ret = append(ret, res)
@@ -764,16 +787,22 @@ func (c *compiler) evalForExpression(node *ast.ForExpression) (interface{}, erro
 
 func (c *compiler) evalBlockStatement(node *ast.BlockStatement) (interface{}, error) {
 	res := []interface{}{}
-
 	for _, s := range node.Statements {
+
 		i, err := c.evalStatement(s)
 		if err != nil {
 			return nil, err
+		}
+		val, ok := i.(continueV)
+		if ok {
+
+			return continueV{Value: append(res, val.Value...)}, nil
 		}
 
 		if i != nil {
 			res = append(res, i)
 			switch retStm := c.curStmt.(type) {
+
 			case *ast.ReturnStatement:
 				if retStm.Type == token.RETURN {
 					return returnValue{Value: res}, nil
@@ -791,7 +820,7 @@ func (c *compiler) evalStatement(node ast.Statement) (interface{}, error) {
 	case *ast.ExpressionStatement:
 		s, err := c.evalExpression(t.Expression)
 		switch s.(type) {
-		case returnValue, ast.Printable, template.HTML:
+		case returnValue, ast.Printable, template.HTML, continueV:
 			return s, err
 		}
 		return nil, err

--- a/for_test.go
+++ b/for_test.go
@@ -37,6 +37,67 @@ func Test_Render_For_Array_Return(t *testing.T) {
 	r.Equal("abc", s)
 }
 
+func Test_Render_For_Array_Continue(t *testing.T) {
+	r := require.New(t)
+	input := `<%= for (i,v) in [1, 2, 3,4,5,6,7,8,9,10] {
+		%>Start<%
+		if (v == 1 || v ==3 || v == 5 || v == 7 || v == 9) {
+			
+			
+			%>Odd<%
+			continue
+		}
+
+		return v   
+		} %>`
+	s, err := Render(input, NewContext())
+
+	r.NoError(err)
+	r.Equal("StartOddStart2StartOddStart4StartOddStart6StartOddStart8StartOddStart10", s)
+}
+
+func Test_Render_For_Array_WithNoOutput(t *testing.T) {
+	r := require.New(t)
+	input := `<%= for (i,v) in [1, 2, 3,4,5,6,7,8,9,10] {
+	
+		if (v == 1 || v == 2 || v ==3 || v == 4|| v == 5 || v == 6 || v == 7 || v == 8 || v == 9 || v == 10) {
+
+			continue
+		}
+
+		return v   
+		} %>`
+	s, err := Render(input, NewContext())
+
+	r.NoError(err)
+	r.Equal("", s)
+}
+
+func Test_Render_For_Array_WithoutContinue(t *testing.T) {
+	r := require.New(t)
+	input := `<%= for (i,v) in [1, 2, 3,4,5,6,7,8,9,10] {
+		if (v == 1 || v ==3 || v == 5 || v == 7 || v == 9) {
+		}
+		return v   
+		} %>`
+	s, err := Render(input, NewContext())
+
+	r.NoError(err)
+	r.Equal("12345678910", s)
+}
+
+func Test_Render_For_Array_ContinueNoControl(t *testing.T) {
+	r := require.New(t)
+	input := `<%= for (i,v) in [1, 2, 3,4,5,6,7,8,9,10] {
+		continue
+		return v   
+		} %>`
+	s, err := Render(input, NewContext())
+
+	r.NoError(err)
+	r.Equal("", s)
+}
+
 func Test_Render_For_Array_Key_Only(t *testing.T) {
 	r := require.New(t)
 	input := `<%= for (v) in ["a", "b", "c"] {%><%=v%><%} %>`

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -111,7 +111,8 @@ func Test_NextToken_WithHTML(t *testing.T) {
 }
 func Test_NextToken_Complete(t *testing.T) {
 	r := require.New(t)
-	input := `<% let five = 5;
+	input := `<% continue
+let five = 5;
 let ten = 10;
 
 let add = fn(x, y) {
@@ -156,6 +157,7 @@ my-helper()
 		expectedLiteral string
 	}{
 		{token.S_START, "<%"},
+		{token.CONTINUE, "continue"},
 		{token.LET, "let"},
 		{token.IDENT, "five"},
 		{token.ASSIGN, "="},

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -33,6 +33,7 @@ func newParser(l *lexer.Lexer) *parser {
 
 	p.prefixParseFns = make(map[token.Type]prefixParseFn)
 	p.registerPrefix(token.IDENT, p.parseIdentifier)
+	p.registerPrefix(token.CONTINUE, p.parseContinue)
 	p.registerPrefix(token.INT, p.parseIntegerLiteral)
 	p.registerPrefix(token.FLOAT, p.parseFloatLiteral)
 	p.registerPrefix(token.STRING, p.parseStringLiteral)
@@ -85,6 +86,7 @@ type parser struct {
 
 	prefixParseFns map[token.Type]prefixParseFn
 	infixParseFns  map[token.Type]infixParseFn
+	inForBlock     bool
 }
 
 func (p *parser) parseProgram() *ast.Program {
@@ -295,6 +297,19 @@ func (p *parser) parseAssignExpression(id *ast.Identifier) ast.Expression {
 	return ae
 }
 
+func (p *parser) parseContinue() ast.Expression {
+
+	if !p.inForBlock {
+
+		p.errors = append(p.errors, fmt.Sprintf("line %d: continue is not in a loop", p.curToken.LineNumber))
+		return nil
+	}
+
+	stmt := &ast.ContinueExpression{TokenAble: ast.TokenAble{p.curToken}}
+
+	return stmt
+}
+
 func (p *parser) parseIntegerLiteral() ast.Expression {
 
 	lit := &ast.IntegerLiteral{TokenAble: ast.TokenAble{p.curToken}}
@@ -404,7 +419,7 @@ func (p *parser) parseForExpression() ast.Expression {
 		return nil
 	}
 	ln := p.curToken.LineNumber
-
+	p.inForBlock = true
 	s := []string{}
 	for !p.curTokenIs(token.RPAREN) {
 		if p.curTokenIs(token.IDENT) {
@@ -448,7 +463,7 @@ func (p *parser) parseForExpression() ast.Expression {
 	if p.curTokenIs(token.RBRACE) {
 		p.nextToken()
 	}
-
+	p.inForBlock = false
 	return expression
 }
 
@@ -558,7 +573,7 @@ func (p *parser) parseFunctionLiteral() ast.Expression {
 	}
 
 	lit.Parameters = p.parseFunctionParameters()
-
+	p.inForBlock = false
 	if !p.expectPeek(token.LBRACE) {
 		return nil
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -991,6 +991,47 @@ func testBooleanLiteral(t *testing.T, exp ast.Expression, value bool) bool {
 	return true
 }
 
+func Test_ForExpression_WithContinue(t *testing.T) {
+	r := require.New(t)
+	input := `<% for (k,v) in myArray {  continue } %>`
+
+	program, err := Parse(input)
+	r.NoError(err)
+
+	r.Len(program.Statements, 1)
+
+	stmt := program.Statements[0].(*ast.ExpressionStatement)
+
+	exp := stmt.Expression.(*ast.ForExpression)
+
+	r.Equal("k", exp.KeyName)
+	r.Equal("v", exp.ValueName)
+	r.Equal("myArray", exp.Iterable.String())
+
+	r.Len(exp.Block.Statements, 1)
+
+	consequence := exp.Block.Statements[0].(*ast.ExpressionStatement).Expression.(*ast.ContinueExpression)
+
+	r.Equal(consequence.String(), "continue")
+	//r.True(testIdentifier(t, consequence.Expression, "v"))
+}
+
+func Test_Continue_IfCondtion(t *testing.T) {
+	r := require.New(t)
+	input := `<% if(x == 2) { continue } %>`
+
+	_, err := Parse(input)
+	r.Error(err)
+}
+
+func Test_Continue_Function(t *testing.T) {
+	r := require.New(t)
+	input := `<% fn(x, y) { continue } %>`
+
+	_, err := Parse(input)
+	r.Error(err)
+}
+
 func Test_ForExpression(t *testing.T) {
 	r := require.New(t)
 	input := `<% for (k,v) in myArray { v } %>`

--- a/token/const.go
+++ b/token/const.go
@@ -61,4 +61,5 @@ const (
 	RETURN   = "RETURN"
 	FOR      = "FOR"
 	IN       = "IN"
+	CONTINUE = "CONTINUE"
 )

--- a/token/token.go
+++ b/token/token.go
@@ -11,16 +11,17 @@ type Token struct {
 }
 
 var keywords = map[string]Type{
-	"fn":     FUNCTION,
-	"func":   FUNCTION,
-	"let":    LET,
-	"true":   TRUE,
-	"false":  FALSE,
-	"if":     IF,
-	"else":   ELSE,
-	"return": RETURN,
-	"for":    FOR,
-	"in":     IN,
+	"fn":       FUNCTION,
+	"func":     FUNCTION,
+	"let":      LET,
+	"true":     TRUE,
+	"false":    FALSE,
+	"if":       IF,
+	"else":     ELSE,
+	"return":   RETURN,
+	"for":      FOR,
+	"in":       IN,
+	"continue": CONTINUE,
 }
 
 // LookupIdent an ident and return a keyword type, or a plain ident


### PR DESCRIPTION
I think it's a must feature to have in plush. I added the feature `continue` to for loops. The `continue` is only limited inside a block statement.   So this is legal
1. ```
	 for (i,v) in [1, 2, 3,4,5,6,7,8,9,10] {
		continue
		return v   
	} 
2. ```
	 for (i,v) in [1, 2, 3,4,5,6,7,8,9,10] {
		if (i > 0) {
                  continue
                }
		return v   
	} 

illegal will be :

1. 
```
	if (x == y){
             continue
		return v   
	} 
```
2.
```
	 for (i,v) in [1, 2, 3,4,5,6,7,8,9,10] {
		func(x,y) {continue}
		return v   
	} 
```

* Updated the README
* Pull request for [issue#12](https://github.com/gobuffalo/plush/issues/12)