### PR TITLE
upgrade unsafeGetBytes to use unsafe.slice

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -1097,7 +1097,5 @@ func unsafeGetBytes(s string) []byte {
 	if s == "" {
 		return []byte{}
 	}
-	return (*[0x7fff0000]byte)(unsafe.Pointer(
-		(*reflect.StringHeader)(unsafe.Pointer(&s)).Data),
-	)[:len(s):len(s)]
+	return unsafe.Slice(unsafe.StringData(s), len(s))
 }


### PR DESCRIPTION
### What is being done in this PR?
Change unsafeGetBytes to use unsafe.Slice. 