### PR TITLE
Fix panic when let statement is not followed by an equal sign

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"fmt"
-	"reflect"
 	"strconv"
 	"strings"
 
@@ -108,9 +107,7 @@ func (p *parser) parseProgram() *ast.Program {
 			}
 		}
 
-		if stmt != nil &&
-			(reflect.ValueOf(stmt).Kind() == reflect.Ptr && !reflect.ValueOf(stmt).IsNil()) &&
-			strings.TrimSpace(stmt.String()) != "" {
+		if stmt != nil && strings.TrimSpace(stmt.String()) != "" {
 			program.Statements = append(program.Statements, stmt)
 		}
 
@@ -162,6 +159,9 @@ func (p *parser) parseStatement() ast.Statement {
 	switch p.curToken.Type {
 	case token.LET:
 		l := p.parseLetStatement()
+		if l == nil {
+			return nil
+		}
 		return l
 	case token.S_START:
 		p.nextToken()
@@ -202,7 +202,7 @@ func (p *parser) parseLetStatement() *ast.LetStatement {
 	stmt.Name = &ast.Identifier{TokenAble: ast.TokenAble{Token: p.curToken}, Value: p.curToken.Literal}
 
 	if !p.expectPeek(token.ASSIGN) {
-		return nil
+		return stmt
 	}
 
 	p.nextToken()

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -107,7 +108,9 @@ func (p *parser) parseProgram() *ast.Program {
 			}
 		}
 
-		if stmt != nil && strings.TrimSpace(stmt.String()) != "" {
+		if stmt != nil &&
+			(reflect.ValueOf(stmt).Kind() == reflect.Ptr && !reflect.ValueOf(stmt).IsNil()) &&
+			strings.TrimSpace(stmt.String()) != "" {
 			program.Statements = append(program.Statements, stmt)
 		}
 

--- a/variables_test.go
+++ b/variables_test.go
@@ -28,6 +28,20 @@ func Test_Let_Reassignment(t *testing.T) {
 	r.Equal("bar\n    \n  \nbaz", strings.TrimSpace(s))
 }
 
+func Test_Let_Ident_NotInitialized(t *testing.T) {
+	r := require.New(t)
+	input := `<% let foo
+		if (foo){
+			foo = 1
+		}
+	%>`
+
+	ctx := NewContext()
+
+	_, err := Render(input, ctx)
+	r.Error(err)
+}
+
 func Test_Let_Reassignment_UnknownIdent(t *testing.T) {
 	r := require.New(t)
 	input := `<% foo = "baz" %>`


### PR DESCRIPTION
### What is being done in this PR?
> Type in here a description of the changes in this PR. 
Fix [170](https://github.com/gobuffalo/plush/issues/170)

### What are the main choices made to get to this solution?
> return `stmt` instead of nil to avoid using reflection in `parseProgram`. Also, improve  `parseStatement` to return nil to safeguard `parseProgram` from panicking when trying to call `String()` on `ast.Statement`

### List the manual test cases you've covered before sending this PR:
> Added a new test Test_Let_Ident_NotInitialized under variables_test.go