### PR TITLE
fix panic when a function argument contains a hash with a syntax error

### DIFF
--- a/ast/call_expression.go
+++ b/ast/call_expression.go
@@ -23,7 +23,10 @@ func (ce *CallExpression) String() string {
 
 	args := []string{}
 	for _, a := range ce.Arguments {
-		args = append(args, a.String())
+		if a != nil {
+
+			args = append(args, a.String())
+		}
 	}
 
 	out.WriteString(ce.Function.String())

--- a/functions_test.go
+++ b/functions_test.go
@@ -71,6 +71,20 @@ func Test_Render_Function_Call_With_Hash(t *testing.T) {
 	r.Equal("<p>hi mark!</p>", s)
 }
 
+func Test_Render_Function_Call_With_SyntaxErrorHash(t *testing.T) {
+	r := require.New(t)
+
+	input := `<p><%= f({name: name) %></p>`
+	_, err := Render(input, NewContextWith(map[string]interface{}{
+		"f": func(m map[string]interface{}) string {
+			return fmt.Sprintf("hi %s!", m["name"])
+		},
+		"name": "mark",
+	}))
+	r.Error(err)
+
+}
+
 func Test_Render_Function_Call_With_Error(t *testing.T) {
 	r := require.New(t)
 


### PR DESCRIPTION
Fixes [#142 ](url)
