### PR TITLE
feat: introduce scoped symbol table with global/local interning

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -172,8 +172,6 @@ func (c *compiler) evalAssignExpression(node *ast.AssignExpression) (interface{}
 			ID: n,
 		}
 	}
-
-	//c.ctx.Update(n, v)
 	return nil, nil
 }
 

--- a/for_test.go
+++ b/for_test.go
@@ -16,6 +16,14 @@ func Test_Render_For_Array(t *testing.T) {
 	r.Equal("", s)
 }
 
+func Test_Render_For_Update_Global_Scope(t *testing.T) {
+	r := require.New(t)
+	input := `<% let varTest = "" %><% for (i,v) in ["a", "b", "c"] {varTest =  v} %><%= varTest %>`
+	s, err := plush.Render(input, plush.NewContext())
+	r.NoError(err)
+	r.Equal("c", s)
+}
+
 func Test_Render_For_Hash(t *testing.T) {
 	r := require.New(t)
 	input := `<%= for (k,v) in myMap { %><%= k + ":" + v%><% } %>`

--- a/helper_context.go
+++ b/helper_context.go
@@ -50,7 +50,8 @@ func (h HelperContext) BlockWith(hc hctx.Context) (string, error) {
 
 	octx := h.compiler.ctx
 	defer func() { h.compiler.ctx = octx }()
-	h.compiler.ctx = ctx
+
+	h.compiler.ctx = ctx.New()
 
 	if h.block == nil {
 		return "", fmt.Errorf("no block defined")

--- a/helpers/hctx/context.go
+++ b/helpers/hctx/context.go
@@ -8,6 +8,7 @@ type Context interface {
 	context.Context
 	New() Context
 	Has(key string) bool
+	Update(key string, value interface{}) bool
 	Set(key string, value interface{})
 }
 

--- a/helpers/helptest/context.go
+++ b/helpers/helptest/context.go
@@ -54,7 +54,9 @@ func (f HelperContext) Value(key interface{}) interface{} {
 	}
 	return f.Context.Value(key)
 }
-
+func (f *HelperContext) Update(key string, value interface{}) (returnData bool) {
+	return
+}
 func (f *HelperContext) Set(key string, value interface{}) {
 	f.data.Store(key, value)
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,6 +1,7 @@
 package plush_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/gobuffalo/plush/v5"
@@ -12,11 +13,13 @@ func Test_Helpers_WithoutData(t *testing.T) {
 	r := require.New(t)
 
 	table := []struct {
-		I string
-		E string
+		I   string
+		E   string
+		Err error
 	}{
 		{I: `<%= foo() {return bar + name} %>`, E: "BARunknown"},
 		{I: `<%= foo({name: "mark"}) {return bar + name} %>`, E: "BARmark"},
+		{I: `<%= foo({name: "mark", bbb: "hello-world"}) {return bar + name} %><%= bbb %>`, Err: errors.New(`line 1: "bbb": unknown identifier`)},
 	}
 
 	for _, tt := range table {
@@ -28,10 +31,18 @@ func Test_Helpers_WithoutData(t *testing.T) {
 			if n, ok := d["name"]; ok {
 				c.Set("name", n)
 			}
+			if n, ok := d["bbb"]; ok {
+				c.Set("bbb", n)
+			}
 			return help.BlockWith(c)
 		})
 		s, err := plush.Render(tt.I, ctx)
-		r.NoError(err)
-		r.Equal(tt.E, s)
+		if tt.Err == nil {
+			r.NoError(err)
+			r.Equal(tt.E, s)
+		} else {
+			r.Error(err)
+			r.EqualError(err, tt.Err.Error())
+		}
 	}
 }

--- a/if_test.go
+++ b/if_test.go
@@ -200,6 +200,45 @@ func Test_If_BlockScope_Declare(t *testing.T) {
 	r.Equal("<p>Hello World</p>", s)
 }
 
+func Test_If_BlockScope_Nested_Declare(t *testing.T) {
+	r := require.New(t)
+
+	ctx := plush.NewContext()
+
+	input := `<p><% let username = "Hello World" %><%= if (username && username != "") { 
+		let username = "hi" 
+		username = "hi" 
+		if (username == "hi"){
+			username = "hi2"
+		}
+	} else { 
+		let username = "bye"
+		username = "1"
+	 }%><%= username %></p>`
+	s, err := plush.Render(input, ctx)
+	r.NoError(err)
+	r.Equal("<p>Hello World</p>", s)
+}
+
+func Test_If_BlockScope_Nested_Overwrite(t *testing.T) {
+	r := require.New(t)
+
+	ctx := plush.NewContext()
+
+	input := `<p><% let username = "Hello World" %><%= if (username && username != "") { 
+		username = "hi" 
+		if (username == "hi"){
+			username = "hi2"
+		}
+	} else { 
+		let username = "bye"
+		username = "1"
+	 }%><%= username %></p>`
+	s, err := plush.Render(input, ctx)
+	r.NoError(err)
+	r.Equal("<p>hi2</p>", s)
+}
+
 func Test_If_Variable_Not_Set_But_Or_Condition_Is_True_Complex(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()

--- a/if_test.go
+++ b/if_test.go
@@ -154,6 +154,52 @@ func Test_If_String_Truthy(t *testing.T) {
 	r.Equal("<p>hi</p>", s)
 }
 
+func Test_If_Updating_Variable_Inside_IF_Scope(t *testing.T) {
+	r := require.New(t)
+
+	ctx := plush.NewContext()
+	ctx.Set("username", "")
+
+	input := `<p><%= if (username && username != "") { username = "hi" } else { username= "bye" } %><%= username %></p>`
+	s, err := plush.Render(input, ctx)
+	r.NoError(err)
+	r.Equal("<p>bye</p>", s)
+
+	ctx.Set("username", "foo")
+	s, err = plush.Render(input, ctx)
+	r.NoError(err)
+	r.Equal("<p>hi</p>", s)
+}
+
+func Test_If_UserName_Is_Declared(t *testing.T) {
+	r := require.New(t)
+
+	ctx := plush.NewContext()
+
+	input := `<p><%= if (username && username != "") { username = "hi" } else { username= "bye" } %><%= username %></p>`
+	s, err := plush.Render(input, ctx)
+	r.Error(err)
+	r.EqualError(err, `line 1: "username": unknown identifier`)
+	r.Empty(s)
+}
+
+func Test_If_BlockScope_Declare(t *testing.T) {
+	r := require.New(t)
+
+	ctx := plush.NewContext()
+
+	input := `<p><% let username = "Hello World" %><%= if (username && username != "") { 
+		let username = "hi" 
+		username = "hi" 
+	} else { 
+		let username = "bye"
+		username = "1"
+	 }%><%= username %></p>`
+	s, err := plush.Render(input, ctx)
+	r.NoError(err)
+	r.Equal("<p>Hello World</p>", s)
+}
+
 func Test_If_Variable_Not_Set_But_Or_Condition_Is_True_Complex(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()

--- a/intern.go
+++ b/intern.go
@@ -1,0 +1,35 @@
+package plush
+
+type InternTable struct {
+	stringToID map[string]int
+	idToString []string
+}
+
+func NewInternTable() *InternTable {
+	return &InternTable{
+		stringToID: make(map[string]int),
+		idToString: []string{},
+	}
+}
+
+func (it *InternTable) Intern(name string) int {
+	if id, ok := it.stringToID[name]; ok {
+		return id
+	}
+	id := len(it.idToString)
+	it.stringToID[name] = id
+	it.idToString = append(it.idToString, name)
+	return id
+}
+
+func (it *InternTable) Lookup(name string) (int, bool) {
+	id, ok := it.stringToID[name]
+	return id, ok
+}
+
+func (it *InternTable) SymbolName(id int) string {
+	if id < len(it.idToString) {
+		return it.idToString[id]
+	}
+	return "<unknown>"
+}

--- a/intern_test.go
+++ b/intern_test.go
@@ -1,0 +1,55 @@
+package plush_test
+
+import (
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInternTable(t *testing.T) {
+	r := require.New(t)
+
+	it := plush.NewInternTable()
+
+	r.NotNil(it)
+	// Intern a new string
+	id1 := it.Intern("alpha")
+
+	r.Equal(0, id1)
+
+	// Intern another string
+	id2 := it.Intern("beta")
+
+	r.Equal(1, id2)
+
+	// Re-intern the first string
+	id1Again := it.Intern("alpha")
+
+	r.Equal(id1, id1Again)
+
+	// Lookup existing string
+	lookupID, found := it.Lookup("beta")
+	r.True(found)
+	r.NotEqual(id1, lookupID)
+	r.Equal(id2, lookupID)
+
+	// Lookup non-existent string
+	_, found = it.Lookup("gamma")
+	r.False(found)
+
+	// SymbolName for known ID
+	name := it.SymbolName(id1)
+	r.Equal("alpha", name)
+
+	// SymbolName for unknown ID
+	unknown := it.SymbolName(999)
+	r.Equal("<unknown>", unknown)
+}
+
+func TestNewInternTable(t *testing.T) {
+	r := require.New(t)
+
+	rs := plush.NewInternTable()
+	r.NotNil(rs)
+}

--- a/symbol_table.go
+++ b/symbol_table.go
@@ -73,7 +73,7 @@ func (s *SymbolTable) Assign(name string, value interface{}) bool {
 	return false
 }
 
-// Resolve finds the value of a variable
+// Has finds the value of a variable
 func (s *SymbolTable) Has(name string) bool {
 	var id int
 	var ok bool

--- a/symbol_table.go
+++ b/symbol_table.go
@@ -74,6 +74,38 @@ func (s *SymbolTable) Assign(name string, value interface{}) bool {
 }
 
 // Resolve finds the value of a variable
+func (s *SymbolTable) Has(name string) bool {
+	var id int
+	var ok bool
+
+	isLocal := false
+	// Try local first
+	if id, ok = s.localInterner.Lookup(name); !ok {
+		// Try global if not found locally
+		if id, ok = s.globalInterner.Lookup(name); !ok {
+			return false
+		}
+	} else {
+		isLocal = true
+	}
+
+	firstK := 0
+	// Only one walk through the scope chain, using the ID we found
+	for curr := s; curr != nil; curr = curr.parent {
+		//Skip if we know it's not in the first local scope
+		if !isLocal && firstK == 0 {
+			firstK += 1
+			continue
+		}
+		if _, exists := curr.vars[id]; exists {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Resolve finds the value of a variable
 func (s *SymbolTable) Resolve(name string) (interface{}, bool) {
 	var id int
 	var ok bool

--- a/symbol_table.go
+++ b/symbol_table.go
@@ -1,0 +1,84 @@
+package plush
+
+// SymbolTable represents a scope
+type SymbolTable struct {
+	vars   map[int]interface{}
+	parent *SymbolTable
+	// Interning system
+	localInterner  *InternTable
+	globalInterner *InternTable
+}
+
+// NewScope creates a new scope with an optional parent
+func NewScope(parent *SymbolTable) *SymbolTable {
+	if parent == nil {
+		global := NewInternTable()
+		local := NewInternTable()
+		return &SymbolTable{
+			vars:           make(map[int]interface{}),
+			parent:         nil,
+			globalInterner: global,
+			localInterner:  local,
+		}
+	}
+
+	// Inherit interning from parent
+	return &SymbolTable{
+		vars:           make(map[int]interface{}),
+		parent:         parent,
+		globalInterner: parent.globalInterner,
+		localInterner:  parent.localInterner,
+	}
+}
+
+// Declare adds or updates a variable in the current scope
+func (s *SymbolTable) Declare(name string, value interface{}) {
+	if value == nil {
+		return
+	}
+	id := s.localInterner.Intern(name)
+	s.vars[id] = value
+}
+
+// Assign searches outer scopes and updates an existing variable
+func (s *SymbolTable) Assign(name string, value interface{}) bool {
+	if id, ok := s.localInterner.Lookup(name); ok {
+		for curr := s; curr != nil; curr = curr.parent {
+			if _, exists := curr.vars[id]; exists {
+				curr.vars[id] = value
+				return true
+			}
+		}
+	}
+	if id, ok := s.globalInterner.Lookup(name); ok {
+		for curr := s; curr != nil; curr = curr.parent {
+			if _, exists := curr.vars[id]; exists {
+				curr.vars[id] = value
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Resolve finds the value of a variable
+func (s *SymbolTable) Resolve(name string) (interface{}, bool) {
+	if id, ok := s.localInterner.Lookup(name); ok {
+		for curr := s; curr != nil; curr = curr.parent {
+			if val, exists := curr.vars[id]; exists {
+
+				return val, true
+			}
+		}
+	}
+
+	if id, ok := s.globalInterner.Lookup(name); ok {
+		for curr := s; curr != nil; curr = curr.parent {
+			if val, exists := curr.vars[id]; exists {
+				return val, true
+			}
+		}
+	}
+
+	return nil, false
+}

--- a/symbol_table_test.go
+++ b/symbol_table_test.go
@@ -28,6 +28,37 @@ func TestSymbolTable_Declare_And_Resolve(t *testing.T) {
 	r.Equal(42, val)
 }
 
+func TestSymbolTable_Declare_And_Has(t *testing.T) {
+	r := require.New(t)
+
+	scope := plush.NewScope(nil)
+	r.NotNil(scope)
+	scope.Declare("x", 42)
+
+	ok := scope.Has("x")
+
+	r.True(ok)
+}
+
+func TestSymbolTable_Declare_And_Has_Child(t *testing.T) {
+	r := require.New(t)
+
+	scope := plush.NewScope(nil)
+	r.NotNil(scope)
+	scope.Declare("x", 42)
+	childA := plush.NewScope(scope)
+	r.NotNil(scope)
+	childA.Declare("y", 42)
+	ok := childA.Has("x")
+
+	r.True(ok)
+
+	ok = childA.Has("y")
+	r.True(ok)
+
+	ok = childA.Has("d")
+	r.False(ok)
+}
 func TestSymbolTable_Resolve_From_Parent_Scope(t *testing.T) {
 	r := require.New(t)
 

--- a/symbol_table_test.go
+++ b/symbol_table_test.go
@@ -1,0 +1,123 @@
+package plush_test
+
+import (
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSymbolTable_NewSymbolTable(t *testing.T) {
+	r := require.New(t)
+
+	scope := plush.NewScope(nil)
+
+	r.NotNil(scope)
+}
+
+func TestSymbolTable_Declare_And_Resolve(t *testing.T) {
+	r := require.New(t)
+
+	scope := plush.NewScope(nil)
+	r.NotNil(scope)
+	scope.Declare("x", 42)
+
+	val, ok := scope.Resolve("x")
+
+	r.True(ok)
+	r.Equal(42, val)
+}
+
+func TestSymbolTable_Resolve_From_Parent_Scope(t *testing.T) {
+	r := require.New(t)
+
+	parent := plush.NewScope(nil)
+
+	r.NotNil(parent)
+
+	parent.Declare("y", "hello")
+
+	child := plush.NewScope(parent)
+
+	r.NotNil(child)
+	val, ok := child.Resolve("y")
+
+	r.Equal("hello", val)
+	r.True(ok)
+}
+
+func TestSymbolTable_Assign_To_ParentScope(t *testing.T) {
+	r := require.New(t)
+	parent := plush.NewScope(nil)
+
+	r.NotNil(parent)
+
+	parent.Declare("z", 100)
+
+	child := plush.NewScope(parent)
+
+	r.NotNil(child)
+
+	assigned := child.Assign("z", 200)
+
+	r.True(assigned)
+
+	valC, okC := child.Resolve("z")
+
+	r.True(okC)
+	r.Equal(200, valC)
+
+	val, ok := parent.Resolve("z")
+
+	r.True(ok)
+	r.Equal(200, val)
+}
+
+func TestSymbolTable_Assign_Non_Existent_Fails(t *testing.T) {
+	r := require.New(t)
+
+	scope := plush.NewScope(nil)
+
+	r.NotNil(scope)
+
+	assigned := scope.Assign("nonexistent", 123)
+
+	r.False(assigned)
+}
+
+func TestSymbolTable_Declare_Nil_Ignored(t *testing.T) {
+	r := require.New(t)
+	scope := plush.NewScope(nil)
+
+	r.NotNil(scope)
+
+	scope.Declare("a", nil)
+
+	_, ok := scope.Resolve("a")
+	r.False(ok)
+}
+
+func TestSymbolTable_Shadowing(t *testing.T) {
+
+	r := require.New(t)
+
+	root := plush.NewScope(nil)
+
+	r.NotNil(root)
+
+	root.Declare("v", 1)
+
+	child := plush.NewScope(root)
+
+	r.NotNil(child)
+	child.Declare("v", 2)
+
+	valRoot, okRoot := root.Resolve("v")
+	valChild, okChild := child.Resolve("v")
+
+	r.True(okRoot)
+	r.Equal(1, valRoot)
+
+	r.True(okChild)
+	r.Equal(2, valChild)
+}


### PR DESCRIPTION
This fixes the issues outlined here [issue#199](https://github.com/gobuffalo/plush/issues/199).

# ✨ Feature: Symbol Table with Interning Support

This feature introduces two core components:

- `InternTable`: Efficient string interning system
- `SymbolTable`: Lexically scoped variable environment


Together, they provide a performant and memory-efficient foundation for variable management in Plush.

---

### InternTable

The `InternTable` transforms strings into unique integer IDs, enabling consistent and fast symbol handling. The old context of 
data `map[string]interface{}` has been deprecated in favour of `InternTable`

Key benefits:

⚡️ 1. Performance (Speed)

String comparisons in Go are `O(n)` — they compare character-by-character until a difference is found. In contrast, comparing two integers is `O(1)`.

By converting strings to unique integer IDs using an `InternTable`:

-  Replace slow string comparisons with fast integer comparisons.

- Speed up lookup in maps like map[int]interface{} versus map[string]interface{}.



💾 2. Memory Efficiency
     
Deduplication: Ensures each unique string is stored only once.

This reduces:

-  Memory duplication of common identifiers.
-  GC pressure with lots of repeated identifiers.

The cost of string hashing and comparison happens every time we access, insert, or update a value in a map[string]T.

```go
vars := map[string]interface{}{}
vars["x"] = 10           // string hash + store
val := vars["x"]         // string hash + compare
```
Using Interned:

```go
id := internTable.Intern("x")  // string hash only once
vars[id] = 10                  // int key is fast
val := vars[id]                // int key lookup
```

🔄 3. Consistent Identity

Interning guarantees string identity consistency:

- "x" in scope A and "x" in scope B are the same ID.


During the lifetime In HTTP request, variable lookups and updates happen frequently — especially inside loops and conditionals. Using map[string] for each access adds overhead from string hashing and comparisons using the old context `Data`, and can lead to memory waste from repeated string usage. Interning converts variable names to unique integer IDs, enabling fast, constant-time lookups. This improves performance and reduces memory usage during template rendering. We introduced Interning so it can be later used efficiently with `SymbolTable`



---

###  SymbolTable

The `SymbolTable` provides plush with a scope variable management, supporting nested scopes and variable resolution.

A few concepts have been introduced: 

1. Parent Scope: A higher-level scope that a child scope inherits from.
   
2. Child Scope: A nested scope that can access variables from its parent. 

3. Shadowing: A child scope can define a variable with the same name as one in a parent scope, effectively overriding it locally.

---

## 🧠 Understanding Parent-Child Scope Connections ?



The scopes are linked through a parent-child relationship, forming a chain of nested environments. This structure supports local scoping and allows inner scopes to access variables defined in outer (parent) scopes. 


**Shadowing** occurs when a variable declared in an inner (child) scope has the same name as one declared in an outer (parent) scope. In this case, the inner variable *shadows* or *hides* the outer one within its own scope.

It's essential for isolating variable declarations.

---

## 🧩 How `SymbolTable` Handles Shadowing

The `SymbolTable` supports shadowing naturally by:

- Storing variables by interned integer IDs for fast and consistent access.
- Keeping each scope's variables in a separate map (`map[int]interface{}`).
- Allowing nested scopes through the `parent` pointer.
- Using `Declare` to define variables in the current scope only.
- Using `Resolve` to search from the current scope up the chain.
- Using `Assign` to update the first existing match found up the chain.

---

## ✅ Example: Shadowing in Action

```go
global := NewScope(nil)
global.Declare("x", 1)

child := NewScope(global)
child.Declare("x", 2)

valGlobal, _ := global.Resolve("x") // => 1
valChild, _ := child.Resolve("x")   // => 2
```

---

A `NewScope` will be called when we call `context.New`. If a parent exists then it will be assigned to the `SymbolTable` and provide a new variable scope to the block calling it. When we bubble up, like in the `for` or `if` we just need to reassign back the old `ctx`. 


---

### Extra Info:

1. Introduce a new function `Update` to the context. This is different than `Set`. The reason why we need this so we can easily know if we're assigning a new variable or updating an existing one. 

2. Remove code that loop over the `ctx.data` in `for`  and `function calls` and set `NewContext` in the for loop. We introduce SymbolTable which takes care of passing the parent vars to the block scope.  

3. `evalAssignExpression` uses `Update`, which is a restricted version of the `Set`.


### Will this PR introduce any breaking changes?

In short, no — unless someone has been relying on unintended behaviours in plush. Which wasn't covered in any tests. Specifically, this affects inconsistencies with if statements, where previously variable scoping wasn't strictly enforced. In contrast, for loops already behaved more correctly, as they would throw an error if a variable was accessed outside its intended scope.