### PR TITLE
Replace bytes.buffer with strings.builder to avoid extra memory allocation

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -1,7 +1,6 @@
 package plush
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/gobuffalo/plush/v4/token"
@@ -36,7 +35,7 @@ type compiler struct {
 }
 
 func (c *compiler) compile() (string, error) {
-	bb := &bytes.Buffer{}
+	bb := &strings.Builder{}
 
 	for _, stmt := range c.program.Statements {
 		var res interface{}
@@ -70,7 +69,7 @@ func (c *compiler) compile() (string, error) {
 	return bb.String(), nil
 }
 
-func (c *compiler) write(bb *bytes.Buffer, i interface{}) {
+func (c *compiler) write(bb *strings.Builder, i interface{}) {
 	switch t := i.(type) {
 	case time.Time:
 		if dtf, ok := c.ctx.Value("TIME_FORMAT").(string); ok {

--- a/helpers.go
+++ b/helpers.go
@@ -1,8 +1,8 @@
 package plush
 
 import (
-	"bytes"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/gobuffalo/helpers"
@@ -80,7 +80,7 @@ func (h HelperContext) BlockWith(hc hctx.Context) (string, error) {
 		return "", err
 	}
 
-	bb := &bytes.Buffer{}
+	bb := &strings.Builder{}
 	h.compiler.write(bb, i)
 
 	return bb.String(), nil


### PR DESCRIPTION
Fixes issue in [186](https://github.com/gobuffalo/plush/issues/186)