### PR TITLE
catch out of bounds slice/array index access

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -355,7 +355,16 @@ func (c *compiler) evalAccessIndex(left, index interface{}, node *ast.IndexExpre
 				returnValue, err = c.evalIndexCallee(rv.Index(i), node)
 
 			} else {
-				returnValue = rv.Index(i).Interface()
+
+				if i >= 0 && i < rv.Len() {
+
+					returnValue = rv.Index(i).Interface()
+
+				} else {
+
+					err = fmt.Errorf("index out of range [%d] with length %d", index, rv.Len())
+
+				}
 			}
 
 		} else {

--- a/variables_test.go
+++ b/variables_test.go
@@ -153,3 +153,13 @@ func Test_Render_Let_ArrayAssign_OutofBoundsIndex(t *testing.T) {
 	r.Error(err)
 
 }
+
+func Test_Render_Access_Array_OutofBoundsIndex(t *testing.T) {
+	r := require.New(t)
+
+	input := `<% let a = [1, 2, "three", "four", 3.75] %><%= a[5]  %>`
+	_, err := Render(input, NewContext())
+	//r.Error(err)
+	r.Error(err)
+
+}


### PR DESCRIPTION
An error will return to the user if they try to access an index that doesn't exist. 

Example: `index out of range [5] with length 5`
