### PR TITLE
Fix panic when accessing a map with a key type that's not comparable with map index

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -320,6 +320,14 @@ func (c *compiler) evalAccessIndex(left, index interface{}, node *ast.IndexExpre
 	rv := reflect.ValueOf(left)
 	switch rv.Kind() {
 	case reflect.Map:
+		mapKeyType := reflect.TypeOf(left).Key().Kind()
+		keyType := reflect.TypeOf(index).Kind()
+		if mapKeyType != reflect.Interface &&
+			keyType != mapKeyType {
+			err = fmt.Errorf("cannot use %v (%s constant) as %s value in map index", index, keyType.String(), mapKeyType.String())
+			return nil, err
+		}
+
 		val := rv.MapIndex(reflect.ValueOf(index))
 		if !val.IsValid() {
 			return nil, nil

--- a/hashes_test.go
+++ b/hashes_test.go
@@ -6,6 +6,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func Test_Render_Hash_Key_Interface(t *testing.T) {
+	r := require.New(t)
+
+	input := `<%= m["first"]%>`
+	s, err := Render(input, NewContextWith(map[string]interface{}{
+
+		"m": map[interface{}]bool{"first": true},
+	}))
+	r.NoError(err)
+	r.Equal("true", s)
+}
+
+func Test_Render_Hash_Key_Int_With_String_Index(t *testing.T) {
+	r := require.New(t)
+
+	input := `<%= m["first"]%>`
+	_, err := Render(input, NewContextWith(map[string]interface{}{
+
+		"m": map[int]bool{0: true},
+	}))
+
+	errStr := "line 1: cannot use first (string constant) as int value in map index"
+	r.Error(err)
+	r.Equal(errStr, err.Error())
+
+}
+
 func Test_Render_Hash_Array_Index(t *testing.T) {
 	r := require.New(t)
 


### PR DESCRIPTION


### What is being done in this PR?
 Fixes [issue#176](https://github.com/gobuffalo/plush/issues/176)
### What are the main choices made to get to this solution?
  If the map key is not of `interface{}` type then the index and map key type should be the same. If not then an error will be returned `"line 1: cannot use first (string constant) as int value in map index"`

### List the manual test cases you've covered before sending this PR:
Created two new tests under `hashes_test.go`.

1.  `Test_Render_Hash_Key_Interface` : This test should pass as the map key type is of a type `interface{}`
2. `Test_Render_Hash_Key_Int_With_String_Index`: This test should return an error because the map key type is int and accessing it with a string.