### PR TITLE
feat: silently ignore missing contentOf block

### DIFF
--- a/helpers/content/of.go
+++ b/helpers/content/of.go
@@ -14,6 +14,9 @@ import (
 	<%= contentOf("buttons", {"label": "Click me"}) %>
 */
 func ContentOf(name string, data hctx.Map, help hctx.HelperContext) (template.HTML, error) {
+	if help.Value("contentFor:"+name) == nil {
+		return template.HTML(""), nil
+	}
 	fn, ok := help.Value("contentFor:" + name).(func(data hctx.Map) (template.HTML, error))
 	if !ok {
 		if !help.HasBlock() {


### PR DESCRIPTION
Improves `contentOf` to silently fail when undefined

This PR updates the `contentOf` helper to no longer throw errors on routes where the `contentFor` block is not defined. Instead, it will fail silently, allowing templates to render without requiring a default value.

Currently, to prevent errors, a default block must be defined for every use route, which adds unnecessary overhead and complexity. This change simplifies template development and improves developer experience.

More info:
https://gobuffalo.io/documentation/frontend-layer/helpers/#the-contentfor-and-contentof-helpers