### PR TITLE
fix: follow pointers when evaling identifiers

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -418,6 +418,12 @@ func (c *compiler) evalIdentifier(node *ast.Identifier) (interface{}, error) {
 		}
 
 		f := rv.FieldByName(node.Value)
+		if f.Kind() == reflect.Ptr {
+			if f.IsNil() {
+				return nil, nil
+			}
+			f = f.Elem()
+		}
 		if !f.IsValid() {
 			m := rv.MethodByName(node.Value)
 			if !m.IsValid() {
@@ -425,11 +431,10 @@ func (c *compiler) evalIdentifier(node *ast.Identifier) (interface{}, error) {
 			}
 			return m.Interface(), nil
 		}
-
 		if !f.CanInterface() {
-
 			return nil, fmt.Errorf("'%s'cannot return value obtained from unexported field or method '%s' (%s)", node.Callee.String(), node.Value, node)
 		}
+
 		return f.Interface(), nil
 	}
 	if c.ctx.Has(node.Value) {

--- a/struct_test.go
+++ b/struct_test.go
@@ -106,13 +106,57 @@ func Test_Render_Struct_PointerMethod_IsNil(t *testing.T) {
 	}
 
 	for p := first; p != nil; p = p.Next {
-
 		ctx := NewContextWith(map[string]interface{}{"p": p})
 		res, err := Render(input, ctx)
 		r.NoError(err)
 		r.Equal(resE[p.N], res)
 
 	}
+}
+
+func Test_Render_Struct_PointerValue_Nil(t *testing.T) {
+	r := require.New(t)
+
+	type user struct {
+		Name  string
+		Image *string
+	}
+
+	u := user{
+		Name:  "Garn Clapstick",
+		Image: nil,
+	}
+	ctx := NewContextWith(map[string]interface{}{
+		"user": u,
+	})
+	input := `<%= user.Name %>: <%= user.Image %>`
+	res, err := Render(input, ctx)
+
+	r.NoError(err)
+	r.Equal(`Garn Clapstick: `, res)
+}
+
+func Test_Render_Struct_PointerValue_NonNil(t *testing.T) {
+	r := require.New(t)
+
+	type user struct {
+		Name  string
+		Image *string
+	}
+
+	image := "bicep.png"
+	u := user{
+		Name:  "Scrinch Archipeligo",
+		Image: &image,
+	}
+	ctx := NewContextWith(map[string]interface{}{
+		"user": u,
+	})
+	input := `<%= user.Name %>: <%= user.Image %>`
+	res, err := Render(input, ctx)
+
+	r.NoError(err)
+	r.Equal(`Scrinch Archipeligo: bicep.png`, res)
 }
 
 func Test_Render_Struct_Multiple_Access(t *testing.T) {


### PR DESCRIPTION
Ensure pointer values can be eval'd

closes #159 