### PR TITLE
fixed #164's bug by focusing on the operator instead of the value

### DIFF
--- a/if_test.go
+++ b/if_test.go
@@ -314,3 +314,18 @@ func Test_Render_If_Variable_Not_Set_But_Or_Condition_Right_Node_Is_True(t *test
 	r.NoError(err)
 	r.Equal("hi", s)
 }
+
+func Test_Condition_UnsetIsNil(t *testing.T) {
+	r := require.New(t)
+	ctx := NewContext()
+
+	input := `<%= paths == nil %>`
+	s, err := Render(input, ctx)
+	r.NoError(err)
+	r.Equal("true", s)
+
+	input = `<%= nil == paths %>`
+	s, err = Render(input, ctx)
+	r.NoError(err)
+	r.Equal("true", s)
+}

--- a/math_test.go
+++ b/math_test.go
@@ -93,6 +93,47 @@ func Test_Render_String_Math(t *testing.T) {
 	}
 }
 
+func Test_Render_Operator_UndefinedVar(t *testing.T) {
+	tests := []struct {
+		operator      string
+		result        interface{}
+		errorExpected bool
+	}{
+		{"+", "", true},
+		{"-", "", true},
+		{"/", "", true},
+		{"*", "", true},
+		{">", "", true},
+		{">=", "", true},
+		{"<=", "", true},
+		{"<", "", true},
+		{"==", "false", false},
+		{"!=", "true", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.operator, func(t *testing.T) {
+			r := require.New(t)
+			input := fmt.Sprintf("<%%= undefined %s 3 %%>", tc.operator)
+			s, err := Render(input, NewContext())
+			if tc.errorExpected {
+				r.Error(err, "undefined %s 3 --> '%v'", tc.operator, tc.result)
+			} else {
+				r.NoError(err, "undefined %s 3 --> '%v'", tc.operator, tc.result)
+			}
+			r.Equal(tc.result, s, "undefined %s 3", tc.operator)
+
+			input = fmt.Sprintf("<%%= 3 %s unknown %%>", tc.operator)
+			s, err = Render(input, NewContext())
+			if tc.errorExpected {
+				r.Error(err, "3 %s undefined --> '%v'", tc.operator, tc.result)
+			} else {
+				r.NoError(err, "3 %s undefined --> '%v'", tc.operator, tc.result)
+			}
+			r.Equal(tc.result, s, "undefined %s 3", tc.operator)
+		})
+	}
+}
+
 func Test_Render_String_Concat_Multiple(t *testing.T) {
 	r := require.New(t)
 


### PR DESCRIPTION
I found that #164's approach is problematic because the fix is focused on the value and it modifies the value itself (from `nil` to `false` when if the error is kind of "unknown identifier"). However, since the method is not only for logical operations, the fix made side effects on the evaluation of arithmetic operators and handling `nil` itself.

This PR has two commits:
- added more test cases
- fixed the method to focus on the operation

fixes #157
fixes #165