### PR TITLE
Add break to for loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,12 +191,12 @@ There are three different types that can be looped over: maps, arrays/slices, an
 
 You can also  `continue` to the next iteration of the loop:
 ```erb
- for (i,v) in [1, 2, 3,4,5,6,7,8,9,10] {
- 	if (i > 0) {
+for (i,v) in [1, 2, 3,4,5,6,7,8,9,10] {
+  if (i > 0) {
     continue
   }
- 	return v   
- } 
+  return v   
+} 
 ```
 
 You can terminate the for loop with `break`:
@@ -205,9 +205,10 @@ for (i,v) in [1, 2, 3,4,5,6,7,8,9,10] {
   if (i > 5) {
     break
   }
- 	return v   
+  return v   
 } 
 ```
+
 The values inside the `()` part of the statement are the names you wish to give to the key (or index) and the value of the expression. The `expression` can be an array, map, or iterator type.
 
 ### Arrays

--- a/README.md
+++ b/README.md
@@ -199,6 +199,15 @@ You can also  `continue` to the next iteration of the loop:
  } 
 ```
 
+You can terminate the for loop with `break`:
+```erb
+for (i,v) in [1, 2, 3,4,5,6,7,8,9,10] {
+  if (i > 5) {
+    break
+  }
+ 	return v   
+} 
+```
 The values inside the `()` part of the statement are the names you wish to give to the key (or index) and the value of the expression. The `expression` can be an array, map, or iterator type.
 
 ### Arrays

--- a/ast/break_expression.go
+++ b/ast/break_expression.go
@@ -1,0 +1,11 @@
+package ast
+
+type BreakExpression struct {
+	TokenAble
+}
+
+func (ce *BreakExpression) expressionNode() {}
+
+func (ce *BreakExpression) String() string {
+	return ce.Token.Literal
+}

--- a/for_test.go
+++ b/for_test.go
@@ -98,6 +98,65 @@ func Test_Render_For_Array_ContinueNoControl(t *testing.T) {
 	r.Equal("", s)
 }
 
