### PR TITLE
Fix isTruthy() to check if interface holding a nil value

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -229,9 +229,12 @@ func (c *compiler) evalElseAndElseIfExpressions(node *ast.IfExpression) (interfa
 }
 
 func (c *compiler) isTruthy(i interface{}) bool {
+
 	if i == nil {
+
 		return false
 	}
+
 	switch t := i.(type) {
 	case bool:
 		return t
@@ -239,9 +242,17 @@ func (c *compiler) isTruthy(i interface{}) bool {
 		return t != ""
 	case template.HTML:
 		return t != ""
-	}
 
-	return true
+	default:
+
+		if reflect.ValueOf(i).Kind() == reflect.Ptr && reflect.ValueOf(i).IsNil() {
+
+			return false
+		}
+
+		return true
+
+	}
 }
 
 func (c *compiler) evalIndexExpression(node *ast.IndexExpression) (interface{}, error) {
@@ -329,9 +340,11 @@ func (c *compiler) evalIdentifier(node *ast.Identifier) (interface{}, error) {
 		if rv.Kind() == reflect.Ptr {
 			rv = rv.Elem()
 		}
+
 		if rv.Kind() != reflect.Struct {
 			return nil, fmt.Errorf("'%s' does not have a field or method named '%s' (%s)", node.Callee.String(), node.Value, node)
 		}
+
 		f := rv.FieldByName(node.Value)
 		if !f.IsValid() {
 			m := rv.MethodByName(node.Value)

--- a/struct_test.go
+++ b/struct_test.go
@@ -78,3 +78,39 @@ func Test_Render_Struct_PointerMethod(t *testing.T) {
 		r.Equal("robot", s)
 	})
 }
+
+func Test_Render_Struct_PointerMethod_IsNil(t *testing.T) {
+	r := require.New(t)
+
+	type mylist struct {
+		N    int
+		Next *mylist
+	}
+
+	input := `Current number is <%= p.N %>.<%= if (p.Next) { %>  Next up is <%= p.Next.N %>.<% } %>`
+	first := &mylist{N: 0}
+	last := first
+
+	for i := 0; i < 5; i++ {
+		last.Next = &mylist{N: i + 1}
+		last = last.Next
+	}
+
+	resE := []string{
+		"Current number is 0.  Next up is 1.",
+		"Current number is 1.  Next up is 2.",
+		"Current number is 2.  Next up is 3.",
+		"Current number is 3.  Next up is 4.",
+		"Current number is 4.  Next up is 5.",
+		"Current number is 5.",
+	}
+
+	for p := first; p != nil; p = p.Next {
+
+		ctx := NewContextWith(map[string]interface{}{"p": p})
+		res, err := Render(input, ctx)
+		r.NoError(err)
+		r.Equal(resE[p.N], res)
+
+	}
+}


### PR DESCRIPTION
Fixes [issue#83](https://github.com/gobuffalo/plush/issues/83)

`isTruthy`  only checks if `i == nil` and not if the interface is actually holding a value of `nil`. 

https://play.golang.org/p/DmhEzXMLkVh