### PR TITLE
Fix #218: Correct nested partial path resolution to prevent AST cache…

### DIFF
--- a/partial_helper.go
+++ b/partial_helper.go
@@ -13,7 +13,7 @@ import (
 // already_in_partial is a unique key used in the helper context to track whether
 // the current execution is already inside a partial template. This helps prevent
 // recursive or redundant partial rendering. The value is constructed with a unique
-// suffix to avoid key collisions with user-defined variables across different program runs.
+// suffix to avoid key collisions with user-defined variables within a single program run.
 var already_in_partial = "__plush_internal_already_in_partial_" + fmt.Sprintf("%d", time.Now().UnixNano()) + "__"
 
 // PartialFeeder is callback function should implemented on application side.

--- a/partial_helper.go
+++ b/partial_helper.go
@@ -5,9 +5,12 @@ import (
 	"html/template"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/gobuffalo/plush/v5/helpers/meta"
 )
+
+var already_in_partial = "__plush_internal_already_in_partial_" + fmt.Sprintf("%d", time.Now().UnixNano()) + "__"
 
 // PartialFeeder is callback function should implemented on application side.
 type PartialFeeder func(string) (string, error)
@@ -21,10 +24,22 @@ func PartialHelper(name string, data map[string]interface{}, help HelperContext)
 	for k, v := range data {
 		help.Set(k, v)
 	}
-	if help.Value(meta.TemplateBaseFileNameKey) != nil && help.Value(meta.TemplateFileKey) != nil && help.Value(meta.TemplateExtensionKey) != nil {
-		consturctFileName := fmt.Sprintf("%s.%s", help.Value(meta.TemplateBaseFileNameKey), help.Value(meta.TemplateExtensionKey))
-		truePath := strings.TrimSuffix(help.Value(meta.TemplateFileKey).(string), consturctFileName)
-		help.Set(meta.TemplateFileKey, filepath.Join(truePath, name))
+	base := help.Value(meta.TemplateBaseFileNameKey)
+	ext := help.Value(meta.TemplateExtensionKey)
+	fileKey := help.Value(meta.TemplateFileKey)
+	if base != nil && fileKey != nil && ext != nil {
+		templateFileKey := fileKey.(string)
+		if help.Value(already_in_partial) != nil {
+			parentPartial := help.Value(already_in_partial).(string)
+			templateFileKey = strings.TrimSuffix(templateFileKey, parentPartial)
+		}
+		baseVal, baseOk := base.(string)
+		extVal, extOk := ext.(string)
+		if baseOk && extOk {
+			consturctFileName := baseVal + "." + extVal
+			templateFileKey = strings.TrimSuffix(templateFileKey, consturctFileName)
+		}
+		help.Set(meta.TemplateFileKey, filepath.Join(templateFileKey, name))
 	} else {
 		help.Set(meta.TemplateFileKey, name)
 	}
@@ -39,7 +54,14 @@ func PartialHelper(name string, data map[string]interface{}, help HelperContext)
 	if part, err = pf(name); err != nil {
 		return "", err
 	}
-
+	if help.Value(already_in_partial) == nil {
+		help.Set(already_in_partial, name)
+		defer help.Set(already_in_partial, nil)
+	} else {
+		extNm := filepath.Ext(name)
+		help.Set(meta.TemplateBaseFileNameKey, strings.TrimSuffix(name, extNm))
+		help.Set(meta.TemplateExtensionKey, strings.TrimPrefix(extNm, "."))
+	}
 	if part, err = Render(part, help.Context); err != nil {
 		return "", err
 	}

--- a/partial_helper.go
+++ b/partial_helper.go
@@ -39,7 +39,7 @@ func PartialHelper(name string, data map[string]interface{}, help HelperContext)
 			consturctFileName := baseVal + "." + extVal
 			templateFileKey = strings.TrimSuffix(templateFileKey, consturctFileName)
 		}
-		help.Set(meta.TemplateFileKey, filepath.Join(templateFileKey, name))
+		help.Set(meta.TemplateFileKey, strings.ReplaceAll(filepath.Join(templateFileKey, name), "\\", "/"))
 	} else {
 		help.Set(meta.TemplateFileKey, name)
 	}

