### PR TITLE
Add map/slice index access

### DIFF
--- a/ast/identifier.go
+++ b/ast/identifier.go
@@ -6,8 +6,9 @@ import (
 
 type Identifier struct {
 	TokenAble
-	Callee *Identifier
-	Value  string
+	Callee         *Identifier
+	Value          string
+	OriginalCallee *Identifier // So robot.Avatar.Name the OriginalCallee will be robot
 }
 
 func (il *Identifier) validIfCondition() bool { return true }

--- a/ast/index_expression.go
+++ b/ast/index_expression.go
@@ -6,9 +6,10 @@ import (
 
 type IndexExpression struct {
 	TokenAble
-	Left  Expression
-	Index Expression
-	Value Expression
+	Left   Expression
+	Index  Expression
+	Value  Expression
+	Callee Expression
 }
 
 func (ie *IndexExpression) validIfCondition() bool { return true }
@@ -22,7 +23,14 @@ func (ie *IndexExpression) String() string {
 	out.WriteString(ie.Left.String())
 	out.WriteString("[")
 	out.WriteString(ie.Index.String())
-	out.WriteString("])")
+	if ie.Callee != nil {
+		out.WriteString("]")
+		out.WriteString("." + ie.Callee.String())
+		out.WriteString(")")
+	} else {
+
+		out.WriteString("])")
+	}
 	if ie.Value != nil {
 		out.WriteString("=")
 		out.WriteString(ie.Value.String())

--- a/compiler.go
+++ b/compiler.go
@@ -280,45 +280,55 @@ func (c *compiler) evalIndexExpression(node *ast.IndexExpression) (interface{}, 
 	switch rv.Kind() {
 	case reflect.Map:
 		val := rv.MapIndex(reflect.ValueOf(index))
-		if !val.IsValid() && node.Value == nil {
-			return nil, nil
-		}
 
 		if node.Callee != nil {
 
-			return c.evalIndexCallee(val, node)
+			rv = val
 
+		} else {
+
+			if !val.IsValid() && node.Value == nil {
+				return nil, nil
+			}
+
+			if node.Value != nil {
+				rv.SetMapIndex(reflect.ValueOf(index), reflect.ValueOf(value))
+				return nil, nil
+			}
+
+			return val.Interface(), nil
 		}
-
-		if node.Value != nil {
-			rv.SetMapIndex(reflect.ValueOf(index), reflect.ValueOf(value))
-			return nil, nil
-		}
-
-		return val.Interface(), nil
 	case reflect.Array, reflect.Slice:
 		if i, ok := index.(int); ok {
 
 			if node.Callee != nil {
 
-				return c.evalIndexCallee(rv.Index(i), node)
+				rv = rv.Index(i)
 
-			}
+			} else {
 
-			if node.Value != nil {
+				if node.Value != nil {
 
-				if rv.Len()-1 < i {
+					if rv.Len()-1 < i {
 
-					return nil, fmt.Errorf("array index out of bounds, got index %d, while array size is %v", i, rv.Len())
+						return nil, fmt.Errorf("array index out of bounds, got index %d, while array size is %v", i, rv.Len())
 
+					}
+					rv.Index(i).Set(reflect.ValueOf(value))
+					return nil, nil
 				}
-				rv.Index(i).Set(reflect.ValueOf(value))
-				return nil, nil
+				return rv.Index(i).Interface(), nil
 			}
-			return rv.Index(i).Interface(), nil
 		}
 	}
-	return nil, fmt.Errorf("could not index %T with %T", left, index)
+	var returnData interface{}
+	err = fmt.Errorf("could not index %T with %T", left, index)
+	if node.Callee != nil {
+
+		returnData, err = c.evalIndexCallee(rv, node)
+	}
+
+	return returnData, err
 }
 func (c *compiler) evalHashLiteral(node *ast.HashLiteral) (interface{}, error) {
 	m := map[string]interface{}{}

--- a/compiler.go
+++ b/compiler.go
@@ -267,7 +267,6 @@ func (c *compiler) evalIndexExpression(node *ast.IndexExpression) (interface{}, 
 		return nil, err
 	}
 	var value interface{}
-
 	if node.Value != nil {
 
 		value, err = c.evalExpression(node.Value)
@@ -276,6 +275,12 @@ func (c *compiler) evalIndexExpression(node *ast.IndexExpression) (interface{}, 
 		}
 
 	}
+
+	return c.accessIndex(left, index, value, node)
+}
+
+func (c *compiler) accessIndex(left, index, value interface{}, node *ast.IndexExpression) (interface{}, error) {
+
 	rv := reflect.ValueOf(left)
 	switch rv.Kind() {
 	case reflect.Map:
@@ -290,7 +295,7 @@ func (c *compiler) evalIndexExpression(node *ast.IndexExpression) (interface{}, 
 
 		}
 
-		if node.Value != nil {
+		if value != nil {
 			rv.SetMapIndex(reflect.ValueOf(index), reflect.ValueOf(value))
 			return nil, nil
 		}
@@ -305,7 +310,7 @@ func (c *compiler) evalIndexExpression(node *ast.IndexExpression) (interface{}, 
 
 			}
 
-			if node.Value != nil {
+			if value != nil {
 
 				if rv.Len()-1 < i {
 
@@ -318,8 +323,10 @@ func (c *compiler) evalIndexExpression(node *ast.IndexExpression) (interface{}, 
 			return rv.Index(i).Interface(), nil
 		}
 	}
+
 	return nil, fmt.Errorf("could not index %T with %T", left, index)
 }
+
 func (c *compiler) evalHashLiteral(node *ast.HashLiteral) (interface{}, error) {
 	m := map[string]interface{}{}
 	for ke, ve := range node.Pairs {

--- a/compiler.go
+++ b/compiler.go
@@ -268,6 +268,7 @@ func (c *compiler) evalIndexExpression(node *ast.IndexExpression) (interface{}, 
 	if err != nil {
 		return nil, err
 	}
+
 	var value interface{}
 
 	if node.Value != nil {
@@ -328,7 +329,7 @@ func (c *compiler) evalAccessIndex(left, index interface{}, node *ast.IndexExpre
 	case reflect.Map:
 		val := rv.MapIndex(reflect.ValueOf(index))
 
-		if !val.IsValid() && node.Value == nil {
+		if !val.IsValid() {
 			return nil, nil
 		}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -688,34 +688,10 @@ func (p *parser) parseIndexExpression(left ast.Expression) ast.Expression {
 		p.nextToken()
 		parseExp := p.parseExpression(LOWEST)
 
-		switch ss := parseExp.(type) {
+		exp.Callee = p.assignCallee(parseExp, calleeIdent)
+		if exp.Callee == nil {
 
-		case *ast.IndexExpression:
-
-			ff, ok := ss.Left.(*ast.Identifier)
-			if ok {
-
-				ff.OriginalCallee.Callee = calleeIdent
-
-				exp.Callee = ss
-			} else {
-
-				msg := fmt.Sprintf("line %d: syntax error: invalid nested index access, expected an identifier %v", p.curToken.LineNumber, ss)
-				p.errors = append(p.errors, msg)
-				return nil
-			}
-		case *ast.Identifier:
-
-			ss.OriginalCallee.Callee = calleeIdent
-
-			exp.Callee = ss
-
-		default:
-
-			msg := fmt.Sprintf("line %d: syntax error: invalid nested index access, got %v", p.curToken.LineNumber, ss)
-			p.errors = append(p.errors, msg)
 			return nil
-
 		}
 	}
 
@@ -727,6 +703,42 @@ func (p *parser) parseIndexExpression(left ast.Expression) ast.Expression {
 	}
 
 	return exp
+}
+
+func (p *parser) assignCallee(exp ast.Expression, calleeIdent *ast.Identifier) (assignedCallee ast.Expression) {
+
+	assignedCallee = nil
+
+	switch ss := exp.(type) {
+
+	case *ast.IndexExpression:
+
+		ff, ok := ss.Left.(*ast.Identifier)
+		if ok {
+
+			ff.OriginalCallee.Callee = calleeIdent
+
+			assignedCallee = ss
+		} else {
+
+			msg := fmt.Sprintf("line %d: syntax error: invalid nested index access, expected an identifier %v", p.curToken.LineNumber, ss)
+			p.errors = append(p.errors, msg)
+
+		}
+	case *ast.Identifier:
+
+		ss.OriginalCallee.Callee = calleeIdent
+
+		assignedCallee = ss
+
+	default:
+
+		msg := fmt.Sprintf("line %d: syntax error: invalid nested index access, got %v", p.curToken.LineNumber, ss)
+		p.errors = append(p.errors, msg)
+
+	}
+
+	return
 }
 
 func (p *parser) parseHashLiteral() ast.Expression {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -268,10 +268,10 @@ func (p *parser) parseIdentifier() ast.Expression {
 		s := ss[i]
 		id = &ast.Identifier{TokenAble: ast.TokenAble{p.curToken}, Value: s, Callee: id}
 	}
+
 	//To avoid a recursive loop to reach the original calle address
-	if len(ss) > 1 {
-		id.OriginalCallee = orignalCalleAddress
-	}
+	id.OriginalCallee = orignalCalleAddress
+	//}
 
 	if p.peekTokenIs(token.ASSIGN) {
 		return p.parseAssignExpression(id)
@@ -694,18 +694,8 @@ func (p *parser) parseIndexExpression(left ast.Expression) ast.Expression {
 
 			ff, ok := ss.Left.(*ast.Identifier)
 			if ok {
-				if ff.Callee != nil {
 
-					if ff.OriginalCallee != nil {
-						if ff.OriginalCallee.Callee == nil {
-
-							ff.OriginalCallee.Callee = calleeIdent
-						}
-					}
-				} else {
-
-					ff.Callee = calleeIdent
-				}
+				ff.OriginalCallee.Callee = calleeIdent
 
 				exp.Callee = ss
 			} else {
@@ -716,20 +706,8 @@ func (p *parser) parseIndexExpression(left ast.Expression) ast.Expression {
 			}
 		case *ast.Identifier:
 
-			ff := ss
-			if ff.Callee != nil {
+			ss.OriginalCallee.Callee = calleeIdent
 
-				if ff.OriginalCallee != nil {
-					if ff.OriginalCallee.Callee == nil {
-
-						ff.OriginalCallee.Callee = calleeIdent
-					}
-				}
-
-			} else {
-
-				ff.Callee = calleeIdent
-			}
 			exp.Callee = ss
 
 		default:

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -708,6 +708,54 @@ func Test_CallExpressionParsing_WithMultipleCallees(t *testing.T) {
 	r.Equal(exp.Arguments[0].String(), "\"mark\"")
 }
 
+func Test_IndexExpression_Nested_Structs_Start_WithCallee(t *testing.T) {
+	r := require.New(t)
+	input := `<% myarray[0].Name.Final %>`
+
+	program, err := Parse(input)
+	r.NoError(err)
+
+	r.Len(program.Statements, 1)
+
+	stmt := program.Statements[0].(*ast.ExpressionStatement)
+
+	exp := stmt.Expression.(*ast.IndexExpression)
+
+	r.Equal("myarray", exp.Left.String())
+	r.Equal("0", exp.Index.String())
+	gg := exp.Callee.(*ast.Identifier)
+	r.Equal("myarray.Name.Final", gg.String())
+
+	r.Equal("Final", gg.Value)
+	r.Equal("Name", gg.Callee.Value)
+}
+
+func Test_IndexExpression_Nested_Structs_Start_WithNested_Array(t *testing.T) {
+	r := require.New(t)
+	input := `<% myarray[0].Name[1].Final %>`
+
+	program, err := Parse(input)
+	r.NoError(err)
+
+	r.Len(program.Statements, 1)
+
+	stmt := program.Statements[0].(*ast.ExpressionStatement)
+
+	exp := stmt.Expression.(*ast.IndexExpression)
+
+	r.Equal("myarray", exp.Left.String())
+	r.Equal("0", exp.Index.String())
+	gg := exp.Callee.(*ast.IndexExpression)
+
+	r.Equal("myarray.Name", gg.Left.String())
+	r.Equal("1", gg.Index.String())
+
+	r.Equal("Name.Final", gg.Callee.String())
+	cc := gg.Callee.(*ast.Identifier)
+
+	r.Equal("Final", cc.Value)
+}
+
 func Test_CallExpressionParsing_WithBlock(t *testing.T) {
 	r := require.New(t)
 	input := `<p><%= foo() { %>hi<% } %></p>`

--- a/struct_test.go
+++ b/struct_test.go
@@ -114,3 +114,305 @@ func Test_Render_Struct_PointerMethod_IsNil(t *testing.T) {
 
 	}
 }
+
+func Test_Render_Struct_Multiple_Access(t *testing.T) {
+	r := require.New(t)
+
+	type mylist struct {
+		Name string
+	}
+
+	input := `<%= myarray[0].Name %> <%= myarray[1].Name %>`
+
+	gg := make([]mylist, 3)
+	gg[0].Name = "John"
+	gg[1].Name = "Doe"
+	ctx := NewContext()
+	ctx.Set("myarray", gg)
+	res, err := Render(input, ctx)
+	r.NoError(err)
+	r.Equal("John Doe", res)
+
+}
+
+func Test_Render_Nested_Structs_Start_With_Slice(t *testing.T) {
+	r := require.New(t)
+
+	type b struct {
+		Final string
+	}
+	type mylist struct {
+		Name b
+	}
+
+	input := `<%= myarray[0].Name.Final %>`
+
+	gg := make([]mylist, 3)
+	gg[0].Name.Final = "Hello World"
+	ctx := NewContext()
+	ctx.Set("myarray", gg)
+	res, err := Render(input, ctx)
+	r.NoError(err)
+	r.Equal("Hello World", res)
+
+}
+
+func Test_Render_Nested_Structs_Start_With_Slice_End_With_Slice(t *testing.T) {
+	r := require.New(t)
+	type b struct {
+		A []string
+	}
+	type mylist struct {
+		Name b
+	}
+
+	input := `<%= myarray[0].Name.A[0] %>`
+
+	gg := make([]mylist, 3)
+	gg[0].Name = b{[]string{"Hello World"}}
+	ctx := NewContext()
+	ctx.Set("myarray", gg)
+	res, err := Render(input, ctx)
+	r.NoError(err)
+	r.Equal("Hello World", res)
+
+}
+func Test_Render_Nested_Structs_Ends_With_Slice(t *testing.T) {
+	r := require.New(t)
+	ctx := NewContext()
+
+	type c struct {
+		Final []string
+	}
+
+	type b struct {
+		B c
+	}
+	type mylist struct {
+		Name b
+	}
+
+	bender := mylist{
+		Name: b{
+			B: c{
+				Final: []string{"bendser.jpg"},
+			},
+		},
+	}
+	ctx.Set("robot", bender)
+	input := `<%= robot.Name.B.Final[0] %>`
+	s, err := Render(input, ctx)
+	r.NoError(err)
+	r.Equal("bendser.jpg", s)
+}
+
+func Test_Render_Nested_Structs(t *testing.T) {
+	r := require.New(t)
+	ctx := NewContext()
+
+	type c struct {
+		Final string
+	}
+
+	type b struct {
+		B c
+	}
+	type mylist struct {
+		Name b
+	}
+
+	bender := mylist{
+		Name: b{
+			B: c{
+				Final: "bendser.jpg",
+			},
+		},
+	}
+	ctx.Set("robot", bender)
+	input := `<%= robot.Name.B.Final %>`
+	s, err := Render(input, ctx)
+	r.NoError(err)
+	r.Equal("bendser.jpg", s)
+}
+func Test_Render_Struct_Access_Slice_Field(t *testing.T) {
+	r := require.New(t)
+	ctx := NewContext()
+	type D struct {
+		Final string
+	}
+	type c struct {
+		Final []D
+	}
+
+	type b struct {
+		B c
+	}
+	type mylist struct {
+		Name b
+	}
+
+	bender := mylist{
+		Name: b{
+			B: c{
+				Final: []D{
+					{Final: "String"},
+				},
+			},
+		},
+	}
+	ctx.Set("robot", bender)
+	input := `<%= robot.Name.B.Final[0].Final %>`
+	s, err := Render(input, ctx)
+	r.NoError(err)
+	r.Equal("String", s)
+}
+
+func Test_Render_Struct_Nested_Slice_Access(t *testing.T) {
+	r := require.New(t)
+	type d struct {
+		Final string
+	}
+	type c struct {
+		He []d
+	}
+	type b struct {
+		A []c
+	}
+	type mylist struct {
+		Name []b
+	}
+
+	input := `<%= myarray[0].Name[0].A[1].He[2].Final %>`
+
+	gg := make([]mylist, 3)
+
+	var bc b
+	var ca c
+	ca.He = make([]d, 3)
+	ca.He[2] = d{"Hello World"}
+	bc.A = make([]c, 3)
+	bc.A[1] = ca
+	gg[0].Name = []b{bc}
+
+	ctx := NewContext()
+	ctx.Set("myarray", gg)
+	res, err := Render(input, ctx)
+	r.NoError(err)
+	r.Equal("Hello World", res)
+
+}
+
+func Test_Render_Struct_Nested_Map_Slice_Access(t *testing.T) {
+	r := require.New(t)
+	type d struct {
+		Final string
+	}
+	type c struct {
+		He map[string]d
+	}
+	type b struct {
+		A []c
+	}
+	type mylist struct {
+		Name []b
+	}
+
+	input := `<%= myarray[0].Name[0].A[1].He["test"].Final %>`
+
+	gg := make([]mylist, 3)
+
+	var bc b
+	var ca c
+	ca.He = make(map[string]d)
+	ca.He["test"] = d{"Hello World"}
+	bc.A = make([]c, 3)
+	bc.A[1] = ca
+	gg[0].Name = []b{bc}
+
+	ctx := NewContext()
+	ctx.Set("myarray", gg)
+	res, err := Render(input, ctx)
+	r.NoError(err)
+	r.Equal("Hello World", res)
+
+}
+
+func Test_Render_Struct_Nested_With_Unexported_Fields(t *testing.T) {
+	r := require.New(t)
+	type people struct {
+		FirstName string
+		LastName  string
+	}
+	type employee struct {
+		employee []people
+	}
+	departments := make(map[string]employee)
+	var joh people
+
+	joh.FirstName = "John"
+	joh.LastName = "Doe"
+
+	var jane people
+
+	jane.FirstName = "Jane"
+	jane.LastName = "Dolittle"
+
+	var employees employee
+	employees.employee = []people{joh, jane}
+	departments["HR"] = employees
+
+	input := `<%= departments["HR"].employee[0].FirstName %>`
+	ctx := NewContext()
+	ctx.Set("departments", departments)
+	_, err := Render(input, ctx)
+	r.Error(err)
+	//r.Equal("John", res)
+
+}
+
+func Test_Render_Struct_Nested_Map_Access(t *testing.T) {
+	r := require.New(t)
+	type people struct {
+		FirstName string
+		LastName  string
+	}
+	type employee struct {
+		Employee []people
+	}
+	departments := make(map[string]employee)
+	var joh people
+
+	joh.FirstName = "John"
+	joh.LastName = "Doe"
+
+	var jane people
+
+	jane.FirstName = "Jane"
+	jane.LastName = "Dolittle"
+
+	var employees employee
+	employees.Employee = []people{joh, jane}
+	departments["HR"] = employees
+
+	input := `<%= departments["HR"].Employee[0].FirstName %> <%= departments["HR"].Employee[0].LastName %>`
+	ctx := NewContext()
+	ctx.Set("departments", departments)
+	res, err := Render(input, ctx)
+	r.NoError(err)
+	r.Equal("John Doe", res)
+
+	input = `<%= departments["HR"].Employee[1].FirstName %> <%= departments["HR"].Employee[1].LastName %>`
+	res, err = Render(input, ctx)
+	r.NoError(err)
+	r.Equal("Jane Dolittle", res)
+
+	input = `<%= departments["HR"].Employee[1].FirstName %> <%= departments["HR"].Employee[0].LastName %>`
+	res, err = Render(input, ctx)
+	r.NoError(err)
+	r.Equal("Jane Doe", res)
+
+	input = `<%= departments["HR"].Employee[0].FirstName %> <%= departments["HR"].Employee[1].LastName %>`
+	res, err = Render(input, ctx)
+	r.NoError(err)
+	r.Equal("John Dolittle", res)
+}


### PR DESCRIPTION
 
Give access to nested array/map structs. For example, `people[0].Name` or `people[0].Children[0].Final`. The nested array/map access depth is unlimited. 

The pull request builds on the existing code that worked with nested structs up to an array. The existing code didn’t give access to the underlying array fields  `people.Name.Chilldren[0]` [issue#101](https://github.com/gobuffalo/plush/issues/101)

## **Background:** 
The existing code processed the nested struct access by building a list of identifiers from back to front. So if the user wanted to access `robot.Avatar.Name` it will return an `ast.Identifier`
 with a nested `Callee`:  
```
ast.Identifier.Value: "Final"  Callee (ast.Identifier.Value = "Avatar" Callee ( ast.Identifier.Value  = robot , Callee = Nil)). 
```

When the compiler receives the  `ast.Identifier`, `evalIdentifier` checks first if `Callee` is not nil. If not, then it evaluates the expression `ast.Callee`. The compiler will keep unwrapping the `ast.Identifier` till it reaches the condition of `ast.Callee` is `nil`. If `ast.Callee` is  `nil` then it will check if the `ast.Identifier.Value` stored in the `ctx`. As a result, `ast.Identifier.Value = robot` value will return the object that was passed in the `ctx`. Since the key `robot` is stored in `ctx` it will then return that object to the upper chain which now will access the object returned by the key `ast.Identifier.Value = Avatar` using reflection thus will return the nested object till it bubbles up to the first Callee which again, will have access to the object returned by  `ast.Identifier.Value: "Final" `.

## Restirctions  of `evalIdentifier`:
The function only processes objects returned by the Callee that are structs. It can’t process objects that return a slice. So if the process of robot returns a slice then Avatar won’t be able to access it. As a result, the existing code wasn't able to process struct fields that are of type map/array. 


