### PR TITLE
Fix panic in evalCallExpression()

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -547,6 +547,9 @@ func (c *compiler) evalCallExpression(node *ast.CallExpression) (interface{}, er
 	}
 
 	rt := rv.Type()
+	if rt.Kind() != reflect.Func {
+		return nil, fmt.Errorf("%+v (%T) is an invalid function", node.String(), rt)
+	}
 	rtNumIn := rt.NumIn()
 	isVariadic := rt.IsVariadic()
 	args := []reflect.Value{}


### PR DESCRIPTION
@paganotoni , while working on the  [continue featue](https://github.com/gobuffalo/plush/pull/134) one of my tests were panicking due to a bug in `evalCallExpression() ` when it calls `rt.NumIn()` [here](https://github.com/gobuffalo/plush/blob/master/compiler.go#L550) . Unfortunately, I don't have the exact test that caused it (I didn't save it  :'( ), however, this pull request shouldn't change any functionality.  I added a check to confirm `rt ` is a function. If not, then it will safely fail and return an error message. 