### PR TITLE
fix: issue#202

### DIFF
--- a/plush.go
+++ b/plush.go
@@ -44,8 +44,13 @@ func BuffaloRenderer(input string, data map[string]interface{}, helpers map[stri
 	for k, v := range helpers {
 		data[k] = v
 	}
-
-	return t.Exec(NewContextWith(data))
+	gs := NewContextWith(data)
+	defer func() {
+		for k := range gs.data.localInterner.stringToID {
+			data[k] = gs.Value(k)
+		}
+	}()
+	return t.Exec(gs)
 }
 
 // Parse an input string and return a Template, and caches the parsed template.

--- a/plush_test.go
+++ b/plush_test.go
@@ -119,6 +119,16 @@ func Test_BuffaloRenderer(t *testing.T) {
 	r.Equal("GeorgeRingo", s)
 }
 
+func Test_BuffaloRenderer_Data_Persistence(t *testing.T) {
+	r := require.New(t)
+	input := `<%= contentFor("name") { %>MD<% }  %>`
+	data := map[string]interface{}{}
+	s, err := plush.BuffaloRenderer(input, data, map[string]interface{}{})
+	r.NoError(err)
+	r.Empty(s)
+	r.Contains(data, "contentFor:name")
+}
+
 func Test_Helper_Nil_Arg(t *testing.T) {
 	r := require.New(t)
 	input := `<%= foo(nil, "k") %><%= foo(one, "k") %>`


### PR DESCRIPTION
Direct access to the internal map has been deprecated. As a result, the data map passed by Buffalo from one file to another during no longer reflects changes made during exec calls, since it no longer holds references to the underlying keys accessed by other components.