--- a/partial_helper_test.go
+++ b/partial_helper_test.go
@@ -56,7 +56,7 @@ func Test_PartialHelper_NestedPartial_PathHandling(t *testing.T) {
 	partials := map[string]string{
 		"partials/code-1.plush.html": `<%= partial("testing/code-2.plush.html") %>`,
 		"testing/code-2.plush.html":  `<%= partial("testing/code-3.plush.html") %>`,
-		"testing/code-3.plush.html":  `CODE3 PRINT <%= ` + gg + ` %>`,
+		"testing/code-3.plush.html":  `<%= ` + gg + ` %>`,
 	}
 	partialFeeder := func(name string) (string, error) {
 		return partials[name], nil
@@ -70,7 +70,7 @@ func Test_PartialHelper_NestedPartial_PathHandling(t *testing.T) {
 
 	html, err := plush.Render(`<%= partial("partials/code-1.plush.html") %>`, help)
 	r.NoError(err)
-	r.Equal("CODE3 PRINT /fake/templates/testing/code-3.plush.html", html)
+	r.Equal("ast:fake_templates_testing_code-3.plush.html", plush.GenerateASTKey(html))
 }
 func Test_PartialHelper_Invalid_FeederFunction(t *testing.T) {
 	r := require.New(t)

--- a/partial_helper_test.go
+++ b/partial_helper_test.go
@@ -74,6 +74,7 @@ func Test_PartialHelper_NestedPartial_PathHandling(t *testing.T) {
 	normalized := strings.ReplaceAll(html, "\\", "/")
 	r.Equal("CODE3 PRINT /fake/templates/testing/code-3.plush.html", normalized)
 }
+
 func Test_PartialHelper_Invalid_FeederFunction(t *testing.T) {
 	r := require.New(t)
 

--- a/partial_helper_test.go
+++ b/partial_helper_test.go
@@ -2,6 +2,7 @@ package plush_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/gobuffalo/plush/v5"
@@ -56,7 +57,7 @@ func Test_PartialHelper_NestedPartial_PathHandling(t *testing.T) {
 	partials := map[string]string{
 		"partials/code-1.plush.html": `<%= partial("testing/code-2.plush.html") %>`,
 		"testing/code-2.plush.html":  `<%= partial("testing/code-3.plush.html") %>`,
-		"testing/code-3.plush.html":  `<%= ` + gg + ` %>`,
+		"testing/code-3.plush.html":  `CODE3 PRINT <%= ` + gg + ` %>`,
 	}
 	partialFeeder := func(name string) (string, error) {
 		return partials[name], nil
@@ -70,7 +71,8 @@ func Test_PartialHelper_NestedPartial_PathHandling(t *testing.T) {
 
 	html, err := plush.Render(`<%= partial("partials/code-1.plush.html") %>`, help)
 	r.NoError(err)
-	r.Equal("ast:fake_templates_testing_code-3.plush.html", plush.GenerateASTKey(html))
+	normalized := strings.ReplaceAll(html, "\\", "/")
+	r.Equal("CODE3 PRINT /fake/templates/testing/code-3.plush.html", normalized)
 }
 func Test_PartialHelper_Invalid_FeederFunction(t *testing.T) {
 	r := require.New(t)


### PR DESCRIPTION
## Pull Request Overview

This PR fixes nested partial path resolution to prevent AST cache issues when calling partials multiple levels deep. The changes ensure that template file paths are correctly constructed for nested partial calls (e.g., partial A calling partial B calling partial C).

- Adds logic to track when rendering is already inside a partial to correctly compute nested paths
- Updates template metadata (base filename and extension) for nested partial contexts
- Includes a 3-layer nested partial test to verify correct path resolution


| File | Description |
| ---- | ----------- |
| partial_helper.go | Implements nested partial path tracking using an internal flag, adds path trimming logic for parent partials, and updates template metadata for nested contexts |
| partial_helper_test.go | Adds comprehensive test case with 3 layers of nested partials to verify correct path resolution and template file key tracking |

---