+func Test_Render_For_Array_Break_String(t *testing.T) {
+	r := require.New(t)
+	input := `<%= for (i,v) in [1, 2, 3,4,5,6,7,8,9,10] {
+		%>Start<%
+		if (v == 5) {
+			
+			
+			%>Odd<%
+			break
+		}
+
+		return v   
+		} %>`
+	s, err := Render(input, NewContext())
+
+	r.NoError(err)
+	r.Equal("Start1Start2Start3Start4StartOdd", s)
+}
+
+func Test_Render_For_Array_WithBreakFirstValue(t *testing.T) {
+	r := require.New(t)
+	input := `<%= for (i,v) in [1, 2, 3,4,5,6,7,8,9,10] {
+		if (v == 1 || v ==3 || v == 5 || v == 7 || v == 9) {
+			break
+		}
+		return v   
+		} %>`
+	s, err := Render(input, NewContext())
+
+	r.NoError(err)
+	r.Equal("", s)
+}
+
+func Test_Render_For_Array_WithBreakFirstValueWithReturn(t *testing.T) {
+	r := require.New(t)
+	input := `<%= for (i,v) in [1, 2, 3,4,5,6,7,8,9,10] {
+		if (v == 1 || v ==3 || v == 5 || v == 7 || v == 9) {
+			%><%=v%><%
+			break
+		}
+		return v   
+		} %>`
+	s, err := Render(input, NewContext())
+
+	r.NoError(err)
+	r.Equal("1", s)
+}
+func Test_Render_For_Array_Break(t *testing.T) {
+	r := require.New(t)
+	input := `<%= for (i,v) in [1, 2, 3,4,5,6,7,8,9,10] {
+		break
+		return v   
+		} %>`
+	s, err := Render(input, NewContext())
+
+	r.NoError(err)
+	r.Equal("", s)
+}
+
 func Test_Render_For_Array_Key_Only(t *testing.T) {
 	r := require.New(t)
 	input := `<%= for (v) in ["a", "b", "c"] {%><%=v%><%} %>`

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -111,7 +111,8 @@ func Test_NextToken_WithHTML(t *testing.T) {
 }
 func Test_NextToken_Complete(t *testing.T) {
 	r := require.New(t)
-	input := `<% continue
+	input := `<% break
+	continue
 let five = 5;
 let ten = 10;
 
@@ -157,6 +158,7 @@ my-helper()
 		expectedLiteral string
 	}{
 		{token.S_START, "<%"},
+		{token.BREAK, "break"},
 		{token.CONTINUE, "continue"},
 		{token.LET, "let"},
 		{token.IDENT, "five"},

--- a/objects.go
+++ b/objects.go
@@ -1,0 +1,20 @@
+package plush
+
+type exitBlockStatment interface {
+	exitBlock()
+}
+
+type returnObject struct {
+	exitBlockStatment
+	Value []interface{}
+}
+
+type continueObject struct {
+	exitBlockStatment
+	Value []interface{}
+}
+
+type breakObject struct {
+	exitBlockStatment
+	Value []interface{}
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -33,8 +33,8 @@ func newParser(l *lexer.Lexer) *parser {
 
 	p.prefixParseFns = make(map[token.Type]prefixParseFn)
 	p.registerPrefix(token.IDENT, p.parseIdentifier)
-	p.registerPrefix(token.CONTINUE, p.parseContinue)
-	p.registerPrefix(token.BREAK, p.parseBreak)
+	p.registerPrefix(token.CONTINUE, p.parseForLoopControlFlow)
+	p.registerPrefix(token.BREAK, p.parseForLoopControlFlow)
 	p.registerPrefix(token.INT, p.parseIntegerLiteral)
 	p.registerPrefix(token.FLOAT, p.parseFloatLiteral)
 	p.registerPrefix(token.STRING, p.parseStringLiteral)
@@ -303,16 +303,19 @@ func (p *parser) parseAssignExpression(id *ast.Identifier) ast.Expression {
 	return ae
 }
 
-func (p *parser) parseBreak() ast.Expression {
-
+func (p *parser) parseForLoopControlFlow() ast.Expression {
+	var stmt ast.Expression
 	if !p.inForBlock {
 
-		p.errors = append(p.errors, fmt.Sprintf("line %d: break is not in a loop", p.curToken.LineNumber))
+		p.errors = append(p.errors, fmt.Sprintf("line %d: %s is not in a loop", p.curToken.LineNumber, p.curToken.Literal))
 		return nil
 	}
+	if p.curTokenIs(token.BREAK) {
 
-	stmt := &ast.BreakExpression{TokenAble: ast.TokenAble{p.curToken}}
-
+		stmt = &ast.BreakExpression{TokenAble: ast.TokenAble{p.curToken}}
+	} else {
+		stmt = &ast.ContinueExpression{TokenAble: ast.TokenAble{p.curToken}}
+	}
 	return stmt
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -34,6 +34,7 @@ func newParser(l *lexer.Lexer) *parser {
 	p.prefixParseFns = make(map[token.Type]prefixParseFn)
 	p.registerPrefix(token.IDENT, p.parseIdentifier)
 	p.registerPrefix(token.CONTINUE, p.parseContinue)
+	p.registerPrefix(token.BREAK, p.parseBreak)
 	p.registerPrefix(token.INT, p.parseIntegerLiteral)
 	p.registerPrefix(token.FLOAT, p.parseFloatLiteral)
 	p.registerPrefix(token.STRING, p.parseStringLiteral)
@@ -300,6 +301,19 @@ func (p *parser) parseAssignExpression(id *ast.Identifier) ast.Expression {
 	}
 
 	return ae
+}
+
+func (p *parser) parseBreak() ast.Expression {
+
+	if !p.inForBlock {
+
+		p.errors = append(p.errors, fmt.Sprintf("line %d: break is not in a loop", p.curToken.LineNumber))
+		return nil
+	}
+
+	stmt := &ast.BreakExpression{TokenAble: ast.TokenAble{p.curToken}}
+
+	return stmt
 }
 
 func (p *parser) parseContinue() ast.Expression {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1073,6 +1073,31 @@ func Test_ForExpression_WithContinue(t *testing.T) {
 	//r.True(testIdentifier(t, consequence.Expression, "v"))
 }
 
+func Test_ForExpression_WithBreak(t *testing.T) {
+	r := require.New(t)
+	input := `<% for (k,v) in myArray {  break } %>`
+
+	program, err := Parse(input)
+	r.NoError(err)
+
+	r.Len(program.Statements, 1)
+
+	stmt := program.Statements[0].(*ast.ExpressionStatement)
+
+	exp := stmt.Expression.(*ast.ForExpression)
+
+	r.Equal("k", exp.KeyName)
+	r.Equal("v", exp.ValueName)
+	r.Equal("myArray", exp.Iterable.String())
+
+	r.Len(exp.Block.Statements, 1)
+
+	consequence := exp.Block.Statements[0].(*ast.ExpressionStatement).Expression.(*ast.BreakExpression)
+
+	r.Equal(consequence.String(), "break")
+	//r.True(testIdentifier(t, consequence.Expression, "v"))
+}
+
 func Test_Continue_IfCondtion(t *testing.T) {
 	r := require.New(t)
 	input := `<% if(x == 2) { continue } %>`
@@ -1081,9 +1106,25 @@ func Test_Continue_IfCondtion(t *testing.T) {
 	r.Error(err)
 }
 
+func Test_Break_IfCondtion(t *testing.T) {
+	r := require.New(t)
+	input := `<% if(x == 2) { break } %>`
+
+	_, err := Parse(input)
+	r.Error(err)
+}
+
 func Test_Continue_Function(t *testing.T) {
 	r := require.New(t)
 	input := `<% fn(x, y) { continue } %>`
+
+	_, err := Parse(input)
+	r.Error(err)
+}
+
+func Test_Break_Function(t *testing.T) {
+	r := require.New(t)
+	input := `<% fn(x, y) { break } %>`
 
 	_, err := Parse(input)
 	r.Error(err)

--- a/token/const.go
+++ b/token/const.go
@@ -62,4 +62,5 @@ const (
 	FOR      = "FOR"
 	IN       = "IN"
 	CONTINUE = "CONTINUE"
+	BREAK    = "BREAK"
 )

--- a/token/token.go
+++ b/token/token.go
@@ -22,6 +22,7 @@ var keywords = map[string]Type{
 	"for":      FOR,
 	"in":       IN,
 	"continue": CONTINUE,
+	"break":    BREAK,
 }
 
 // LookupIdent an ident and return a keyword type, or a plain ident


### PR DESCRIPTION
 I added the feature `break` to for loops. The `break` command will cause the for loop to terminate when called. The `break` is only limited inside a block statement.   So this is legal
1. ```
	 for (i,v) in [1, 2, 3,4,5,6,7,8,9,10] {
		break
		return v   
	} 
2. ```
	 for (i,v) in [1, 2, 3,4,5,6,7,8,9,10] {
		if (i > 0) {
                  break
                }
		return v   
	} 

illegal will be :

1. 
```
	if (x == y){
             break
		return v   
	} 
```
2.
```
	 for (i,v) in [1, 2, 3,4,5,6,7,8,9,10] {
		func(x,y) {break}
		return v   
	} 
```

* Updated the README