### PR TITLE
feat: add compiled VM renderer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.log
 .DS_Store
+Makefile
 doc
 tmp
 pkg

--- a/README.md
+++ b/README.md
@@ -53,6 +53,47 @@ let greet = fn(n) {
 <h1><%= greet(h["name"]) %></h1>
 ```
 
+#### Recursion
+
+Template functions can call themselves by name. Define the function with `let name = fn(...) { ... }`, then call `name(...)` inside the function body. This works in both the interpreter and the compiled VM renderer.
+
+```erb
+<%
+let countdown = fn(x) {
+  if (x == 0) {
+    return "done"
+  }
+  return countdown(x - 1)
+}
+%>
+<%= countdown(3) %>
+```
+
+renders:
+
+```html
+done
+```
+
+Recursive functions can also close over values from the surrounding template scope:
+
+```erb
+<%
+let remaining = 3
+let tick = fn() {
+  if (remaining == 0) {
+    return "done"
+  } else {
+    remaining = remaining - 1
+    return tick()
+  }
+}
+%>
+<%= tick() %>
+```
+
+The important rule is that recursive functions need a stopping condition. Without a base case, the function will keep calling itself until the render fails or a configured render budget stops it. Use `let` and `fn`; Go-style `var a = func() { ... }` is not Plush syntax.
+
 #### Whitespace Trim Output
 
 Use `<%- %>` when you want to render an expression and remove contiguous whitespace immediately around that tag:

--- a/README.md
+++ b/README.md
@@ -53,6 +53,24 @@ let greet = fn(n) {
 <h1><%= greet(h["name"]) %></h1>
 ```
 
+#### Whitespace Trim Output
+
+Use `<%- %>` when you want to render an expression and remove contiguous whitespace immediately around that tag:
+
+```erb
+<pre>
+<%- "Hello" %>
+</pre>
+```
+
+renders:
+
+```html
+<pre>Hello</pre>
+```
+
+Only spaces, tabs, `\r`, and `\n` directly before the opening tag and directly after the closing tag are trimmed. `<%- %>` renders and escapes values the same way as `<%= %>`. Existing `<%= %>` whitespace behavior is unchanged.
+
 #### Full Example:
 
 ```go
@@ -119,6 +137,16 @@ if (true) {
 %>
 ```
 
+Parentheses around `if` and `else if` conditions are optional. The older parenthesized form still works:
+
+```erb
+<%= if name == "mark" { %>
+  hello mark
+<% } else if admin { %>
+  hello admin
+<% } %>
+```
+
 When using `if/else` statements to control output, remember to use the `<%= %>` tag to output the result of the statement:
 
 ```erb
@@ -142,6 +170,17 @@ Complex `if` statements can be built in Plush using "common" operators:
 * `>=` - checks the left expression is greater than or equal to the right expression
 * `&&` - requires both the left **and** right expression to be true
 * `||` - requires either the left **or** right expression to be true
+
+Numeric equality and ordering are safe across common Go numeric types. This lets backend values such as `int32`, `uint32`, `uint64`, `float32`, and `float64` compare against template integer or float literals without type errors:
+
+```erb
+<%= product.Count == 0 %>
+<%= order.Total > 0.0 %>
+<%= uintValue == 3.0 %>
+<%= floatValue == 3 %>
+```
+
+The same mixed numeric comparison rules apply to struct fields, map values, indexed values, helper returns, and method returns.
 
 ### Grouped Expressions
 
@@ -176,6 +215,20 @@ Accessing maps is just like access a JSON object:
 ```erb
 <%= h["key"] %>
 ```
+
+Go maps passed through the render context use the same bracket syntax, including typed maps from backend code:
+
+```go
+ctx.Set("labels", map[string]string{"status": "ready"})
+ctx.Set("counts", map[string]uint32{"active": 7})
+```
+
+```erb
+<%= labels["status"] %>
+<%= counts["active"] %>
+```
+
+When using the compiled VM renderer, static string-key map access is optimized automatically for typed maps such as `map[string]string`, `map[string]uint32`, and nested chains such as `robots["bender"].Name`. The VM caches the access plan and typed map key, not the map value itself.
 
 Using maps as options to functions in Plush is incredibly powerful. See the sections on Functions and Helpers to see more examples.
 
@@ -351,15 +404,556 @@ fmt.Print(s)
 // <p>i can update</p>
 ```
 
-### Special Thanks
+## Partial Rendering With Data Maps
 
-This package absolutely 100% could not have been written without the help of Thorsten Ball's incredible book, [Writing an Interpreter in Go](https://interpreterbook.com).
+Partials can receive a data map as their second argument:
 
-Not only did the book make understanding the process of writing lexers, parsers, and asts, but it also provided the basis for the syntax of Plush itself.
+```erb
+<%= partial("row.plush", {name: product.Name, title: "Robot"}) %>
+```
 
-If you have yet to read Thorsten's book, I can't recommend it enough. Please go and buy it!
+The keys in the map become local values inside the partial. The values are evaluated from the current render context each time the partial runs.
 
----
+Parent template:
+
+```erb
+<%= partial("row.plush", {name: product.Name, title: product.Category.Label}) %>
+<%= product.Name %>
+```
+
+Partial source for `row.plush`:
+
+```erb
+<span><%= title %>: <%= name %></span>
+```
+
+Go setup:
+
+```go
+type Product struct {
+  Name     string
+  Category Category
+}
+
+type Category struct {
+  Label string
+}
+
+ctx := plush.NewContextWith(map[string]interface{}{
+  "product": Product{
+    Name:     "Bender",
+    Category: Category{Label: "Robot"},
+  },
+  "partialFeeder": func(name string) (string, error) {
+    if name == "row.plush" {
+      return `<span><%= title %>: <%= name %></span>`, nil
+    }
+    return "", fmt.Errorf("unknown partial %s", name)
+  },
+})
+
+input := `<%= partial("row.plush", {name: product.Name, title: product.Category.Label}) %>
+<%= product.Name %>`
+
+html, err := plush.Render(input, ctx)
+```
+
+This renders the partial with `name` and `title` available as local values:
+
+```html
+<span>Robot: Bender</span>
+Bender
+```
+
+Partial data is scoped to that partial render. Passing `{name: product.Name}` does not replace `product.Name` or `name` in the parent context after the partial finishes.
+
+You can pass literals, variables, struct fields, indexed values, and nested property chains:
+
+```erb
+<%= partial("user.plush", {name: user.Name, role: "admin"}) %>
+<%= partial("robot.plush", {name: robots[0].Name, echo: robots[0].Name.Echo()}) %>
+<%= partial("row.plush", {label: label(product.Name, prefix)}) %>
+```
+
+Layouts still use the existing Plush partial behavior:
+
+```erb
+<%= partial("card.plush", {name: product.Name, layout: "shell.plush"}) %>
+```
+
+When using the compiled VM renderer, simple static-key partial data maps are optimized automatically. The VM reuses the compiled partial bytecode, prepares a small key/value binding plan, and writes the evaluated data values into a scoped partial context. Data-map values may also be helper calls such as `label(product.Name, prefix)`; the VM compiles those calls into the data binding plan and uses direct no-reflect invokers for common helper signatures. It does not cache request data, struct values, helper results, or rendered partial output.
+
+## Performance Recommendations
+
+Plush now has two render engines:
+
+- The classic interpreter, which remains the default.
+- The compiled VM renderer, available from `github.com/gobuffalo/plush/v5/VM/plush`.
+
+For one-off template strings, the interpreter is still a good default because the VM has to parse and compile before it can run. For templates rendered repeatedly, use the VM path.
+
+### Best Options
+
+| Use case | Recommended path | Why |
+| --- | --- | --- |
+| Hot template string reused many times | `vmplush.Compile` once, then `tmpl.Render(ctx)` | Avoids parse and compile on every render |
+| File-backed app templates | `plush.SetRenderMode(plush.RenderModeVM)` plus `PlushCacheSetup` | Reuses cached VM bytecode by filename |
+| One-off/dynamic template strings | Default `plush.Render` interpreter | Avoids compile overhead when reuse is unlikely |
+| App-specific hot helpers | Optional `vmplush.SetFastHelper` | Skips generic reflection for helper hot paths |
+
+### Compiled Template API
+
+Use this when you can hold a compiled template object:
+
+```go
+import (
+  "log"
+
+  plush "github.com/gobuffalo/plush/v5"
+  vmplush "github.com/gobuffalo/plush/v5/VM/plush"
+)
+
+tmpl, err := vmplush.Compile(`<p><%= greet(name) %></p>`)
+if err != nil {
+  log.Fatal(err)
+}
+
+ctx := plush.NewContextWith(map[string]interface{}{
+  "name": "mark",
+  "greet": func(name string) string {
+    return "Hi " + name
+  },
+})
+
+html, err := tmpl.Render(ctx)
+```
+
+This is the fastest path for repeated renders because the template is parsed and compiled only once.
+
+### VM Render Mode
+
+Use this when an application already calls the root `plush.Render` function and you want to switch that render path to the VM. `SetRenderMode` is global, so most applications call it once during startup:
+
+```go
+import (
+  plush "github.com/gobuffalo/plush/v5"
+  _ "github.com/gobuffalo/plush/v5/VM/plush"
+)
+
+plush.SetRenderMode(plush.RenderModeVM)
+```
+
+The blank import registers the VM renderer. Without it, `RenderModeVM` cannot call the VM path.
+
+### Filename Cache
+
+For file-backed templates, enable a template cache. The interpreter stores parsed ASTs in this cache, and the VM stores compiled bytecode on the same cache entry.
+
+```go
+import (
+  plush "github.com/gobuffalo/plush/v5"
+  _ "github.com/gobuffalo/plush/v5/VM/plush"
+  "github.com/gobuffalo/plush/v5/helpers/meta"
+  "github.com/gobuffalo/plush/v5/templatecache/inmemory"
+)
+
+cache := inmemory.NewMemoryCache()
+plush.PlushCacheSetup(cache)
+plush.SetRenderMode(plush.RenderModeVM)
+
+ctx := plush.NewContext()
+ctx.Set(meta.TemplateFileKey, "templates/items/show.plush.html")
+
+html, err := plush.Render(input, ctx)
+```
+
+The filename must be present in the context for filename-backed cache reuse. On the first render, the VM compiles the template. On later renders of the same filename, it can reuse bytecode.
+
+### Compiled Render Diagnostics
+
+Plush records lightweight render diagnostics on the render context. Use these when comparing interpreter and VM mode, confirming bytecode-cache hits, or understanding why a template did or did not use the VM fast path. The diagnostics API lives in [`render_diagnostics.go`](render_diagnostics.go).
+
+Diagnostics are collected automatically during `plush.Render`; no global flag is required for the basic fields.
+
+The normal request flow is:
+
+1. Set `meta.TemplateFileKey` on the Plush context for file-backed templates.
+2. Render through `plush.Render`, `BuffaloRendererWithContext`, or a compiled VM template.
+3. Read diagnostics after the render with `RenderDiagnosticsFromContext` or `RenderDiagnosticsFromData`.
+4. Log the values or expose selected values as internal-only response headers.
+
+```go
+import (
+  "fmt"
+
+  plush "github.com/gobuffalo/plush/v5"
+  _ "github.com/gobuffalo/plush/v5/VM/plush"
+  "github.com/gobuffalo/plush/v5/helpers/meta"
+)
+
+ctx := plush.NewContext()
+ctx.Set(meta.TemplateFileKey, "templates/report/show.plush.html")
+
+plush.SetRenderMode(plush.RenderModeVM)
+html, err := plush.Render(input, ctx)
+if err != nil {
+  return err
+}
+
+diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+if ok {
+  fmt.Printf(
+    "mode=%s cache=%s fast=%s engine=%.3fms\n",
+    diagnostics.Mode,
+    diagnostics.VMBytecodeCache,
+    diagnostics.FastPath,
+    diagnostics.EngineDurationMilliseconds(),
+  )
+}
+
+_ = html
+```
+
+Useful fields:
+
+| Field | Meaning |
+| --- | --- |
+| `Mode` | Render engine used for the call: `interpreter` or `vm`. |
+| `TemplateFilename` | Clean filename used for filename-backed cache lookup, when one was present in the context. |
+| `VMBytecodeCache` | VM cache state, such as `disabled`, `miss`, `miss-store`, `miss-store-source`, `hit`, `hit-static`, `hit-source`, or `compiled-template`. |
+| `FastPath` | VM execution path, such as `static`, `fast`, `generic`, or `interpreter-fallback`. |
+| `FastReject` / `FastRejectLine` | Reason and source line when the compiler could not build a fast render plan. |
+| `PunchHoleCache` | Punch-hole cache state, such as `disabled`, `hit`, or `miss`. |
+| `EngineDuration` | Time spent inside Plush rendering. Use `EngineDurationMilliseconds()` for reporting. |
+| `FastPlan` | Static complexity counters for the compiled fast plan: bindings, segments, static segments, name segments, property reads, value writes, helper calls, conditionals, loops, loop parts, partials, max depth, helper names, and partial names. |
+| `VMHotspots` | Optional helper and partial call counts/timings when VM hotspot diagnostics are enabled. |
+
+`FastPlan` describes the compiled template shape, not elapsed time. It includes bindings, segments, static segments, name segments, property reads, value writes, helper calls, conditionals, loops, loop parts, partials, max depth, helper names, and partial names.
+
+Hotspot diagnostics are optional. They time VM helper and partial calls, so enable them only when profiling or sampling because they add measurement overhead:
+
+```go
+ctx := plush.NewContext()
+ctx.Set(meta.TemplateFileKey, "templates/report/show.plush.html")
+plush.EnableRenderVMHotspotDiagnostics(ctx)
+
+_, err := plush.Render(input, ctx)
+if err != nil {
+  return err
+}
+
+diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+if ok {
+  fmt.Printf("helper calls: %d\n", diagnostics.VMHotspots.HelperCalls)
+  fmt.Printf("helper time: %.3fms\n", diagnostics.VMHelperDurationMilliseconds())
+  fmt.Printf("partial calls: %d\n", diagnostics.VMHotspots.PartialCalls)
+  fmt.Printf("partial time: %.3fms\n", diagnostics.VMPartialDurationMilliseconds())
+  fmt.Println("helper hotspots:", diagnostics.VMHelperHotspotsHeader())
+  fmt.Println("partial hotspots:", diagnostics.VMPartialHotspotsHeader())
+}
+```
+
+`VMHelperHotspotsHeader()` and `VMPartialHotspotsHeader()` return a compact `name:calls:time_ms` list sorted by total time, for example `formatValue:7:34.660;layout.plush:1:26.120`. The list is meant for diagnostics and A/B testing; it is not a stable application data format.
+
+If your renderer creates a Plush context internally and then copies local values back into a data map, use `RenderDiagnosticsFromData` after rendering. `BuffaloRendererWithContext` is useful when you also need to set `meta.TemplateFileKey` or enable hotspot diagnostics:
+
+```go
+data := map[string]interface{}{
+  "title": "Dashboard",
+}
+
+html, err := plush.BuffaloRendererWithContext(input, data, helpers, func(ctx *plush.Context) {
+  ctx.Set(meta.TemplateFileKey, "templates/report/show.plush.html")
+  plush.EnableRenderVMHotspotDiagnostics(ctx)
+})
+if err != nil {
+  return err
+}
+
+diagnostics, ok := plush.RenderDiagnosticsFromData(data)
+if ok {
+  fmt.Printf("mode=%s cache=%s helper_time=%.3fms\n",
+    diagnostics.Mode,
+    diagnostics.VMBytecodeCache,
+    diagnostics.VMHelperDurationMilliseconds(),
+  )
+}
+
+_ = html
+```
+
+If an HTTP integration wants response headers, read the diagnostics after rendering and before writing the HTTP response, then map the fields explicitly:
+
+```go
+diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+if ok {
+  w.Header().Set("X-Plush-Render-Mode", diagnostics.Mode)
+  w.Header().Set("X-Plush-VM-Bytecode-Cache", diagnostics.VMBytecodeCache)
+  w.Header().Set("X-Plush-Template-Filename", diagnostics.TemplateFilename)
+  w.Header().Set("X-Plush-Fast-Path", diagnostics.FastPath)
+  w.Header().Set("X-Plush-Render-Engine-Time-Ms",
+    fmt.Sprintf("%.3f", diagnostics.EngineDurationMilliseconds()))
+  w.Header().Set("X-Plush-Punch-Hole-Cache", diagnostics.PunchHoleCache)
+  w.Header().Set("X-Plush-Fast-Plan-Bindings",
+    fmt.Sprintf("%d", diagnostics.FastPlan.Bindings))
+  w.Header().Set("X-Plush-Fast-Plan-Segments",
+    fmt.Sprintf("%d", diagnostics.FastPlan.Segments))
+  w.Header().Set("X-Plush-Fast-Plan-Static-Segments",
+    fmt.Sprintf("%d", diagnostics.FastPlan.StaticSegments))
+  w.Header().Set("X-Plush-Fast-Plan-Name-Segments",
+    fmt.Sprintf("%d", diagnostics.FastPlan.NameSegments))
+  w.Header().Set("X-Plush-Fast-Plan-Property-Reads",
+    fmt.Sprintf("%d", diagnostics.FastPlan.PropertyReads))
+  w.Header().Set("X-Plush-Fast-Plan-Value-Writes",
+    fmt.Sprintf("%d", diagnostics.FastPlan.ValueWrites))
+  w.Header().Set("X-Plush-Fast-Plan-Helper-Calls",
+    fmt.Sprintf("%d", diagnostics.FastPlan.HelperCalls))
+  w.Header().Set("X-Plush-Fast-Plan-Conditionals",
+    fmt.Sprintf("%d", diagnostics.FastPlan.Conditionals))
+  w.Header().Set("X-Plush-Fast-Plan-Loops",
+    fmt.Sprintf("%d", diagnostics.FastPlan.Loops))
+  w.Header().Set("X-Plush-Fast-Plan-Loop-Parts",
+    fmt.Sprintf("%d", diagnostics.FastPlan.LoopParts))
+  w.Header().Set("X-Plush-Fast-Plan-Partials",
+    fmt.Sprintf("%d", diagnostics.FastPlan.Partials))
+  w.Header().Set("X-Plush-Fast-Plan-Max-Depth",
+    fmt.Sprintf("%d", diagnostics.FastPlan.MaxDepth))
+  w.Header().Set("X-Plush-Fast-Plan-Helper-Names",
+    diagnostics.FastPlanHelperNamesHeader())
+  w.Header().Set("X-Plush-Fast-Plan-Partial-Names",
+    diagnostics.FastPlanPartialNamesHeader())
+  w.Header().Set("X-Plush-VM-Helper-Calls",
+    fmt.Sprintf("%d", diagnostics.VMHotspots.HelperCalls))
+  w.Header().Set("X-Plush-VM-Helper-Time-Ms",
+    fmt.Sprintf("%.3f", diagnostics.VMHelperDurationMilliseconds()))
+  w.Header().Set("X-Plush-VM-Partial-Calls",
+    fmt.Sprintf("%d", diagnostics.VMHotspots.PartialCalls))
+  w.Header().Set("X-Plush-VM-Partial-Time-Ms",
+    fmt.Sprintf("%.3f", diagnostics.VMPartialDurationMilliseconds()))
+  w.Header().Set("X-Plush-VM-Helper-Hotspots",
+    diagnostics.VMHelperHotspotsHeader())
+  w.Header().Set("X-Plush-VM-Partial-Hotspots",
+    diagnostics.VMPartialHotspotsHeader())
+  w.Header().Set("Server-Timing",
+    fmt.Sprintf(
+      "plush;dur=%.3f, plush_helpers;dur=%.3f, plush_partials;dur=%.3f",
+      diagnostics.EngineDurationMilliseconds(),
+      diagnostics.VMHelperDurationMilliseconds(),
+      diagnostics.VMPartialDurationMilliseconds(),
+    ))
+}
+```
+
+These `X-Plush-*` and `Server-Timing` headers are not emitted by Plush automatically. Plush records the diagnostics; the HTTP application decides which values to expose. In production, put these headers behind a debug, benchmark, or internal-only flag because filenames, helper names, and partial names may reveal application structure.
+
+Common header meanings:
+
+| Header | Meaning |
+| --- | --- |
+| `X-Plush-Render-Mode` | `interpreter` or `vm`, showing which renderer handled this request. |
+| `X-Plush-VM-Bytecode-Cache` | VM cache status. Warm file-backed templates should usually move from `miss-store` on first render to `hit`, `hit-static`, or `hit-source` on later renders. |
+| `X-Plush-Template-Filename` | Filename used as the cache key when `meta.TemplateFileKey` was set on the context. |
+| `X-Plush-Render-Engine-Time-Ms` | Time spent inside Plush rendering only, in milliseconds. Use this instead of total request time when comparing interpreter vs VM. |
+| `X-Plush-Fast-Path` | VM execution path: `static`, `fast`, `generic`, or `interpreter-fallback`. The best steady-state VM path is usually `fast`; `interpreter-fallback` means the VM intentionally delegated unsupported syntax to the old interpreter. |
+| `X-Plush-Punch-Hole-Cache` | Punch-hole cache status for templates that mix static HTML with embedded Plush code. |
+| `X-Plush-Fast-Plan-*` | Static counters captured from the compiled fast plan. These describe template complexity, not elapsed time. |
+| `X-Plush-Fast-Plan-Helper-Names` | Helper names the fast plan found while compiling. Useful for spotting expensive helper-heavy templates. |
+| `X-Plush-Fast-Plan-Partial-Names` | Partial names the fast plan found while compiling. Useful for spotting partial-heavy templates. |
+| `X-Plush-VM-Helper-*` | Optional helper-call count and timing fields. They are zero unless `EnableRenderVMHotspotDiagnostics` was enabled for that context. |
+| `X-Plush-VM-Partial-*` | Optional partial-call count and timing fields. They are zero unless `EnableRenderVMHotspotDiagnostics` was enabled for that context. |
+| `Server-Timing` | Browser/devtools-friendly timing summary. The example maps Plush engine time plus optional VM helper and partial hotspot time into server timing metrics. |
+
+For fair VM measurements, warm file-backed templates until `VMBytecodeCache` reports `hit` and `FastPath` reports `fast`. A first render may report `miss-store` because the VM is parsing, compiling, storing bytecode, and then rendering. Fast-plan counters describe template shape, not elapsed time; use `EngineDurationMilliseconds`, `VMHelperDurationMilliseconds`, and `VMPartialDurationMilliseconds` for timings.
+
+### Measured Gains
+
+Latest local benchmark checkpoint, VM bytecode cache compared with interpreter AST cache:
+
+| Benchmark set | Time | B/op | allocs/op |
+| --- | ---: | ---: | ---: |
+| Full render-mode matrix, 26 scenarios | 61.2% faster | 59.6% less | 71.8% fewer |
+| Realistic mixed template | 59.6% faster | 73.3% less | 81.3% fewer |
+| Simple conditional access output | 45.0% faster | 32.8% less | 65.6% fewer |
+| Nested access/simple access output | 55.4% faster | 56.7% less | 61.8% fewer |
+| Partial simple access bodies | 52.5% faster | 49.6% less | 70.6% fewer |
+| Partial rendering with data maps | 53.6% faster | 55.6% less | 68.9% fewer |
+| Partial data maps with helper-call values | 63.4% faster | 53.5% less | 68.0% fewer |
+| Typed map access | 35.6% faster | 24.8% less | 56.8% fewer |
+| Loop helper direct string calls | 69.6% faster | 50.6% less | 74.5% fewer |
+| Loop helper direct int calls | 58.9% faster | 51.1% less | 70.3% fewer |
+| Mixed numeric operator output | 46.4% faster | 28.3% less | 61.5% fewer |
+
+The full matrix includes static output, variable interpolation, helpers, loops, struct fields, nested access, conditionals, regex, partials, whitespace trim, and mixed numeric comparisons. These numbers come from the latest local post-profile checkpoint using medians from `count=3` / `500ms`. The exact percentage will move with hardware and template shape, but repeated cached VM renders should usually be materially faster than interpreter AST-cache renders.
+
+This checkpoint includes the partial no-overlay fast path, stack-backed partial data locals, helper-call partial data value plans, cleaner cache-key/punch-hole lookup, and lower-allocation request context construction. Some percentages moved because those context changes speed up the interpreter too; the VM partial rows still improved sharply in absolute `ns/op`, `B/op`, and `allocs/op`.
+
+Important caveat: one-shot VM rendering is not the headline number because it includes parse and compile work. Use cached VM render or compiled-template reuse for the real compiled-performance path.
+
+Run the benchmark matrix locally:
+
+```sh
+go test ./VM/vm -run '^$' -bench '^BenchmarkRenderModeMatrix/.*/(interpreter_ast_cache|vm_bytecode_cache)$' -benchmem -count=3 -benchtime=500ms
+```
+
+### Automatic VM Fast Paths
+
+Most VM optimizations need no template changes. The VM automatically specializes common Plush shapes:
+
+- static output and mixed static/name templates
+- simple mixed templates that combine static text, names, property/access chains, and rendered infix booleans
+- repeated name lookups
+- safe mixed numeric comparisons such as `uint32 == 0` and `float32 == 3`
+- struct fields, nested property chains, indexed property chains, and no-arg method tails
+- typed Go map access with static string keys, such as `labels["status"]` and `robots["bender"].Name`
+- loops over strings, slices, structs, and pointers to structs
+- simple top-level conditionals whose branches contain static/name/property/access/infix output
+- conditionals and infix conditions inside loops
+- direct helper calls for common helper signatures
+- direct scalar helper calls for common string, int, uint32, bool, and float64 argument shapes
+- regex match expressions
+- partials with no data, including direct linked rendering when the partial body is simple and does not need partial metadata
+- partials with simple static-key data maps, such as `partial("row", {name: product.Name})`; the VM prepares the keys and value lookup plan, then reads fresh values each render
+- partial data maps with helper-call values, such as `partial("row", {label: label(product.Name, prefix)})`; the VM compiles the call arguments and uses direct value invokers for common helper signatures
+- linked partial bodies that contain simple property/access/infix output, such as `<%= robot.Name %>` or `<%= labels["status"] %>`
+- clean filename cache keys and punch-hole filename checks for file-backed cached renders
+
+The VM caches plans and bytecode, not request values. It does not cache the current product, helper return values, rendered HTML, partial output, or branch decisions.
+
+Helpers whose Go function signature uses an application-defined scalar parameter, such as `func(ProductName, string) string`, still use the safe reflective call path unless an app registers a custom fast helper. Go does not safely convert `func(ProductName, string) string` into `func(string, string) string` even when `ProductName` is backed by `string`.
+
+### Advanced Fast Helpers
+
+The VM already specializes common helper shapes at runtime. For example, this normal helper needs no extra setup:
+
+```go
+ctx.Set("greet", func(name string) string {
+  return "Hi " + name
+})
+```
+
+```erb
+<%= greet(name) %>
+```
+
+For app-specific hot helpers that use broad types like `interface{}` or complex domain values, you can optionally register a custom fast helper. Keep the normal helper in the context for correctness and fallback.
+
+```go
+ctx.Set("money", func(value interface{}) string {
+  return formatMoney(value)
+})
+
+vmplush.SetFastHelper(ctx, "money", func(w vmplush.FastWriter, args vmplush.FastArgs) error {
+  amount, ok := args.Float64(0)
+  if !ok {
+    return vmplush.ErrFastUnsupported // fall back to the normal helper
+  }
+
+  w.WriteEscapedString(formatMoneyFloat(amount))
+  return nil
+})
+```
+
+The template stays normal:
+
+```erb
+<%= money(amount) %>
+```
+
+Fast helpers should only optimize the hot path. They must not cache request values or rendered output. Use `WriteEscapedString` for normal text and `WriteHTML` only for trusted `template.HTML`. If a fast helper cannot safely handle the current arguments, return `vmplush.ErrFastUnsupported` so the VM can call the regular helper.
+
+For generated gRPC/protobuf objects, use `args.Raw(i)` and type assert to the generated message type:
+
+```go
+ctx.Set("productName", func(value interface{}) string {
+  product, ok := value.(*pb.Product)
+  if !ok || product == nil {
+    return ""
+  }
+  return product.GetName()
+})
+
+vmplush.SetFastHelper(ctx, "productName", func(w vmplush.FastWriter, args vmplush.FastArgs) error {
+  raw, ok := args.Raw(0)
+  if !ok {
+    return vmplush.ErrFastUnsupported
+  }
+
+  product, ok := raw.(*pb.Product)
+  if !ok || product == nil {
+    return vmplush.ErrFastUnsupported
+  }
+
+  w.WriteEscapedString(product.GetName())
+  return nil
+})
+```
+
+The template does not change:
+
+```erb
+<%= productName(product) %>
+```
+
+This avoids reflection and generic property access for the hot helper body while still keeping the normal helper as a safe fallback.
+
+For nested Go structs, the pattern is the same. Register a normal helper first:
+
+```go
+type Product struct {
+  Name     string
+  Category Category
+}
+
+type Category struct {
+  Label string
+}
+
+ctx.Set("productLabel", func(value interface{}) string {
+  product, ok := value.(Product)
+  if !ok {
+    return ""
+  }
+  return product.Category.Label + ":" + product.Name
+})
+```
+
+Then add an optional fast helper for the hot path:
+
+```go
+vmplush.SetFastHelper(ctx, "productLabel", func(w vmplush.FastWriter, args vmplush.FastArgs) error {
+  raw, ok := args.Raw(0)
+  if !ok {
+    return vmplush.ErrFastUnsupported
+  }
+
+  product, ok := raw.(Product)
+  if !ok {
+    return vmplush.ErrFastUnsupported
+  }
+
+  w.WriteEscapedString(product.Category.Label + ":" + product.Name)
+  return nil
+})
+```
+
+If the context stores pointers, assert the pointer type and nil-check it:
+
+```go
+product, ok := raw.(*Product)
+if !ok || product == nil {
+  return vmplush.ErrFastUnsupported
+}
+
+w.WriteEscapedString(product.Category.Label + ":" + product.Name)
+```
+
+Normal templates can still use regular Plush access without a fast helper:
+
+```erb
+<%= product.Category.Label %>
+```
+
+Partial calls with simple data maps are also optimized automatically by the VM. See [Partial Rendering With Data Maps](#partial-rendering-with-data-maps) for syntax and behavior.
 
 ## Render Budget
 
@@ -456,3 +1050,15 @@ for name, units := range s.ByFunction {
 | `Assignments` | Units from variable assignments |
 | `ObjectTraversals` | Units from dot-notation traversal |
 | `ByFunction` | Per-function breakdown (map of name → units) |
+
+
+
+### Special Thanks
+
+This package absolutely, 100%, could not have been written without the help of Thorsten Ball’s incredible books, [Writing an Interpreter in Go](https://interpreterbook.com) and [Writing a Compiler in Go](https://compilerbook.com/).
+
+Not only did the book make understanding the process of writing lexers, parsers, and asts, compilers, vm but it also provided the basis for the syntax of Plush itself.
+
+If you have yet to read Thorsten's book, I can't recommend it enough. Please go and buy it!
+
+---

--- a/VM/code/code.go
+++ b/VM/code/code.go
@@ -1,0 +1,287 @@
+package code
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"strings"
+)
+
+type Instructions []byte
+
+func (ins Instructions) String() string {
+	var out bytes.Buffer
+
+	i := 0
+	for i < len(ins) {
+		def, err := Lookup(ins[i])
+		if err != nil {
+			fmt.Fprintf(&out, "ERROR: %s\n", err)
+			i++
+			continue
+		}
+
+		operands, read := ReadOperands(def, ins[i+1:])
+
+		fmt.Fprintf(&out, "%04d %s\n", i, ins.fmtInstruction(def, operands))
+
+		i += 1 + read
+	}
+
+	return out.String()
+}
+
+func (ins Instructions) fmtInstruction(def *Definition, operands []int) string {
+	if len(operands) != len(def.OperandWidths) {
+		return fmt.Sprintf("ERROR: operand len %d does not match defined %d\n",
+			len(operands), len(def.OperandWidths))
+	}
+
+	if len(operands) == 0 {
+		return def.Name
+	}
+
+	parts := make([]string, len(operands))
+	for i, operand := range operands {
+		parts[i] = fmt.Sprintf("%d", operand)
+	}
+
+	return fmt.Sprintf("%s %s", def.Name, strings.Join(parts, " "))
+}
+
+type Opcode byte
+
+const (
+	OpConstant Opcode = iota
+
+	OpAdd
+
+	OpPop
+
+	OpSub
+	OpMul
+	OpDiv
+
+	OpTrue
+	OpFalse
+
+	OpEqual
+	OpNotEqual
+	OpGreaterThan
+
+	OpMinus
+	OpBang
+
+	OpJumpNotTruthy
+	OpJump
+
+	OpNull
+
+	OpGetGlobal
+	OpSetGlobal
+
+	OpArray
+	OpHash
+	OpIndex
+
+	OpCall
+
+	OpReturnValue
+	OpReturn
+
+	OpGetLocal
+	OpSetLocal
+
+	OpGetBuiltin
+
+	OpClosure
+
+	OpGetFree
+
+	OpCurrentClosure
+
+	// Plush extensions. These are appended after the core VM opcodes so their
+	// numeric values remain stable.
+	OpGreaterEqual
+	OpMatches
+	OpAnd
+	OpOr
+	OpGetName
+	OpSetName
+	OpAssignName
+	OpGetProperty
+	OpSetIndex
+	OpWrite
+	OpFor
+	OpBreak
+	OpContinue
+	OpCallBlock
+	OpRenderTemplate
+	OpGetNameOrNull
+	OpHole
+
+	// Direct write opcodes are Plush fast paths. They fuse common
+	// "load or call, then OpWrite" instruction pairs so rendering can write to
+	// the frame output without unnecessary stack traffic. See VM/FAST_PATHS.md.
+	OpWriteConstant
+	OpWriteName
+	OpWriteNameOrNull
+	OpWriteLocal
+	OpWriteGlobal
+	OpWriteString
+	OpWriteHTML
+	OpWriteLocalProperty
+	OpWriteGlobalProperty
+	OpWriteNameProperty
+	OpWriteCall
+	OpWriteNameCall
+)
+
+type Definition struct {
+	Name          string
+	OperandWidths []int
+}
+
+var definitions = map[Opcode]*Definition{
+	OpConstant: {"OpConstant", []int{2}},
+
+	OpAdd: {"OpAdd", []int{}},
+
+	OpPop: {"OpPop", []int{}},
+
+	OpSub: {"OpSub", []int{}},
+	OpMul: {"OpMul", []int{}},
+	OpDiv: {"OpDiv", []int{}},
+
+	OpTrue:  {"OpTrue", []int{}},
+	OpFalse: {"OpFalse", []int{}},
+
+	OpEqual:       {"OpEqual", []int{}},
+	OpNotEqual:    {"OpNotEqual", []int{}},
+	OpGreaterThan: {"OpGreaterThan", []int{}},
+
+	OpMinus: {"OpMinus", []int{}},
+	OpBang:  {"OpBang", []int{}},
+
+	OpJumpNotTruthy: {"OpJumpNotTruthy", []int{2}},
+	OpJump:          {"OpJump", []int{2}},
+
+	OpNull: {"OpNull", []int{}},
+
+	OpGetGlobal: {"OpGetGlobal", []int{2}},
+	OpSetGlobal: {"OpSetGlobal", []int{2}},
+
+	OpArray: {"OpArray", []int{2}},
+	OpHash:  {"OpHash", []int{2}},
+	OpIndex: {"OpIndex", []int{}},
+
+	OpCall: {"OpCall", []int{1}},
+
+	OpReturnValue: {"OpReturnValue", []int{}},
+	OpReturn:      {"OpReturn", []int{}},
+
+	OpGetLocal: {"OpGetLocal", []int{1}},
+	OpSetLocal: {"OpSetLocal", []int{1}},
+
+	OpGetBuiltin: {"OpGetBuiltin", []int{1}},
+
+	OpClosure: {"OpClosure", []int{2, 1}},
+
+	OpGetFree: {"OpGetFree", []int{1}},
+
+	OpCurrentClosure: {"OpCurrentClosure", []int{}},
+
+	OpGreaterEqual:        {"OpGreaterEqual", []int{}},
+	OpMatches:             {"OpMatches", []int{}},
+	OpAnd:                 {"OpAnd", []int{}},
+	OpOr:                  {"OpOr", []int{}},
+	OpGetName:             {"OpGetName", []int{2}},
+	OpSetName:             {"OpSetName", []int{2}},
+	OpAssignName:          {"OpAssignName", []int{2}},
+	OpGetProperty:         {"OpGetProperty", []int{2}},
+	OpSetIndex:            {"OpSetIndex", []int{}},
+	OpWrite:               {"OpWrite", []int{}},
+	OpFor:                 {"OpFor", []int{2, 2, 2, 1}},
+	OpBreak:               {"OpBreak", []int{}},
+	OpContinue:            {"OpContinue", []int{}},
+	OpCallBlock:           {"OpCallBlock", []int{1, 2, 1}},
+	OpRenderTemplate:      {"OpRenderTemplate", []int{}},
+	OpGetNameOrNull:       {"OpGetNameOrNull", []int{2}},
+	OpHole:                {"OpHole", []int{2}},
+	OpWriteConstant:       {"OpWriteConstant", []int{2}},
+	OpWriteName:           {"OpWriteName", []int{2}},
+	OpWriteNameOrNull:     {"OpWriteNameOrNull", []int{2}},
+	OpWriteLocal:          {"OpWriteLocal", []int{1}},
+	OpWriteGlobal:         {"OpWriteGlobal", []int{2}},
+	OpWriteString:         {"OpWriteString", []int{2}},
+	OpWriteHTML:           {"OpWriteHTML", []int{2}},
+	OpWriteLocalProperty:  {"OpWriteLocalProperty", []int{1, 2}},
+	OpWriteGlobalProperty: {"OpWriteGlobalProperty", []int{2, 2}},
+	OpWriteNameProperty:   {"OpWriteNameProperty", []int{2, 2}},
+	OpWriteCall:           {"OpWriteCall", []int{1}},
+	OpWriteNameCall:       {"OpWriteNameCall", []int{2, 1}},
+}
+
+func Lookup(op byte) (*Definition, error) {
+	def, ok := definitions[Opcode(op)]
+	if !ok {
+		return nil, fmt.Errorf("opcode %d undefined", op)
+	}
+
+	return def, nil
+}
+
+func Make(op Opcode, operands ...int) []byte {
+	def, ok := definitions[op]
+	if !ok {
+		return []byte{}
+	}
+
+	instructionLen := 1
+	for _, width := range def.OperandWidths {
+		instructionLen += width
+	}
+
+	instruction := make([]byte, instructionLen)
+	instruction[0] = byte(op)
+
+	offset := 1
+	for i, operand := range operands {
+		width := def.OperandWidths[i]
+		switch width {
+		case 2:
+			binary.BigEndian.PutUint16(instruction[offset:], uint16(operand))
+		case 1:
+			instruction[offset] = byte(operand)
+		}
+		offset += width
+	}
+
+	return instruction
+}
+
+func ReadOperands(def *Definition, ins Instructions) ([]int, int) {
+	operands := make([]int, len(def.OperandWidths))
+	offset := 0
+
+	for i, width := range def.OperandWidths {
+		switch width {
+		case 2:
+			operands[i] = int(ReadUint16(ins[offset:]))
+		case 1:
+			operands[i] = int(ReadUint8(ins[offset:]))
+		}
+
+		offset += width
+	}
+
+	return operands, offset
+}
+
+func ReadUint8(ins Instructions) uint8 {
+	return uint8(ins[0])
+}
+
+func ReadUint16(ins Instructions) uint16 {
+	return binary.BigEndian.Uint16(ins)
+}

--- a/VM/code/code_test.go
+++ b/VM/code/code_test.go
@@ -1,0 +1,87 @@
+package code
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Make(t *testing.T) {
+	tests := []struct {
+		op       Opcode
+		operands []int
+		expected []byte
+	}{
+		{OpConstant, []int{65534}, []byte{byte(OpConstant), 255, 254}},
+		{OpAdd, []int{}, []byte{byte(OpAdd)}},
+		{OpGetLocal, []int{255}, []byte{byte(OpGetLocal), 255}},
+		{OpClosure, []int{65534, 255}, []byte{byte(OpClosure), 255, 254, 255}},
+		{OpFor, []int{65534, 65533, 65532, 255}, []byte{byte(OpFor), 255, 254, 255, 253, 255, 252, 255}},
+		{OpCallBlock, []int{7, 65534, 1}, []byte{byte(OpCallBlock), 7, 255, 254, 1}},
+		{OpWriteNameCall, []int{65534, 2}, []byte{byte(OpWriteNameCall), 255, 254, 2}},
+	}
+
+	for _, tt := range tests {
+		instruction := Make(tt.op, tt.operands...)
+		require.Equal(t, tt.expected, []byte(instruction))
+	}
+}
+
+func Test_Instructions_String(t *testing.T) {
+	instructions := []Instructions{
+		Make(OpAdd),
+		Make(OpGetLocal, 1),
+		Make(OpConstant, 2),
+		Make(OpConstant, 65535),
+		Make(OpClosure, 65535, 255),
+		Make(OpFor, 10, 20, 30, 1),
+	}
+
+	concatted := Instructions{}
+	for _, ins := range instructions {
+		concatted = append(concatted, ins...)
+	}
+
+	expected := `0000 OpAdd
+0001 OpGetLocal 1
+0003 OpConstant 2
+0006 OpConstant 65535
+0009 OpClosure 65535 255
+0013 OpFor 10 20 30 1
+`
+
+	require.Equal(t, expected, concatted.String())
+}
+
+func Test_Read_Operands(t *testing.T) {
+	tests := []struct {
+		op            Opcode
+		operands      []int
+		bytesRead     int
+		expectedWidth int
+	}{
+		{OpConstant, []int{65535}, 2, 2},
+		{OpGetLocal, []int{255}, 1, 1},
+		{OpClosure, []int{65535, 255}, 3, 3},
+		{OpFor, []int{1, 2, 3, 4}, 7, 7},
+		{OpCallBlock, []int{1, 65535, 2}, 4, 4},
+		{OpWriteNameCall, []int{65535, 3}, 3, 3},
+	}
+
+	for _, tt := range tests {
+		instruction := Make(tt.op, tt.operands...)
+		def, err := Lookup(byte(tt.op))
+		require.NoError(t, err)
+
+		operandsRead, n := ReadOperands(def, instruction[1:])
+		require.Equal(t, tt.bytesRead, n)
+		require.Equal(t, tt.expectedWidth, n)
+		require.Equal(t, tt.operands, operandsRead)
+	}
+}
+
+func Test_Lookup_Unknown_Opcode(t *testing.T) {
+	_, err := Lookup(255)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "opcode 255 undefined")
+}

--- a/VM/compiler/compiler.go
+++ b/VM/compiler/compiler.go
@@ -1,0 +1,1372 @@
+package compiler
+
+import (
+	"fmt"
+	"html/template"
+	"sort"
+	"strings"
+
+	"github.com/gobuffalo/plush/v5/VM/code"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/gobuffalo/plush/v5/ast"
+	"github.com/gobuffalo/plush/v5/parser"
+	"github.com/gobuffalo/plush/v5/token"
+)
+
+type Compiler struct {
+	constants []object.Object
+
+	symbolTable *SymbolTable
+	globalNames map[int]string
+	program     *ast.Program
+
+	scopes     []CompilationScope
+	scopeIndex int
+
+	softNames int
+	line      int
+
+	suppressOutput             int
+	topLevelBlockReturnAsValue int
+}
+
+const anonymousCallName = "<anonymous>"
+
+func New() *Compiler {
+	mainScope := CompilationScope{
+		instructions:        code.Instructions{},
+		callNames:           map[int]string{},
+		localNames:          map[int]string{},
+		lineNumbers:         map[int]int{},
+		properties:          map[int]object.PropertyAccess{},
+		lastInstruction:     EmittedInstruction{},
+		previousInstruction: EmittedInstruction{},
+	}
+
+	symbolTable := NewSymbolTable()
+	for i, v := range object.Builtins {
+		symbolTable.DefineBuiltin(i, v.Name)
+	}
+
+	return &Compiler{
+		constants:   []object.Object{},
+		symbolTable: symbolTable,
+		globalNames: map[int]string{},
+		scopes:      []CompilationScope{mainScope},
+		scopeIndex:  0,
+	}
+}
+
+func NewWithState(s *SymbolTable, constants []object.Object) *Compiler {
+	compiler := New()
+	compiler.symbolTable = s
+	compiler.constants = constants
+	return compiler
+}
+
+// ParseScript parses a plain Plush expression script by wrapping it in script
+// tags before handing it to Plush's parser.
+func ParseScript(input string) (*ast.Program, error) {
+	return parser.Parse("<% " + input + " %>")
+}
+
+func (c *Compiler) Compile(node interface{}) error {
+	switch node := node.(type) {
+	case *ast.Program:
+		if c.scopeIndex == 0 {
+			c.program = node
+		}
+		for _, s := range node.Statements {
+			if err := c.compileStatement(s); err != nil {
+				return err
+			}
+		}
+
+	case *ast.ExpressionStatement:
+		return c.compileExpressionStatement(node)
+
+	case *ast.BlockStatement:
+		for _, s := range node.Statements {
+			if err := c.compileStatement(s); err != nil {
+				return err
+			}
+		}
+
+	case *ast.HoleStatement:
+		c.emit(code.OpHole, c.addStringConstant("<%= "+node.String()+" %>"))
+
+	case *ast.LetStatement:
+		return c.compileLetStatement(node)
+
+	case *ast.ReturnStatement:
+		writeReturn := node.Type == token.E_START && c.suppressOutput == 0
+		if writeReturn {
+			handled, err := c.compileWriteExpression(node.ReturnValue)
+			if handled || err != nil {
+				return err
+			}
+		}
+		if err := c.Compile(node.ReturnValue); err != nil {
+			return err
+		}
+		if writeReturn {
+			c.emit(code.OpWrite)
+		} else if node.Type == token.RETURN && c.scopeIndex > 0 {
+			c.emit(code.OpReturnValue)
+		} else if node.Type == token.RETURN && c.topLevelBlockReturnAsValue == 0 && c.suppressOutput == 0 {
+			c.emit(code.OpReturnValue)
+		} else {
+			c.emit(code.OpPop)
+		}
+
+	case *ast.InfixExpression:
+		return c.compileInfixExpression(node)
+
+	case *ast.IntegerLiteral:
+		c.emitConstant(&object.Integer{Value: int64(node.Value)})
+
+	case *ast.FloatLiteral:
+		c.emitConstant(&object.Float{Value: node.Value})
+
+	case *ast.Boolean:
+		if node.Value {
+			c.emit(code.OpTrue)
+		} else {
+			c.emit(code.OpFalse)
+		}
+
+	case *ast.PrefixExpression:
+		switch node.Operator {
+		case "!":
+			if err := c.compileSoft(node.Right); err != nil {
+				return err
+			}
+			c.emit(code.OpBang)
+		case "-":
+			if err := c.Compile(node.Right); err != nil {
+				return err
+			}
+			c.emit(code.OpMinus)
+		default:
+			return fmt.Errorf("unknown operator %s", node.Operator)
+		}
+
+	case *ast.IfExpression:
+		return c.compileIfExpression(node)
+
+	case *ast.Identifier:
+		return c.compileIdentifier(node)
+
+	case *ast.StringLiteral:
+		c.emitConstant(&object.String{Value: node.Value})
+
+	case *ast.HTMLLiteral:
+		c.emitConstant(&object.Native{Value: template.HTML(node.Value)})
+
+	case *ast.ArrayLiteral:
+		for _, el := range node.Elements {
+			if err := c.Compile(el); err != nil {
+				return err
+			}
+		}
+		c.emit(code.OpArray, len(node.Elements))
+
+	case *ast.HashLiteral:
+		return c.compileHashLiteral(node)
+
+	case *ast.IndexExpression:
+		return c.compileIndexExpression(node)
+
+	case *ast.AssignExpression:
+		return c.compileAssignExpression(node)
+
+	case *ast.FunctionLiteral:
+		return c.compileFunctionLiteral(node, "")
+
+	case *ast.CallExpression:
+		return c.compileCallExpression(node)
+
+	case *ast.ForExpression:
+		return c.compileForExpression(node)
+
+	case *ast.BreakExpression:
+		c.emit(code.OpBreak)
+
+	case *ast.ContinueExpression:
+		c.emit(code.OpContinue)
+
+	case nil:
+		c.emit(code.OpNull)
+	}
+
+	return nil
+}
+
+func (c *Compiler) compileStatement(stmt ast.Statement) error {
+	previousLine := c.line
+	if stmt != nil && stmt.T().LineNumber > 0 {
+		c.line = stmt.T().LineNumber
+	}
+	err := c.Compile(stmt)
+	c.line = previousLine
+	return err
+}
+
+func (c *Compiler) compileExpressionStatement(node *ast.ExpressionStatement) error {
+	if html, ok := node.Expression.(*ast.HTMLLiteral); ok {
+		if c.suppressOutput > 0 {
+			return nil
+		}
+		c.emitWriteHTML(html.Value)
+		return nil
+	}
+
+	switch node.Expression.(type) {
+	case *ast.BreakExpression, *ast.ContinueExpression:
+		return c.Compile(node.Expression)
+	}
+
+	suppressOutput := true
+	if ifExpression, ok := node.Expression.(*ast.IfExpression); ok && ifExpressionHasLoopControl(ifExpression) {
+		suppressOutput = false
+	}
+
+	if suppressOutput {
+		c.suppressOutput++
+	}
+	err := c.Compile(node.Expression)
+	if suppressOutput {
+		c.suppressOutput--
+	}
+	if err != nil {
+		return err
+	}
+	c.emit(code.OpPop)
+	return nil
+}
+
+func (c *Compiler) compileWriteExpression(expr ast.Expression) (bool, error) {
+	switch node := expr.(type) {
+	case *ast.Identifier:
+		if node.Callee != nil {
+			return c.compileWriteIdentifierProperty(node)
+		}
+		if node.Value == "nil" {
+			return true, nil
+		}
+		symbol, ok := c.symbolTable.Resolve(node.Value)
+		if !ok {
+			c.emit(code.OpWriteName, c.addStringConstant(node.Value))
+			return true, nil
+		}
+		switch symbol.Scope {
+		case GlobalScope:
+			c.emit(code.OpWriteGlobal, symbol.Index)
+			return true, nil
+		case LocalScope:
+			c.emit(code.OpWriteLocal, symbol.Index)
+			return true, nil
+		}
+	case *ast.StringLiteral:
+		c.emitWriteString(node.Value)
+		return true, nil
+	case *ast.HTMLLiteral:
+		c.emitWriteHTML(node.Value)
+		return true, nil
+	case *ast.CallExpression:
+		return c.compileWriteNameCallExpression(node)
+	}
+	return false, nil
+}
+
+func ifExpressionHasLoopControl(expr *ast.IfExpression) bool {
+	if expr == nil {
+		return false
+	}
+	if blockHasLoopControl(expr.Block) || blockHasLoopControl(expr.ElseBlock) {
+		return true
+	}
+	for _, elseIf := range expr.ElseIf {
+		if blockHasLoopControl(elseIf.Block) {
+			return true
+		}
+	}
+	return false
+}
+
+func blockHasLoopControl(block *ast.BlockStatement) bool {
+	if block == nil {
+		return false
+	}
+	for _, stmt := range block.Statements {
+		if statementHasLoopControl(stmt) {
+			return true
+		}
+	}
+	return false
+}
+
+func statementHasLoopControl(stmt ast.Statement) bool {
+	exprStmt, ok := stmt.(*ast.ExpressionStatement)
+	if !ok {
+		return false
+	}
+	switch expr := exprStmt.Expression.(type) {
+	case *ast.BreakExpression, *ast.ContinueExpression:
+		return true
+	case *ast.IfExpression:
+		return ifExpressionHasLoopControl(expr)
+	default:
+		return false
+	}
+}
+
+func (c *Compiler) compileWriteNameCallExpression(node *ast.CallExpression) (bool, error) {
+	if node == nil || node.Block != nil || node.ChainCallee != nil {
+		return false, nil
+	}
+	ident, ok := node.Function.(*ast.Identifier)
+	if !ok || ident.Callee != nil {
+		return false, nil
+	}
+	if _, ok := c.symbolTable.Resolve(ident.Value); ok {
+		return false, nil
+	}
+
+	for _, arg := range node.Arguments {
+		if err := c.compileHard(arg); err != nil {
+			return true, err
+		}
+	}
+	c.emitCall(code.OpWriteNameCall, ident.Value, c.addStringConstant(ident.Value), len(node.Arguments))
+	return true, nil
+}
+
+func (c *Compiler) compileWriteIdentifierProperty(node *ast.Identifier) (bool, error) {
+	if node == nil || node.Callee == nil || node.Callee.Callee != nil {
+		return false, nil
+	}
+
+	base := node.Callee.Value
+	if base == "" || strings.Contains(base, ".") || strings.Contains(node.Value, ".") {
+		return false, nil
+	}
+	propertyIndex := c.addStringConstant(node.Value)
+	receiver := node.Callee.String()
+	full := node.String()
+
+	symbol, ok := c.symbolTable.Resolve(base)
+	if !ok {
+		pos := c.emit(code.OpWriteNameProperty, c.addStringConstant(base), propertyIndex)
+		c.scopes[c.scopeIndex].properties[pos] = object.PropertyAccess{
+			Receiver: receiver,
+			Full:     full,
+		}
+		return true, nil
+	}
+
+	switch symbol.Scope {
+	case LocalScope:
+		pos := c.emit(code.OpWriteLocalProperty, symbol.Index, propertyIndex)
+		c.scopes[c.scopeIndex].properties[pos] = object.PropertyAccess{
+			Receiver: receiver,
+			Full:     full,
+		}
+		return true, nil
+	case GlobalScope:
+		pos := c.emit(code.OpWriteGlobalProperty, symbol.Index, propertyIndex)
+		c.scopes[c.scopeIndex].properties[pos] = object.PropertyAccess{
+			Receiver: receiver,
+			Full:     full,
+		}
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (c *Compiler) compileLetStatement(node *ast.LetStatement) error {
+	if fn, ok := node.Value.(*ast.FunctionLiteral); ok {
+		symbol := c.symbolTable.Define(node.Name.Value)
+		c.recordLocalName(symbol)
+		if symbol.Scope == GlobalScope {
+			c.globalNames[symbol.Index] = node.Name.Value
+		}
+		if err := c.compileFunctionLiteral(fn, node.Name.Value); err != nil {
+			return err
+		}
+		if symbol.Scope == GlobalScope {
+			c.emit(code.OpSetGlobal, symbol.Index)
+		} else {
+			c.emit(code.OpSetLocal, symbol.Index)
+		}
+		return nil
+	}
+
+	if err := c.Compile(node.Value); err != nil {
+		return err
+	}
+	symbol := c.symbolTable.Define(node.Name.Value)
+	c.recordLocalName(symbol)
+	if symbol.Scope == GlobalScope {
+		c.globalNames[symbol.Index] = node.Name.Value
+	}
+	if symbol.Scope == GlobalScope {
+		c.emit(code.OpSetGlobal, symbol.Index)
+	} else {
+		c.emit(code.OpSetLocal, symbol.Index)
+	}
+
+	return nil
+}
+
+func (c *Compiler) compileInfixExpression(node *ast.InfixExpression) error {
+	switch node.Operator {
+	case "&&":
+		return c.compileLogicalAnd(node)
+	case "||":
+		return c.compileLogicalOr(node)
+	}
+
+	switch node.Operator {
+	case "<":
+		if err := c.Compile(node.Right); err != nil {
+			return err
+		}
+		if err := c.Compile(node.Left); err != nil {
+			return err
+		}
+		c.emit(code.OpGreaterThan)
+		return nil
+	case "<=":
+		if err := c.Compile(node.Right); err != nil {
+			return err
+		}
+		if err := c.Compile(node.Left); err != nil {
+			return err
+		}
+		c.emit(code.OpGreaterEqual)
+		return nil
+	}
+
+	switch node.Operator {
+	case "==", "!=":
+		if err := c.compileSoft(node.Left); err != nil {
+			return err
+		}
+		if err := c.compileSoft(node.Right); err != nil {
+			return err
+		}
+	default:
+		if err := c.Compile(node.Left); err != nil {
+			return err
+		}
+		if err := c.Compile(node.Right); err != nil {
+			return err
+		}
+	}
+
+	switch node.Operator {
+	case "+":
+		c.emit(code.OpAdd)
+	case "-":
+		c.emit(code.OpSub)
+	case "*":
+		c.emit(code.OpMul)
+	case "/":
+		c.emit(code.OpDiv)
+	case ">":
+		c.emit(code.OpGreaterThan)
+	case ">=":
+		c.emit(code.OpGreaterEqual)
+	case "==":
+		c.emit(code.OpEqual)
+	case "!=":
+		c.emit(code.OpNotEqual)
+	case "~=":
+		c.emit(code.OpMatches)
+	default:
+		return fmt.Errorf("unknown operator %s", node.Operator)
+	}
+
+	return nil
+}
+
+func (c *Compiler) compileLogicalAnd(node *ast.InfixExpression) error {
+	if err := c.compileSoft(node.Left); err != nil {
+		return err
+	}
+
+	jumpNotTruthyPos := c.emit(code.OpJumpNotTruthy, 9999)
+
+	if err := c.compileSoft(node.Right); err != nil {
+		return err
+	}
+	c.emit(code.OpBang)
+	c.emit(code.OpBang)
+
+	jumpEndPos := c.emit(code.OpJump, 9999)
+	falsePos := len(c.currentInstructions())
+	c.changeOperand(jumpNotTruthyPos, falsePos)
+	c.emit(code.OpFalse)
+
+	afterPos := len(c.currentInstructions())
+	c.changeOperand(jumpEndPos, afterPos)
+	return nil
+}
+
+func (c *Compiler) compileLogicalOr(node *ast.InfixExpression) error {
+	if err := c.compileSoft(node.Left); err != nil {
+		return err
+	}
+
+	evalRightPos := c.emit(code.OpJumpNotTruthy, 9999)
+	c.emit(code.OpTrue)
+
+	jumpEndPos := c.emit(code.OpJump, 9999)
+	rightPos := len(c.currentInstructions())
+	c.changeOperand(evalRightPos, rightPos)
+
+	if err := c.compileSoft(node.Right); err != nil {
+		return err
+	}
+	c.emit(code.OpBang)
+	c.emit(code.OpBang)
+
+	afterPos := len(c.currentInstructions())
+	c.changeOperand(jumpEndPos, afterPos)
+	return nil
+}
+
+func (c *Compiler) compileIfExpression(node *ast.IfExpression) error {
+	if err := c.compileCondition(node.Condition); err != nil {
+		return err
+	}
+
+	jumpNotTruthyPos := c.emit(code.OpJumpNotTruthy, 9999)
+
+	blockStart := len(c.currentInstructions())
+	if err := c.compileScopedBlockStatement(node.Block); err != nil {
+		return err
+	}
+	c.ensureBranchValue(blockStart)
+
+	jumpPositions := []int{c.emit(code.OpJump, 9999)}
+	afterBlockPos := len(c.currentInstructions())
+	c.changeOperand(jumpNotTruthyPos, afterBlockPos)
+
+	for _, elseIf := range node.ElseIf {
+		if err := c.compileCondition(elseIf.Condition); err != nil {
+			return err
+		}
+
+		elseIfJumpNotTruthyPos := c.emit(code.OpJumpNotTruthy, 9999)
+		elseIfBlockStart := len(c.currentInstructions())
+		if err := c.compileScopedBlockStatement(elseIf.Block); err != nil {
+			return err
+		}
+		c.ensureBranchValue(elseIfBlockStart)
+
+		jumpPositions = append(jumpPositions, c.emit(code.OpJump, 9999))
+		afterElseIfPos := len(c.currentInstructions())
+		c.changeOperand(elseIfJumpNotTruthyPos, afterElseIfPos)
+	}
+
+	if node.ElseBlock == nil {
+		c.emit(code.OpNull)
+	} else {
+		elseBlockStart := len(c.currentInstructions())
+		if err := c.compileScopedBlockStatement(node.ElseBlock); err != nil {
+			return err
+		}
+		c.ensureBranchValue(elseBlockStart)
+	}
+
+	afterAlternativePos := len(c.currentInstructions())
+	for _, pos := range jumpPositions {
+		c.changeOperand(pos, afterAlternativePos)
+	}
+
+	return nil
+}
+
+func (c *Compiler) compileScopedBlockStatement(block *ast.BlockStatement) error {
+	outer := c.symbolTable
+	c.symbolTable = NewInlineBlockSymbolTable(c.symbolTable)
+	if c.scopeIndex == 0 {
+		c.topLevelBlockReturnAsValue++
+		defer func() {
+			c.topLevelBlockReturnAsValue--
+		}()
+	}
+	defer func() {
+		c.symbolTable = outer
+	}()
+	return c.Compile(block)
+}
+
+func (c *Compiler) ensureBranchValue(startPos int) {
+	if len(c.currentInstructions()) == startPos {
+		c.emit(code.OpNull)
+		return
+	}
+	if c.lastInstructionIs(code.OpPop) {
+		c.removeLastPop()
+		return
+	}
+
+	switch c.scopes[c.scopeIndex].lastInstruction.Opcode {
+	case code.OpSetGlobal, code.OpSetLocal, code.OpSetName,
+		code.OpAssignName, code.OpWrite, code.OpWriteConstant, code.OpWriteName,
+		code.OpWriteNameOrNull, code.OpWriteLocal, code.OpWriteGlobal,
+		code.OpWriteString, code.OpWriteHTML, code.OpWriteLocalProperty,
+		code.OpWriteGlobalProperty, code.OpWriteNameProperty, code.OpWriteCall,
+		code.OpWriteNameCall,
+		code.OpHole, code.OpBreak, code.OpContinue:
+		c.emit(code.OpNull)
+	}
+}
+
+func (c *Compiler) compileIdentifier(node *ast.Identifier) error {
+	if node.Callee != nil {
+		_ = c.compileIdentifier(node.Callee)
+		c.emitProperty(node.Value, node.Callee.String(), node.String())
+		return nil
+	}
+
+	symbol, ok := c.symbolTable.Resolve(node.Value)
+	if !ok {
+		if node.Value == "nil" {
+			c.emit(code.OpNull)
+			return nil
+		}
+		if c.softNames > 0 {
+			c.emit(code.OpGetNameOrNull, c.addStringConstant(node.Value))
+			return nil
+		}
+		c.emit(code.OpGetName, c.addStringConstant(node.Value))
+		return nil
+	}
+
+	if symbol.Scope == BuiltinScope && c.softNames > 0 {
+		c.emit(code.OpGetNameOrNull, c.addStringConstant(symbol.Name))
+		return nil
+	}
+
+	c.loadSymbol(symbol)
+	return nil
+}
+
+func (c *Compiler) compileHashLiteral(node *ast.HashLiteral) error {
+	keys := append([]ast.Expression(nil), node.Order...)
+	if len(keys) == 0 {
+		for k := range node.Pairs {
+			keys = append(keys, k)
+		}
+		sort.Slice(keys, func(i, j int) bool {
+			return keys[i].String() < keys[j].String()
+		})
+	}
+
+	for _, k := range keys {
+		if ident, ok := k.(*ast.Identifier); ok && ident.Callee == nil {
+			c.emitConstant(&object.String{Value: ident.TokenLiteral()})
+		} else if err := c.Compile(k); err != nil {
+			return err
+		}
+
+		if err := c.Compile(node.Pairs[k]); err != nil {
+			return err
+		}
+	}
+
+	c.emit(code.OpHash, len(node.Pairs)*2)
+	return nil
+}
+
+func (c *Compiler) compileIndexExpression(node *ast.IndexExpression) error {
+	if err := c.Compile(node.Left); err != nil {
+		return err
+	}
+	if err := c.Compile(node.Index); err != nil {
+		return err
+	}
+
+	if node.Value != nil {
+		if err := c.Compile(node.Value); err != nil {
+			return err
+		}
+		c.emit(code.OpSetIndex)
+		return nil
+	}
+
+	c.emit(code.OpIndex)
+
+	if node.Callee != nil {
+		return c.compileReceiverCallee(node.Callee, lastChainPart(node.Left))
+	}
+
+	return nil
+}
+
+func (c *Compiler) compileReceiverCallee(exp ast.Expression, base string) error {
+	switch exp := exp.(type) {
+	case *ast.Identifier:
+		for _, property := range trimReceiverParts(identifierParts(exp), base) {
+			c.emit(code.OpGetProperty, c.addStringConstant(property))
+		}
+		return nil
+	case *ast.IndexExpression:
+		if err := c.compileReceiverCallee(exp.Left, base); err != nil {
+			return err
+		}
+		if err := c.Compile(exp.Index); err != nil {
+			return err
+		}
+		if exp.Value != nil {
+			if err := c.Compile(exp.Value); err != nil {
+				return err
+			}
+			c.emit(code.OpSetIndex)
+		} else {
+			c.emit(code.OpIndex)
+		}
+		if exp.Callee != nil {
+			return c.compileReceiverCallee(exp.Callee, lastChainPart(exp.Left))
+		}
+		return nil
+	case *ast.CallExpression:
+		if ident, ok := exp.Function.(*ast.Identifier); ok {
+			for _, property := range trimReceiverParts(identifierParts(ident), base) {
+				c.emit(code.OpGetProperty, c.addStringConstant(property))
+			}
+		} else if err := c.compileReceiverCallee(exp.Function, base); err != nil {
+			return err
+		}
+
+		for _, a := range exp.Arguments {
+			if err := c.compileHard(a); err != nil {
+				return err
+			}
+		}
+
+		if exp.Block != nil {
+			blockIndex, numFree, err := c.compileBlockConstant(exp.Block, nil)
+			if err != nil {
+				return err
+			}
+			c.emitCall(code.OpCallBlock, callExpressionName(exp), len(exp.Arguments), blockIndex, numFree)
+		} else {
+			c.emitCall(code.OpCall, callExpressionName(exp), len(exp.Arguments))
+		}
+
+		if exp.ChainCallee != nil {
+			return c.compileReceiverCallee(exp.ChainCallee, lastChainPart(exp.Function))
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported chained callee %T", exp)
+	}
+}
+
+func identifierParts(id *ast.Identifier) []string {
+	if id == nil {
+		return nil
+	}
+	parts := identifierParts(id.Callee)
+	for _, part := range strings.Split(id.Value, ".") {
+		if part != "" {
+			parts = append(parts, part)
+		}
+	}
+	return parts
+}
+
+func trimReceiverParts(parts []string, base string) []string {
+	if len(parts) == 0 {
+		return parts
+	}
+	basePart := lastStringPart(base)
+	if basePart == "" {
+		return parts
+	}
+	for i, part := range parts {
+		if part == basePart || lastStringPart(part) == basePart {
+			return parts[i+1:]
+		}
+	}
+	return parts
+}
+
+func splitChainBase(base string) []string {
+	parts := []string{}
+	for _, part := range strings.Split(base, ".") {
+		part = strings.Trim(part, "()")
+		if i := strings.Index(part, "["); i >= 0 {
+			part = part[:i]
+		}
+		if part != "" {
+			parts = append(parts, part)
+		}
+	}
+	return parts
+}
+
+func lastChainPart(exp ast.Expression) string {
+	switch exp := exp.(type) {
+	case *ast.Identifier:
+		parts := identifierParts(exp)
+		if len(parts) == 0 {
+			return ""
+		}
+		return parts[len(parts)-1]
+	case *ast.IndexExpression:
+		return lastChainPart(exp.Left)
+	case *ast.CallExpression:
+		return lastChainPart(exp.Function)
+	default:
+		return lastStringPart(exp.String())
+	}
+}
+
+func callExpressionName(exp *ast.CallExpression) string {
+	if exp == nil {
+		return anonymousCallName
+	}
+	name := expressionCallName(exp.Function)
+	if name == "" {
+		return anonymousCallName
+	}
+	return name
+}
+
+func expressionCallName(exp ast.Expression) string {
+	switch exp := exp.(type) {
+	case *ast.Identifier:
+		parts := identifierParts(exp)
+		if len(parts) == 0 {
+			return exp.Value
+		}
+		return parts[len(parts)-1]
+	case *ast.IndexExpression:
+		return lastChainPart(exp.Left)
+	case *ast.CallExpression:
+		return callExpressionName(exp)
+	default:
+		return ""
+	}
+}
+
+func lastStringPart(value string) string {
+	parts := splitChainBase(value)
+	if len(parts) == 0 {
+		return ""
+	}
+	return parts[len(parts)-1]
+}
+
+func (c *Compiler) compileAssignExpression(node *ast.AssignExpression) error {
+	if err := c.Compile(node.Value); err != nil {
+		return err
+	}
+
+	name := node.Name.Value
+	if symbol, ok := c.symbolTable.Resolve(name); ok {
+		switch symbol.Scope {
+		case GlobalScope:
+			c.emit(code.OpSetGlobal, symbol.Index)
+		case LocalScope:
+			c.emit(code.OpSetLocal, symbol.Index)
+		default:
+			c.emit(code.OpAssignName, c.addStringConstant(name))
+			return nil
+		}
+		c.emit(code.OpNull)
+		return nil
+	}
+
+	c.emit(code.OpAssignName, c.addStringConstant(name))
+	return nil
+}
+
+func (c *Compiler) compileFunctionLiteral(node *ast.FunctionLiteral, name string) error {
+	c.enterScope()
+	previousSuppressOutput := c.suppressOutput
+	c.suppressOutput = 0
+	defer func() {
+		c.suppressOutput = previousSuppressOutput
+	}()
+
+	if name != "" {
+		c.symbolTable.DefineFunctionName(name)
+	}
+
+	for _, p := range node.Parameters {
+		c.recordLocalName(c.symbolTable.Define(p.Value))
+	}
+
+	if err := c.Compile(node.Block); err != nil {
+		return err
+	}
+
+	if c.lastInstructionIs(code.OpPop) {
+		c.replaceLastPopWithReturn()
+	}
+	if !c.lastInstructionIs(code.OpReturnValue) {
+		c.emit(code.OpReturn)
+	}
+
+	freeSymbols := c.symbolTable.FreeSymbols
+	numLocals := c.symbolTable.numDefinitions
+	callNames := c.currentCallNames()
+	localNames := c.currentLocalNames()
+	lineNumbers := c.currentLineNumbers()
+	properties := c.currentProperties()
+	instructions := c.leaveScope()
+	instructions, callNames, lineNumbers, properties = optimizeScope(instructions, callNames, lineNumbers, properties, c.constants)
+
+	for _, s := range freeSymbols {
+		c.loadSymbol(s)
+	}
+
+	compiledFn := &object.CompiledFunction{
+		Instructions:   instructions,
+		CallNames:      callNames,
+		LocalNames:     localNames,
+		LineNumbers:    lineNumbers,
+		Properties:     properties,
+		PropertyCaches: object.NewInlineCacheSlots(len(instructions)),
+		CallCaches:     object.NewInlineCacheSlots(len(instructions)),
+		NumLocals:      numLocals,
+		NumParameters:  len(node.Parameters),
+	}
+
+	fnIndex := c.addConstant(compiledFn)
+	c.emit(code.OpClosure, fnIndex, len(freeSymbols))
+	return nil
+}
+
+func (c *Compiler) compileCallExpression(node *ast.CallExpression) error {
+	if err := c.compileHard(node.Function); err != nil {
+		return err
+	}
+	c.markLastPropertyAsMethod()
+
+	for _, a := range node.Arguments {
+		if err := c.compileHard(a); err != nil {
+			return err
+		}
+	}
+
+	if node.Block != nil {
+		blockIndex, numFree, err := c.compileOutputBlockConstant(node.Block, nil)
+		if err != nil {
+			return err
+		}
+		c.emitCall(code.OpCallBlock, callExpressionName(node), len(node.Arguments), blockIndex, numFree)
+	} else {
+		c.emitCall(code.OpCall, callExpressionName(node), len(node.Arguments))
+	}
+
+	if node.ChainCallee != nil {
+		return c.compileReceiverCallee(node.ChainCallee, lastChainPart(node.Function))
+	}
+
+	return nil
+}
+
+func (c *Compiler) compileCondition(node ast.Expression) error {
+	switch node.(type) {
+	case *ast.Identifier:
+		return c.compileSoft(node)
+	default:
+		return c.Compile(node)
+	}
+}
+
+func (c *Compiler) compileSoft(node interface{}) error {
+	c.softNames++
+	defer func() { c.softNames-- }()
+	return c.Compile(node)
+}
+
+func (c *Compiler) compileHard(node interface{}) error {
+	softNames := c.softNames
+	c.softNames = 0
+	defer func() { c.softNames = softNames }()
+	return c.Compile(node)
+}
+
+func (c *Compiler) compileForExpression(node *ast.ForExpression) error {
+	if err := c.Compile(node.Iterable); err != nil {
+		return err
+	}
+
+	blockIndex, numFree, err := c.compileBlockConstant(node.Block, []string{node.KeyName, node.ValueName})
+	if err != nil {
+		return err
+	}
+
+	c.emit(code.OpFor, blockIndex, c.addStringConstant(node.KeyName), c.addStringConstant(node.ValueName), numFree)
+	return nil
+}
+
+func (c *Compiler) compileBlockConstant(block *ast.BlockStatement, params []string) (int, int, error) {
+	c.enterScope()
+
+	for _, name := range params {
+		c.recordLocalName(c.symbolTable.Define(name))
+	}
+
+	if err := c.Compile(block); err != nil {
+		return 0, 0, err
+	}
+
+	if !c.lastInstructionIs(code.OpReturnValue) {
+		c.emit(code.OpReturn)
+	}
+
+	freeSymbols := c.symbolTable.FreeSymbols
+	numLocals := c.symbolTable.numDefinitions
+	callNames := c.currentCallNames()
+	localNames := c.currentLocalNames()
+	lineNumbers := c.currentLineNumbers()
+	properties := c.currentProperties()
+	instructions := c.leaveScope()
+	instructions, callNames, lineNumbers, properties = optimizeScope(instructions, callNames, lineNumbers, properties, c.constants)
+
+	for _, s := range freeSymbols {
+		c.loadSymbol(s)
+	}
+
+	compiledFn := &object.CompiledFunction{
+		Instructions:   instructions,
+		CallNames:      callNames,
+		LocalNames:     localNames,
+		LineNumbers:    lineNumbers,
+		Properties:     properties,
+		PropertyCaches: object.NewInlineCacheSlots(len(instructions)),
+		CallCaches:     object.NewInlineCacheSlots(len(instructions)),
+		NumLocals:      numLocals,
+		NumParameters:  len(params),
+	}
+
+	return c.addConstant(compiledFn), len(freeSymbols), nil
+}
+
+func (c *Compiler) compileOutputBlockConstant(block *ast.BlockStatement, params []string) (int, int, error) {
+	previousSuppressOutput := c.suppressOutput
+	c.suppressOutput = 0
+	defer func() {
+		c.suppressOutput = previousSuppressOutput
+	}()
+	return c.compileBlockConstant(block, params)
+}
+
+func (c *Compiler) Bytecode() *Bytecode {
+	names := map[int]string{}
+	for k, v := range c.globalNames {
+		names[k] = v
+	}
+	instructions, callNames, lineNumbers, properties := optimizeScope(
+		c.currentInstructions(),
+		c.currentCallNames(),
+		c.currentLineNumbers(),
+		c.currentProperties(),
+		c.constants,
+	)
+	staticOutput, static := staticOutputFromInstructions(instructions, c.constants)
+	fastRenderPlan, fastReject := fastRenderPlanAnalysisFromProgram(c.program)
+	if fastRenderPlan != nil {
+		if reject := compileFastRenderPlanBlocks(fastRenderPlan); reject.Reason != "" {
+			fastReject = reject
+			fastRenderPlan = nil
+		}
+	}
+	if fastRenderPlan == nil {
+		fastRenderPlan = fastRenderPlanFromInstructions(instructions, c.constants, lineNumbers)
+		if fastRenderPlan != nil {
+			fastReject = FastRenderReject{}
+		}
+	}
+	features := bytecodeFeaturesFromInstructions(instructions, c.constants, callNames)
+
+	return &Bytecode{
+		Instructions:   instructions,
+		CallNames:      callNames,
+		LocalNames:     c.currentLocalNames(),
+		LineNumbers:    lineNumbers,
+		Properties:     properties,
+		PropertyCaches: object.NewInlineCacheSlots(len(instructions)),
+		CallCaches:     object.NewInlineCacheSlots(len(instructions)),
+		NumLocals:      c.currentLocalCount(),
+		NumGlobals:     c.globalCount(),
+		Constants:      c.constants,
+		GlobalNames:    names,
+		Static:         static,
+		StaticOutput:   staticOutput,
+		FastRenderPlan: fastRenderPlan,
+		FastRejectLine: fastReject.Line,
+		FastReject:     fastReject.Reason,
+		HasHoles:       features.HasHoles,
+		HasPartials:    features.HasPartials,
+	}
+}
+
+func compileFastRenderPlanBlocks(plan *FastRenderPlan) FastRenderReject {
+	if plan == nil {
+		return FastRenderReject{}
+	}
+	return compileFastRenderSegmentBlocks(plan.Segments)
+}
+
+func compileFastRenderSegmentBlocks(segments []FastRenderSegment) FastRenderReject {
+	for i := range segments {
+		segment := &segments[i]
+		switch segment.Kind {
+		case FastRenderSegmentBlockCall:
+			if segment.BlockCall == nil {
+				return FastRenderReject{Line: segment.Line, Reason: "missing fast block helper call plan"}
+			}
+			if reject := compileFastBlockCall(segment.BlockCall); reject.Reason != "" {
+				return reject
+			}
+		case FastRenderSegmentConditional:
+			if segment.Conditional == nil {
+				continue
+			}
+			for branchIndex := range segment.Conditional.Branches {
+				if reject := compileFastRenderSegmentBlocks(segment.Conditional.Branches[branchIndex].Segments); reject.Reason != "" {
+					return reject
+				}
+			}
+			if reject := compileFastRenderSegmentBlocks(segment.Conditional.ElseSegments); reject.Reason != "" {
+				return reject
+			}
+		case FastRenderSegmentLoop:
+			if reject := compileFastLoopBlocks(segment.Loop); reject.Reason != "" {
+				return reject
+			}
+		}
+	}
+	return FastRenderReject{}
+}
+
+func compileFastLoopBlocks(loop *FastLoopPlan) FastRenderReject {
+	if loop == nil {
+		return FastRenderReject{}
+	}
+	return compileFastLoopPartBlocks(loop.Parts)
+}
+
+func compileFastLoopPartBlocks(parts []FastLoopPart) FastRenderReject {
+	for i := range parts {
+		part := &parts[i]
+		switch part.Kind {
+		case FastLoopPartBlockCall:
+			if part.BlockCall == nil {
+				return FastRenderReject{Line: part.Line, Reason: "missing fast loop block helper call plan"}
+			}
+			if reject := compileFastBlockCall(part.BlockCall); reject.Reason != "" {
+				return reject
+			}
+		case FastLoopPartConditional:
+			if part.Conditional == nil {
+				continue
+			}
+			for branchIndex := range part.Conditional.Branches {
+				if reject := compileFastLoopPartBlocks(part.Conditional.Branches[branchIndex].Parts); reject.Reason != "" {
+					return reject
+				}
+			}
+			if reject := compileFastLoopPartBlocks(part.Conditional.ElseParts); reject.Reason != "" {
+				return reject
+			}
+		case FastLoopPartLoop:
+			if reject := compileFastLoopBlocks(part.Loop); reject.Reason != "" {
+				return reject
+			}
+		}
+	}
+	return FastRenderReject{}
+}
+
+func compileFastBlockCall(call *FastBlockCallPlan) FastRenderReject {
+	if call == nil || (call.Block == nil && call.BlockSource == "") {
+		return FastRenderReject{Line: callLine(call), Reason: "empty fast block helper body"}
+	}
+	var program *ast.Program
+	if call.Block != nil {
+		program = &ast.Program{Statements: call.Block.Statements}
+	} else {
+		parsed, err := parser.Parse(call.BlockSource)
+		if err != nil {
+			return FastRenderReject{Line: call.Line, Reason: "could not parse fast block helper body: " + err.Error()}
+		}
+		program = parsed
+	}
+	comp := New()
+	if err := comp.Compile(program); err != nil {
+		return FastRenderReject{Line: call.Line, Reason: "could not compile fast block helper body: " + err.Error()}
+	}
+	call.BlockBytecode = comp.Bytecode()
+	call.Block = nil
+	return FastRenderReject{}
+}
+
+func callLine(call *FastBlockCallPlan) int {
+	if call == nil {
+		return 1
+	}
+	return call.Line
+}
+
+func (c *Compiler) emitConstant(obj object.Object) int {
+	return c.emit(code.OpConstant, c.addConstant(obj))
+}
+
+func (c *Compiler) addStringConstant(value string) int {
+	return c.addConstant(&object.String{Value: value})
+}
+
+func (c *Compiler) addHTMLConstant(value string) int {
+	return c.addConstant(&object.Native{Value: template.HTML(value)})
+}
+
+func (c *Compiler) emitWriteString(value string) int {
+	if index, ok := c.lastWriteConstantIndex(code.OpWriteString); ok {
+		if previous, ok := stringConstantValue(c.constants, index); ok {
+			c.constants[index] = &object.String{Value: previous + value}
+			return c.scopes[c.scopeIndex].lastInstruction.Position
+		}
+	}
+	if index, ok := c.lastWriteConstantIndex(code.OpWriteHTML); ok {
+		if previous, ok := htmlConstantValue(c.constants, index); ok {
+			c.constants[index] = &object.Native{
+				Value: template.HTML(previous + template.HTMLEscapeString(value)),
+			}
+			return c.scopes[c.scopeIndex].lastInstruction.Position
+		}
+	}
+	return c.emit(code.OpWriteString, c.addStringConstant(value))
+}
+
+func (c *Compiler) emitWriteHTML(value string) int {
+	if index, ok := c.lastWriteConstantIndex(code.OpWriteHTML); ok {
+		if previous, ok := htmlConstantValue(c.constants, index); ok {
+			c.constants[index] = &object.Native{Value: template.HTML(previous + value)}
+			return c.scopes[c.scopeIndex].lastInstruction.Position
+		}
+	}
+	if index, ok := c.lastWriteConstantIndex(code.OpWriteString); ok {
+		if previous, ok := stringConstantValue(c.constants, index); ok {
+			c.constants[index] = &object.Native{
+				Value: template.HTML(template.HTMLEscapeString(previous) + value),
+			}
+			c.currentInstructions()[c.scopes[c.scopeIndex].lastInstruction.Position] = byte(code.OpWriteHTML)
+			c.scopes[c.scopeIndex].lastInstruction.Opcode = code.OpWriteHTML
+			return c.scopes[c.scopeIndex].lastInstruction.Position
+		}
+	}
+	return c.emit(code.OpWriteHTML, c.addHTMLConstant(value))
+}
+
+func (c *Compiler) lastWriteConstantIndex(op code.Opcode) (int, bool) {
+	last := c.scopes[c.scopeIndex].lastInstruction
+	if last.Opcode != op {
+		return 0, false
+	}
+	instructions := c.currentInstructions()
+	if last.Position < 0 || last.Position >= len(instructions) {
+		return 0, false
+	}
+	def, err := code.Lookup(byte(last.Opcode))
+	if err != nil || len(def.OperandWidths) != 1 {
+		return 0, false
+	}
+	operands, _ := code.ReadOperands(def, instructions[last.Position+1:])
+	return operands[0], true
+}
+
+func staticOutputFromInstructions(instructions code.Instructions, constants []object.Object) (string, bool) {
+	var out strings.Builder
+	for i := 0; i < len(instructions); {
+		op := code.Opcode(instructions[i])
+		def, err := code.Lookup(instructions[i])
+		if err != nil {
+			return "", false
+		}
+		operands, read := code.ReadOperands(def, instructions[i+1:])
+		switch op {
+		case code.OpWriteHTML:
+			value, ok := htmlConstantValue(constants, operands[0])
+			if !ok {
+				return "", false
+			}
+			out.WriteString(value)
+		case code.OpWriteString:
+			value, ok := stringConstantValue(constants, operands[0])
+			if !ok {
+				return "", false
+			}
+			out.WriteString(template.HTMLEscapeString(value))
+		case code.OpWriteConstant:
+			value, ok := staticConstantOutput(constants, operands[0])
+			if !ok {
+				return "", false
+			}
+			out.WriteString(value)
+		default:
+			return "", false
+		}
+		i += 1 + read
+	}
+	return out.String(), true
+}
+
+func stringConstantValue(constants []object.Object, index int) (string, bool) {
+	if index < 0 || index >= len(constants) {
+		return "", false
+	}
+	obj, ok := constants[index].(*object.String)
+	if !ok {
+		return "", false
+	}
+	return obj.Value, true
+}
+
+func htmlConstantValue(constants []object.Object, index int) (string, bool) {
+	if index < 0 || index >= len(constants) {
+		return "", false
+	}
+	obj, ok := constants[index].(*object.Native)
+	if !ok {
+		return "", false
+	}
+	html, ok := obj.Value.(template.HTML)
+	if !ok {
+		return "", false
+	}
+	return string(html), true
+}
+
+func staticConstantOutput(constants []object.Object, index int) (string, bool) {
+	if index < 0 || index >= len(constants) {
+		return "", false
+	}
+	obj := constants[index]
+	if object.IsNull(obj) {
+		return "", true
+	}
+	switch obj := obj.(type) {
+	case *object.Integer, *object.Float, *object.Boolean:
+		return template.HTMLEscaper(obj.Inspect()), true
+	case *object.String:
+		return template.HTMLEscapeString(obj.Value), true
+	case *object.Native:
+		if html, ok := obj.Value.(template.HTML); ok {
+			return string(html), true
+		}
+	}
+	return "", false
+}

--- a/VM/compiler/compiler_test.go
+++ b/VM/compiler/compiler_test.go
@@ -1,0 +1,3281 @@
+package compiler
+
+import (
+	"html/template"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5/VM/code"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/gobuffalo/plush/v5/ast"
+	"github.com/gobuffalo/plush/v5/parser"
+	"github.com/gobuffalo/plush/v5/token"
+	"github.com/stretchr/testify/require"
+)
+
+type compilerTestCase struct {
+	input                string
+	expectedConstants    []interface{}
+	expectedInstructions []code.Instructions
+}
+
+func Test_Integer_Arithmetic(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input:             "1 + 2",
+			expectedConstants: []interface{}{1, 2},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpAdd),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "1 - 2",
+			expectedConstants: []interface{}{1, 2},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpSub),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "-1",
+			expectedConstants: []interface{}{1},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpMinus),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+
+	runCompilerTests(t, tests)
+}
+
+func Test_Comparison_Operand_Optimization(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input:             "1 < 2",
+			expectedConstants: []interface{}{2, 1},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpGreaterThan),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "1 <= 2",
+			expectedConstants: []interface{}{2, 1},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpGreaterEqual),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "1 > 2",
+			expectedConstants: []interface{}{1, 2},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpGreaterThan),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "1 >= 2",
+			expectedConstants: []interface{}{1, 2},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpGreaterEqual),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+
+	runCompilerTests(t, tests)
+}
+
+func Test_Infix_Operator_Opcode_Branches(t *testing.T) {
+	tests := []struct {
+		input string
+		op    code.Opcode
+	}{
+		{input: `2 * 3`, op: code.OpMul},
+		{input: `6 / 2`, op: code.OpDiv},
+		{input: `1 == 1`, op: code.OpEqual},
+		{input: `1 != 2`, op: code.OpNotEqual},
+		{input: `"abc" ~= "a"`, op: code.OpMatches},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			program, err := ParseScript(tt.input)
+			require.NoError(t, err)
+
+			compiler := New()
+			require.NoError(t, compiler.Compile(program))
+			require.Truef(t, bytecodeContainsOpcode(compiler.Bytecode(), tt.op), "expected opcode %s in:\n%s", tt.op, compiler.Bytecode().Instructions.String())
+		})
+	}
+}
+
+func Test_Compiler_Hash_Index_And_Receiver_Branch_Opcodes(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		opcodes []code.Opcode
+	}{
+		{
+			name:    "hash literal identifier and string keys",
+			input:   `{name: 1, "age": 2}`,
+			opcodes: []code.Opcode{code.OpHash},
+		},
+		{
+			name:    "index read",
+			input:   `items[0]`,
+			opcodes: []code.Opcode{code.OpIndex},
+		},
+		{
+			name:    "index write",
+			input:   `items[0] = "x"`,
+			opcodes: []code.Opcode{code.OpSetIndex},
+		},
+		{
+			name:    "nested indexed receiver call",
+			input:   `robots[0].Name.Echo()`,
+			opcodes: []code.Opcode{code.OpIndex, code.OpGetProperty, code.OpCall},
+		},
+		{
+			name:    "call result receiver with index",
+			input:   `factory().Robots()[0].Name`,
+			opcodes: []code.Opcode{code.OpCall, code.OpIndex, code.OpGetProperty},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			program, err := ParseScript(tt.input)
+			require.NoError(t, err)
+
+			compiler := New()
+			require.NoError(t, compiler.Compile(program))
+			instructions := compiler.Bytecode().Instructions
+
+			for _, op := range tt.opcodes {
+				require.Truef(t, instructionContainsOpcode(instructions, op), "expected %s in:\n%s", op, instructions.String())
+			}
+		})
+	}
+}
+
+func Test_Compiler_Call_Name_And_Partial_Data_Key_Helpers(t *testing.T) {
+	require.Equal(t, anonymousCallName, callExpressionName(nil))
+	require.Equal(t, "helper", callExpressionName(&ast.CallExpression{Function: &ast.Identifier{Value: "helper"}}))
+	require.Equal(t, "Name", expressionCallName(&ast.Identifier{Callee: &ast.Identifier{Value: "robot"}, Value: "Name"}))
+	require.Equal(t, "robots", expressionCallName(&ast.IndexExpression{Left: &ast.Identifier{Value: "robots"}}))
+	require.Equal(t, "helper", expressionCallName(&ast.CallExpression{Function: &ast.Identifier{Value: "helper"}}))
+	require.Equal(t, "", expressionCallName(&ast.StringLiteral{Value: "not-callable"}))
+
+	key, ok := fastPartialDataKey(&ast.Identifier{Value: "label"})
+	require.True(t, ok)
+	require.Equal(t, "label", key)
+
+	key, ok = fastPartialDataKey(&ast.StringLiteral{Value: "label"})
+	require.True(t, ok)
+	require.Equal(t, "label", key)
+
+	_, ok = fastPartialDataKey(&ast.Identifier{Value: ""})
+	require.False(t, ok)
+
+	_, ok = fastPartialDataKey(&ast.Identifier{Callee: &ast.Identifier{Value: "data"}, Value: "label"})
+	require.False(t, ok)
+
+	_, ok = fastPartialDataKey(&ast.IntegerLiteral{Value: 1})
+	require.False(t, ok)
+}
+
+func Test_Compiler_Receiver_Chain_Helper_Branches(t *testing.T) {
+	robotName := &ast.Identifier{Callee: &ast.Identifier{Value: "robot"}, Value: "Name"}
+	require.Equal(t, []string{"robot", "Name"}, identifierParts(robotName))
+	require.Nil(t, identifierParts(nil))
+
+	require.Equal(t, []string{"Name"}, trimReceiverParts([]string{"robot", "Name"}, "robot"))
+	require.Equal(t, []string{"Name"}, trimReceiverParts([]string{"robots[0]", "Name"}, "robots[0]"))
+	require.Equal(t, []string{"robot", "Name"}, trimReceiverParts([]string{"robot", "Name"}, "factory"))
+	require.Empty(t, trimReceiverParts(nil, "robot"))
+
+	require.Equal(t, []string{"robot", "Name", "Echo"}, splitChainBase("robot.Name[0].Echo()"))
+	require.Equal(t, []string{"robot", "Name"}, splitChainBase("(robot).Name"))
+	require.Empty(t, splitChainBase(""))
+
+	require.Equal(t, "Name", lastChainPart(robotName))
+	require.Equal(t, "", lastChainPart(&ast.Identifier{}))
+	require.Equal(t, "robots", lastChainPart(&ast.IndexExpression{Left: &ast.Identifier{Value: "robots"}}))
+	require.Equal(t, "factory", lastChainPart(&ast.CallExpression{Function: &ast.Identifier{Value: "factory"}}))
+	require.Equal(t, "Name", lastChainPart(&ast.IntegerLiteral{TokenAble: ast.TokenAble{Token: token.Token{Literal: "robot.Name"}}}))
+	require.Equal(t, "Name", lastStringPart("factory().Robots()[0].Name"))
+	require.Equal(t, "", lastStringPart(""))
+
+	value := FastValuePlan{}
+	require.True(t, appendFastReceiverCallee(&value, robotName, "robot", 7))
+	require.Equal(t, []FastPathStep{{
+		Kind:     FastPathStepProperty,
+		Value:    "Name",
+		Receiver: "robot",
+		Full:     "robot.Name",
+		Line:     7,
+	}}, value.Path)
+
+	value = FastValuePlan{}
+	require.True(t, appendFastReceiverCallee(&value, &ast.IndexExpression{
+		Left:   &ast.Identifier{Value: "robots"},
+		Index:  &ast.IntegerLiteral{Value: 0},
+		Callee: &ast.Identifier{Value: "Name"},
+	}, "", 8))
+	require.Equal(t, []FastPathStepKind{FastPathStepProperty, FastPathStepIndexInteger, FastPathStepProperty}, []FastPathStepKind{
+		value.Path[0].Kind,
+		value.Path[1].Kind,
+		value.Path[2].Kind,
+	})
+	require.Equal(t, "robots", value.Path[0].Value)
+	require.Equal(t, 0, value.Path[1].Index)
+	require.Equal(t, "Name", value.Path[2].Value)
+
+	value = FastValuePlan{}
+	require.True(t, appendFastReceiverCallee(&value, &ast.CallExpression{
+		Function:    &ast.Identifier{Value: "Robots"},
+		ChainCallee: &ast.Identifier{Value: "Name"},
+	}, "factory", 9))
+	require.Equal(t, []FastPathStepKind{FastPathStepProperty, FastPathStepCall, FastPathStepProperty}, []FastPathStepKind{
+		value.Path[0].Kind,
+		value.Path[1].Kind,
+		value.Path[2].Kind,
+	})
+	require.True(t, value.Path[0].Method)
+	require.Equal(t, "Robots", value.Path[1].Value)
+	require.Equal(t, "Name", value.Path[2].Value)
+
+	value = FastValuePlan{}
+	require.False(t, appendFastReceiverCallee(&value, &ast.IndexExpression{
+		Left:  &ast.Identifier{Value: "robots"},
+		Index: &ast.Identifier{Value: "dynamic"},
+	}, "", 10))
+
+	value = FastValuePlan{}
+	require.False(t, appendFastReceiverCallee(&value, &ast.CallExpression{
+		Function:  &ast.Identifier{Value: "helper"},
+		Arguments: []ast.Expression{&ast.Identifier{Value: "name"}},
+	}, "", 11))
+
+	value = FastValuePlan{}
+	require.False(t, appendFastReceiverCallee(&value, &ast.StringLiteral{Value: "nope"}, "", 12))
+}
+
+func Test_Compiler_Line_Helpers(t *testing.T) {
+	require.Equal(t, 1, lineForNode(nil))
+	require.Equal(t, 1, lineForNode(&ast.Identifier{}))
+	require.Equal(t, 23, lineForNode(&ast.Identifier{TokenAble: ast.TokenAble{Token: token.Token{LineNumber: 23}}}))
+	require.Equal(t, 1, lineForToken(ast.TokenAble{}))
+	require.Equal(t, 24, lineForToken(ast.TokenAble{Token: token.Token{LineNumber: 24}}))
+}
+
+func Test_Compiler_Emit_And_Symbol_Helper_Branches(t *testing.T) {
+	compiler := New()
+	require.Nil(t, compiler.currentLineNumbers())
+	require.Zero(t, compiler.globalCount())
+	compiler.globalNames[3] = "late"
+	require.Equal(t, 4, compiler.globalCount())
+
+	require.False(t, compiler.lastInstructionIs(code.OpAdd))
+
+	pos := compiler.emit(code.OpAdd)
+	require.True(t, compiler.lastInstructionIs(code.OpAdd))
+	require.False(t, compiler.lastInstructionIs(code.OpSub))
+
+	compiler.recordCallName(pos, "")
+	require.Equal(t, anonymousCallName, compiler.scopes[compiler.scopeIndex].callNames[pos])
+
+	compiler.recordLocalName(Symbol{Name: "global", Scope: GlobalScope, Index: 2})
+	require.Empty(t, compiler.scopes[compiler.scopeIndex].localNames)
+	compiler.recordLocalName(Symbol{Name: "local", Scope: LocalScope, Index: 3})
+	require.Equal(t, "local", compiler.scopes[compiler.scopeIndex].localNames[3])
+	require.Equal(t, 4, compiler.scopes[compiler.scopeIndex].numLocals)
+
+	compiler.markLastPropertyAsMethod()
+	propertyPos := compiler.emitProperty("Name", "robot", "robot.Name")
+	compiler.markLastPropertyAsMethod()
+	property := compiler.scopes[compiler.scopeIndex].properties[propertyPos]
+	require.True(t, property.Method)
+	require.Equal(t, "robot.Name", property.Full)
+
+	for _, symbol := range []Symbol{
+		{Name: "global", Scope: GlobalScope, Index: 0},
+		{Name: "local", Scope: LocalScope, Index: 1},
+		{Name: "builtin", Scope: BuiltinScope, Index: 2},
+		{Name: "free", Scope: FreeScope, Index: 3},
+		{Name: "fn", Scope: FunctionScope},
+	} {
+		compiler.loadSymbol(symbol)
+	}
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpGetGlobal))
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpGetLocal))
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpGetBuiltin))
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpGetFree))
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpCurrentClosure))
+
+	require.Equal(t, anonymousCallName, callExpressionName(nil))
+	require.Equal(t, anonymousCallName, callExpressionName(&ast.CallExpression{Function: &ast.StringLiteral{Value: "literal"}}))
+	require.Empty(t, expressionCallName(&ast.Identifier{}))
+	require.Equal(t, "items", expressionCallName(&ast.IndexExpression{Left: &ast.Identifier{Value: "items"}}))
+	require.Equal(t, "helper", expressionCallName(&ast.CallExpression{Function: &ast.Identifier{Value: "helper"}}))
+}
+
+func Test_Compiler_Direct_Expression_Helper_Branches(t *testing.T) {
+	compiler := New()
+	err := compiler.compileInfixExpression(&ast.InfixExpression{
+		Left:     &ast.IntegerLiteral{Value: 1},
+		Operator: "??",
+		Right:    &ast.IntegerLiteral{Value: 2},
+	})
+	require.ErrorContains(t, err, "unknown operator ??")
+
+	compiler = New()
+	nameKey := &ast.Identifier{TokenAble: ast.TokenAble{Token: token.Token{Literal: "name"}}, Value: "name"}
+	ageKey := &ast.StringLiteral{TokenAble: ast.TokenAble{Token: token.Token{Literal: "age"}}, Value: "age"}
+	hash := &ast.HashLiteral{
+		Pairs: map[ast.Expression]ast.Expression{
+			nameKey: &ast.IntegerLiteral{Value: 1},
+			ageKey:  &ast.IntegerLiteral{Value: 2},
+		},
+	}
+	require.NoError(t, compiler.compileHashLiteral(hash))
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpHash))
+
+	compiler = New()
+	firstKey := &ast.StringLiteral{Value: "first"}
+	orderedHash := &ast.HashLiteral{
+		Order: []ast.Expression{firstKey},
+		Pairs: map[ast.Expression]ast.Expression{
+			firstKey: &ast.Boolean{Value: true},
+		},
+	}
+	require.NoError(t, compiler.compileHashLiteral(orderedHash))
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpTrue))
+
+	compiler = New()
+	err = compiler.compileReceiverCallee(&ast.StringLiteral{Value: "bad"}, "")
+	require.ErrorContains(t, err, "unsupported chained callee")
+
+	compiler = New()
+	require.NoError(t, compiler.compileReceiverCallee(&ast.IndexExpression{
+		Left:   &ast.Identifier{Value: "robots"},
+		Index:  &ast.IntegerLiteral{Value: 0},
+		Value:  &ast.StringLiteral{Value: "updated"},
+		Callee: &ast.Identifier{Value: "Name"},
+	}, ""))
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpSetIndex))
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpGetProperty))
+
+	compiler = New()
+	require.NoError(t, compiler.compileReceiverCallee(&ast.CallExpression{
+		Function: &ast.CallExpression{Function: &ast.Identifier{Value: "factory"}},
+		Arguments: []ast.Expression{
+			&ast.StringLiteral{Value: "arg"},
+		},
+		ChainCallee: &ast.Identifier{Value: "Name"},
+	}, ""))
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpCall))
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpGetProperty))
+}
+
+func Test_Compiler_Fast_Value_And_Partial_Data_Helper_Edges(t *testing.T) {
+	plan := &FastRenderPlan{}
+	require.True(t, fastInfixOperator("=="))
+	require.False(t, fastInfixOperator("??"))
+
+	_, ok := fastValuePlanFromInfixExpression(plan, nil, 1)
+	require.False(t, ok)
+
+	value, ok := fastValuePlanFromInfixExpression(plan, parseCompilerExpression(t, `name + 1`).(*ast.InfixExpression), 1)
+	require.True(t, ok)
+	require.Equal(t, FastValueConcat, value.Kind)
+
+	value, ok = fastValuePlanFromInfixExpression(plan, parseCompilerExpression(t, `name == 1`).(*ast.InfixExpression), 1)
+	require.True(t, ok)
+	require.Equal(t, FastValueInfix, value.Kind)
+	require.Equal(t, "==", value.Operator)
+
+	_, ok = fastValuePlanFromInfixExpression(plan, &ast.InfixExpression{
+		Operator: "==",
+		Left:     &ast.FunctionLiteral{},
+		Right:    &ast.IntegerLiteral{Value: 1},
+	}, 1)
+	require.False(t, ok)
+
+	_, ok = fastValuePlanFromInfixExpression(plan, &ast.InfixExpression{
+		Operator: "==",
+		Left:     &ast.IntegerLiteral{Value: 1},
+		Right:    &ast.FunctionLiteral{},
+	}, 1)
+	require.False(t, ok)
+
+	value, ok = fastValuePlanFromIndexExpression(plan, parseCompilerExpression(t, `items[0]`).(*ast.IndexExpression), false, 1)
+	require.True(t, ok)
+	require.Equal(t, FastValuePath, value.Kind)
+	require.Equal(t, FastPathStepIndexInteger, value.Path[0].Kind)
+
+	_, ok = fastValuePlanFromIndexExpression(plan, parseCompilerExpression(t, `1[0]`).(*ast.IndexExpression), false, 1)
+	require.False(t, ok)
+
+	_, ok = fastValuePlanFromIndexExpression(plan, parseCompilerExpression(t, `items[key]`).(*ast.IndexExpression), false, 1)
+	require.False(t, ok)
+
+	_, ok = fastPartialDataPlanFromExpression(plan, &ast.Identifier{Value: "name"}, 1)
+	require.False(t, ok)
+
+	data, ok := fastPartialDataPlanFromExpression(plan, &ast.HashLiteral{
+		Pairs: map[ast.Expression]ast.Expression{
+			&ast.StringLiteral{Value: "b"}: &ast.StringLiteral{Value: "B"},
+			&ast.StringLiteral{Value: "a"}: &ast.IntegerLiteral{Value: 1},
+		},
+	}, 1)
+	require.True(t, ok)
+	require.ElementsMatch(t, []string{"a", "b"}, []string{data[0].Key, data[1].Key})
+	dataByKey := map[string]FastValuePlan{}
+	for _, pair := range data {
+		dataByKey[pair.Key] = pair.Value
+	}
+	require.Equal(t, FastValueInteger, dataByKey["a"].Kind)
+	require.Equal(t, FastValueString, dataByKey["b"].Kind)
+
+	layoutKey := &ast.Identifier{Value: "layout"}
+	_, ok = fastPartialDataPlanFromExpression(plan, &ast.HashLiteral{
+		Order: []ast.Expression{layoutKey},
+		Pairs: map[ast.Expression]ast.Expression{
+			layoutKey: &ast.StringLiteral{Value: "shell"},
+		},
+	}, 1)
+	require.False(t, ok)
+
+	invalidKey := &ast.IntegerLiteral{Value: 1}
+	_, ok = fastPartialDataPlanFromExpression(plan, &ast.HashLiteral{
+		Order: []ast.Expression{invalidKey},
+		Pairs: map[ast.Expression]ast.Expression{
+			invalidKey: &ast.StringLiteral{Value: "bad"},
+		},
+	}, 1)
+	require.False(t, ok)
+
+	unsupportedValueKey := &ast.Identifier{Value: "bad"}
+	_, ok = fastPartialDataPlanFromExpression(plan, &ast.HashLiteral{
+		Order: []ast.Expression{unsupportedValueKey},
+		Pairs: map[ast.Expression]ast.Expression{
+			unsupportedValueKey: &ast.FunctionLiteral{},
+		},
+	}, 1)
+	require.False(t, ok)
+}
+
+func Test_Compiler_Fast_Loop_Value_Helper_Edges(t *testing.T) {
+	plan := &FastRenderPlan{}
+	loop := &FastLoopPlan{KeyName: "i", ValueName: "product"}
+
+	_, ok := fastValuePlanFromLoopOperand(plan, nil, &ast.Identifier{Value: "product"}, false, 1)
+	require.False(t, ok)
+
+	_, ok = fastValuePlanFromLoopInfix(plan, loop, nil, 1)
+	require.False(t, ok)
+
+	value, ok := fastValuePlanFromLoopInfix(plan, loop, parseCompilerExpression(t, `product.Name + "x"`).(*ast.InfixExpression), 1)
+	require.True(t, ok)
+	require.Equal(t, FastValueConcat, value.Kind)
+
+	_, ok = fastValuePlanFromLoopInfix(plan, loop, parseCompilerExpression(t, `i.Name == "x"`).(*ast.InfixExpression), 1)
+	require.False(t, ok)
+
+	value, ok = fastValuePlanFromLoopInfix(plan, loop, parseCompilerExpression(t, `product.Name == "x"`).(*ast.InfixExpression), 1)
+	require.True(t, ok)
+	require.Equal(t, FastValueInfix, value.Kind)
+
+	root, ok := fastLoopExpressionRootName(parseCompilerExpression(t, `product.Tags[0]`))
+	require.True(t, ok)
+	require.Equal(t, "product", root)
+
+	_, ok = fastLoopExpressionRootName(&ast.StringLiteral{Value: "nope"})
+	require.False(t, ok)
+
+	require.False(t, isFastLoopKeyIdentifier(loop, parseCompilerExpression(t, `i.Name`)))
+	require.True(t, isFastLoopKeyIdentifier(loop, &ast.Identifier{Value: "i"}))
+
+	_, ok = fastValuePlanFromLoopIndex(loop, &ast.Identifier{Value: "product"}, 1)
+	require.False(t, ok)
+
+	_, ok = fastValuePlanFromLoopIndex(loop, parseCompilerExpression(t, `other[0]`), 1)
+	require.False(t, ok)
+
+	_, ok = fastValuePlanFromLoopIndex(loop, parseCompilerExpression(t, `product[dynamic]`), 1)
+	require.False(t, ok)
+
+	value, ok = fastValuePlanFromLoopIndex(loop, parseCompilerExpression(t, `product.Tags[0].Name`), 1)
+	require.True(t, ok)
+	require.Equal(t, FastValuePath, value.Kind)
+	require.Equal(t, []FastPathStepKind{FastPathStepProperty, FastPathStepIndexInteger, FastPathStepProperty}, []FastPathStepKind{
+		value.Path[0].Kind,
+		value.Path[1].Kind,
+		value.Path[2].Kind,
+	})
+
+	_, ok = fastValuePlanFromLoopCall(loop, nil, 1)
+	require.False(t, ok)
+
+	_, ok = fastValuePlanFromLoopCall(loop, &ast.CallExpression{
+		Function:  &ast.Identifier{Value: "Echo"},
+		Arguments: []ast.Expression{&ast.StringLiteral{Value: "arg"}},
+	}, 1)
+	require.False(t, ok)
+
+	_, ok = fastValuePlanFromLoopCall(loop, &ast.CallExpression{
+		Function: &ast.Identifier{Value: "Echo"},
+		Block:    &ast.BlockStatement{},
+	}, 1)
+	require.False(t, ok)
+
+	value, ok = fastValuePlanFromLoopCall(loop, parseCompilerExpression(t, `product.Name.Echo()`).(*ast.CallExpression), 1)
+	require.True(t, ok)
+	require.Equal(t, FastPathStepCall, value.Path[len(value.Path)-1].Kind)
+
+	_, ok = fastLoopCallPlanFromExpression(plan, loop, nil, 1)
+	require.False(t, ok)
+
+	_, ok = fastLoopCallPlanFromExpression(plan, loop, &ast.CallExpression{
+		Function:    &ast.Identifier{Value: "label"},
+		ChainCallee: &ast.Identifier{Value: "Echo"},
+	}, 1)
+	require.False(t, ok)
+
+	_, ok = fastLoopCallPlanFromExpression(plan, loop, &ast.CallExpression{
+		Function: &ast.Identifier{Callee: &ast.Identifier{Value: "helpers"}, Value: "label"},
+	}, 1)
+	require.False(t, ok)
+}
+
+func Test_Compiler_Fast_Loop_And_Conditional_Plan_Edges(t *testing.T) {
+	plan := &FastRenderPlan{}
+	loop := &FastLoopPlan{KeyName: "i", ValueName: "product"}
+
+	_, ok := fastLoopPlanFromExpression(plan, nil, 1)
+	require.False(t, ok)
+
+	_, ok = fastLoopPlanFromExpression(plan, &ast.ForExpression{}, 1)
+	require.False(t, ok)
+
+	_, ok = fastLoopPlanFromExpression(plan, &ast.ForExpression{
+		Iterable: &ast.StringLiteral{Value: "products"},
+		Block:    &ast.BlockStatement{},
+	}, 1)
+	require.False(t, ok)
+
+	_, ok = fastLoopPlanFromExpression(plan, &ast.ForExpression{
+		Iterable: &ast.Identifier{Value: "nil"},
+		Block:    &ast.BlockStatement{},
+	}, 1)
+	require.False(t, ok)
+
+	fastLoop, ok := fastLoopPlanFromExpression(plan, &ast.ForExpression{
+		KeyName:   "i",
+		ValueName: "product",
+		Iterable:  &ast.Identifier{Value: "products"},
+		Block: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: &ast.HTMLLiteral{Value: "<li>"}},
+			&ast.ReturnStatement{Type: token.E_START, ReturnValue: &ast.Identifier{Value: "product"}},
+		}},
+	}, 7)
+	require.True(t, ok)
+	require.Equal(t, "products", fastLoop.IterableName)
+	require.Equal(t, []FastLoopPartKind{FastLoopPartStatic, FastLoopPartValue}, []FastLoopPartKind{
+		fastLoop.Parts[0].Kind,
+		fastLoop.Parts[1].Kind,
+	})
+
+	parts := []FastLoopPart{}
+	require.False(t, appendFastLoopStatements(plan, loop, &parts, []ast.Statement{&ast.BlockStatement{}}))
+	require.False(t, appendFastLoopStatement(plan, loop, &parts, &ast.ReturnStatement{Type: token.RETURN, ReturnValue: &ast.Identifier{Value: "product"}}))
+	require.False(t, appendFastLoopStatement(plan, loop, &parts, &ast.ExpressionStatement{Expression: &ast.Identifier{Value: "notHTML"}}))
+
+	parts = nil
+	require.True(t, appendFastLoopOutputParts(plan, loop, &parts, &ast.StringLiteral{Value: "<x>"}, 1))
+	require.True(t, appendFastLoopOutputParts(plan, loop, &parts, &ast.HTMLLiteral{Value: "<b>"}, 1))
+	require.True(t, appendFastLoopOutputParts(plan, loop, &parts, &ast.IntegerLiteral{Value: 7}, 1))
+	require.True(t, appendFastLoopOutputParts(plan, loop, &parts, &ast.FloatLiteral{Value: 1.5}, 1))
+	require.True(t, appendFastLoopOutputParts(plan, loop, &parts, &ast.Boolean{Value: true}, 1))
+	require.Equal(t, FastLoopPartStatic, parts[0].Kind)
+	require.Contains(t, parts[0].Value, "&lt;x&gt;")
+	require.Contains(t, parts[0].Value, "<b>")
+	require.Contains(t, parts[0].Value, "71.5true")
+
+	parts = nil
+	require.True(t, appendFastLoopOutputParts(plan, loop, &parts, &ast.Identifier{Value: "i"}, 2))
+	require.Equal(t, FastLoopPartKey, parts[0].Kind)
+
+	parts = nil
+	require.True(t, appendFastLoopOutputParts(plan, loop, &parts, &ast.Identifier{Value: "product"}, 2))
+	require.Equal(t, FastLoopPartValue, parts[0].Kind)
+
+	parts = nil
+	require.True(t, appendFastLoopOutputParts(plan, loop, &parts, parseCompilerExpression(t, `product.Name`), 2))
+	require.Equal(t, FastLoopPartValueProperty, parts[0].Kind)
+
+	parts = nil
+	require.True(t, appendFastLoopOutputParts(plan, loop, &parts, parseCompilerExpression(t, `product.Profile.Name`), 2))
+	require.Equal(t, FastLoopPartValuePath, parts[0].Kind)
+
+	parts = nil
+	require.True(t, appendFastLoopOutputParts(plan, loop, &parts, parseCompilerExpression(t, `product.Name.Echo()`), 2))
+	require.Equal(t, FastLoopPartValuePath, parts[0].Kind)
+
+	parts = nil
+	require.True(t, appendFastLoopOutputParts(plan, loop, &parts, parseCompilerExpression(t, `label(product.Name, i)`), 2))
+	require.Equal(t, FastLoopPartCall, parts[0].Kind)
+
+	parts = nil
+	require.True(t, appendFastLoopOutputParts(plan, loop, &parts, &ast.Identifier{Value: "other"}, 2))
+	require.Equal(t, FastLoopPartValuePath, parts[0].Kind)
+
+	_, ok = fastConditionalPlanFromExpression(plan, nil, 1)
+	require.False(t, ok)
+
+	_, ok = fastConditionalPlanFromExpression(plan, &ast.IfExpression{
+		Condition: &ast.FunctionLiteral{},
+		Block:     &ast.BlockStatement{},
+	}, 1)
+	require.False(t, ok)
+
+	_, ok = fastConditionalPlanFromExpression(plan, &ast.IfExpression{
+		Condition: &ast.Boolean{Value: true},
+		Block: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.BlockStatement{},
+		}},
+	}, 1)
+	require.False(t, ok)
+
+	_, ok = fastConditionalPlanFromExpression(plan, &ast.IfExpression{
+		Condition: &ast.Boolean{Value: true},
+		Block:     &ast.BlockStatement{},
+		ElseIf:    []*ast.ElseIfExpression{nil},
+	}, 1)
+	require.False(t, ok)
+
+	conditional, ok := fastConditionalPlanFromExpression(plan, &ast.IfExpression{
+		Condition: &ast.Boolean{Value: true},
+		Block: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: &ast.HTMLLiteral{Value: "yes"}},
+		}},
+		ElseIf: []*ast.ElseIfExpression{{
+			Condition: &ast.Identifier{Value: "fallback"},
+			Block: &ast.BlockStatement{Statements: []ast.Statement{
+				&ast.ExpressionStatement{Expression: &ast.HTMLLiteral{Value: "fallback"}},
+			}},
+		}},
+		ElseBlock: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: &ast.HTMLLiteral{Value: "no"}},
+		}},
+	}, 1)
+	require.True(t, ok)
+	require.Len(t, conditional.Branches, 2)
+	require.Len(t, conditional.ElseSegments, 1)
+
+	_, ok = fastLoopConditionalPlanFromExpression(plan, loop, nil, 1)
+	require.False(t, ok)
+
+	_, ok = fastLoopConditionalPlanFromExpression(plan, loop, &ast.IfExpression{
+		Condition: &ast.Boolean{Value: true},
+	}, 1)
+	require.False(t, ok)
+
+	_, ok = fastLoopConditionalPlanFromExpression(plan, loop, &ast.IfExpression{
+		Condition: &ast.FunctionLiteral{},
+		Block:     &ast.BlockStatement{},
+	}, 1)
+	require.False(t, ok)
+
+	_, ok = fastLoopConditionalPlanFromExpression(plan, loop, &ast.IfExpression{
+		Condition: &ast.Boolean{Value: true},
+		Block:     &ast.BlockStatement{},
+		ElseIf:    []*ast.ElseIfExpression{nil},
+	}, 1)
+	require.False(t, ok)
+
+	_, ok = fastLoopConditionalPlanFromExpression(plan, loop, &ast.IfExpression{
+		Condition: &ast.Boolean{Value: true},
+		Block: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.BlockStatement{},
+		}},
+	}, 1)
+	require.False(t, ok)
+
+	loopConditional, ok := fastLoopConditionalPlanFromExpression(plan, loop, &ast.IfExpression{
+		Condition: &ast.Identifier{Value: "product"},
+		Block: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ReturnStatement{Type: token.E_START, ReturnValue: &ast.Identifier{Value: "product"}},
+		}},
+		ElseIf: []*ast.ElseIfExpression{{
+			Condition: &ast.Identifier{Value: "i"},
+			Block: &ast.BlockStatement{Statements: []ast.Statement{
+				&ast.ReturnStatement{Type: token.E_START, ReturnValue: &ast.Identifier{Value: "i"}},
+			}},
+		}},
+		ElseBlock: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: &ast.HTMLLiteral{Value: "none"}},
+		}},
+	}, 1)
+	require.True(t, ok)
+	require.Len(t, loopConditional.Branches, 2)
+	require.Len(t, loopConditional.ElseParts, 1)
+}
+
+func Test_Compiler_Core_Helper_Branch_Edges(t *testing.T) {
+	loopControlBlock := func(expr ast.Expression) *ast.BlockStatement {
+		return &ast.BlockStatement{
+			Statements: []ast.Statement{
+				&ast.ExpressionStatement{Expression: expr},
+			},
+		}
+	}
+
+	require.False(t, ifExpressionHasLoopControl(nil))
+	require.False(t, ifExpressionHasLoopControl(&ast.IfExpression{
+		Block: &ast.BlockStatement{
+			Statements: []ast.Statement{
+				&ast.LetStatement{Name: &ast.Identifier{Value: "x"}, Value: &ast.IntegerLiteral{Value: 1}},
+			},
+		},
+	}))
+	require.True(t, ifExpressionHasLoopControl(&ast.IfExpression{
+		Block: loopControlBlock(&ast.BreakExpression{}),
+	}))
+	require.True(t, ifExpressionHasLoopControl(&ast.IfExpression{
+		ElseBlock: loopControlBlock(&ast.ContinueExpression{}),
+	}))
+	require.True(t, ifExpressionHasLoopControl(&ast.IfExpression{
+		ElseIf: []*ast.ElseIfExpression{
+			{Block: loopControlBlock(&ast.ContinueExpression{})},
+		},
+	}))
+	require.False(t, statementHasLoopControl(nil))
+	require.False(t, statementHasLoopControl(&ast.LetStatement{Name: &ast.Identifier{Value: "x"}, Value: &ast.IntegerLiteral{Value: 1}}))
+	require.True(t, statementHasLoopControl(&ast.ExpressionStatement{Expression: &ast.BreakExpression{}}))
+	require.True(t, statementHasLoopControl(&ast.ExpressionStatement{Expression: &ast.ContinueExpression{}}))
+	require.True(t, statementHasLoopControl(&ast.ExpressionStatement{Expression: &ast.IfExpression{
+		Block: loopControlBlock(&ast.BreakExpression{}),
+	}}))
+	require.False(t, statementHasLoopControl(&ast.ExpressionStatement{Expression: &ast.IntegerLiteral{Value: 1}}))
+
+	compiler := New()
+	require.NoError(t, compiler.compileExpressionStatement(&ast.ExpressionStatement{Expression: &ast.HTMLLiteral{Value: "<b>"}}))
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpWriteHTML))
+
+	compiler = New()
+	require.NoError(t, compiler.compileExpressionStatement(&ast.ExpressionStatement{Expression: &ast.IfExpression{
+		Condition: &ast.Boolean{Value: true},
+		Block:     loopControlBlock(&ast.BreakExpression{}),
+	}}))
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpBreak))
+
+	compiler = New()
+	require.NoError(t, compiler.compileExpressionStatement(&ast.ExpressionStatement{Expression: &ast.BreakExpression{}}))
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpBreak))
+	require.False(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpPop))
+
+	compiler = New()
+	require.NoError(t, compiler.compileExpressionStatement(&ast.ExpressionStatement{Expression: &ast.ContinueExpression{}}))
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpContinue))
+	require.False(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpPop))
+
+	compiler = New()
+	require.NoError(t, compiler.compileIdentifier(&ast.Identifier{Value: "nil"}))
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpNull))
+
+	compiler = New()
+	compiler.softNames = 1
+	require.NoError(t, compiler.compileIdentifier(&ast.Identifier{Value: "unknown"}))
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpGetNameOrNull))
+
+	compiler = New()
+	compiler.softNames = 1
+	require.NoError(t, compiler.compileIdentifier(&ast.Identifier{Value: "len"}))
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpGetNameOrNull))
+
+	compiler = New()
+	require.NoError(t, compiler.compileIdentifier(&ast.Identifier{Callee: &ast.Identifier{Value: "robot"}, Value: "Name"}))
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpGetProperty))
+
+	compiler = New()
+	start := len(compiler.currentInstructions())
+	compiler.ensureBranchValue(start)
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpNull))
+
+	compiler = New()
+	start = len(compiler.currentInstructions())
+	compiler.emitConstant(&object.Integer{Value: 1})
+	compiler.emit(code.OpPop)
+	compiler.ensureBranchValue(start)
+	require.False(t, compiler.lastInstructionIs(code.OpPop))
+
+	compiler = New()
+	start = len(compiler.currentInstructions())
+	compiler.emit(code.OpWrite)
+	compiler.ensureBranchValue(start)
+	require.True(t, compiler.lastInstructionIs(code.OpNull))
+
+	compiler = New()
+	_, ok := compiler.lastWriteConstantIndex(code.OpWriteString)
+	require.False(t, ok)
+
+	pos := compiler.emitWriteString("hello")
+	index, ok := compiler.lastWriteConstantIndex(code.OpWriteString)
+	require.True(t, ok)
+	require.Zero(t, index)
+
+	compiler.scopes[compiler.scopeIndex].lastInstruction = EmittedInstruction{Opcode: code.OpWriteString, Position: len(compiler.currentInstructions()) + 10}
+	_, ok = compiler.lastWriteConstantIndex(code.OpWriteString)
+	require.False(t, ok)
+
+	compiler.scopes[compiler.scopeIndex].lastInstruction = EmittedInstruction{Opcode: code.OpAdd, Position: pos}
+	_, ok = compiler.lastWriteConstantIndex(code.OpAdd)
+	require.False(t, ok)
+
+	_, ok = compiledFunctionConstant(nil, 0)
+	require.False(t, ok)
+
+	_, ok = compiledFunctionConstant([]object.Object{&object.String{Value: "nope"}}, 0)
+	require.False(t, ok)
+
+	fn := &object.CompiledFunction{}
+	gotFn, ok := compiledFunctionConstant([]object.Object{fn}, 0)
+	require.True(t, ok)
+	require.Same(t, fn, gotFn)
+
+	require.Nil(t, NewSymbolTable().localDefinitionOwner())
+}
+
+func Test_Compile_For_Expression_Error_Branches(t *testing.T) {
+	compiler := New()
+	err := compiler.compileForExpression(&ast.ForExpression{
+		KeyName:   "i",
+		ValueName: "item",
+		Iterable: &ast.PrefixExpression{
+			Operator: "??",
+			Right:    &ast.Boolean{Value: true},
+		},
+		Block: &ast.BlockStatement{},
+	})
+	require.ErrorContains(t, err, "unknown operator ??")
+
+	compiler = New()
+	err = compiler.compileForExpression(&ast.ForExpression{
+		KeyName:   "i",
+		ValueName: "item",
+		Iterable:  &ast.ArrayLiteral{},
+		Block: &ast.BlockStatement{
+			Statements: []ast.Statement{
+				&ast.ExpressionStatement{
+					Expression: &ast.PrefixExpression{
+						Operator: "??",
+						Right:    &ast.Boolean{Value: true},
+					},
+				},
+			},
+		},
+	})
+	require.ErrorContains(t, err, "unknown operator ??")
+}
+
+func Test_Compiler_Expression_Error_Branches(t *testing.T) {
+	badExpression := func() ast.Expression {
+		return &ast.PrefixExpression{
+			Operator: "??",
+			Right:    &ast.Boolean{Value: true},
+		}
+	}
+	badBlock := func() *ast.BlockStatement {
+		return &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: badExpression()},
+		}}
+	}
+
+	for _, tt := range []struct {
+		name string
+		node *ast.InfixExpression
+	}{
+		{
+			name: "less-than right compile error",
+			node: &ast.InfixExpression{Operator: "<", Left: &ast.IntegerLiteral{Value: 1}, Right: badExpression()},
+		},
+		{
+			name: "less-than left compile error",
+			node: &ast.InfixExpression{Operator: "<", Left: badExpression(), Right: &ast.IntegerLiteral{Value: 1}},
+		},
+		{
+			name: "less-equal right compile error",
+			node: &ast.InfixExpression{Operator: "<=", Left: &ast.IntegerLiteral{Value: 1}, Right: badExpression()},
+		},
+		{
+			name: "less-equal left compile error",
+			node: &ast.InfixExpression{Operator: "<=", Left: badExpression(), Right: &ast.IntegerLiteral{Value: 1}},
+		},
+		{
+			name: "soft equality left compile error",
+			node: &ast.InfixExpression{Operator: "==", Left: badExpression(), Right: &ast.IntegerLiteral{Value: 1}},
+		},
+		{
+			name: "soft equality right compile error",
+			node: &ast.InfixExpression{Operator: "==", Left: &ast.IntegerLiteral{Value: 1}, Right: badExpression()},
+		},
+		{
+			name: "default left compile error",
+			node: &ast.InfixExpression{Operator: "+", Left: badExpression(), Right: &ast.IntegerLiteral{Value: 1}},
+		},
+		{
+			name: "default right compile error",
+			node: &ast.InfixExpression{Operator: "+", Left: &ast.IntegerLiteral{Value: 1}, Right: badExpression()},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := New().compileInfixExpression(tt.node)
+			require.ErrorContains(t, err, "unknown operator ??")
+		})
+	}
+
+	require.NoError(t, New().compileInfixExpression(&ast.InfixExpression{
+		Operator: "~=",
+		Left:     &ast.StringLiteral{Value: "abc"},
+		Right:    &ast.StringLiteral{Value: "a"},
+	}))
+
+	err := New().compileIfExpression(&ast.IfExpression{Condition: badExpression(), Block: &ast.BlockStatement{}})
+	require.ErrorContains(t, err, "unknown operator ??")
+
+	err = New().compileIfExpression(&ast.IfExpression{Condition: &ast.Boolean{Value: true}, Block: badBlock()})
+	require.ErrorContains(t, err, "unknown operator ??")
+
+	err = New().compileIfExpression(&ast.IfExpression{
+		Condition: &ast.Boolean{Value: true},
+		Block:     &ast.BlockStatement{},
+		ElseIf: []*ast.ElseIfExpression{
+			{Condition: badExpression(), Block: &ast.BlockStatement{}},
+		},
+	})
+	require.ErrorContains(t, err, "unknown operator ??")
+
+	err = New().compileIfExpression(&ast.IfExpression{
+		Condition: &ast.Boolean{Value: true},
+		Block:     &ast.BlockStatement{},
+		ElseIf: []*ast.ElseIfExpression{
+			{Condition: &ast.Boolean{Value: true}, Block: badBlock()},
+		},
+	})
+	require.ErrorContains(t, err, "unknown operator ??")
+
+	err = New().compileIfExpression(&ast.IfExpression{
+		Condition: &ast.Boolean{Value: true},
+		Block:     &ast.BlockStatement{},
+		ElseBlock: badBlock(),
+	})
+	require.ErrorContains(t, err, "unknown operator ??")
+
+	err = New().compileIndexExpression(&ast.IndexExpression{
+		Left:  badExpression(),
+		Index: &ast.IntegerLiteral{Value: 0},
+	})
+	require.ErrorContains(t, err, "unknown operator ??")
+
+	err = New().compileIndexExpression(&ast.IndexExpression{
+		Left:  &ast.Identifier{Value: "items"},
+		Index: badExpression(),
+	})
+	require.ErrorContains(t, err, "unknown operator ??")
+
+	err = New().compileIndexExpression(&ast.IndexExpression{
+		Left:  &ast.Identifier{Value: "items"},
+		Index: &ast.IntegerLiteral{Value: 0},
+		Value: badExpression(),
+	})
+	require.ErrorContains(t, err, "unknown operator ??")
+
+	err = New().compileIndexExpression(&ast.IndexExpression{
+		Left:   &ast.Identifier{Value: "items"},
+		Index:  &ast.IntegerLiteral{Value: 0},
+		Callee: &ast.StringLiteral{Value: "bad"},
+	})
+	require.ErrorContains(t, err, "unsupported chained callee")
+
+	err = New().compileAssignExpression(&ast.AssignExpression{
+		Name:  &ast.Identifier{Value: "name"},
+		Value: badExpression(),
+	})
+	require.ErrorContains(t, err, "unknown operator ??")
+
+	compiler := New()
+	require.NoError(t, compiler.compileAssignExpression(&ast.AssignExpression{
+		Name:  &ast.Identifier{Value: "len"},
+		Value: &ast.IntegerLiteral{Value: 1},
+	}))
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpAssignName))
+}
+
+func Test_Compiler_Call_And_Receiver_Error_Branches(t *testing.T) {
+	badExpression := func() ast.Expression {
+		return &ast.PrefixExpression{
+			Operator: "??",
+			Right:    &ast.Boolean{Value: true},
+		}
+	}
+	badBlock := func() *ast.BlockStatement {
+		return &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: badExpression()},
+		}}
+	}
+
+	err := New().compileReceiverCallee(&ast.IndexExpression{
+		Left:  &ast.StringLiteral{Value: "bad"},
+		Index: &ast.IntegerLiteral{Value: 0},
+	}, "")
+	require.ErrorContains(t, err, "unsupported chained callee")
+
+	err = New().compileReceiverCallee(&ast.IndexExpression{
+		Left:  &ast.Identifier{Value: "items"},
+		Index: badExpression(),
+	}, "")
+	require.ErrorContains(t, err, "unknown operator ??")
+
+	err = New().compileReceiverCallee(&ast.IndexExpression{
+		Left:  &ast.Identifier{Value: "items"},
+		Index: &ast.IntegerLiteral{Value: 0},
+		Value: badExpression(),
+	}, "")
+	require.ErrorContains(t, err, "unknown operator ??")
+
+	err = New().compileReceiverCallee(&ast.IndexExpression{
+		Left:   &ast.Identifier{Value: "items"},
+		Index:  &ast.IntegerLiteral{Value: 0},
+		Callee: &ast.StringLiteral{Value: "bad"},
+	}, "")
+	require.ErrorContains(t, err, "unsupported chained callee")
+
+	err = New().compileReceiverCallee(&ast.CallExpression{
+		Function: &ast.StringLiteral{Value: "bad"},
+	}, "")
+	require.ErrorContains(t, err, "unsupported chained callee")
+
+	err = New().compileReceiverCallee(&ast.CallExpression{
+		Function:  &ast.Identifier{Value: "label"},
+		Arguments: []ast.Expression{badExpression()},
+	}, "")
+	require.ErrorContains(t, err, "unknown operator ??")
+
+	err = New().compileReceiverCallee(&ast.CallExpression{
+		Function: &ast.Identifier{Value: "label"},
+		Block:    badBlock(),
+	}, "")
+	require.ErrorContains(t, err, "unknown operator ??")
+
+	compiler := New()
+	err = compiler.compileReceiverCallee(&ast.CallExpression{
+		Function: &ast.Identifier{Value: "label"},
+		Block: &ast.BlockStatement{Statements: []ast.Statement{
+			compilerFast_Test_Return(&ast.StringLiteral{Value: "ok"}),
+		}},
+	}, "")
+	require.NoError(t, err)
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpCallBlock))
+
+	err = New().compileReceiverCallee(&ast.CallExpression{
+		Function:    &ast.Identifier{Value: "label"},
+		ChainCallee: &ast.StringLiteral{Value: "bad"},
+	}, "")
+	require.ErrorContains(t, err, "unsupported chained callee")
+
+	err = New().compileCallExpression(&ast.CallExpression{Function: badExpression()})
+	require.ErrorContains(t, err, "unknown operator ??")
+
+	err = New().compileCallExpression(&ast.CallExpression{
+		Function:  &ast.Identifier{Value: "label"},
+		Arguments: []ast.Expression{badExpression()},
+	})
+	require.ErrorContains(t, err, "unknown operator ??")
+
+	err = New().compileCallExpression(&ast.CallExpression{
+		Function: &ast.Identifier{Value: "label"},
+		Block:    badBlock(),
+	})
+	require.ErrorContains(t, err, "unknown operator ??")
+
+	err = New().compileCallExpression(&ast.CallExpression{
+		Function:    &ast.Identifier{Value: "label"},
+		ChainCallee: &ast.StringLiteral{Value: "bad"},
+	})
+	require.ErrorContains(t, err, "unsupported chained callee")
+}
+
+func Test_Compiler_Core_Compile_And_Helper_Error_Branches(t *testing.T) {
+	badExpression := func() ast.Expression {
+		return &ast.PrefixExpression{
+			Operator: "??",
+			Right:    &ast.Boolean{Value: true},
+		}
+	}
+	badStatement := func() ast.Statement {
+		return &ast.ExpressionStatement{Expression: badExpression()}
+	}
+
+	require.ErrorContains(t, New().Compile(&ast.Program{Statements: []ast.Statement{badStatement()}}), "unknown operator ??")
+	require.ErrorContains(t, New().Compile(&ast.BlockStatement{Statements: []ast.Statement{badStatement()}}), "unknown operator ??")
+	require.ErrorContains(t, New().Compile(&ast.ReturnStatement{Type: token.E_START, ReturnValue: badExpression()}), "unknown operator ??")
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(&ast.ReturnStatement{Type: token.RETURN, ReturnValue: &ast.IntegerLiteral{Value: 7}}))
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpReturnValue))
+
+	compiler = New()
+	require.NoError(t, compiler.Compile(nil))
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpNull))
+
+	compiler = New()
+	require.NoError(t, compiler.Compile(&ast.HTMLLiteral{Value: "<b>"}))
+	require.Len(t, compiler.constants, 1)
+
+	compiler = New()
+	require.NoError(t, compiler.Compile(&ast.PrefixExpression{Operator: "!", Right: &ast.Boolean{Value: true}}))
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpBang))
+
+	require.ErrorContains(t, New().Compile(&ast.ArrayLiteral{Elements: []ast.Expression{badExpression()}}), "unknown operator ??")
+	require.ErrorContains(t, New().Compile(&ast.PrefixExpression{Operator: "!", Right: badExpression()}), "unknown operator ??")
+	require.ErrorContains(t, New().Compile(&ast.PrefixExpression{Operator: "-", Right: badExpression()}), "unknown operator ??")
+
+	require.ErrorContains(t, New().compileLogicalAnd(&ast.InfixExpression{
+		Operator: "&&",
+		Left:     badExpression(),
+		Right:    &ast.Boolean{Value: true},
+	}), "unknown operator ??")
+	require.ErrorContains(t, New().compileLogicalAnd(&ast.InfixExpression{
+		Operator: "&&",
+		Left:     &ast.Boolean{Value: true},
+		Right:    badExpression(),
+	}), "unknown operator ??")
+	require.ErrorContains(t, New().compileLogicalOr(&ast.InfixExpression{
+		Operator: "||",
+		Left:     badExpression(),
+		Right:    &ast.Boolean{Value: true},
+	}), "unknown operator ??")
+	require.ErrorContains(t, New().compileLogicalOr(&ast.InfixExpression{
+		Operator: "||",
+		Left:     &ast.Boolean{Value: true},
+		Right:    badExpression(),
+	}), "unknown operator ??")
+
+	key := badExpression()
+	require.ErrorContains(t, New().compileHashLiteral(&ast.HashLiteral{
+		Order: []ast.Expression{key},
+		Pairs: map[ast.Expression]ast.Expression{key: &ast.IntegerLiteral{Value: 1}},
+	}), "unknown operator ??")
+
+	key = &ast.StringLiteral{Value: "name"}
+	require.ErrorContains(t, New().compileHashLiteral(&ast.HashLiteral{
+		Order: []ast.Expression{key},
+		Pairs: map[ast.Expression]ast.Expression{key: badExpression()},
+	}), "unknown operator ??")
+
+	compiler = New()
+	handled, err := compiler.compileWriteExpression(&ast.Identifier{Value: "nil"})
+	require.NoError(t, err)
+	require.True(t, handled)
+
+	compiler = New()
+	handled, err = compiler.compileWriteExpression(&ast.HTMLLiteral{Value: "<b>"})
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpWriteHTML))
+
+	compiler = New()
+	handled, err = compiler.compileWriteNameCallExpression(&ast.CallExpression{
+		Function:  &ast.Identifier{Value: "missing"},
+		Arguments: []ast.Expression{badExpression()},
+	})
+	require.True(t, handled)
+	require.ErrorContains(t, err, "unknown operator ??")
+
+	compiler = New()
+	handled, err = compiler.compileWriteIdentifierProperty(nil)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	handled, err = compiler.compileWriteIdentifierProperty(&ast.Identifier{
+		Callee: &ast.Identifier{Callee: &ast.Identifier{Value: "root"}, Value: "robot"},
+		Value:  "Name",
+	})
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	handled, err = compiler.compileWriteIdentifierProperty(&ast.Identifier{
+		Callee: &ast.Identifier{Value: "robot.name"},
+		Value:  "Name",
+	})
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	handled, err = compiler.compileWriteIdentifierProperty(&ast.Identifier{
+		Callee: &ast.Identifier{Value: "len"},
+		Value:  "Name",
+	})
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	require.ErrorContains(t, New().compileLetStatement(&ast.LetStatement{
+		Name: &ast.Identifier{Value: "fn"},
+		Value: &ast.FunctionLiteral{Block: &ast.BlockStatement{
+			Statements: []ast.Statement{badStatement()},
+		}},
+	}), "unknown operator ??")
+
+	require.ErrorContains(t, New().compileLetStatement(&ast.LetStatement{
+		Name:  &ast.Identifier{Value: "x"},
+		Value: badExpression(),
+	}), "unknown operator ??")
+}
+
+func Test_Compiler_Free_Symbol_Loading_For_Functions_And_Blocks(t *testing.T) {
+	compiler := New()
+	require.NoError(t, compiler.compileFunctionLiteral(&ast.FunctionLiteral{Block: &ast.BlockStatement{}}, ""))
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpClosure))
+
+	compiler = New()
+	compiler.enterScope()
+	compiler.symbolTable.Define("name")
+
+	require.NoError(t, compiler.compileFunctionLiteral(&ast.FunctionLiteral{
+		Block: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: &ast.Identifier{Value: "name"}},
+		}},
+	}, ""))
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpGetLocal))
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpClosure))
+
+	compiler = New()
+	compiler.enterScope()
+	compiler.symbolTable.Define("name")
+
+	blockIndex, numFree, err := compiler.compileBlockConstant(&ast.BlockStatement{Statements: []ast.Statement{
+		compilerFast_Test_Return(&ast.Identifier{Value: "name"}),
+	}}, nil)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, blockIndex, 0)
+	require.Equal(t, 1, numFree)
+	require.True(t, instructionContainsOpcode(compiler.currentInstructions(), code.OpGetLocal))
+}
+
+func Test_Compiler_Script_Tag_Control_Blocks_Suppress_Nested_Output(t *testing.T) {
+	program, err := parser.Parse(`<% if (true) { %>hidden<% } %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+	instructions := compiler.Bytecode().Instructions
+	require.Falsef(t, instructionContainsOpcode(instructions, code.OpWriteHTML), "script if should not write HTML:\n%s", instructions.String())
+	require.Falsef(t, instructionContainsOpcode(instructions, code.OpWriteString), "script if should not write strings:\n%s", instructions.String())
+
+	program, err = parser.Parse(`<% if (true) { %><%= "hidden" %><% } %>`)
+	require.NoError(t, err)
+	compiler = New()
+	require.NoError(t, compiler.Compile(program))
+	instructions = compiler.Bytecode().Instructions
+	require.Falsef(t, instructionContainsOpcode(instructions, code.OpWriteString), "script if should not write nested eval output:\n%s", instructions.String())
+
+	program, err = parser.Parse(`<%= if (true) { %>shown<% } %>`)
+	require.NoError(t, err)
+	compiler = New()
+	require.NoError(t, compiler.Compile(program))
+	instructions = compiler.Bytecode().Instructions
+	require.Truef(t, instructionContainsOpcode(instructions, code.OpWrite), "output if should keep shared write:\n%s", instructions.String())
+}
+
+func Test_Compiler_Static_Write_Merge_Branches(t *testing.T) {
+	compiler := New()
+	first := compiler.emitWriteString("<")
+	second := compiler.emitWriteString(">")
+	require.Equal(t, first, second)
+	require.Len(t, compiler.constants, 1)
+	require.Equal(t, "<>", compiler.constants[0].(*object.String).Value)
+
+	htmlPos := compiler.emitWriteHTML("<b>")
+	require.Equal(t, first, htmlPos)
+	require.Len(t, compiler.constants, 1)
+	require.Equal(t, template.HTML("&lt;&gt;<b>"), compiler.constants[0].(*object.Native).Value)
+	require.Equal(t, code.OpWriteHTML, compiler.scopes[compiler.scopeIndex].lastInstruction.Opcode)
+
+	htmlCompiler := New()
+	first = htmlCompiler.emitWriteHTML("<b>")
+	second = htmlCompiler.emitWriteHTML("<i>")
+	require.Equal(t, first, second)
+	require.Len(t, htmlCompiler.constants, 1)
+	require.Equal(t, template.HTML("<b><i>"), htmlCompiler.constants[0].(*object.Native).Value)
+
+	mixedCompiler := New()
+	first = mixedCompiler.emitWriteHTML("<b>")
+	second = mixedCompiler.emitWriteString("<x>")
+	require.Equal(t, first, second)
+	require.Len(t, mixedCompiler.constants, 1)
+	require.Equal(t, template.HTML("<b>&lt;x&gt;"), mixedCompiler.constants[0].(*object.Native).Value)
+}
+
+func Test_New_With_State_Keeps_Provided_State(t *testing.T) {
+	symbols := NewSymbolTable()
+	constants := []object.Object{&object.Integer{Value: 7}}
+
+	compiler := NewWithState(symbols, constants)
+
+	require.Same(t, symbols, compiler.symbolTable)
+	require.Same(t, constants[0], compiler.constants[0])
+}
+
+func Test_Logical_Or_Compilation_Branch(t *testing.T) {
+	program, err := ParseScript(`true || false`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	instructions := compiler.Bytecode().Instructions
+	require.True(t, instructionContainsOpcode(instructions, code.OpJumpNotTruthy))
+	require.True(t, instructionContainsOpcode(instructions, code.OpJump))
+	require.True(t, instructionContainsOpcode(instructions, code.OpTrue))
+}
+
+func Test_Assign_Expression_Compilation_Branches(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  code.Opcode
+	}{
+		{
+			name:  "unknown name assignment",
+			input: `missing = 1`,
+			want:  code.OpAssignName,
+		},
+		{
+			name:  "global assignment",
+			input: `let value = 1; value = 2`,
+			want:  code.OpSetGlobal,
+		},
+		{
+			name:  "local assignment",
+			input: `fn() { let value = 1; value = 2 }`,
+			want:  code.OpSetLocal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			program, err := ParseScript(tt.input)
+			require.NoError(t, err)
+
+			compiler := New()
+			require.NoError(t, compiler.Compile(program))
+
+			require.True(t, bytecodeContainsOpcode(compiler.Bytecode(), tt.want))
+		})
+	}
+}
+
+func Test_Soft_Undefined_Equality_Names(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input:             `3 == unknown; unknown != 3;`,
+			expectedConstants: []interface{}{3, "unknown", "unknown", 3},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpGetNameOrNull, 1),
+				code.Make(code.OpEqual),
+				code.Make(code.OpPop),
+				code.Make(code.OpGetNameOrNull, 2),
+				code.Make(code.OpConstant, 3),
+				code.Make(code.OpNotEqual),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+
+	runCompilerTests(t, tests)
+}
+
+func Test_Conditionals(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input:             `if (true) { 10 }; 3333;`,
+			expectedConstants: []interface{}{10, 3333},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpTrue),
+				code.Make(code.OpJumpNotTruthy, 10),
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpJump, 10),
+				code.Make(code.OpPop),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             `if (true) { 10 } else { 20 }; 3333;`,
+			expectedConstants: []interface{}{10, 20, 3333},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpTrue),
+				code.Make(code.OpJumpNotTruthy, 10),
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpJump, 13),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpPop),
+				code.Make(code.OpConstant, 2),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+
+	runCompilerTests(t, tests)
+}
+
+func Test_Peephole_Null_Pop_Optimization(t *testing.T) {
+	program, err := ParseScript(`if (false) { 10 };`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.False(t, instructionContainsSequence(bytecode.Instructions, code.OpNull, code.OpPop))
+	testInstructions(t, []code.Instructions{
+		code.Make(code.OpFalse),
+		code.Make(code.OpJumpNotTruthy, 10),
+		code.Make(code.OpConstant, 0),
+		code.Make(code.OpJump, 10),
+		code.Make(code.OpPop),
+	}, bytecode.Instructions)
+}
+
+func Test_Peephole_Write_Superinstructions(t *testing.T) {
+	program, err := parser.Parse(`<%= "static" %><%= 10 %>prefix<%= name %><% let local = "local" %><%= local %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.Truef(t, instructionContainsOpcode(bytecode.Instructions, code.OpWriteConstant), "expected OpWriteConstant:\n%s", bytecode.Instructions.String())
+	require.Truef(t, instructionContainsOpcode(bytecode.Instructions, code.OpWriteString), "expected OpWriteString:\n%s", bytecode.Instructions.String())
+	require.Truef(t, instructionContainsOpcode(bytecode.Instructions, code.OpWriteHTML), "expected OpWriteHTML:\n%s", bytecode.Instructions.String())
+	require.Truef(t, instructionContainsOpcode(bytecode.Instructions, code.OpWriteName), "expected OpWriteName:\n%s", bytecode.Instructions.String())
+	require.Truef(t, instructionContainsOpcode(bytecode.Instructions, code.OpWriteGlobal), "expected OpWriteGlobal:\n%s", bytecode.Instructions.String())
+	require.Falsef(t, instructionContainsSequence(bytecode.Instructions, code.OpConstant, code.OpWrite), "expected constant/write pair to be fused:\n%s", bytecode.Instructions.String())
+	require.Falsef(t, instructionContainsSequence(bytecode.Instructions, code.OpGetName, code.OpWrite), "expected name/write pair to be fused:\n%s", bytecode.Instructions.String())
+	require.Falsef(t, instructionContainsSequence(bytecode.Instructions, code.OpGetGlobal, code.OpWrite), "expected global/write pair to be fused:\n%s", bytecode.Instructions.String())
+}
+
+func Test_Static_Only_Bytecode_Fast_Path(t *testing.T) {
+	program, err := parser.Parse(`<section><p>Hello</p></section>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.True(t, bytecode.Static)
+	require.Equal(t, `<section><p>Hello</p></section>`, bytecode.StaticOutput)
+	require.Equal(t, 1, instructionOpcodeCount(bytecode.Instructions, code.OpWriteHTML))
+}
+
+func Test_Static_Only_Bytecode_Escapes_String_Literal(t *testing.T) {
+	program, err := parser.Parse(`<strong><%= "<x>" %></strong>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.True(t, bytecode.Static)
+	require.Equal(t, `<strong>&lt;x&gt;</strong>`, bytecode.StaticOutput)
+	require.Equal(t, 1, instructionOpcodeCount(bytecode.Instructions, code.OpWriteHTML))
+}
+
+func Test_Static_Only_Bytecode_Includes_Scalar_Constants(t *testing.T) {
+	program, err := parser.Parse(`<%= 10 %><span>items</span>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.True(t, bytecode.Static)
+	require.Equal(t, `10<span>items</span>`, bytecode.StaticOutput)
+	require.Truef(t, instructionContainsOpcode(bytecode.Instructions, code.OpWriteConstant), "expected OpWriteConstant:\n%s", bytecode.Instructions.String())
+}
+
+func Test_Bytecode_Feature_Flags(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		hasHoles    bool
+		hasPartials bool
+	}{
+		{
+			name:  "plain",
+			input: `<p><%= name %></p>`,
+		},
+		{
+			name:        "partial call",
+			input:       `<%= partial("row") %>`,
+			hasPartials: true,
+		},
+		{
+			name:        "partial alias",
+			input:       `<% let p = partial %><%= p("row") %>`,
+			hasPartials: true,
+		},
+		{
+			name:     "hole",
+			input:    `<%H "hole" %>`,
+			hasHoles: true,
+		},
+		{
+			name:        "partial in function",
+			input:       `<% let render = fn() { return partial("row") } %><%= render() %>`,
+			hasPartials: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			program, err := parser.Parse(tt.input)
+			require.NoError(t, err)
+
+			compiler := New()
+			require.NoError(t, compiler.Compile(program))
+
+			bytecode := compiler.Bytecode()
+			require.Equal(t, tt.hasHoles, bytecode.HasHoles)
+			require.Equal(t, tt.hasPartials, bytecode.HasPartials)
+		})
+	}
+}
+
+func Test_Mixed_Static_Runs_Are_Coalesced_Without_Marking_Template_Static(t *testing.T) {
+	program, err := parser.Parse(`a<%= "b<c>" %>d<%= name %>e<%= "f" %>g`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.False(t, bytecode.Static)
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Equal(t, []string{"name"}, bytecode.FastRenderPlan.Bindings)
+	require.Equal(t, 15, bytecode.FastRenderPlan.StaticSize)
+	require.Equal(t, 1, bytecode.FastRenderPlan.NameCount)
+	require.Equal(t, []FastRenderSegment{
+		{Kind: FastRenderSegmentStatic, Value: `ab&lt;c&gt;d`},
+		{Kind: FastRenderSegmentName, Value: "name", Line: 1},
+		{Kind: FastRenderSegmentStatic, Value: `efg`},
+	}, bytecode.FastRenderPlan.Segments)
+	require.Equal(t, 2, instructionOpcodeCount(bytecode.Instructions, code.OpWriteHTML))
+	require.Truef(t, instructionContainsOpcode(bytecode.Instructions, code.OpWriteName), "expected OpWriteName:\n%s", bytecode.Instructions.String())
+}
+
+func Test_Fast_Render_Plan_From_Instructions_Edges(t *testing.T) {
+	require.Nil(t, fastRenderPlanFromInstructions(code.Instructions{255}, nil, nil))
+
+	require.Nil(t, fastRenderPlanFromInstructions(code.Make(code.OpWriteString, 0), []object.Object{&object.String{Value: "static"}}, nil))
+	require.Nil(t, fastRenderPlanFromInstructions(code.Make(code.OpWriteName, 0), []object.Object{&object.String{Value: "nil"}}, nil))
+	require.Nil(t, fastRenderPlanFromInstructions(code.Make(code.OpWriteNameProperty, 0, 1), []object.Object{
+		&object.String{Value: "nil"},
+		&object.String{Value: "Name"},
+	}, nil))
+
+	require.Nil(t, fastRenderPlanFromInstructions(code.Make(code.OpWriteHTML, 0), []object.Object{&object.String{Value: "bad"}}, nil))
+	require.Nil(t, fastRenderPlanFromInstructions(code.Make(code.OpWriteName, 0), []object.Object{&object.Integer{Value: 1}}, nil))
+	require.Nil(t, fastRenderPlanFromInstructions(code.Make(code.OpWriteNameProperty, 0, 1), []object.Object{
+		&object.Integer{Value: 1},
+		&object.String{Value: "Name"},
+	}, nil))
+	require.Nil(t, fastRenderPlanFromInstructions(code.Make(code.OpWriteNameProperty, 0, 1), []object.Object{
+		&object.String{Value: "user"},
+		&object.Integer{Value: 1},
+	}, nil))
+	require.Nil(t, fastRenderPlanFromInstructions(code.Make(code.OpWriteString, 0), []object.Object{&object.Integer{Value: 1}}, nil))
+	require.Nil(t, fastRenderPlanFromInstructions(code.Make(code.OpWriteConstant, 0), []object.Object{&object.Array{}}, nil))
+	require.Nil(t, fastRenderPlanFromInstructions(code.Make(code.OpAdd), nil, nil))
+
+	plan := fastRenderPlanFromInstructions(
+		append(code.Make(code.OpWriteString, 0), code.Make(code.OpWriteName, 1)...),
+		[]object.Object{&object.String{Value: "<"}, &object.String{Value: "name"}},
+		map[int]int{len(code.Make(code.OpWriteString, 0)): 9},
+	)
+	require.NotNil(t, plan)
+	require.Equal(t, []string{"name"}, plan.Bindings)
+	require.Equal(t, []FastRenderSegment{
+		{Kind: FastRenderSegmentStatic, Value: "&lt;"},
+		{Kind: FastRenderSegmentName, Value: "name", Line: 9},
+	}, plan.Segments)
+
+	plan = fastRenderPlanFromInstructions(code.Make(code.OpWriteNameProperty, 0, 1), []object.Object{
+		&object.String{Value: "user"},
+		&object.String{Value: "Name"},
+	}, map[int]int{0: 4})
+	require.NotNil(t, plan)
+	require.Equal(t, FastRenderSegmentProperty, plan.Segments[0].Kind)
+	require.Equal(t, "user.Name", plan.Segments[0].Full)
+
+	loopInstructions := code.Instructions(append(code.Make(code.OpWriteLocal, 0), code.Make(code.OpReturn)...))
+	loopConstants := []object.Object{
+		&object.CompiledFunction{Instructions: loopInstructions, NumParameters: 2},
+		&object.String{Value: "nil"},
+		&object.String{Value: "i"},
+		&object.String{Value: "item"},
+	}
+	loopPlanInstructions := code.Instructions{}
+	loopPlanInstructions = append(loopPlanInstructions, code.Make(code.OpGetName, 1)...)
+	loopPlanInstructions = append(loopPlanInstructions, code.Make(code.OpFor, 0, 2, 3, 0)...)
+	loopPlanInstructions = append(loopPlanInstructions, code.Make(code.OpWrite)...)
+	require.Nil(t, fastRenderPlanFromInstructions(loopPlanInstructions, loopConstants, nil))
+
+	loopConstants[1] = &object.Integer{Value: 1}
+	require.Nil(t, fastRenderPlanFromInstructions(loopPlanInstructions, loopConstants, nil))
+
+	output, ok := staticOutputFromInstructions(code.Instructions{255}, nil)
+	require.False(t, ok)
+	require.Empty(t, output)
+
+	output, ok = staticOutputFromInstructions(code.Make(code.OpWriteHTML, 0), []object.Object{&object.String{Value: "bad"}})
+	require.False(t, ok)
+	require.Empty(t, output)
+
+	output, ok = staticOutputFromInstructions(code.Make(code.OpWriteString, 0), []object.Object{&object.Integer{Value: 1}})
+	require.False(t, ok)
+	require.Empty(t, output)
+
+	output, ok = staticOutputFromInstructions(code.Make(code.OpWriteConstant, 0), []object.Object{&object.Array{}})
+	require.False(t, ok)
+	require.Empty(t, output)
+}
+
+func Test_Fast_Render_Plan_Includes_Property_Access(t *testing.T) {
+	program, err := parser.Parse(`<p><%= user.Name %></p>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Equal(t, []string{"user"}, bytecode.FastRenderPlan.Bindings)
+	require.Equal(t, []FastRenderSegment{
+		{Kind: FastRenderSegmentStatic, Value: `<p>`},
+		{Kind: FastRenderSegmentProperty, Value: "user", Property: "Name", Receiver: "user", Full: "user.Name", Line: 1},
+		{Kind: FastRenderSegmentStatic, Value: `</p>`},
+	}, bytecode.FastRenderPlan.Segments)
+}
+
+func Test_Fast_Render_Plan_Includes_Simple_Loops(t *testing.T) {
+	program, err := parser.Parse(`<%= for (i, product) in products { %><%= i %>:<%= product.Name %>;<% } %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Equal(t, []string{"products"}, bytecode.FastRenderPlan.Bindings)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+	segment := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+	require.Equal(t, "products", segment.Loop.IterableName)
+	require.Equal(t, "i", segment.Loop.KeyName)
+	require.Equal(t, "product", segment.Loop.ValueName)
+	require.Equal(t, []FastLoopPart{
+		{Kind: FastLoopPartKey, Line: 1},
+		{Kind: FastLoopPartStatic, Value: ":"},
+		{Kind: FastLoopPartValueProperty, Value: "Name", Receiver: "product", Full: "product.Name", Line: 1},
+		{Kind: FastLoopPartStatic, Value: ";"},
+	}, segment.Loop.Parts)
+}
+
+func Test_Fast_Render_Plan_Includes_Loop_Indexed_Value_Paths(t *testing.T) {
+	program, err := parser.Parse(`<%= for (i, product) in products { %><%= product.Friends[0].Name %>;<% } %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+	segment := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+	require.Len(t, segment.Loop.Parts, 2)
+	part := segment.Loop.Parts[0]
+	require.Equal(t, FastLoopPartValuePath, part.Kind)
+	require.Equal(t, FastValuePath, part.ValuePlan.Kind)
+	require.Equal(t, "product", part.ValuePlan.Value)
+	require.Len(t, part.ValuePlan.Path, 3)
+	require.Equal(t, FastPathStepProperty, part.ValuePlan.Path[0].Kind)
+	require.Equal(t, "Friends", part.ValuePlan.Path[0].Value)
+	require.False(t, part.ValuePlan.Path[0].Method)
+	require.Equal(t, FastPathStepIndexInteger, part.ValuePlan.Path[1].Kind)
+	require.Equal(t, 0, part.ValuePlan.Path[1].Index)
+	require.Equal(t, FastPathStepProperty, part.ValuePlan.Path[2].Kind)
+	require.Equal(t, "Name", part.ValuePlan.Path[2].Value)
+	require.False(t, part.ValuePlan.Path[2].Method)
+}
+
+func Test_Fast_Render_Plan_Includes_Loop_String_Indexed_Value_Paths(t *testing.T) {
+	program, err := parser.Parse(`<%= for (i, product) in products { %><%= product.Meta["label"] %>;<% } %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	segment := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+	require.Len(t, segment.Loop.Parts, 2)
+	part := segment.Loop.Parts[0]
+	require.Equal(t, FastLoopPartValuePath, part.Kind)
+	require.Equal(t, FastValuePath, part.ValuePlan.Kind)
+	require.Len(t, part.ValuePlan.Path, 2)
+	require.Equal(t, FastPathStepProperty, part.ValuePlan.Path[0].Kind)
+	require.Equal(t, "Meta", part.ValuePlan.Path[0].Value)
+	require.Equal(t, FastPathStepIndexString, part.ValuePlan.Path[1].Kind)
+	require.Equal(t, "label", part.ValuePlan.Path[1].Value)
+}
+
+func Test_Fast_Render_Plan_Includes_Top_Level_Context_Paths_Inside_Loops(t *testing.T) {
+	program, err := parser.Parse(`<%= for (_, product) in products { %><%= category.CategorySeoTitle %>/<%= product.ProductSeoUrl %><% } %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Empty(t, bytecode.FastReject)
+	require.Equal(t, []string{"products", "category"}, bytecode.FastRenderPlan.Bindings)
+
+	loop := bytecode.FastRenderPlan.Segments[0].Loop
+	require.NotNil(t, loop)
+	require.Len(t, loop.Parts, 3)
+	require.Equal(t, FastLoopPartValuePath, loop.Parts[0].Kind)
+	require.Equal(t, "category", loop.Parts[0].ValuePlan.Value)
+	require.Equal(t, FastLoopPartStatic, loop.Parts[1].Kind)
+	require.Equal(t, FastLoopPartValueProperty, loop.Parts[2].Kind)
+}
+
+func Test_Fast_Render_Plan_Includes_Loop_Method_Call_Value_Paths(t *testing.T) {
+	program, err := parser.Parse(`<%= for (i, product) in products { %><%= product.Name.Echo() %>;<% } %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	segment := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+	require.Len(t, segment.Loop.Parts, 2)
+	part := segment.Loop.Parts[0]
+	require.Equal(t, FastLoopPartValuePath, part.Kind)
+	require.Equal(t, FastValuePath, part.ValuePlan.Kind)
+	require.Len(t, part.ValuePlan.Path, 3)
+	require.Equal(t, FastPathStepProperty, part.ValuePlan.Path[0].Kind)
+	require.Equal(t, "Name", part.ValuePlan.Path[0].Value)
+	require.Equal(t, FastPathStepProperty, part.ValuePlan.Path[1].Kind)
+	require.Equal(t, "Echo", part.ValuePlan.Path[1].Value)
+	require.True(t, part.ValuePlan.Path[1].Method)
+	require.Equal(t, FastPathStepCall, part.ValuePlan.Path[2].Kind)
+	require.Equal(t, "Echo", part.ValuePlan.Path[2].Value)
+}
+
+func Test_Fast_Render_Plan_Includes_Loop_Literal_Outputs(t *testing.T) {
+	program, err := parser.Parse(`<%= for (i, product) in products { %><%= "x<y>" %><%= 3 %><%= 1.5 %><%= true %><% } %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	segment := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+	require.Len(t, segment.Loop.Parts, 1)
+	require.Equal(t, FastLoopPartStatic, segment.Loop.Parts[0].Kind)
+	require.Equal(t, "x&lt;y&gt;31.5true", segment.Loop.Parts[0].Value)
+}
+
+func Test_Fast_Render_Plan_Includes_Loop_Helper_Calls(t *testing.T) {
+	program, err := parser.Parse(`<%= for (i, product) in products { %><%= label(product.Name, prefix) %>;<% } %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Equal(t, []string{"products", "label", "prefix"}, bytecode.FastRenderPlan.Bindings)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+	segment := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+	require.Len(t, segment.Loop.Parts, 2)
+
+	part := segment.Loop.Parts[0]
+	require.Equal(t, FastLoopPartCall, part.Kind)
+	require.NotNil(t, part.Call)
+	require.Equal(t, "label", part.Call.Name)
+	require.Equal(t, 1, part.Call.NameIndex)
+	require.Len(t, part.Call.Args, 2)
+
+	productArg := part.Call.Args[0]
+	require.Equal(t, FastValuePath, productArg.Kind)
+	require.Equal(t, "product", productArg.Value)
+	require.Equal(t, -1, productArg.NameIndex)
+	require.Len(t, productArg.Path, 1)
+	require.Equal(t, FastPathStepProperty, productArg.Path[0].Kind)
+	require.Equal(t, "Name", productArg.Path[0].Value)
+
+	prefixArg := part.Call.Args[1]
+	require.Equal(t, FastValueName, prefixArg.Kind)
+	require.Equal(t, "prefix", prefixArg.Value)
+	require.Equal(t, 2, prefixArg.NameIndex)
+	require.Equal(t, FastLoopPartStatic, segment.Loop.Parts[1].Kind)
+	require.Equal(t, ";", segment.Loop.Parts[1].Value)
+}
+
+func Test_Fast_Render_Plan_Includes_Loop_Helper_Call_Method_Arguments(t *testing.T) {
+	program, err := parser.Parse(`<%= for (i, product) in products { %><%= label(product.Name.Echo(), prefix) %>;<% } %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Equal(t, []string{"products", "label", "prefix"}, bytecode.FastRenderPlan.Bindings)
+	segment := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+	part := segment.Loop.Parts[0]
+	require.Equal(t, FastLoopPartCall, part.Kind)
+	require.NotNil(t, part.Call)
+	require.Len(t, part.Call.Args, 2)
+	arg := part.Call.Args[0]
+	require.Equal(t, FastValuePath, arg.Kind)
+	require.Len(t, arg.Path, 3)
+	require.Equal(t, FastPathStepProperty, arg.Path[0].Kind)
+	require.Equal(t, "Name", arg.Path[0].Value)
+	require.Equal(t, FastPathStepProperty, arg.Path[1].Kind)
+	require.True(t, arg.Path[1].Method)
+	require.Equal(t, FastPathStepCall, arg.Path[2].Kind)
+}
+
+func Test_Fast_Render_Plan_Includes_Loop_Conditionals(t *testing.T) {
+	program, err := parser.Parse(`<%= for (i, product) in products { %><%= if product.Enabled { %><%= product.Name %><% } else if fallback { %>fallback<% } else { %>hidden<% } %>;<% } %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Equal(t, []string{"products", "fallback"}, bytecode.FastRenderPlan.Bindings)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+	segment := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+	require.Len(t, segment.Loop.Parts, 2)
+
+	part := segment.Loop.Parts[0]
+	require.Equal(t, FastLoopPartConditional, part.Kind)
+	require.NotNil(t, part.Conditional)
+	require.Len(t, part.Conditional.Branches, 2)
+
+	first := part.Conditional.Branches[0]
+	require.Equal(t, FastValuePath, first.Condition.Kind)
+	require.Equal(t, "product", first.Condition.Value)
+	require.Equal(t, -1, first.Condition.NameIndex)
+	require.Len(t, first.Condition.Path, 1)
+	require.Equal(t, "Enabled", first.Condition.Path[0].Value)
+	require.Len(t, first.Parts, 1)
+	require.Equal(t, FastLoopPartValueProperty, first.Parts[0].Kind)
+	require.Equal(t, "Name", first.Parts[0].Value)
+
+	second := part.Conditional.Branches[1]
+	require.Equal(t, FastValueName, second.Condition.Kind)
+	require.Equal(t, "fallback", second.Condition.Value)
+	require.Equal(t, 1, second.Condition.NameIndex)
+	require.Len(t, second.Parts, 1)
+	require.Equal(t, FastLoopPartStatic, second.Parts[0].Kind)
+	require.Equal(t, "fallback", second.Parts[0].Value)
+
+	require.Len(t, part.Conditional.ElseParts, 1)
+	require.Equal(t, FastLoopPartStatic, part.Conditional.ElseParts[0].Kind)
+	require.Equal(t, "hidden", part.Conditional.ElseParts[0].Value)
+	require.Equal(t, FastLoopPartStatic, segment.Loop.Parts[1].Kind)
+	require.Equal(t, ";", segment.Loop.Parts[1].Value)
+}
+
+func Test_Fast_Render_Plan_Includes_Loop_Break_And_Continue(t *testing.T) {
+	program, err := parser.Parse(`<%= for (i, product) in products { %><%= if product.Stop { %><%= break %><% } %><%= if product.Skip { %><%= continue %><% } %><%= product.Name %><% } %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Empty(t, bytecode.FastReject)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+
+	loop := bytecode.FastRenderPlan.Segments[0].Loop
+	require.NotNil(t, loop)
+	require.Len(t, loop.Parts, 3)
+	require.Equal(t, FastLoopPartConditional, loop.Parts[0].Kind)
+	require.Len(t, loop.Parts[0].Conditional.Branches[0].Parts, 1)
+	require.Equal(t, FastLoopPartBreak, loop.Parts[0].Conditional.Branches[0].Parts[0].Kind)
+	require.Equal(t, FastLoopPartConditional, loop.Parts[1].Kind)
+	require.Len(t, loop.Parts[1].Conditional.Branches[0].Parts, 1)
+	require.Equal(t, FastLoopPartContinue, loop.Parts[1].Conditional.Branches[0].Parts[0].Kind)
+	require.Equal(t, FastLoopPartValueProperty, loop.Parts[2].Kind)
+}
+
+func Test_Fast_Render_Plan_Includes_Script_Loop_Control(t *testing.T) {
+	program, err := parser.Parse(`<%= for (i, product) in products { break } %><%= for (i, product) in products { continue } %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Empty(t, bytecode.FastReject)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 2)
+	require.Equal(t, FastLoopPartBreak, bytecode.FastRenderPlan.Segments[0].Loop.Parts[0].Kind)
+	require.Equal(t, FastLoopPartContinue, bytecode.FastRenderPlan.Segments[1].Loop.Parts[0].Kind)
+}
+
+func Test_Fast_Render_Plan_Includes_Loop_Block_Helper_Calls(t *testing.T) {
+	program, err := parser.Parse(`<%= for (_, product) in products { %><%= form({id: product.ID, path: cartPath()}) { %><span><%= product.Name %></span><% } %><% } %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Empty(t, bytecode.FastReject)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+
+	loop := bytecode.FastRenderPlan.Segments[0].Loop
+	require.NotNil(t, loop)
+	require.Len(t, loop.Parts, 1)
+	require.Equal(t, FastLoopPartBlockCall, loop.Parts[0].Kind)
+	require.NotNil(t, loop.Parts[0].BlockCall)
+	require.Equal(t, "form", loop.Parts[0].BlockCall.Name)
+	require.Len(t, loop.Parts[0].BlockCall.Args, 1)
+	require.NotNil(t, loop.Parts[0].BlockCall.BlockBytecode)
+	require.NotEmpty(t, loop.Parts[0].BlockCall.BlockSource)
+}
+
+func Test_Fast_Render_Plan_Includes_Loop_Helper_Calls_Using_Key_Argument(t *testing.T) {
+	program, err := parser.Parse(`<%= for (i, product) in products { %><%= label(i) %>;<% } %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Equal(t, []string{"products", "label"}, bytecode.FastRenderPlan.Bindings)
+	segment := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+	require.Len(t, segment.Loop.Parts, 2)
+	part := segment.Loop.Parts[0]
+	require.Equal(t, FastLoopPartCall, part.Kind)
+	require.NotNil(t, part.Call)
+	require.Len(t, part.Call.Args, 1)
+	require.Equal(t, FastValueLoopKey, part.Call.Args[0].Kind)
+	require.Equal(t, "i", part.Call.Args[0].Value)
+}
+
+func Test_Fast_Render_Plan_Includes_Loop_Conditionals_Using_Key_Condition(t *testing.T) {
+	program, err := parser.Parse(`<%= for (i, product) in products { %><%= if i { %><%= product.Name %><% } %><% } %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	segment := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+	require.Len(t, segment.Loop.Parts, 1)
+	part := segment.Loop.Parts[0]
+	require.Equal(t, FastLoopPartConditional, part.Kind)
+	require.NotNil(t, part.Conditional)
+	require.Len(t, part.Conditional.Branches, 1)
+	require.Equal(t, FastValueLoopKey, part.Conditional.Branches[0].Condition.Kind)
+	require.Equal(t, "i", part.Conditional.Branches[0].Condition.Value)
+}
+
+func Test_Fast_Render_Plan_Includes_Loop_Infix_Conditionals(t *testing.T) {
+	program, err := parser.Parse(`<%= for (i, product) in products { %><%= if product.Stock > min { %><%= product.Name %><% } else if i == 0 { %>first<% } %><% } %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Equal(t, []string{"products", "min"}, bytecode.FastRenderPlan.Bindings)
+	segment := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+	require.Len(t, segment.Loop.Parts, 1)
+	part := segment.Loop.Parts[0]
+	require.Equal(t, FastLoopPartConditional, part.Kind)
+	require.NotNil(t, part.Conditional)
+	require.Len(t, part.Conditional.Branches, 2)
+
+	first := part.Conditional.Branches[0].Condition
+	require.Equal(t, FastValueInfix, first.Kind)
+	require.Equal(t, ">", first.Operator)
+	require.NotNil(t, first.Left)
+	require.NotNil(t, first.Right)
+	require.Equal(t, FastValuePath, first.Left.Kind)
+	require.Equal(t, "product", first.Left.Value)
+	require.Len(t, first.Left.Path, 1)
+	require.Equal(t, "Stock", first.Left.Path[0].Value)
+	require.Equal(t, FastValueName, first.Right.Kind)
+	require.Equal(t, "min", first.Right.Value)
+
+	second := part.Conditional.Branches[1].Condition
+	require.Equal(t, FastValueInfix, second.Kind)
+	require.Equal(t, "==", second.Operator)
+	require.Equal(t, FastValueLoopKey, second.Left.Kind)
+	require.Equal(t, FastValueInteger, second.Right.Kind)
+	require.Equal(t, int64(0), second.Right.IntValue)
+}
+
+func Test_Fast_Render_Plan_Includes_Top_Level_Infix_Output(t *testing.T) {
+	program, err := parser.Parse(`<%= robot.Stock == 3.0 %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Equal(t, []string{"robot"}, bytecode.FastRenderPlan.Bindings)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+
+	segment := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentValue, segment.Kind)
+	require.Equal(t, FastValueInfix, segment.ValuePlan.Kind)
+	require.Equal(t, "==", segment.ValuePlan.Operator)
+	require.NotNil(t, segment.ValuePlan.Left)
+	require.NotNil(t, segment.ValuePlan.Right)
+	require.Equal(t, FastValuePath, segment.ValuePlan.Left.Kind)
+	require.Equal(t, "robot", segment.ValuePlan.Left.Value)
+	require.Len(t, segment.ValuePlan.Left.Path, 1)
+	require.Equal(t, "Stock", segment.ValuePlan.Left.Path[0].Value)
+	require.Equal(t, FastValueFloat, segment.ValuePlan.Right.Kind)
+	require.Equal(t, 3.0, segment.ValuePlan.Right.FloatValue)
+}
+
+func Test_Fast_Render_Plan_Includes_Top_Level_Logical_Infix_Output(t *testing.T) {
+	program, err := parser.Parse(`<%= enabled && count == 1 %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Equal(t, []string{"enabled", "count"}, bytecode.FastRenderPlan.Bindings)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+
+	segment := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentValue, segment.Kind)
+	require.Equal(t, FastValueInfix, segment.ValuePlan.Kind)
+	require.Equal(t, "&&", segment.ValuePlan.Operator)
+	require.NotNil(t, segment.ValuePlan.Left)
+	require.NotNil(t, segment.ValuePlan.Right)
+	require.Equal(t, FastValueName, segment.ValuePlan.Left.Kind)
+	require.Equal(t, FastValueInfix, segment.ValuePlan.Right.Kind)
+	require.Equal(t, "==", segment.ValuePlan.Right.Operator)
+}
+
+func Test_Fast_Render_Plan_From_Instructions_Includes_Loop_Function(t *testing.T) {
+	loopInstructions := code.Instructions{}
+	loopInstructions = append(loopInstructions, code.Make(code.OpWriteHTML, 1)...)
+	loopInstructions = append(loopInstructions, code.Make(code.OpWriteLocal, 0)...)
+	loopInstructions = append(loopInstructions, code.Make(code.OpWriteString, 2)...)
+	loopInstructions = append(loopInstructions, code.Make(code.OpWriteLocalProperty, 1, 3)...)
+	loopInstructions = append(loopInstructions, code.Make(code.OpReturn)...)
+
+	constants := []object.Object{
+		&object.CompiledFunction{
+			Instructions:  loopInstructions,
+			NumParameters: 2,
+			LineNumbers: map[int]int{
+				0: 3,
+			},
+		},
+		&object.Native{Value: template.HTML("<b>")},
+		&object.String{Value: ":"},
+		&object.String{Value: "Name"},
+		&object.String{Value: "items"},
+		&object.String{Value: "i"},
+		&object.String{Value: "product"},
+	}
+	instructions := code.Instructions{}
+	instructions = append(instructions, code.Make(code.OpGetName, 4)...)
+	instructions = append(instructions, code.Make(code.OpFor, 0, 5, 6, 0)...)
+	instructions = append(instructions, code.Make(code.OpWrite)...)
+
+	plan := fastRenderPlanFromInstructions(instructions, constants, map[int]int{0: 2})
+
+	require.NotNil(t, plan)
+	require.Equal(t, []string{"items"}, plan.Bindings)
+	require.Len(t, plan.Segments, 1)
+	loop := plan.Segments[0].Loop
+	require.NotNil(t, loop)
+	require.Equal(t, "items", loop.IterableName)
+	require.Equal(t, "i", loop.KeyName)
+	require.Equal(t, "product", loop.ValueName)
+	require.Len(t, loop.Parts, 4)
+	require.Equal(t, FastLoopPartStatic, loop.Parts[0].Kind)
+	require.Equal(t, "<b>", loop.Parts[0].Value)
+	require.Equal(t, FastLoopPartKey, loop.Parts[1].Kind)
+	require.Equal(t, FastLoopPartStatic, loop.Parts[2].Kind)
+	require.Equal(t, ":", loop.Parts[2].Value)
+	require.Equal(t, FastLoopPartValueProperty, loop.Parts[3].Kind)
+	require.Equal(t, "Name", loop.Parts[3].Value)
+}
+
+func Test_Fast_Loop_Plan_From_Function_Branches(t *testing.T) {
+	constants := []object.Object{
+		&object.String{Value: "<raw>"},
+		&object.Integer{Value: 7},
+		&object.Native{Value: template.HTML("<b>")},
+		&object.String{Value: "Name"},
+	}
+	instructions := code.Instructions{}
+	instructions = append(instructions, code.Make(code.OpWriteString, 0)...)
+	instructions = append(instructions, code.Make(code.OpWriteConstant, 1)...)
+	instructions = append(instructions, code.Make(code.OpWriteHTML, 2)...)
+	instructions = append(instructions, code.Make(code.OpWriteLocal, 1)...)
+	instructions = append(instructions, code.Make(code.OpWriteLocalProperty, 1, 3)...)
+	instructions = append(instructions, code.Make(code.OpReturn)...)
+
+	loop, ok := fastLoopPlanFromFunction(&object.CompiledFunction{
+		Instructions:  instructions,
+		NumParameters: 2,
+		LineNumbers: map[int]int{
+			0:  3,
+			12: 4,
+		},
+	}, constants, "i", "product")
+	require.True(t, ok)
+	require.NotNil(t, loop)
+	require.Equal(t, "i", loop.KeyName)
+	require.Equal(t, "product", loop.ValueName)
+	require.Len(t, loop.Parts, 3)
+	require.Equal(t, FastLoopPartStatic, loop.Parts[0].Kind)
+	require.Equal(t, "&lt;raw&gt;7<b>", loop.Parts[0].Value)
+	require.Equal(t, FastLoopPartValue, loop.Parts[1].Kind)
+	require.Equal(t, FastLoopPartValueProperty, loop.Parts[2].Kind)
+	require.Equal(t, "Name", loop.Parts[2].Value)
+
+	_, ok = fastLoopPlanFromFunction(nil, constants, "i", "product")
+	require.False(t, ok)
+	_, ok = fastLoopPlanFromFunction(&object.CompiledFunction{NumParameters: 1}, constants, "i", "product")
+	require.False(t, ok)
+	_, ok = fastLoopPlanFromFunction(&object.CompiledFunction{NumParameters: 2, Instructions: code.Instructions{byte(255)}}, constants, "i", "product")
+	require.False(t, ok)
+	_, ok = fastLoopPlanFromFunction(&object.CompiledFunction{NumParameters: 2, Instructions: code.Make(code.OpWriteHTML, 99)}, constants, "i", "product")
+	require.False(t, ok)
+	_, ok = fastLoopPlanFromFunction(&object.CompiledFunction{NumParameters: 2, Instructions: code.Make(code.OpWriteString, 2)}, constants, "i", "product")
+	require.False(t, ok)
+	_, ok = fastLoopPlanFromFunction(&object.CompiledFunction{NumParameters: 2, Instructions: code.Make(code.OpWriteConstant, 99)}, constants, "i", "product")
+	require.False(t, ok)
+	_, ok = fastLoopPlanFromFunction(&object.CompiledFunction{NumParameters: 2, Instructions: code.Make(code.OpWriteLocal, 2)}, constants, "i", "product")
+	require.False(t, ok)
+	_, ok = fastLoopPlanFromFunction(&object.CompiledFunction{NumParameters: 2, Instructions: code.Make(code.OpWriteLocalProperty, 0, 3)}, constants, "i", "product")
+	require.False(t, ok)
+	_, ok = fastLoopPlanFromFunction(&object.CompiledFunction{NumParameters: 2, Instructions: code.Make(code.OpWriteLocalProperty, 1, 1)}, constants, "i", "product")
+	require.False(t, ok)
+	_, ok = fastLoopPlanFromFunction(&object.CompiledFunction{NumParameters: 2, Instructions: code.Make(code.OpAdd)}, constants, "i", "product")
+	require.False(t, ok)
+	_, ok = fastLoopPlanFromFunction(&object.CompiledFunction{NumParameters: 2, Instructions: code.Make(code.OpWriteString, 0)}, constants, "i", "product")
+	require.False(t, ok)
+
+	renderPlan := &FastRenderPlan{}
+	renderPlan.appendStatic("")
+	require.Empty(t, renderPlan.Segments)
+
+	emptyLoop := &FastLoopPlan{}
+	emptyLoop.appendStatic("")
+	require.Empty(t, emptyLoop.Parts)
+}
+
+func Test_Fast_Loop_Plan_At_Branches(t *testing.T) {
+	fn := &object.CompiledFunction{
+		NumParameters: 2,
+		Instructions: code.Instructions(append(
+			code.Make(code.OpWriteLocal, 0),
+			code.Make(code.OpReturn)...,
+		)),
+	}
+	constants := []object.Object{
+		fn,
+		&object.String{Value: "items"},
+		&object.String{Value: "i"},
+		&object.String{Value: "item"},
+	}
+	instructions := code.Instructions{}
+	instructions = append(instructions, code.Make(code.OpFor, 0, 2, 3, 0)...)
+	instructions = append(instructions, code.Make(code.OpWrite)...)
+
+	loop, next, ok := fastLoopPlanAt(instructions, 0, constants, map[int]int{0: 9})
+	require.True(t, ok)
+	require.NotNil(t, loop)
+	require.Equal(t, 9, loop.Line)
+	require.Equal(t, len(instructions), next)
+
+	_, _, ok = fastLoopPlanAt(code.Make(code.OpConstant, 0), 0, constants, nil)
+	require.False(t, ok)
+	_, _, ok = fastLoopPlanAt(code.Make(code.OpFor, 0, 2, 3, 1), 0, constants, nil)
+	require.False(t, ok)
+	_, _, ok = fastLoopPlanAt(code.Make(code.OpFor, 0, 2, 3, 0), 0, constants, nil)
+	require.False(t, ok)
+	_, _, ok = fastLoopPlanAt(instructions, 0, []object.Object{fn, constants[1], &object.Integer{Value: 1}, constants[3]}, nil)
+	require.False(t, ok)
+	_, _, ok = fastLoopPlanAt(instructions, 0, []object.Object{fn, constants[1], constants[2], &object.Integer{Value: 1}}, nil)
+	require.False(t, ok)
+	_, _, ok = fastLoopPlanAt(instructions, 0, []object.Object{&object.String{Value: "nope"}, constants[1], constants[2], constants[3]}, nil)
+	require.False(t, ok)
+	_, _, ok = fastLoopPlanAt(instructions, 0, []object.Object{
+		&object.CompiledFunction{NumParameters: 2, Instructions: code.Make(code.OpAdd)},
+		constants[1],
+		constants[2],
+		constants[3],
+	}, nil)
+	require.False(t, ok)
+}
+
+func Test_Fast_Render_Plan_Includes_Helper_Calls(t *testing.T) {
+	program, err := parser.Parse(`<%= greet(name) %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Equal(t, []string{"greet", "name"}, bytecode.FastRenderPlan.Bindings)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+	segment := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentCall, segment.Kind)
+	require.NotNil(t, segment.Call)
+	require.Equal(t, "greet", segment.Call.Name)
+	require.Len(t, segment.Call.Args, 1)
+	require.Equal(t, FastValueName, segment.Call.Args[0].Kind)
+	require.Equal(t, "name", segment.Call.Args[0].Value)
+}
+
+func Test_Fast_Render_Plan_Includes_Helper_Call_Array_Arguments(t *testing.T) {
+	program, err := parser.Parse(`<%= multiple_menu_items([menu_nav, menu_categories_string]) %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Empty(t, bytecode.FastReject)
+	require.Equal(t, []string{"multiple_menu_items", "menu_nav", "menu_categories_string"}, bytecode.FastRenderPlan.Bindings)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+
+	segment := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentCall, segment.Kind)
+	require.NotNil(t, segment.Call)
+	require.Len(t, segment.Call.Args, 1)
+
+	arg := segment.Call.Args[0]
+	require.Equal(t, FastValueArray, arg.Kind)
+	require.Len(t, arg.Elements, 2)
+	require.Equal(t, FastValueName, arg.Elements[0].Kind)
+	require.Equal(t, "menu_nav", arg.Elements[0].Value)
+	require.Equal(t, FastValueName, arg.Elements[1].Kind)
+	require.Equal(t, "menu_categories_string", arg.Elements[1].Value)
+}
+
+func Test_Fast_Render_Plan_Includes_Block_Helper_Call_With_Hash_Arguments(t *testing.T) {
+	program, err := parser.Parse(`<%= form({content_for: "head", count: count}) { %><span><%= name %></span><% } %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Empty(t, bytecode.FastReject)
+	require.Equal(t, []string{"form", "count"}, bytecode.FastRenderPlan.Bindings[:2])
+	require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+
+	segment := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentBlockCall, segment.Kind)
+	require.NotNil(t, segment.BlockCall)
+	require.Equal(t, "form", segment.BlockCall.Name)
+	require.Len(t, segment.BlockCall.Args, 1)
+	require.NotNil(t, segment.BlockCall.BlockBytecode)
+	require.NotNil(t, segment.BlockCall.BlockBytecode.FastRenderPlan)
+
+	arg := segment.BlockCall.Args[0]
+	require.Equal(t, FastValueHash, arg.Kind)
+	require.Len(t, arg.Pairs, 2)
+	require.Equal(t, "content_for", arg.Pairs[0].Key)
+	require.Equal(t, FastValueString, arg.Pairs[0].Value.Kind)
+	require.Equal(t, "head", arg.Pairs[0].Value.Value)
+	require.Equal(t, "count", arg.Pairs[1].Key)
+	require.Equal(t, FastValueName, arg.Pairs[1].Value.Kind)
+	require.Equal(t, "count", arg.Pairs[1].Value.Value)
+}
+
+func Test_Fast_Render_Plan_Block_Helper_Source_Preserves_Output_Tags(t *testing.T) {
+	program, err := parser.Parse(`<%= form({action: path}) { %><%= f.InputTag({name: "A"}) %><%= f.InputTag({name: "B"}) %><button>Go</button><% } %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Empty(t, bytecode.FastReject)
+	block := bytecode.FastRenderPlan.Segments[0].BlockCall
+	require.NotNil(t, block)
+	require.Contains(t, block.BlockSource, `<%= f.InputTag`)
+	require.Contains(t, block.BlockSource, `<button>Go</button>`)
+	require.NotNil(t, block.BlockBytecode)
+}
+
+func Test_Fast_Render_Plan_Block_Helper_Source_Preserves_Shipping_Form(t *testing.T) {
+	input := `<%= form({action: shippingEstimatorPath(), method: "POST", id: "shippingEstimate"}) { %>
+	<%= f.InputTag({name:"CartAdd[0].CartAddProductID", value: product.ProductId}) %>
+	<%= f.InputTag({name: "CartAdd[0].CartAddVariantID[]", value: product.ProductVariants[0].VariantId}) %>
+	<%= f.InputTag({name:"CartAdd[0].CartAddVariantAddQty", value: "1"}) %>
+	<%= f.InputTag({type:"text",label:"Shipping First Name", name:"Shipping.FirstName", value:"test"} ) %>
+<button class="btn btn-success" role="submit">Get ESTIMATED Rates</button>
+<% } %>`
+	program, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan, bytecode.FastReject)
+	require.Empty(t, bytecode.FastReject)
+	require.NotNil(t, bytecode.FastRenderPlan.Segments[0].BlockCall.BlockBytecode)
+}
+
+func Test_Fast_Render_Plan_Includes_Top_Level_Let(t *testing.T) {
+	program, err := parser.Parse(`<% let message = greet(name) %><%= message %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Equal(t, []string{"greet", "name", "message"}, bytecode.FastRenderPlan.Bindings)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 2)
+
+	assign := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentLet, assign.Kind)
+	require.Equal(t, "message", assign.Value)
+	require.Equal(t, FastValueCall, assign.ValuePlan.Kind)
+	require.NotNil(t, assign.ValuePlan.Call)
+	require.Equal(t, "greet", assign.ValuePlan.Call.Name)
+
+	output := bytecode.FastRenderPlan.Segments[1]
+	require.Equal(t, FastRenderSegmentName, output.Kind)
+	require.Equal(t, "message", output.Value)
+}
+
+func Test_Fast_Render_Plan_Includes_Silent_If_Assignment(t *testing.T) {
+	program, err := parser.Parse(`<% let displayResult = listing.DisplayResult
+if (listing.TotalResult < listing.DisplayResult) {
+	displayResult = listing.TotalResult
+}
+%><%= displayResult %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan, bytecode.FastReject)
+	require.Equal(t, []string{"listing", "displayResult"}, bytecode.FastRenderPlan.Bindings)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 3)
+
+	initial := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentLet, initial.Kind)
+	require.Equal(t, "displayResult", initial.Value)
+
+	conditional := bytecode.FastRenderPlan.Segments[1]
+	require.Equal(t, FastRenderSegmentConditional, conditional.Kind)
+	require.NotNil(t, conditional.Conditional)
+	require.True(t, conditional.Conditional.Silent)
+	require.Len(t, conditional.Conditional.Branches, 1)
+	require.Len(t, conditional.Conditional.Branches[0].Segments, 1)
+
+	assign := conditional.Conditional.Branches[0].Segments[0]
+	require.Equal(t, FastRenderSegmentAssign, assign.Kind)
+	require.Equal(t, "displayResult", assign.Value)
+	require.Equal(t, FastValuePath, assign.ValuePlan.Kind)
+
+	output := bytecode.FastRenderPlan.Segments[2]
+	require.Equal(t, FastRenderSegmentName, output.Kind)
+	require.Equal(t, "displayResult", output.Value)
+}
+
+func Test_Fast_Render_Plan_Includes_Indexed_Property_Chains(t *testing.T) {
+	program, err := parser.Parse(`<%= robots[0].Name.Echo() %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Equal(t, []string{"robots"}, bytecode.FastRenderPlan.Bindings)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+	segment := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentValue, segment.Kind)
+	require.Equal(t, FastValuePath, segment.ValuePlan.Kind)
+	require.Equal(t, "robots", segment.ValuePlan.Value)
+	require.Len(t, segment.ValuePlan.Path, 4)
+	require.Equal(t, []FastPathStepKind{
+		FastPathStepIndexInteger,
+		FastPathStepProperty,
+		FastPathStepProperty,
+		FastPathStepCall,
+	}, []FastPathStepKind{
+		segment.ValuePlan.Path[0].Kind,
+		segment.ValuePlan.Path[1].Kind,
+		segment.ValuePlan.Path[2].Kind,
+		segment.ValuePlan.Path[3].Kind,
+	})
+}
+
+func Test_Fast_Render_Plan_Includes_String_Indexed_Map_Chains(t *testing.T) {
+	program, err := parser.Parse(`<%= labels["status"] %><%= robots["bender"].Name %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Equal(t, []string{"labels", "robots"}, bytecode.FastRenderPlan.Bindings)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 2)
+
+	first := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentValue, first.Kind)
+	require.Equal(t, FastValuePath, first.ValuePlan.Kind)
+	require.Equal(t, "labels", first.ValuePlan.Value)
+	require.Len(t, first.ValuePlan.Path, 1)
+	require.Equal(t, FastPathStepIndexString, first.ValuePlan.Path[0].Kind)
+	require.Equal(t, "status", first.ValuePlan.Path[0].Value)
+
+	second := bytecode.FastRenderPlan.Segments[1]
+	require.Equal(t, FastRenderSegmentValue, second.Kind)
+	require.Equal(t, FastValuePath, second.ValuePlan.Kind)
+	require.Equal(t, "robots", second.ValuePlan.Value)
+	require.Len(t, second.ValuePlan.Path, 2)
+	require.Equal(t, FastPathStepIndexString, second.ValuePlan.Path[0].Kind)
+	require.Equal(t, "bender", second.ValuePlan.Path[0].Value)
+	require.Equal(t, FastPathStepProperty, second.ValuePlan.Path[1].Kind)
+	require.Equal(t, "Name", second.ValuePlan.Path[1].Value)
+}
+
+func Test_Fast_Render_Plan_Includes_Conditionals_And_Partials(t *testing.T) {
+	program, err := parser.Parse(`<%= if enabled { %>yes<% } else if fallback { %><%= name %><% } else { %>no<% } %><%= partial("row.plush") %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 2)
+	conditional := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentConditional, conditional.Kind)
+	require.NotNil(t, conditional.Conditional)
+	require.Len(t, conditional.Conditional.Branches, 2)
+	require.Len(t, conditional.Conditional.ElseSegments, 1)
+	require.Equal(t, FastRenderSegmentPartial, bytecode.FastRenderPlan.Segments[1].Kind)
+	require.Equal(t, "row.plush", bytecode.FastRenderPlan.Segments[1].Partial.Name)
+}
+
+func Test_Fast_Render_Plan_Includes_Loop_Partial(t *testing.T) {
+	program, err := parser.Parse(`<%= for (_, product) in products { %><%= partial("partials/product-card.plush.html") %><% } %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+
+	segment := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+	require.Len(t, segment.Loop.Parts, 1)
+	require.Equal(t, FastLoopPartPartial, segment.Loop.Parts[0].Kind)
+	require.NotNil(t, segment.Loop.Parts[0].Partial)
+	require.Equal(t, "partials/product-card.plush.html", segment.Loop.Parts[0].Partial.Name)
+}
+
+func Test_Fast_Render_Plan_Includes_Partial_Data_Map(t *testing.T) {
+	program, err := parser.Parse(`<%= partial("row.plush", {name: name, title: product.Name, literal: "ok"}) %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+
+	segment := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentPartial, segment.Kind)
+	require.NotNil(t, segment.Partial)
+	require.Equal(t, "row.plush", segment.Partial.Name)
+	require.Len(t, segment.Partial.Data, 3)
+	require.Equal(t, "name", segment.Partial.Data[0].Key)
+	require.Equal(t, FastValueName, segment.Partial.Data[0].Value.Kind)
+	require.Equal(t, "title", segment.Partial.Data[1].Key)
+	require.Equal(t, FastValuePath, segment.Partial.Data[1].Value.Kind)
+	require.Equal(t, "literal", segment.Partial.Data[2].Key)
+	require.Equal(t, FastValueString, segment.Partial.Data[2].Value.Kind)
+}
+
+func Test_Fast_Render_Plan_Includes_Partial_Data_Helper_Call(t *testing.T) {
+	program, err := parser.Parse(`<%= partial("row.plush", {label: label(product.Name, prefix)}) %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Equal(t, []string{"label", "product", "prefix"}, bytecode.FastRenderPlan.Bindings)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+
+	segment := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentPartial, segment.Kind)
+	require.NotNil(t, segment.Partial)
+	require.Len(t, segment.Partial.Data, 1)
+	require.Equal(t, "label", segment.Partial.Data[0].Key)
+
+	value := segment.Partial.Data[0].Value
+	require.Equal(t, FastValueCall, value.Kind)
+	require.NotNil(t, value.Call)
+	require.Equal(t, "label", value.Call.Name)
+	require.Len(t, value.Call.Args, 2)
+	require.Equal(t, FastValuePath, value.Call.Args[0].Kind)
+	require.Equal(t, "product", value.Call.Args[0].Value)
+	require.Equal(t, []FastPathStep{{
+		Kind:     FastPathStepProperty,
+		Value:    "Name",
+		Receiver: "product",
+		Full:     "product.Name",
+		Line:     1,
+	}}, value.Call.Args[0].Path)
+	require.Equal(t, FastValueName, value.Call.Args[1].Kind)
+	require.Equal(t, "prefix", value.Call.Args[1].Value)
+}
+
+func Test_Fast_Render_Plan_Skips_Partial_Data_Map_Layout(t *testing.T) {
+	program, err := parser.Parse(`<%= partial("row.plush", {name: name, layout: "shell"}) %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	require.Nil(t, compiler.Bytecode().FastRenderPlan)
+}
+
+func Test_Direct_Write_Call_Fusion_Chains(t *testing.T) {
+	program, err := parser.Parse(`<%= greet(name) %><%= robot.Name.Echo() %><%= factory().Robots().Name().Echo() %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.Equal(t, 1, instructionOpcodeCount(bytecode.Instructions, code.OpWriteNameCall))
+	require.Equal(t, 2, instructionOpcodeCount(bytecode.Instructions, code.OpWriteCall))
+	require.Truef(t, instructionContainsOpcode(bytecode.Instructions, code.OpCall), "expected intermediate OpCall:\n%s", bytecode.Instructions.String())
+	require.Falsef(t, instructionContainsSequence(bytecode.Instructions, code.OpCall, code.OpWrite), "expected call/write pair to be fused:\n%s", bytecode.Instructions.String())
+	require.False(t, bytecode.Static)
+}
+
+func Test_Direct_Write_Call_Fusion_Skips_Block_Helpers(t *testing.T) {
+	program, err := parser.Parse(`<%= wrap() { %>body<% } %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.Falsef(t, instructionContainsOpcode(bytecode.Instructions, code.OpWriteCall), "block helper should stay on OpCallBlock:\n%s", bytecode.Instructions.String())
+	require.Truef(t, instructionContainsOpcode(bytecode.Instructions, code.OpCallBlock), "expected OpCallBlock:\n%s", bytecode.Instructions.String())
+	require.Truef(t, instructionContainsOpcode(bytecode.Instructions, code.OpWrite), "expected OpWrite:\n%s", bytecode.Instructions.String())
+}
+
+func Test_Direct_Property_Write_Fusion(t *testing.T) {
+	program, err := parser.Parse(`<%= user.Name %><% let robot = {Name: "Bender"} %><%= robot.Name %><%= for (i, product) in products { %><%= product.Name %><% } %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.Truef(t, instructionContainsOpcode(bytecode.Instructions, code.OpWriteNameProperty), "expected OpWriteNameProperty:\n%s", bytecode.Instructions.String())
+	require.Truef(t, instructionContainsOpcode(bytecode.Instructions, code.OpWriteGlobalProperty), "expected OpWriteGlobalProperty:\n%s", bytecode.Instructions.String())
+
+	var loopFn *object.CompiledFunction
+	for _, constant := range bytecode.Constants {
+		if fn, ok := constant.(*object.CompiledFunction); ok && instructionContainsOpcode(fn.Instructions, code.OpWriteLocalProperty) {
+			loopFn = fn
+			break
+		}
+	}
+	require.NotNil(t, loopFn, "expected loop body to contain OpWriteLocalProperty")
+	require.Falsef(t, instructionContainsSequence(loopFn.Instructions, code.OpGetLocal, code.OpGetProperty), "expected local/property/write path to be fused:\n%s", loopFn.Instructions.String())
+}
+
+func Test_Direct_Write_Call_Fusion_Keeps_Call_Names(t *testing.T) {
+	program, err := parser.Parse(`<%= greet(name) %><%= robot.Name.Echo() %><%= wrap() { return "x" } %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.Equalf(t, 1, instructionOpcodeCount(bytecode.Instructions, code.OpWriteNameCall), "expected OpWriteNameCall:\n%s", bytecode.Instructions.String())
+	require.Equalf(t, 1, instructionOpcodeCount(bytecode.Instructions, code.OpWriteCall), "expected OpWriteCall:\n%s", bytecode.Instructions.String())
+	require.Truef(t, instructionContainsOpcode(bytecode.Instructions, code.OpCallBlock), "expected OpCallBlock:\n%s", bytecode.Instructions.String())
+	require.Truef(t, instructionContainsOpcode(bytecode.Instructions, code.OpWrite), "expected block helper to keep OpWrite:\n%s", bytecode.Instructions.String())
+	require.Falsef(t, instructionContainsSequence(bytecode.Instructions, code.OpCall, code.OpWrite), "expected call/write pair to be fused:\n%s", bytecode.Instructions.String())
+	require.True(t, callNamesContain(bytecode.CallNames, "greet"))
+	require.True(t, callNamesContain(bytecode.CallNames, "Echo"))
+	require.True(t, callNamesContain(bytecode.CallNames, "wrap"))
+}
+
+func Test_Peephole_Optimizes_Compiled_Function_Constants(t *testing.T) {
+	program, err := ParseScript(`fn() { if (false) { 10 }; 20 }`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	fn, ok := bytecode.Constants[2].(*object.CompiledFunction)
+	require.True(t, ok)
+	require.False(t, instructionContainsSequence(fn.Instructions, code.OpNull, code.OpPop))
+}
+
+func Test_Indexed_Receiver_Callee_Chain(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input:             `product_listing.Products[0].Name[0]`,
+			expectedConstants: []interface{}{"product_listing", "Products", 0, "Name", 0},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpGetName, 0),
+				code.Make(code.OpGetProperty, 1),
+				code.Make(code.OpConstant, 2),
+				code.Make(code.OpIndex),
+				code.Make(code.OpGetProperty, 3),
+				code.Make(code.OpConstant, 4),
+				code.Make(code.OpIndex),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             `robots[0].Stats.Count == 0`,
+			expectedConstants: []interface{}{"robots", 0, "Stats", "Count", 0},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpGetNameOrNull, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpIndex),
+				code.Make(code.OpGetProperty, 2),
+				code.Make(code.OpGetProperty, 3),
+				code.Make(code.OpConstant, 4),
+				code.Make(code.OpEqual),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             `getRobot().Name.Echo()`,
+			expectedConstants: []interface{}{"getRobot", "Name", "Echo"},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpGetName, 0),
+				code.Make(code.OpCall, 0),
+				code.Make(code.OpGetProperty, 1),
+				code.Make(code.OpGetProperty, 2),
+				code.Make(code.OpCall, 0),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             `getRobots()[0].Name`,
+			expectedConstants: []interface{}{"getRobots", 0, "Name"},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpGetName, 0),
+				code.Make(code.OpCall, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpIndex),
+				code.Make(code.OpGetProperty, 2),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             `factory().Robots()[0].Name.Echo()`,
+			expectedConstants: []interface{}{"factory", "Robots", 0, "Name", "Echo"},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpGetName, 0),
+				code.Make(code.OpCall, 0),
+				code.Make(code.OpGetProperty, 1),
+				code.Make(code.OpCall, 0),
+				code.Make(code.OpConstant, 2),
+				code.Make(code.OpIndex),
+				code.Make(code.OpGetProperty, 3),
+				code.Make(code.OpGetProperty, 4),
+				code.Make(code.OpCall, 0),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             `robot.Map[key].Name`,
+			expectedConstants: []interface{}{"robot", "Map", "key", "Name"},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpGetName, 0),
+				code.Make(code.OpGetProperty, 1),
+				code.Make(code.OpGetName, 2),
+				code.Make(code.OpIndex),
+				code.Make(code.OpGetProperty, 3),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             `robot.Map[key].Name.Echo()`,
+			expectedConstants: []interface{}{"robot", "Map", "key", "Name", "Echo"},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpGetName, 0),
+				code.Make(code.OpGetProperty, 1),
+				code.Make(code.OpGetName, 2),
+				code.Make(code.OpIndex),
+				code.Make(code.OpGetProperty, 3),
+				code.Make(code.OpGetProperty, 4),
+				code.Make(code.OpCall, 0),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             `robot.Nested.Map[nestedKey].Items[0].Name`,
+			expectedConstants: []interface{}{"robot", "Nested", "Map", "nestedKey", "Items", 0, "Name"},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpGetName, 0),
+				code.Make(code.OpGetProperty, 1),
+				code.Make(code.OpGetProperty, 2),
+				code.Make(code.OpGetName, 3),
+				code.Make(code.OpIndex),
+				code.Make(code.OpGetProperty, 4),
+				code.Make(code.OpConstant, 5),
+				code.Make(code.OpIndex),
+				code.Make(code.OpGetProperty, 6),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             `robot.Nested.Map[nestedKey].Items[0].Name.Echo()`,
+			expectedConstants: []interface{}{"robot", "Nested", "Map", "nestedKey", "Items", 0, "Name", "Echo"},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpGetName, 0),
+				code.Make(code.OpGetProperty, 1),
+				code.Make(code.OpGetProperty, 2),
+				code.Make(code.OpGetName, 3),
+				code.Make(code.OpIndex),
+				code.Make(code.OpGetProperty, 4),
+				code.Make(code.OpConstant, 5),
+				code.Make(code.OpIndex),
+				code.Make(code.OpGetProperty, 6),
+				code.Make(code.OpGetProperty, 7),
+				code.Make(code.OpCall, 0),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             `robot.GetFriends()[0].Name.Echo()`,
+			expectedConstants: []interface{}{"robot", "GetFriends", 0, "Name", "Echo"},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpGetName, 0),
+				code.Make(code.OpGetProperty, 1),
+				code.Make(code.OpCall, 0),
+				code.Make(code.OpConstant, 2),
+				code.Make(code.OpIndex),
+				code.Make(code.OpGetProperty, 3),
+				code.Make(code.OpGetProperty, 4),
+				code.Make(code.OpCall, 0),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             `factory().Robots().Name().Echo()`,
+			expectedConstants: []interface{}{"factory", "Robots", "Name", "Echo"},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpGetName, 0),
+				code.Make(code.OpCall, 0),
+				code.Make(code.OpGetProperty, 1),
+				code.Make(code.OpCall, 0),
+				code.Make(code.OpGetProperty, 2),
+				code.Make(code.OpCall, 0),
+				code.Make(code.OpGetProperty, 3),
+				code.Make(code.OpCall, 0),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+
+	runCompilerTests(t, tests)
+}
+
+func Test_If_Inline_Scope_Does_Not_Capture_Function_Parameter(t *testing.T) {
+	program, err := ParseScript(`fn(obj) { if (obj.Secret) { return obj.String } return obj.String }`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotEmpty(t, bytecode.Constants, "expected compiled function constant")
+
+	fn, ok := bytecode.Constants[len(bytecode.Constants)-1].(*object.CompiledFunction)
+	require.Truef(t, ok, "last constant is not compiled function: %T", bytecode.Constants[len(bytecode.Constants)-1])
+	require.Equal(t, 1, fn.NumLocals)
+	require.Falsef(t, instructionContainsOpcode(fn.Instructions, code.OpGetFree), "inline if scope should not turn function parameter into free symbol:\n%s", fn.Instructions.String())
+	require.Truef(t, instructionContainsOpcode(fn.Instructions, code.OpGetLocal), "expected inline if scope to read function parameter as local:\n%s", fn.Instructions.String())
+}
+
+func Test_If_Inline_Scope_Let_Allocates_Function_Local(t *testing.T) {
+	program, err := ParseScript(`fn(username) { if (username) { let username = "inner"; username } return username }`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	fn, ok := bytecode.Constants[len(bytecode.Constants)-1].(*object.CompiledFunction)
+	require.Truef(t, ok, "last constant is not compiled function: %T", bytecode.Constants[len(bytecode.Constants)-1])
+	require.Equal(t, 2, fn.NumLocals)
+	require.Truef(t, instructionContainsOpcode(fn.Instructions, code.OpSetLocal), "expected branch-scoped let to compile to local assignment:\n%s", fn.Instructions.String())
+}
+
+func Test_Compiler_Hole_Statement(t *testing.T) {
+	program, err := parser.Parse(`<%H "hello" %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	testInstructions(t, []code.Instructions{
+		code.Make(code.OpHole, 0),
+	}, bytecode.Instructions)
+	testConstants(t, []interface{}{`<%= "hello" %>`}, bytecode.Constants)
+}
+
+func Test_Compiler_Hole_Statement_Inside_Rendered_Template(t *testing.T) {
+	program, err := parser.Parse(`prefix<%H name %>suffix`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	testInstructions(t, []code.Instructions{
+		code.Make(code.OpWriteHTML, 0),
+		code.Make(code.OpHole, 1),
+		code.Make(code.OpWriteHTML, 2),
+	}, bytecode.Instructions)
+	require.Len(t, bytecode.Constants, 3)
+	prefix, ok := htmlConstantValue(bytecode.Constants, 0)
+	require.True(t, ok)
+	require.Equal(t, "prefix", prefix)
+	testStringObject(t, `<%= name %>`, bytecode.Constants[1])
+	suffix, ok := htmlConstantValue(bytecode.Constants, 2)
+	require.True(t, ok)
+	require.Equal(t, "suffix", suffix)
+}
+
+func Test_Phase_11_Call_Name_Metadata(t *testing.T) {
+	program, err := ParseScript(`factory().Robots().Name().Echo(); len([]);`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.Equal(t, map[int]string{
+		3:  "factory",
+		8:  "Robots",
+		13: "Name",
+		18: "Echo",
+		26: "len",
+	}, bytecode.CallNames)
+}
+
+func Test_Phase_11_Nested_Function_Call_Name_Metadata(t *testing.T) {
+	program, err := ParseScript(`let make = fn() { let inner = fn() { return greet() }; return inner() }; make();`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.True(t, callNamesContain(bytecode.CallNames, "make"))
+
+	var foundGreet bool
+	var foundInner bool
+	for _, constant := range bytecode.Constants {
+		fn, ok := constant.(*object.CompiledFunction)
+		if !ok {
+			continue
+		}
+		foundGreet = foundGreet || callNamesContain(fn.CallNames, "greet")
+		foundInner = foundInner || callNamesContain(fn.CallNames, "inner")
+	}
+
+	require.True(t, foundGreet, "expected nested function constant to record greet() call")
+	require.True(t, foundInner, "expected outer function constant to record inner() call")
+}
+
+func Test_Global_Let_Statements(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input:             `let one = 1; one;`,
+			expectedConstants: []interface{}{1},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpSetGlobal, 0),
+				code.Make(code.OpGetGlobal, 0),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+
+	runCompilerTests(t, tests)
+}
+
+func Test_Global_Count_Metadata(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expectedCount int
+	}{
+		{
+			name:          "no globals",
+			input:         `1 + 2;`,
+			expectedCount: 0,
+		},
+		{
+			name:          "two globals",
+			input:         `let one = 1; let two = 2; one + two;`,
+			expectedCount: 2,
+		},
+		{
+			name:          "top level inline block locals are not globals",
+			input:         `if (true) { let local = 1; local; }`,
+			expectedCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			program, err := ParseScript(tt.input)
+			require.NoError(t, err)
+
+			compiler := New()
+			require.NoError(t, compiler.Compile(program))
+
+			require.Equal(t, tt.expectedCount, compiler.Bytecode().NumGlobals)
+		})
+	}
+}
+
+func Test_Functions(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input: `fn() { 5 + 10 }`,
+			expectedConstants: []interface{}{
+				5,
+				10,
+				[]code.Instructions{
+					code.Make(code.OpConstant, 0),
+					code.Make(code.OpConstant, 1),
+					code.Make(code.OpAdd),
+					code.Make(code.OpReturnValue),
+				},
+			},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpClosure, 2, 0),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input: `fn(a) { a }`,
+			expectedConstants: []interface{}{
+				[]code.Instructions{
+					code.Make(code.OpGetLocal, 0),
+					code.Make(code.OpReturnValue),
+				},
+			},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpClosure, 0, 0),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+
+	runCompilerTests(t, tests)
+}
+
+func Test_Builtins(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input:             `len;`,
+			expectedConstants: []interface{}{},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpGetBuiltin, 0),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             `len([]); push([], 1);`,
+			expectedConstants: []interface{}{1},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpGetBuiltin, 0),
+				code.Make(code.OpArray, 0),
+				code.Make(code.OpCall, 1),
+				code.Make(code.OpPop),
+				code.Make(code.OpGetBuiltin, 5),
+				code.Make(code.OpArray, 0),
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpCall, 2),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+
+	runCompilerTests(t, tests)
+}
+
+func parseCompilerExpression(t *testing.T, input string) ast.Expression {
+	t.Helper()
+
+	program, err := ParseScript(input)
+	require.NoError(t, err)
+	require.Len(t, program.Statements, 1)
+
+	stmt, ok := program.Statements[0].(*ast.ExpressionStatement)
+	require.True(t, ok)
+	require.NotNil(t, stmt.Expression)
+	return stmt.Expression
+}
+
+func runCompilerTests(t *testing.T, tests []compilerTestCase) {
+	t.Helper()
+
+	for _, tt := range tests {
+		program, err := ParseScript(tt.input)
+		require.NoError(t, err)
+
+		compiler := New()
+		require.NoError(t, compiler.Compile(program))
+
+		bytecode := compiler.Bytecode()
+		testInstructions(t, tt.expectedInstructions, bytecode.Instructions)
+		testConstants(t, tt.expectedConstants, bytecode.Constants)
+	}
+}
+
+func testInstructions(t *testing.T, expected []code.Instructions, actual code.Instructions) {
+	t.Helper()
+
+	concatted := concatInstructions(expected)
+
+	require.Lenf(t, actual, len(concatted), "wrong instructions length.\nwant=%q\ngot =%q", concatted, actual)
+
+	for i, ins := range concatted {
+		require.Equalf(t, ins, actual[i], "wrong instruction at %d.\nwant=%q\ngot =%q", i, concatted, actual)
+	}
+}
+
+func concatInstructions(s []code.Instructions) code.Instructions {
+	out := code.Instructions{}
+	for _, ins := range s {
+		out = append(out, ins...)
+	}
+	return out
+}
+
+func instructionContainsOpcode(instructions code.Instructions, target code.Opcode) bool {
+	for i := 0; i < len(instructions); {
+		op := code.Opcode(instructions[i])
+		if op == target {
+			return true
+		}
+
+		def, err := code.Lookup(byte(op))
+		if err != nil {
+			i++
+			continue
+		}
+		_, read := code.ReadOperands(def, instructions[i+1:])
+		i += 1 + read
+	}
+	return false
+}
+
+func instructionOpcodeCount(instructions code.Instructions, target code.Opcode) int {
+	count := 0
+	for i := 0; i < len(instructions); {
+		op := code.Opcode(instructions[i])
+		if op == target {
+			count++
+		}
+
+		def, err := code.Lookup(byte(op))
+		if err != nil {
+			i++
+			continue
+		}
+		_, read := code.ReadOperands(def, instructions[i+1:])
+		i += 1 + read
+	}
+	return count
+}
+
+func instructionContainsSequence(instructions code.Instructions, first, second code.Opcode) bool {
+	for i := 0; i < len(instructions); {
+		op := code.Opcode(instructions[i])
+		def, err := code.Lookup(byte(op))
+		if err != nil {
+			i++
+			continue
+		}
+		_, read := code.ReadOperands(def, instructions[i+1:])
+		next := i + 1 + read
+		if op == first && next < len(instructions) && code.Opcode(instructions[next]) == second {
+			return true
+		}
+		i = next
+	}
+	return false
+}
+
+func callNamesContain(callNames map[int]string, target string) bool {
+	for _, name := range callNames {
+		if name == target {
+			return true
+		}
+	}
+	return false
+}
+
+func bytecodeContainsOpcode(bytecode *Bytecode, target code.Opcode) bool {
+	if bytecode == nil {
+		return false
+	}
+	if instructionContainsOpcode(bytecode.Instructions, target) {
+		return true
+	}
+	for _, constant := range bytecode.Constants {
+		fn, ok := constant.(*object.CompiledFunction)
+		if !ok {
+			continue
+		}
+		if instructionContainsOpcode(fn.Instructions, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func testConstants(t *testing.T, expected []interface{}, actual []object.Object) {
+	t.Helper()
+
+	require.Lenf(t, actual, len(expected), "wrong number of constants. got=%d, want=%d", len(actual), len(expected))
+
+	for i, constant := range expected {
+		switch constant := constant.(type) {
+		case string:
+			testStringObject(t, constant, actual[i])
+		case int:
+			testIntegerObject(t, int64(constant), actual[i])
+		case []code.Instructions:
+			fn, ok := actual[i].(*object.CompiledFunction)
+			require.Truef(t, ok, "constant %d - not a function: %T", i, actual[i])
+			testInstructions(t, constant, fn.Instructions)
+		}
+	}
+}
+
+func testIntegerObject(t *testing.T, expected int64, actual object.Object) {
+	t.Helper()
+
+	result, ok := actual.(*object.Integer)
+	require.Truef(t, ok, "object is not Integer. got=%T (%+v)", actual, actual)
+	require.Equal(t, expected, result.Value)
+}
+
+func testStringObject(t *testing.T, expected string, actual object.Object) {
+	t.Helper()
+
+	result, ok := actual.(*object.String)
+	require.Truef(t, ok, "object is not String. got=%T (%+v)", actual, actual)
+	require.Equal(t, expected, result.Value)
+}

--- a/VM/compiler/emit.go
+++ b/VM/compiler/emit.go
@@ -1,0 +1,235 @@
+package compiler
+
+import (
+	"github.com/gobuffalo/plush/v5/VM/code"
+	"github.com/gobuffalo/plush/v5/VM/object"
+)
+
+func (c *Compiler) addConstant(obj object.Object) int {
+	c.constants = append(c.constants, obj)
+	return len(c.constants) - 1
+}
+
+func (c *Compiler) emit(op code.Opcode, operands ...int) int {
+	ins := code.Make(op, operands...)
+	pos := c.addInstruction(ins)
+
+	c.setLastInstruction(op, pos)
+	c.recordLineNumber(pos)
+
+	return pos
+}
+
+func (c *Compiler) emitCall(op code.Opcode, name string, operands ...int) int {
+	pos := c.emit(op, operands...)
+	c.recordCallName(pos, name)
+	return pos
+}
+
+func (c *Compiler) emitProperty(name, receiver, full string) int {
+	pos := c.emit(code.OpGetProperty, c.addStringConstant(name))
+	c.scopes[c.scopeIndex].properties[pos] = object.PropertyAccess{
+		Receiver: receiver,
+		Full:     full,
+	}
+	return pos
+}
+
+func (c *Compiler) markLastPropertyAsMethod() {
+	last := c.scopes[c.scopeIndex].lastInstruction
+	if last.Opcode != code.OpGetProperty {
+		return
+	}
+	info := c.scopes[c.scopeIndex].properties[last.Position]
+	info.Method = true
+	c.scopes[c.scopeIndex].properties[last.Position] = info
+}
+
+func (c *Compiler) recordCallName(pos int, name string) {
+	if name == "" {
+		name = anonymousCallName
+	}
+	c.scopes[c.scopeIndex].callNames[pos] = name
+}
+
+func (c *Compiler) recordLocalName(symbol Symbol) {
+	if symbol.Scope == LocalScope {
+		c.scopes[c.scopeIndex].localNames[symbol.Index] = symbol.Name
+		if symbol.Index+1 > c.scopes[c.scopeIndex].numLocals {
+			c.scopes[c.scopeIndex].numLocals = symbol.Index + 1
+		}
+	}
+}
+
+func (c *Compiler) recordLineNumber(pos int) {
+	if c.line > 0 {
+		c.scopes[c.scopeIndex].lineNumbers[pos] = c.line
+	}
+}
+
+func (c *Compiler) addInstruction(ins []byte) int {
+	posNewInstruction := len(c.currentInstructions())
+	updatedInstructions := append(c.currentInstructions(), ins...)
+
+	c.scopes[c.scopeIndex].instructions = updatedInstructions
+
+	return posNewInstruction
+}
+
+func (c *Compiler) setLastInstruction(op code.Opcode, pos int) {
+	previous := c.scopes[c.scopeIndex].lastInstruction
+	last := EmittedInstruction{Opcode: op, Position: pos}
+
+	c.scopes[c.scopeIndex].previousInstruction = previous
+	c.scopes[c.scopeIndex].lastInstruction = last
+}
+
+func (c *Compiler) lastInstructionIs(op code.Opcode) bool {
+	if len(c.currentInstructions()) == 0 {
+		return false
+	}
+
+	return c.scopes[c.scopeIndex].lastInstruction.Opcode == op
+}
+
+func (c *Compiler) removeLastPop() {
+	last := c.scopes[c.scopeIndex].lastInstruction
+	previous := c.scopes[c.scopeIndex].previousInstruction
+
+	old := c.currentInstructions()
+	newInstructions := old[:last.Position]
+
+	c.scopes[c.scopeIndex].instructions = newInstructions
+	c.scopes[c.scopeIndex].lastInstruction = previous
+}
+
+func (c *Compiler) replaceInstruction(pos int, newInstruction []byte) {
+	ins := c.currentInstructions()
+	for i := 0; i < len(newInstruction); i++ {
+		ins[pos+i] = newInstruction[i]
+	}
+}
+
+func (c *Compiler) changeOperand(opPos int, operand int) {
+	op := code.Opcode(c.currentInstructions()[opPos])
+	newInstruction := code.Make(op, operand)
+
+	c.replaceInstruction(opPos, newInstruction)
+}
+
+func (c *Compiler) currentInstructions() code.Instructions {
+	return c.scopes[c.scopeIndex].instructions
+}
+
+func (c *Compiler) currentCallNames() map[int]string {
+	callNames := c.scopes[c.scopeIndex].callNames
+	if len(callNames) == 0 {
+		return nil
+	}
+	copied := make(map[int]string, len(callNames))
+	for pos, name := range callNames {
+		copied[pos] = name
+	}
+	return copied
+}
+
+func (c *Compiler) currentLocalNames() map[int]string {
+	localNames := c.scopes[c.scopeIndex].localNames
+	if len(localNames) == 0 {
+		return nil
+	}
+	copied := make(map[int]string, len(localNames))
+	for index, name := range localNames {
+		copied[index] = name
+	}
+	return copied
+}
+
+func (c *Compiler) currentLineNumbers() map[int]int {
+	lineNumbers := c.scopes[c.scopeIndex].lineNumbers
+	if len(lineNumbers) == 0 {
+		return nil
+	}
+	copied := make(map[int]int, len(lineNumbers))
+	for pos, line := range lineNumbers {
+		copied[pos] = line
+	}
+	return copied
+}
+
+func (c *Compiler) currentProperties() map[int]object.PropertyAccess {
+	properties := c.scopes[c.scopeIndex].properties
+	if len(properties) == 0 {
+		return nil
+	}
+	copied := make(map[int]object.PropertyAccess, len(properties))
+	for pos, property := range properties {
+		copied[pos] = property
+	}
+	return copied
+}
+
+func (c *Compiler) currentLocalCount() int {
+	return c.scopes[c.scopeIndex].numLocals
+}
+
+func (c *Compiler) globalCount() int {
+	count := 0
+	if c.symbolTable != nil && c.symbolTable.Outer == nil {
+		count = c.symbolTable.numDefinitions
+	}
+	for index := range c.globalNames {
+		if index+1 > count {
+			count = index + 1
+		}
+	}
+	return count
+}
+
+func (c *Compiler) enterScope() {
+	scope := CompilationScope{
+		instructions:        code.Instructions{},
+		callNames:           map[int]string{},
+		localNames:          map[int]string{},
+		lineNumbers:         map[int]int{},
+		properties:          map[int]object.PropertyAccess{},
+		lastInstruction:     EmittedInstruction{},
+		previousInstruction: EmittedInstruction{},
+	}
+	c.scopes = append(c.scopes, scope)
+	c.scopeIndex++
+
+	c.symbolTable = NewEnclosedSymbolTable(c.symbolTable)
+}
+
+func (c *Compiler) leaveScope() code.Instructions {
+	instructions := c.currentInstructions()
+
+	c.scopes = c.scopes[:len(c.scopes)-1]
+	c.scopeIndex--
+
+	c.symbolTable = c.symbolTable.Outer
+	return instructions
+}
+
+func (c *Compiler) replaceLastPopWithReturn() {
+	lastPos := c.scopes[c.scopeIndex].lastInstruction.Position
+	c.replaceInstruction(lastPos, code.Make(code.OpReturnValue))
+
+	c.scopes[c.scopeIndex].lastInstruction.Opcode = code.OpReturnValue
+}
+
+func (c *Compiler) loadSymbol(s Symbol) {
+	switch s.Scope {
+	case GlobalScope:
+		c.emit(code.OpGetGlobal, s.Index)
+	case LocalScope:
+		c.emit(code.OpGetLocal, s.Index)
+	case BuiltinScope:
+		c.emit(code.OpGetBuiltin, s.Index)
+	case FreeScope:
+		c.emit(code.OpGetFree, s.Index)
+	case FunctionScope:
+		c.emit(code.OpCurrentClosure)
+	}
+}

--- a/VM/compiler/fast_plan_ast.go
+++ b/VM/compiler/fast_plan_ast.go
@@ -1,0 +1,2468 @@
+package compiler
+
+import (
+	"fmt"
+	"html/template"
+	"sort"
+	"strings"
+
+	"github.com/gobuffalo/plush/v5/VM/code"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/gobuffalo/plush/v5/ast"
+	"github.com/gobuffalo/plush/v5/token"
+)
+
+// fastRenderPlanFromProgram builds the richest fast render plan directly from
+// the Plush AST. It only returns a plan when every top-level statement has a
+// supported render shape; unsupported shapes intentionally fall back to
+// bytecode/VM execution. See VM/FAST_PATHS.md.
+func fastRenderPlanFromProgram(program *ast.Program) *FastRenderPlan {
+	plan, _ := fastRenderPlanAnalysisFromProgram(program)
+	return plan
+}
+
+func fastRenderPlanAnalysisFromProgram(program *ast.Program) (*FastRenderPlan, FastRenderReject) {
+	if program == nil {
+		return nil, FastRenderReject{}
+	}
+	plan := &FastRenderPlan{}
+	if !appendFastStatements(plan, &plan.Segments, program.Statements) {
+		reject := firstFastRenderReject(program)
+		if reject.Reason == "" {
+			reject = firstFastRenderBuildReject(program)
+		}
+		if reject.Reason == "" {
+			reject = FastRenderReject{Line: 1, Reason: "fast render plan builder declined after analyzer accepted"}
+		}
+		return nil, reject
+	}
+	if plan.NameCount == 0 {
+		return nil, FastRenderReject{}
+	}
+	return plan, FastRenderReject{}
+}
+
+func firstFastRenderReject(program *ast.Program) FastRenderReject {
+	if program == nil {
+		return FastRenderReject{}
+	}
+	plan := &FastRenderPlan{}
+	return firstFastRenderStatementReject(plan, nil, program.Statements, false)
+}
+
+func firstFastRenderBuildReject(program *ast.Program) FastRenderReject {
+	if program == nil {
+		return FastRenderReject{}
+	}
+	plan := &FastRenderPlan{}
+	return fastRenderBuildStatementsReject(plan, nil, nil, program.Statements, false)
+}
+
+func fastRenderBuildStatementsReject(plan *FastRenderPlan, segments *[]FastRenderSegment, loop *FastLoopPlan, statements []ast.Statement, inLoop bool) FastRenderReject {
+	for _, stmt := range statements {
+		if reject := fastRenderBuildStatementReject(plan, segments, loop, stmt, inLoop); reject.Reason != "" {
+			return reject
+		}
+	}
+	return FastRenderReject{}
+}
+
+func fastRenderBuildStatementReject(plan *FastRenderPlan, segments *[]FastRenderSegment, loop *FastLoopPlan, stmt ast.Statement, inLoop bool) FastRenderReject {
+	if inLoop {
+		parts := []FastLoopPart{}
+		if appendFastLoopStatement(plan, loop, &parts, stmt) {
+			return FastRenderReject{}
+		}
+		return fastRenderBuildLoopStatementReject(plan, loop, stmt)
+	}
+	if segments == nil {
+		local := []FastRenderSegment{}
+		segments = &local
+	}
+	if appendFastStatement(plan, segments, stmt) {
+		return FastRenderReject{}
+	}
+	switch stmt := stmt.(type) {
+	case *ast.ExpressionStatement:
+		if ifExpression, ok := stmt.Expression.(*ast.IfExpression); ok {
+			return fastRenderBuildConditionalReject(plan, ifExpression, lineForNode(stmt), true)
+		}
+		return rejectFastRender(stmt, "fast render builder declined expression statement: "+fastExpressionSummary(stmt.Expression))
+	case *ast.ReturnStatement:
+		if stmt.Type != token.E_START {
+			return rejectFastRender(stmt, "fast render builder declined non-output return")
+		}
+		return fastRenderBuildOutputReject(plan, stmt.ReturnValue, lineForNode(stmt))
+	case *ast.LetStatement:
+		return rejectFastRender(stmt, "fast render builder declined let statement")
+	default:
+		return rejectFastRender(stmt, "fast render builder declined statement")
+	}
+}
+
+func fastRenderBuildOutputReject(plan *FastRenderPlan, expr ast.Expression, line int) FastRenderReject {
+	segments := []FastRenderSegment{}
+	if appendFastOutputExpression(plan, &segments, expr, line) {
+		return FastRenderReject{}
+	}
+	switch expr := expr.(type) {
+	case *ast.IfExpression:
+		return fastRenderBuildConditionalReject(plan, expr, line, false)
+	case *ast.ForExpression:
+		return fastRenderBuildLoopReject(plan, nil, expr, line)
+	default:
+		return FastRenderReject{Line: line, Reason: "fast render builder declined output expression: " + fastExpressionSummary(expr)}
+	}
+}
+
+func fastRenderBuildConditionalReject(plan *FastRenderPlan, expr *ast.IfExpression, line int, silent bool) FastRenderReject {
+	var conditional *FastConditionalPlan
+	var ok bool
+	if silent {
+		conditional, ok = fastSilentConditionalPlanFromExpression(plan, expr, line)
+	} else {
+		conditional, ok = fastConditionalPlanFromExpression(plan, expr, line)
+	}
+	if ok && conditional != nil {
+		return FastRenderReject{}
+	}
+	if expr == nil || expr.Block == nil {
+		return FastRenderReject{Line: line, Reason: "fast render builder declined if without block"}
+	}
+	if reject := fastRenderBuildStatementsReject(plan, nil, nil, expr.Block.Statements, false); reject.Reason != "" {
+		return reject
+	}
+	for _, elseIf := range expr.ElseIf {
+		if elseIf != nil && elseIf.Block != nil {
+			if reject := fastRenderBuildStatementsReject(plan, nil, nil, elseIf.Block.Statements, false); reject.Reason != "" {
+				return reject
+			}
+		}
+	}
+	if expr.ElseBlock != nil {
+		return fastRenderBuildStatementsReject(plan, nil, nil, expr.ElseBlock.Statements, false)
+	}
+	return FastRenderReject{Line: line, Reason: "fast render builder declined if expression"}
+}
+
+func fastRenderBuildLoopReject(plan *FastRenderPlan, parent *FastLoopPlan, expr *ast.ForExpression, line int) FastRenderReject {
+	loop, ok := fastLoopPlanFromExpressionWithOuterNames(plan, fastLoopOuterNames(parent), expr, line)
+	if ok && loop != nil {
+		return FastRenderReject{}
+	}
+	if expr == nil || expr.Block == nil {
+		return FastRenderReject{Line: line, Reason: "fast render builder declined loop without block"}
+	}
+	iterable, _ := fastValuePlanFromExpression(plan, expr.Iterable, false, lineForNode(expr.Iterable))
+	loop = &FastLoopPlan{
+		IterableName:      iterable.Value,
+		IterableNameIndex: iterable.NameIndex,
+		Iterable:          iterable,
+		KeyName:           expr.KeyName,
+		ValueName:         expr.ValueName,
+		OuterNames:        fastLoopOuterNames(parent),
+		Line:              line,
+	}
+	return fastRenderBuildStatementsReject(plan, nil, loop, expr.Block.Statements, true)
+}
+
+func fastRenderBuildLoopStatementReject(plan *FastRenderPlan, loop *FastLoopPlan, stmt ast.Statement) FastRenderReject {
+	switch stmt := stmt.(type) {
+	case *ast.ExpressionStatement:
+		if ifExpression, ok := stmt.Expression.(*ast.IfExpression); ok {
+			return fastRenderBuildLoopConditionalReject(plan, loop, ifExpression, lineForNode(stmt), true)
+		}
+		return rejectFastRender(stmt, "fast render builder declined loop expression statement: "+fastExpressionSummary(stmt.Expression))
+	case *ast.ReturnStatement:
+		if stmt.Type != token.E_START {
+			return rejectFastRender(stmt, "fast render builder declined loop non-output return")
+		}
+		return fastRenderBuildLoopOutputReject(plan, loop, stmt.ReturnValue, lineForNode(stmt))
+	default:
+		return rejectFastRender(stmt, "fast render builder declined loop statement")
+	}
+}
+
+func fastRenderBuildLoopOutputReject(plan *FastRenderPlan, loop *FastLoopPlan, expr ast.Expression, line int) FastRenderReject {
+	parts := []FastLoopPart{}
+	if appendFastLoopOutputParts(plan, loop, &parts, expr, line) {
+		return FastRenderReject{}
+	}
+	switch expr := expr.(type) {
+	case *ast.IfExpression:
+		return fastRenderBuildLoopConditionalReject(plan, loop, expr, line, false)
+	case *ast.ForExpression:
+		return fastRenderBuildLoopReject(plan, loop, expr, line)
+	default:
+		return FastRenderReject{Line: line, Reason: "fast render builder declined loop output expression: " + fastExpressionSummary(expr)}
+	}
+}
+
+func fastRenderBuildLoopConditionalReject(plan *FastRenderPlan, loop *FastLoopPlan, expr *ast.IfExpression, line int, silent bool) FastRenderReject {
+	var conditional *FastLoopConditionalPlan
+	var ok bool
+	if silent {
+		conditional, ok = fastSilentLoopConditionalPlanFromExpression(plan, loop, expr, line)
+	} else {
+		conditional, ok = fastLoopConditionalPlanFromExpression(plan, loop, expr, line)
+	}
+	if ok && conditional != nil {
+		return FastRenderReject{}
+	}
+	if expr == nil || expr.Block == nil {
+		return FastRenderReject{Line: line, Reason: "fast render builder declined loop if without block"}
+	}
+	if reject := fastRenderBuildStatementsReject(plan, nil, loop, expr.Block.Statements, true); reject.Reason != "" {
+		return reject
+	}
+	for _, elseIf := range expr.ElseIf {
+		if elseIf != nil && elseIf.Block != nil {
+			if reject := fastRenderBuildStatementsReject(plan, nil, loop, elseIf.Block.Statements, true); reject.Reason != "" {
+				return reject
+			}
+		}
+	}
+	if expr.ElseBlock != nil {
+		return fastRenderBuildStatementsReject(plan, nil, loop, expr.ElseBlock.Statements, true)
+	}
+	return FastRenderReject{Line: line, Reason: "fast render builder declined loop if expression"}
+}
+
+func firstFastRenderStatementReject(plan *FastRenderPlan, loop *FastLoopPlan, statements []ast.Statement, inLoop bool) FastRenderReject {
+	for _, stmt := range statements {
+		if reject := fastRenderStatementReject(plan, loop, stmt, inLoop); reject.Reason != "" {
+			return reject
+		}
+	}
+	return FastRenderReject{}
+}
+
+func fastRenderStatementReject(plan *FastRenderPlan, loop *FastLoopPlan, stmt ast.Statement, inLoop bool) FastRenderReject {
+	switch stmt := stmt.(type) {
+	case *ast.ExpressionStatement:
+		if _, ok := stmt.Expression.(*ast.HTMLLiteral); ok {
+			return FastRenderReject{}
+		}
+		if inLoop {
+			switch stmt.Expression.(type) {
+			case *ast.BreakExpression, *ast.ContinueExpression:
+				return FastRenderReject{}
+			}
+		}
+		if ifExpression, ok := stmt.Expression.(*ast.IfExpression); ok {
+			if inLoop {
+				if _, ok := fastSilentLoopConditionalPlanFromExpression(plan, loop, ifExpression, lineForNode(stmt)); ok {
+					return FastRenderReject{}
+				}
+				return fastRenderLoopConditionalReject(plan, loop, ifExpression, lineForNode(stmt))
+			}
+			if _, ok := fastSilentConditionalPlanFromExpression(plan, ifExpression, lineForNode(stmt)); ok {
+				return FastRenderReject{}
+			}
+			if reject := fastSilentConditionalReject(plan, ifExpression, lineForNode(stmt)); reject.Reason != "" {
+				return reject
+			}
+		}
+		if !inLoop {
+			if assign, ok := stmt.Expression.(*ast.AssignExpression); ok {
+				segments := []FastRenderSegment{}
+				if appendFastAssignExpression(plan, &segments, assign, lineForNode(stmt)) {
+					return FastRenderReject{}
+				}
+				return fastRenderValueReject(plan, assign.Value, "assignment value")
+			}
+		}
+		return rejectFastRender(stmt, "script expression statements are not fast-planned: "+fastExpressionSummary(stmt.Expression))
+	case *ast.ReturnStatement:
+		if stmt.Type != token.E_START {
+			return rejectFastRender(stmt, "non-output return statements are not fast-planned")
+		}
+		if inLoop {
+			return fastRenderLoopOutputReject(plan, loop, stmt.ReturnValue, lineForNode(stmt))
+		}
+		return fastRenderOutputReject(plan, stmt.ReturnValue, lineForNode(stmt))
+	case *ast.LetStatement:
+		if stmt.Name == nil || stmt.Name.Callee != nil || stmt.Name.Value == "" {
+			return rejectFastRender(stmt, "unsupported let target")
+		}
+		if inLoop {
+			if _, ok := fastValuePlanFromLoopOperand(plan, loop, stmt.Value, false, lineForNode(stmt.Value)); ok {
+				return FastRenderReject{}
+			}
+			return rejectFastRender(stmt.Value, "loop let value is not fast-planned: "+fastExpressionSummary(stmt.Value))
+		}
+		if _, ok := fastValuePlanFromExpression(plan, stmt.Value, false, lineForNode(stmt.Value)); ok {
+			return FastRenderReject{}
+		}
+		return fastRenderValueReject(plan, stmt.Value, "let value")
+	default:
+		return rejectFastRender(stmt, "unsupported statement type for fast render")
+	}
+}
+
+func fastRenderOutputReject(plan *FastRenderPlan, expr ast.Expression, line int) FastRenderReject {
+	switch expr := expr.(type) {
+	case *ast.StringLiteral, *ast.HTMLLiteral, *ast.IntegerLiteral, *ast.FloatLiteral, *ast.Boolean:
+		return FastRenderReject{}
+	case *ast.ForExpression:
+		return fastRenderLoopReject(plan, nil, expr, line)
+	case *ast.IfExpression:
+		return fastRenderConditionalReject(plan, expr, line)
+	case *ast.CallExpression:
+		if _, ok := fastBlockCallPlanFromExpression(plan, expr, line); ok {
+			return FastRenderReject{}
+		}
+		if _, ok := fastPartialPlanFromCall(plan, expr, line); ok {
+			return FastRenderReject{}
+		}
+		if _, ok := fastCallPlanFromExpression(plan, expr, line); ok {
+			return FastRenderReject{}
+		}
+		if _, ok := fastValuePlanFromExpression(plan, expr, false, line); ok {
+			return FastRenderReject{}
+		}
+		return fastRenderCallReject(plan, expr, line)
+	default:
+		if _, ok := fastValuePlanFromExpression(plan, expr, false, line); ok {
+			return FastRenderReject{}
+		}
+		return fastRenderValueReject(plan, expr, "output expression")
+	}
+}
+
+func fastRenderConditionalReject(plan *FastRenderPlan, expr *ast.IfExpression, line int) FastRenderReject {
+	if expr == nil || expr.Block == nil {
+		return FastRenderReject{Line: line, Reason: "if expressions without a block are not fast-planned"}
+	}
+	if _, ok := fastValuePlanFromExpression(plan, expr.Condition, true, lineForNode(expr.Condition)); !ok {
+		return fastRenderValueReject(plan, expr.Condition, "if condition")
+	}
+	if reject := firstFastRenderStatementReject(plan, nil, expr.Block.Statements, false); reject.Reason != "" {
+		return reject
+	}
+	for _, elseIf := range expr.ElseIf {
+		if elseIf == nil || elseIf.Block == nil {
+			return FastRenderReject{Line: line, Reason: "else-if expressions without a block are not fast-planned"}
+		}
+		if _, ok := fastValuePlanFromExpression(plan, elseIf.Condition, true, lineForNode(elseIf.Condition)); !ok {
+			return fastRenderValueReject(plan, elseIf.Condition, "else-if condition")
+		}
+		if reject := firstFastRenderStatementReject(plan, nil, elseIf.Block.Statements, false); reject.Reason != "" {
+			return reject
+		}
+	}
+	if expr.ElseBlock != nil {
+		return firstFastRenderStatementReject(plan, nil, expr.ElseBlock.Statements, false)
+	}
+	return FastRenderReject{}
+}
+
+func fastRenderLoopReject(plan *FastRenderPlan, parent *FastLoopPlan, expr *ast.ForExpression, line int) FastRenderReject {
+	if expr == nil || expr.Block == nil {
+		return FastRenderReject{Line: line, Reason: "for expressions without a block are not fast-planned"}
+	}
+	iterable, ok := fastValuePlanFromExpression(plan, expr.Iterable, false, lineForNode(expr.Iterable))
+	if !ok {
+		return fastRenderValueReject(plan, expr.Iterable, "for iterable")
+	}
+	if iterable.Value == "nil" || !fastLoopIterableValueSupported(iterable) {
+		return FastRenderReject{Line: lineForNode(expr.Iterable), Reason: "unsupported for iterable for fast render: " + fastValuePlanSummary(iterable)}
+	}
+	loop := &FastLoopPlan{
+		IterableName:      iterable.Value,
+		IterableNameIndex: iterable.NameIndex,
+		Iterable:          iterable,
+		KeyName:           expr.KeyName,
+		ValueName:         expr.ValueName,
+		OuterNames:        fastLoopOuterNames(parent),
+		Line:              line,
+	}
+	return firstFastRenderStatementReject(plan, loop, expr.Block.Statements, true)
+}
+
+func fastRenderLoopOutputReject(plan *FastRenderPlan, loop *FastLoopPlan, expr ast.Expression, line int) FastRenderReject {
+	switch expr := expr.(type) {
+	case *ast.StringLiteral, *ast.HTMLLiteral, *ast.IntegerLiteral, *ast.FloatLiteral, *ast.Boolean:
+		return FastRenderReject{}
+	case *ast.BreakExpression, *ast.ContinueExpression:
+		return FastRenderReject{}
+	case *ast.IfExpression:
+		if _, ok := fastLoopConditionalPlanFromExpression(plan, loop, expr, line); ok {
+			return FastRenderReject{}
+		}
+		return fastRenderLoopConditionalReject(plan, loop, expr, line)
+	case *ast.ForExpression:
+		return fastRenderLoopReject(plan, loop, expr, line)
+	case *ast.CallExpression:
+		if expr.Block != nil {
+			if _, ok := fastLoopBlockCallPlanFromExpression(plan, loop, expr, line); ok {
+				return FastRenderReject{}
+			}
+			return fastRenderLoopBlockCallReject(plan, loop, expr, line)
+		}
+		if _, ok := fastPartialPlanFromCall(plan, expr, line); ok {
+			return FastRenderReject{}
+		}
+		if _, ok := fastValuePlanFromLoopCall(loop, expr, line); ok {
+			return FastRenderReject{}
+		}
+		if root, ok := fastLoopExpressionRootName(expr); ok && fastLoopHasOuterName(loop, root) {
+			if _, ok := fastValuePlanFromExpression(plan, expr, false, line); ok {
+				return FastRenderReject{}
+			}
+		}
+		if _, ok := fastLoopCallPlanFromExpression(plan, loop, expr, line); ok {
+			return FastRenderReject{}
+		}
+		return fastRenderCallReject(plan, expr, line)
+	default:
+		if _, ok := fastValuePlanFromLoopOperand(plan, loop, expr, false, line); ok {
+			return FastRenderReject{}
+		}
+		if _, ok := fastValuePlanFromLoopIndex(loop, expr, line); ok {
+			return FastRenderReject{}
+		}
+		return fastRenderValueReject(plan, expr, "loop output expression")
+	}
+}
+
+func fastRenderLoopBlockCallReject(plan *FastRenderPlan, loop *FastLoopPlan, expr *ast.CallExpression, line int) FastRenderReject {
+	if expr == nil {
+		return FastRenderReject{Line: line, Reason: "nil loop block helper calls are not fast-planned"}
+	}
+	if loop == nil {
+		return FastRenderReject{Line: line, Reason: "loop block helper call without loop context"}
+	}
+	if expr.ChainCallee != nil {
+		return rejectFastRender(expr, "chained loop block helper calls are not fast-planned")
+	}
+	ident, ok := expr.Function.(*ast.Identifier)
+	if !ok || !fastPlainHelperIdentifier(ident) || ident.Value == "nil" {
+		return rejectFastRender(expr, "unsupported loop block helper callee for fast render")
+	}
+	if !fastBlockCanRenderFromSource(expr.Block) {
+		return rejectFastRender(expr.Block, "loop block helper body contains statements that cannot be source-rendered")
+	}
+	for _, arg := range expr.Arguments {
+		if _, ok := fastValuePlanFromLoopCallArgument(plan, loop, arg, lineForNode(arg)); !ok {
+			return fastRenderValueReject(plan, arg, "loop block helper argument")
+		}
+	}
+	return rejectFastRender(expr, "unsupported loop block helper call shape for fast render")
+}
+
+func fastRenderLoopConditionalReject(plan *FastRenderPlan, loop *FastLoopPlan, expr *ast.IfExpression, line int) FastRenderReject {
+	if expr == nil || expr.Block == nil {
+		return FastRenderReject{Line: line, Reason: "loop if expressions without a block are not fast-planned"}
+	}
+	if _, ok := fastValuePlanFromLoopCondition(plan, loop, expr.Condition, lineForNode(expr.Condition)); !ok {
+		return fastRenderValueReject(plan, expr.Condition, "loop if condition")
+	}
+	if reject := firstFastRenderStatementReject(plan, loop, expr.Block.Statements, true); reject.Reason != "" {
+		return reject
+	}
+	for _, elseIf := range expr.ElseIf {
+		if elseIf == nil || elseIf.Block == nil {
+			return FastRenderReject{Line: line, Reason: "loop else-if expressions without a block are not fast-planned"}
+		}
+		if _, ok := fastValuePlanFromLoopCondition(plan, loop, elseIf.Condition, lineForNode(elseIf.Condition)); !ok {
+			return fastRenderValueReject(plan, elseIf.Condition, "loop else-if condition")
+		}
+		if reject := firstFastRenderStatementReject(plan, loop, elseIf.Block.Statements, true); reject.Reason != "" {
+			return reject
+		}
+	}
+	if expr.ElseBlock != nil {
+		return firstFastRenderStatementReject(plan, loop, expr.ElseBlock.Statements, true)
+	}
+	return FastRenderReject{}
+}
+
+func fastRenderCallReject(plan *FastRenderPlan, expr *ast.CallExpression, line int) FastRenderReject {
+	if expr == nil {
+		return FastRenderReject{Line: line, Reason: "nil call expressions are not fast-planned"}
+	}
+	if expr.Block != nil {
+		return fastRenderBlockCallReject(plan, expr, line)
+	}
+	if expr.ChainCallee != nil {
+		return rejectFastRender(expr, "chained helper calls with arguments are not fast-planned")
+	}
+	for _, arg := range expr.Arguments {
+		if _, ok := fastValuePlanFromExpression(plan, arg, false, lineForNode(arg)); !ok {
+			return fastRenderValueReject(plan, arg, "helper argument")
+		}
+	}
+	return rejectFastRender(expr, "unsupported helper call shape for fast render: "+fastExpressionSummary(expr))
+}
+
+func fastRenderBlockCallReject(plan *FastRenderPlan, expr *ast.CallExpression, line int) FastRenderReject {
+	if expr == nil {
+		return FastRenderReject{Line: line, Reason: "nil block helper calls are not fast-planned"}
+	}
+	if expr.ChainCallee != nil {
+		return rejectFastRender(expr, "chained block helper calls are not fast-planned")
+	}
+	ident, ok := expr.Function.(*ast.Identifier)
+	if !ok || !fastPlainHelperIdentifier(ident) || ident.Value == "nil" {
+		return rejectFastRender(expr, "unsupported block helper callee for fast render")
+	}
+	if !fastBlockCanRenderFromSource(expr.Block) {
+		return rejectFastRender(expr.Block, "block helper body contains statements that cannot be source-rendered")
+	}
+	for _, arg := range expr.Arguments {
+		if _, ok := fastValuePlanFromExpression(plan, arg, false, lineForNode(arg)); !ok {
+			return fastRenderValueReject(plan, arg, "block helper argument")
+		}
+	}
+	return rejectFastRender(expr, "unsupported block helper call shape for fast render")
+}
+
+func fastRenderValueReject(plan *FastRenderPlan, expr ast.Expression, role string) FastRenderReject {
+	line := lineForNode(expr)
+	switch expr := expr.(type) {
+	case *ast.ArrayLiteral:
+		for _, element := range expr.Elements {
+			if _, ok := fastValuePlanFromExpression(plan, element, false, lineForNode(element)); !ok {
+				return fastRenderValueReject(plan, element, role+": array literal element")
+			}
+		}
+		return FastRenderReject{Line: line, Reason: role + ": unsupported array literal for fast render"}
+	case *ast.HashLiteral:
+		keys := append([]ast.Expression(nil), expr.Order...)
+		if len(keys) == 0 {
+			for key := range expr.Pairs {
+				keys = append(keys, key)
+			}
+			sort.Slice(keys, func(i, j int) bool {
+				return keys[i].String() < keys[j].String()
+			})
+		}
+		for _, key := range keys {
+			if _, ok := fastPartialDataKey(key); !ok {
+				return FastRenderReject{Line: lineForNode(key), Reason: role + ": hash literal keys must be identifiers or strings"}
+			}
+			value := expr.Pairs[key]
+			if _, ok := fastValuePlanFromExpression(plan, value, false, lineForNode(value)); !ok {
+				return fastRenderValueReject(plan, value, role+": hash literal value")
+			}
+		}
+		return FastRenderReject{Line: line, Reason: role + ": unsupported hash literal for fast render"}
+	case *ast.IndexExpression:
+		if _, ok := fastIndexStepFromExpression(expr.Index, line); !ok {
+			return FastRenderReject{Line: lineForNode(expr.Index), Reason: role + ": dynamic index expressions are not fast-planned"}
+		}
+		return FastRenderReject{Line: line, Reason: role + ": unsupported index expression for fast render"}
+	case *ast.AssignExpression:
+		return FastRenderReject{Line: line, Reason: role + ": assignment expressions are not fast-planned"}
+	case *ast.FunctionLiteral:
+		return FastRenderReject{Line: line, Reason: role + ": function literals are not fast-planned"}
+	case *ast.CallExpression:
+		return fastRenderCallReject(plan, expr, line)
+	default:
+		return FastRenderReject{Line: line, Reason: role + ": unsupported expression type for fast render: " + fastExpressionSummary(expr)}
+	}
+}
+
+func rejectFastRender(node ast.Node, reason string) FastRenderReject {
+	return FastRenderReject{Line: lineForNode(node), Reason: reason}
+}
+
+func fastExpressionSummary(expr ast.Expression) string {
+	if expr == nil {
+		return "<nil>"
+	}
+	text := strings.TrimSpace(expr.String())
+	if len(text) > 80 {
+		text = text[:80] + "..."
+	}
+	return fmt.Sprintf("%T %q", expr, text)
+}
+
+func fastValuePlanSummary(value FastValuePlan) string {
+	switch value.Kind {
+	case FastValueName:
+		return fmt.Sprintf("name(%s)", value.Value)
+	case FastValueString:
+		return "string"
+	case FastValueInteger:
+		return "integer"
+	case FastValueFloat:
+		return "float"
+	case FastValueBool:
+		return "bool"
+	case FastValuePath:
+		return fmt.Sprintf("path(%s)", value.Value)
+	case FastValueLoopKey:
+		return fmt.Sprintf("loop-key(%s)", value.Value)
+	case FastValueInfix:
+		return fmt.Sprintf("infix(%s)", value.Operator)
+	case FastValueCall:
+		if value.Call != nil {
+			return fmt.Sprintf("call(%s)", value.Call.Name)
+		}
+		return "call"
+	case FastValuePrefix:
+		return fmt.Sprintf("prefix(%s)", value.Operator)
+	case FastValueConcat:
+		return "concat"
+	case FastValueArray:
+		return "array"
+	case FastValueHash:
+		return "hash"
+	default:
+		return fmt.Sprintf("kind(%d)", value.Kind)
+	}
+}
+
+type bytecodeFeatures struct {
+	HasHoles    bool
+	HasPartials bool
+}
+
+// bytecodeFeaturesFromInstructions records features that affect whether a fast
+// render shortcut is safe, such as holes and partial calls. The VM uses these
+// flags to keep cache, partial, and punch-hole behavior aligned with the
+// interpreter.
+func bytecodeFeaturesFromInstructions(instructions code.Instructions, constants []object.Object, callNames map[int]string) bytecodeFeatures {
+	features := scanInstructionFeatures(instructions, constants, callNames)
+	seen := map[*object.CompiledFunction]bool{}
+	for _, constant := range constants {
+		fn, ok := constant.(*object.CompiledFunction)
+		if !ok {
+			continue
+		}
+		features.merge(scanFunctionFeatures(fn, constants, seen))
+	}
+	return features
+}
+
+func scanFunctionFeatures(fn *object.CompiledFunction, constants []object.Object, seen map[*object.CompiledFunction]bool) bytecodeFeatures {
+	if fn == nil || seen[fn] {
+		return bytecodeFeatures{}
+	}
+	seen[fn] = true
+	features := scanInstructionFeatures(fn.Instructions, constants, fn.CallNames)
+	for _, constant := range constants {
+		nested, ok := constant.(*object.CompiledFunction)
+		if !ok || seen[nested] {
+			continue
+		}
+		features.merge(scanFunctionFeatures(nested, constants, seen))
+	}
+	return features
+}
+
+func scanInstructionFeatures(instructions code.Instructions, constants []object.Object, callNames map[int]string) bytecodeFeatures {
+	var features bytecodeFeatures
+	for i := 0; i < len(instructions); {
+		op, operands, read, ok := instructionAt(instructions, i)
+		if !ok {
+			return features
+		}
+
+		switch op {
+		case code.OpHole:
+			features.HasHoles = true
+		case code.OpGetName, code.OpGetNameOrNull, code.OpSetName, code.OpAssignName,
+			code.OpWriteName, code.OpWriteNameOrNull:
+			if len(operands) > 0 && stringConstantEquals(constants, operands[0], "partial") {
+				features.HasPartials = true
+			}
+		case code.OpWriteNameCall:
+			if len(operands) > 0 && stringConstantEquals(constants, operands[0], "partial") {
+				features.HasPartials = true
+			}
+		case code.OpCall, code.OpWriteCall, code.OpCallBlock:
+			if callNames != nil && callNames[i] == "partial" {
+				features.HasPartials = true
+			}
+		}
+
+		if features.HasHoles && features.HasPartials {
+			return features
+		}
+		i += 1 + read
+	}
+	return features
+}
+
+func stringConstantEquals(constants []object.Object, index int, want string) bool {
+	value, ok := stringConstantValue(constants, index)
+	return ok && value == want
+}
+
+func (f *bytecodeFeatures) merge(other bytecodeFeatures) {
+	f.HasHoles = f.HasHoles || other.HasHoles
+	f.HasPartials = f.HasPartials || other.HasPartials
+}
+
+func appendFastStatements(plan *FastRenderPlan, segments *[]FastRenderSegment, statements []ast.Statement) bool {
+	for _, stmt := range statements {
+		if !appendFastStatement(plan, segments, stmt) {
+			return false
+		}
+	}
+	return true
+}
+
+func appendFastSilentStatements(plan *FastRenderPlan, segments *[]FastRenderSegment, statements []ast.Statement) bool {
+	for _, stmt := range statements {
+		if !appendFastSilentStatement(plan, segments, stmt) {
+			return false
+		}
+	}
+	return true
+}
+
+func appendFastSilentStatement(plan *FastRenderPlan, segments *[]FastRenderSegment, stmt ast.Statement) bool {
+	switch stmt := stmt.(type) {
+	case *ast.ExpressionStatement:
+		if html, ok := stmt.Expression.(*ast.HTMLLiteral); ok {
+			appendFastStatic(plan, segments, html.Value)
+			return true
+		}
+		if assign, ok := stmt.Expression.(*ast.AssignExpression); ok {
+			return appendFastAssignExpression(plan, segments, assign, lineForNode(stmt))
+		}
+		if ifExpression, ok := stmt.Expression.(*ast.IfExpression); ok {
+			conditional, ok := fastSilentConditionalPlanFromExpression(plan, ifExpression, lineForNode(stmt))
+			if !ok {
+				return false
+			}
+			*segments = append(*segments, FastRenderSegment{
+				Kind:        FastRenderSegmentConditional,
+				Conditional: conditional,
+				Line:        lineForNode(stmt),
+			})
+			plan.NameCount++
+			return true
+		}
+		return false
+	case *ast.ReturnStatement:
+		return appendFastOutputExpression(plan, segments, stmt.ReturnValue, lineForNode(stmt))
+	default:
+		return false
+	}
+}
+
+func appendFastStatement(plan *FastRenderPlan, segments *[]FastRenderSegment, stmt ast.Statement) bool {
+	switch stmt := stmt.(type) {
+	case *ast.ExpressionStatement:
+		if html, ok := stmt.Expression.(*ast.HTMLLiteral); ok {
+			appendFastStatic(plan, segments, html.Value)
+			return true
+		}
+		if assign, ok := stmt.Expression.(*ast.AssignExpression); ok {
+			return appendFastAssignExpression(plan, segments, assign, lineForNode(stmt))
+		}
+		if ifExpression, ok := stmt.Expression.(*ast.IfExpression); ok {
+			conditional, ok := fastSilentConditionalPlanFromExpression(plan, ifExpression, lineForNode(stmt))
+			if !ok {
+				return false
+			}
+			*segments = append(*segments, FastRenderSegment{
+				Kind:        FastRenderSegmentConditional,
+				Conditional: conditional,
+				Line:        lineForNode(stmt),
+			})
+			plan.NameCount++
+			return true
+		}
+		return false
+	case *ast.ReturnStatement:
+		if stmt.Type != token.E_START {
+			return false
+		}
+		return appendFastOutputExpression(plan, segments, stmt.ReturnValue, lineForNode(stmt))
+	case *ast.LetStatement:
+		return appendFastLetStatement(plan, segments, stmt)
+	default:
+		return false
+	}
+}
+
+func appendFastLetStatement(plan *FastRenderPlan, segments *[]FastRenderSegment, stmt *ast.LetStatement) bool {
+	if stmt == nil || stmt.Name == nil || stmt.Name.Callee != nil || stmt.Name.Value == "" || stmt.Value == nil {
+		return false
+	}
+	value, ok := fastValuePlanFromExpression(plan, stmt.Value, false, lineForNode(stmt.Value))
+	if !ok {
+		return false
+	}
+	*segments = append(*segments, FastRenderSegment{
+		Kind:      FastRenderSegmentLet,
+		Value:     stmt.Name.Value,
+		NameIndex: plan.bindName(stmt.Name.Value),
+		ValuePlan: value,
+		Line:      lineForNode(stmt),
+	})
+	plan.NameCount++
+	return true
+}
+
+func appendFastAssignExpression(plan *FastRenderPlan, segments *[]FastRenderSegment, expr *ast.AssignExpression, line int) bool {
+	if expr == nil || expr.Name == nil || expr.Name.Callee != nil || expr.Name.Value == "" || expr.Value == nil {
+		return false
+	}
+	value, ok := fastValuePlanFromExpression(plan, expr.Value, false, lineForNode(expr.Value))
+	if !ok || !fastAssignValueSupported(value) {
+		return false
+	}
+	*segments = append(*segments, FastRenderSegment{
+		Kind:      FastRenderSegmentAssign,
+		Value:     expr.Name.Value,
+		NameIndex: plan.bindName(expr.Name.Value),
+		ValuePlan: value,
+		Line:      line,
+	})
+	plan.NameCount++
+	return true
+}
+
+func fastAssignValueSupported(value FastValuePlan) bool {
+	switch value.Kind {
+	case FastValueName, FastValueString, FastValueInteger, FastValueFloat, FastValueBool, FastValuePath, FastValueCall, FastValuePrefix:
+		return true
+	default:
+		return false
+	}
+}
+
+func appendFastOutputExpression(plan *FastRenderPlan, segments *[]FastRenderSegment, expr ast.Expression, line int) bool {
+	switch expr := expr.(type) {
+	case *ast.StringLiteral:
+		appendFastStatic(plan, segments, template.HTMLEscapeString(expr.Value))
+		return true
+	case *ast.HTMLLiteral:
+		appendFastStatic(plan, segments, expr.Value)
+		return true
+	case *ast.IntegerLiteral:
+		appendFastStatic(plan, segments, fmt.Sprint(expr.Value))
+		return true
+	case *ast.FloatLiteral:
+		appendFastStatic(plan, segments, fmt.Sprint(expr.Value))
+		return true
+	case *ast.Boolean:
+		appendFastStatic(plan, segments, fmt.Sprint(expr.Value))
+		return true
+	case *ast.ForExpression:
+		loop, ok := fastLoopPlanFromExpression(plan, expr, line)
+		if !ok {
+			return false
+		}
+		*segments = append(*segments, FastRenderSegment{
+			Kind: FastRenderSegmentLoop,
+			Loop: loop,
+			Line: line,
+		})
+		plan.NameCount++
+		return true
+	case *ast.IfExpression:
+		conditional, ok := fastConditionalPlanFromExpression(plan, expr, line)
+		if !ok {
+			return false
+		}
+		*segments = append(*segments, FastRenderSegment{
+			Kind:        FastRenderSegmentConditional,
+			Conditional: conditional,
+			Line:        line,
+		})
+		plan.NameCount++
+		return true
+	case *ast.CallExpression:
+		if blockCall, ok := fastBlockCallPlanFromExpression(plan, expr, line); ok {
+			*segments = append(*segments, FastRenderSegment{
+				Kind:      FastRenderSegmentBlockCall,
+				BlockCall: blockCall,
+				Line:      line,
+				Value:     blockCall.Name,
+			})
+			plan.NameCount++
+			return true
+		}
+		if partial, ok := fastPartialPlanFromCall(plan, expr, line); ok {
+			*segments = append(*segments, FastRenderSegment{
+				Kind:    FastRenderSegmentPartial,
+				Partial: partial,
+				Line:    line,
+			})
+			plan.NameCount++
+			return true
+		}
+		if call, ok := fastCallPlanFromExpression(plan, expr, line); ok {
+			*segments = append(*segments, FastRenderSegment{
+				Kind:  FastRenderSegmentCall,
+				Call:  call,
+				Line:  line,
+				Value: call.Name,
+			})
+			plan.NameCount++
+			return true
+		}
+	}
+
+	value, ok := fastValuePlanFromExpression(plan, expr, false, line)
+	if !ok {
+		return false
+	}
+	switch value.Kind {
+	case FastValueName:
+		if value.Value != "nil" {
+			*segments = append(*segments, FastRenderSegment{
+				Kind:          FastRenderSegmentName,
+				Value:         value.Value,
+				NameIndex:     value.NameIndex,
+				NullOnMissing: value.NullOnMissing,
+				Line:          line,
+			})
+			plan.NameCount++
+		}
+	case FastValuePath:
+		if len(value.Path) == 1 && value.Path[0].Kind == FastPathStepProperty {
+			step := value.Path[0]
+			*segments = append(*segments, FastRenderSegment{
+				Kind:          FastRenderSegmentProperty,
+				Value:         value.Value,
+				NameIndex:     value.NameIndex,
+				Property:      step.Value,
+				Receiver:      step.Receiver,
+				Full:          step.Full,
+				Line:          line,
+				PropertyCache: object.InlineCacheSlot{},
+			})
+		} else {
+			*segments = append(*segments, FastRenderSegment{
+				Kind:      FastRenderSegmentValue,
+				ValuePlan: value,
+				Line:      line,
+			})
+		}
+		plan.NameCount++
+	default:
+		*segments = append(*segments, FastRenderSegment{
+			Kind:      FastRenderSegmentValue,
+			ValuePlan: value,
+			Line:      line,
+		})
+		plan.NameCount++
+	}
+	return true
+}
+
+func appendFastStatic(plan *FastRenderPlan, segments *[]FastRenderSegment, value string) {
+	if value == "" {
+		return
+	}
+	last := len(*segments) - 1
+	if last >= 0 && (*segments)[last].Kind == FastRenderSegmentStatic {
+		(*segments)[last].Value += value
+	} else {
+		*segments = append(*segments, FastRenderSegment{
+			Kind:  FastRenderSegmentStatic,
+			Value: value,
+		})
+	}
+	plan.StaticSize += len(value)
+}
+
+func fastValuePlanFromExpression(plan *FastRenderPlan, expr ast.Expression, nullOnMissing bool, line int) (FastValuePlan, bool) {
+	switch expr := expr.(type) {
+	case *ast.Identifier:
+		return fastValuePlanFromIdentifier(plan, expr, nullOnMissing, line)
+	case *ast.IndexExpression:
+		return fastValuePlanFromIndexExpression(plan, expr, nullOnMissing, line)
+	case *ast.CallExpression:
+		return fastValuePlanFromCallExpression(plan, expr, nullOnMissing, line)
+	case *ast.PrefixExpression:
+		return fastValuePlanFromPrefixExpression(plan, expr, line)
+	case *ast.InfixExpression:
+		return fastValuePlanFromInfixExpression(plan, expr, line)
+	case *ast.ArrayLiteral:
+		return fastValuePlanFromArrayLiteral(plan, expr, line)
+	case *ast.HashLiteral:
+		return fastValuePlanFromHashLiteral(plan, expr, line)
+	case *ast.StringLiteral:
+		return FastValuePlan{Kind: FastValueString, Value: expr.Value, Line: line}, true
+	case *ast.IntegerLiteral:
+		return FastValuePlan{Kind: FastValueInteger, IntValue: int64(expr.Value), Line: line}, true
+	case *ast.FloatLiteral:
+		return FastValuePlan{Kind: FastValueFloat, FloatValue: expr.Value, Line: line}, true
+	case *ast.Boolean:
+		return FastValuePlan{Kind: FastValueBool, BoolValue: expr.Value, Line: line}, true
+	default:
+		return FastValuePlan{}, false
+	}
+}
+
+func fastValuePlanFromArrayLiteral(plan *FastRenderPlan, expr *ast.ArrayLiteral, line int) (FastValuePlan, bool) {
+	if expr == nil {
+		return FastValuePlan{}, false
+	}
+	elements := make([]FastValuePlan, 0, len(expr.Elements))
+	for _, elementExpr := range expr.Elements {
+		value, ok := fastValuePlanFromExpression(plan, elementExpr, false, lineForNode(elementExpr))
+		if !ok {
+			return FastValuePlan{}, false
+		}
+		elements = append(elements, value)
+	}
+	return FastValuePlan{
+		Kind:     FastValueArray,
+		Elements: elements,
+		Line:     line,
+	}, true
+}
+
+func fastValuePlanFromHashLiteral(plan *FastRenderPlan, expr *ast.HashLiteral, line int) (FastValuePlan, bool) {
+	if expr == nil {
+		return FastValuePlan{}, false
+	}
+	keys := append([]ast.Expression(nil), expr.Order...)
+	if len(keys) == 0 {
+		for key := range expr.Pairs {
+			keys = append(keys, key)
+		}
+		sort.Slice(keys, func(i, j int) bool {
+			return keys[i].String() < keys[j].String()
+		})
+	}
+	pairs := make([]FastValuePair, 0, len(keys))
+	for _, keyExpr := range keys {
+		key, ok := fastPartialDataKey(keyExpr)
+		if !ok {
+			return FastValuePlan{}, false
+		}
+		valueExpr := expr.Pairs[keyExpr]
+		value, ok := fastValuePlanFromExpression(plan, valueExpr, false, lineForNode(valueExpr))
+		if !ok {
+			return FastValuePlan{}, false
+		}
+		pairs = append(pairs, FastValuePair{
+			Key:   key,
+			Value: value,
+			Line:  lineForNode(valueExpr),
+		})
+	}
+	return FastValuePlan{
+		Kind:  FastValueHash,
+		Pairs: pairs,
+		Line:  line,
+	}, true
+}
+
+func fastValuePlanFromInfixExpression(plan *FastRenderPlan, expr *ast.InfixExpression, line int) (FastValuePlan, bool) {
+	if expr == nil || !fastInfixOperator(expr.Operator) {
+		if expr != nil && expr.Operator == "+" {
+			return fastValuePlanFromConcatExpression(plan, expr, line)
+		}
+		return FastValuePlan{}, false
+	}
+	left, ok := fastValuePlanFromExpression(plan, expr.Left, true, lineForNode(expr.Left))
+	if !ok {
+		return FastValuePlan{}, false
+	}
+	right, ok := fastValuePlanFromExpression(plan, expr.Right, true, lineForNode(expr.Right))
+	if !ok {
+		return FastValuePlan{}, false
+	}
+	if !fastInfixOperandSupported(left) || !fastInfixOperandSupported(right) {
+		return FastValuePlan{}, false
+	}
+	return FastValuePlan{
+		Kind:     FastValueInfix,
+		Operator: expr.Operator,
+		Left:     &left,
+		Right:    &right,
+		Line:     line,
+	}, true
+}
+
+func fastValuePlanFromPrefixExpression(plan *FastRenderPlan, expr *ast.PrefixExpression, line int) (FastValuePlan, bool) {
+	if expr == nil || expr.Operator != "!" || expr.Right == nil {
+		return FastValuePlan{}, false
+	}
+	right, ok := fastValuePlanFromExpression(plan, expr.Right, true, lineForNode(expr.Right))
+	if !ok {
+		return FastValuePlan{}, false
+	}
+	return FastValuePlan{
+		Kind:     FastValuePrefix,
+		Operator: expr.Operator,
+		Right:    &right,
+		Line:     line,
+	}, true
+}
+
+func fastValuePlanFromConcatExpression(plan *FastRenderPlan, expr *ast.InfixExpression, line int) (FastValuePlan, bool) {
+	if expr == nil || expr.Operator != "+" {
+		return FastValuePlan{}, false
+	}
+	left, ok := fastValuePlanFromExpression(plan, expr.Left, false, lineForNode(expr.Left))
+	if !ok {
+		return FastValuePlan{}, false
+	}
+	right, ok := fastValuePlanFromExpression(plan, expr.Right, false, lineForNode(expr.Right))
+	if !ok {
+		return FastValuePlan{}, false
+	}
+	return FastValuePlan{
+		Kind:     FastValueConcat,
+		Operator: expr.Operator,
+		Left:     &left,
+		Right:    &right,
+		Line:     line,
+	}, true
+}
+
+func fastValuePlanFromIdentifier(plan *FastRenderPlan, ident *ast.Identifier, nullOnMissing bool, line int) (FastValuePlan, bool) {
+	parts := identifierParts(ident)
+	if len(parts) == 0 {
+		return FastValuePlan{}, false
+	}
+	if parts[0] == "nil" {
+		return FastValuePlan{
+			Kind:          FastValueName,
+			Value:         "nil",
+			NameIndex:     -1,
+			NullOnMissing: true,
+			Line:          line,
+		}, true
+	}
+	value := FastValuePlan{
+		Kind:          FastValueName,
+		Value:         parts[0],
+		NameIndex:     plan.bindName(parts[0]),
+		NullOnMissing: nullOnMissing,
+		Line:          line,
+	}
+	if len(parts) == 1 {
+		return value, true
+	}
+	value.Kind = FastValuePath
+	for i, property := range parts[1:] {
+		value.Path = append(value.Path, fastPropertyStep(property, strings.Join(parts[:i+1], "."), strings.Join(parts[:i+2], "."), line, false))
+	}
+	return value, true
+}
+
+func fastValuePlanFromIndexExpression(plan *FastRenderPlan, exp *ast.IndexExpression, nullOnMissing bool, line int) (FastValuePlan, bool) {
+	value, ok := fastValuePlanFromExpression(plan, exp.Left, nullOnMissing, line)
+	if !ok || !value.canUsePath() {
+		return FastValuePlan{}, false
+	}
+	indexStep, ok := fastIndexStepFromExpression(exp.Index, line)
+	if !ok {
+		return FastValuePlan{}, false
+	}
+	value.Kind = FastValuePath
+	value.Path = append(value.Path, indexStep)
+	if exp.Callee != nil {
+		if !appendFastReceiverCallee(&value, exp.Callee, lastChainPart(exp.Left), line) {
+			return FastValuePlan{}, false
+		}
+	}
+	return value, true
+}
+
+func fastValuePlanFromCallExpression(plan *FastRenderPlan, exp *ast.CallExpression, nullOnMissing bool, line int) (FastValuePlan, bool) {
+	if exp.Block != nil {
+		return FastValuePlan{}, false
+	}
+	if ident, ok := exp.Function.(*ast.Identifier); ok {
+		parts := identifierParts(ident)
+		if len(parts) > 1 && len(exp.Arguments) == 0 {
+			value := FastValuePlan{
+				Kind:          FastValuePath,
+				Value:         parts[0],
+				NameIndex:     plan.bindName(parts[0]),
+				NullOnMissing: nullOnMissing,
+				Line:          line,
+			}
+			for i, property := range parts[1:] {
+				value.Path = append(value.Path, fastPropertyStep(property, strings.Join(parts[:i+1], "."), strings.Join(parts[:i+2], "."), line, i == len(parts[1:])-1))
+			}
+			value.Path = append(value.Path, FastPathStep{
+				Kind:  FastPathStepCall,
+				Value: callExpressionName(exp),
+				Line:  line,
+			})
+			if exp.ChainCallee != nil && !appendFastReceiverCallee(&value, exp.ChainCallee, lastChainPart(exp.Function), line) {
+				return FastValuePlan{}, false
+			}
+			return value, true
+		}
+	}
+	if call, ok := fastCallPlanFromExpression(plan, exp, line); ok {
+		if call.Name == "partial" {
+			return FastValuePlan{}, false
+		}
+		return FastValuePlan{
+			Kind: FastValueCall,
+			Call: call,
+			Line: line,
+		}, true
+	}
+	if len(exp.Arguments) == 0 {
+		value, ok := fastValuePlanFromExpression(plan, exp.Function, nullOnMissing, line)
+		if !ok || !value.canUsePath() {
+			return FastValuePlan{}, false
+		}
+		value.Kind = FastValuePath
+		value.Path = append(value.Path, FastPathStep{
+			Kind:  FastPathStepCall,
+			Value: callExpressionName(exp),
+			Line:  line,
+		})
+		if exp.ChainCallee != nil && !appendFastReceiverCallee(&value, exp.ChainCallee, lastChainPart(exp.Function), line) {
+			return FastValuePlan{}, false
+		}
+		return value, true
+	}
+	return FastValuePlan{}, false
+}
+
+func (v FastValuePlan) canUsePath() bool {
+	return v.Kind == FastValueName || v.Kind == FastValuePath
+}
+
+func appendFastReceiverCallee(value *FastValuePlan, exp ast.Expression, base string, line int) bool {
+	switch exp := exp.(type) {
+	case *ast.Identifier:
+		receiver := base
+		for _, property := range trimReceiverParts(identifierParts(exp), base) {
+			full := property
+			if receiver != "" {
+				full = receiver + "." + property
+			}
+			value.Path = append(value.Path, fastPropertyStep(property, receiver, full, line, false))
+			receiver = full
+		}
+		return true
+	case *ast.IndexExpression:
+		if !appendFastReceiverCallee(value, exp.Left, base, line) {
+			return false
+		}
+		indexStep, ok := fastIndexStepFromExpression(exp.Index, line)
+		if !ok {
+			return false
+		}
+		value.Path = append(value.Path, indexStep)
+		if exp.Callee != nil {
+			return appendFastReceiverCallee(value, exp.Callee, lastChainPart(exp.Left), line)
+		}
+		return true
+	case *ast.CallExpression:
+		if exp.Block != nil || len(exp.Arguments) != 0 {
+			return false
+		}
+		if ident, ok := exp.Function.(*ast.Identifier); ok {
+			receiver := base
+			parts := trimReceiverParts(identifierParts(ident), base)
+			for i, property := range parts {
+				full := property
+				if receiver != "" {
+					full = receiver + "." + property
+				}
+				value.Path = append(value.Path, fastPropertyStep(property, receiver, full, line, i == len(parts)-1))
+				receiver = full
+			}
+		} else if !appendFastReceiverCallee(value, exp.Function, base, line) {
+			return false
+		}
+		value.Path = append(value.Path, FastPathStep{
+			Kind:  FastPathStepCall,
+			Value: callExpressionName(exp),
+			Line:  line,
+		})
+		if exp.ChainCallee != nil {
+			return appendFastReceiverCallee(value, exp.ChainCallee, lastChainPart(exp.Function), line)
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+func fastPropertyStep(property, receiver, full string, line int, method bool) FastPathStep {
+	return FastPathStep{
+		Kind:     FastPathStepProperty,
+		Value:    property,
+		Receiver: receiver,
+		Full:     full,
+		Method:   method,
+		Line:     line,
+	}
+}
+
+func fastIntegerIndex(expr ast.Expression) (int, bool) {
+	switch expr := expr.(type) {
+	case *ast.IntegerLiteral:
+		return expr.Value, true
+	default:
+		return 0, false
+	}
+}
+
+func fastStringIndex(expr ast.Expression) (string, bool) {
+	switch expr := expr.(type) {
+	case *ast.StringLiteral:
+		return expr.Value, true
+	default:
+		return "", false
+	}
+}
+
+func fastIndexStepFromExpression(expr ast.Expression, line int) (FastPathStep, bool) {
+	if index, ok := fastIntegerIndex(expr); ok {
+		return FastPathStep{Kind: FastPathStepIndexInteger, Index: index, Line: line}, true
+	}
+	if index, ok := fastStringIndex(expr); ok {
+		return FastPathStep{Kind: FastPathStepIndexString, Value: index, Line: line}, true
+	}
+	return FastPathStep{}, false
+}
+
+func fastCallPlanFromExpression(plan *FastRenderPlan, exp *ast.CallExpression, line int) (*FastCallPlan, bool) {
+	if exp == nil || exp.Block != nil || exp.ChainCallee != nil {
+		return nil, false
+	}
+	ident, ok := exp.Function.(*ast.Identifier)
+	if !ok || ident.Callee != nil || ident.Value == "" || ident.Value == "nil" || ident.Value == "partial" {
+		return nil, false
+	}
+	call := &FastCallPlan{
+		Name:      ident.Value,
+		NameIndex: plan.bindName(ident.Value),
+		Line:      line,
+	}
+	for _, arg := range exp.Arguments {
+		value, ok := fastValuePlanFromExpression(plan, arg, false, line)
+		if !ok {
+			return nil, false
+		}
+		call.Args = append(call.Args, value)
+	}
+	return call, true
+}
+
+func fastBlockCallPlanFromExpression(plan *FastRenderPlan, exp *ast.CallExpression, line int) (*FastBlockCallPlan, bool) {
+	if exp == nil || exp.Block == nil || exp.ChainCallee != nil {
+		return nil, false
+	}
+	ident, ok := exp.Function.(*ast.Identifier)
+	if !ok || !fastPlainHelperIdentifier(ident) || ident.Value == "nil" {
+		return nil, false
+	}
+	if !fastBlockCanRenderFromSource(exp.Block) {
+		return nil, false
+	}
+	call := &FastBlockCallPlan{
+		Name:        ident.Value,
+		NameIndex:   plan.bindName(ident.Value),
+		Block:       exp.Block,
+		BlockSource: fastBlockSource(exp.Block),
+		Line:        line,
+	}
+	for _, arg := range exp.Arguments {
+		value, ok := fastValuePlanFromExpression(plan, arg, false, lineForNode(arg))
+		if !ok {
+			return nil, false
+		}
+		call.Args = append(call.Args, value)
+	}
+	return call, true
+}
+
+func fastBlockCanRenderFromSource(block *ast.BlockStatement) bool {
+	return block != nil && !fastBlockStatementsHaveAssignment(block.Statements)
+}
+
+func fastBlockStatementsHaveAssignment(statements []ast.Statement) bool {
+	for _, stmt := range statements {
+		if fastBlockStatementHasAssignment(stmt) {
+			return true
+		}
+	}
+	return false
+}
+
+func fastBlockStatementHasAssignment(stmt ast.Statement) bool {
+	switch stmt := stmt.(type) {
+	case nil:
+		return false
+	case *ast.ExpressionStatement:
+		return fastBlockExpressionHasAssignment(stmt.Expression)
+	case *ast.ReturnStatement:
+		return fastBlockExpressionHasAssignment(stmt.ReturnValue)
+	case *ast.LetStatement:
+		return fastBlockExpressionHasAssignment(stmt.Value)
+	case *ast.BlockStatement:
+		return fastBlockStatementsHaveAssignment(stmt.Statements)
+	default:
+		return false
+	}
+}
+
+func fastBlockExpressionHasAssignment(expr ast.Expression) bool {
+	switch expr := expr.(type) {
+	case nil:
+		return false
+	case *ast.AssignExpression:
+		return true
+	case *ast.PrefixExpression:
+		return fastBlockExpressionHasAssignment(expr.Right)
+	case *ast.InfixExpression:
+		return fastBlockExpressionHasAssignment(expr.Left) || fastBlockExpressionHasAssignment(expr.Right)
+	case *ast.IndexExpression:
+		return fastBlockExpressionHasAssignment(expr.Left) || fastBlockExpressionHasAssignment(expr.Index) || fastBlockExpressionHasAssignment(expr.Callee)
+	case *ast.CallExpression:
+		if fastBlockExpressionHasAssignment(expr.Function) || fastBlockExpressionHasAssignment(expr.ChainCallee) {
+			return true
+		}
+		for _, arg := range expr.Arguments {
+			if fastBlockExpressionHasAssignment(arg) {
+				return true
+			}
+		}
+		return expr.Block != nil && fastBlockStatementsHaveAssignment(expr.Block.Statements)
+	case *ast.IfExpression:
+		if fastBlockExpressionHasAssignment(expr.Condition) || (expr.Block != nil && fastBlockStatementsHaveAssignment(expr.Block.Statements)) {
+			return true
+		}
+		for _, elseIf := range expr.ElseIf {
+			if elseIf != nil && (fastBlockExpressionHasAssignment(elseIf.Condition) || (elseIf.Block != nil && fastBlockStatementsHaveAssignment(elseIf.Block.Statements))) {
+				return true
+			}
+		}
+		return expr.ElseBlock != nil && fastBlockStatementsHaveAssignment(expr.ElseBlock.Statements)
+	case *ast.ForExpression:
+		return fastBlockExpressionHasAssignment(expr.Iterable) || (expr.Block != nil && fastBlockStatementsHaveAssignment(expr.Block.Statements))
+	case *ast.ArrayLiteral:
+		for _, element := range expr.Elements {
+			if fastBlockExpressionHasAssignment(element) {
+				return true
+			}
+		}
+		return false
+	case *ast.HashLiteral:
+		for key, value := range expr.Pairs {
+			if fastBlockExpressionHasAssignment(key) || fastBlockExpressionHasAssignment(value) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+func fastBlockSource(block *ast.BlockStatement) string {
+	if block == nil {
+		return ""
+	}
+	var out strings.Builder
+	for _, stmt := range block.Statements {
+		out.WriteString(fastBlockStatementSource(stmt))
+	}
+	return out.String()
+}
+
+func fastBlockStatementSource(stmt ast.Statement) string {
+	switch stmt := stmt.(type) {
+	case nil:
+		return ""
+	case *ast.ExpressionStatement:
+		if html, ok := stmt.Expression.(*ast.HTMLLiteral); ok {
+			return html.Value
+		}
+		return "<% " + stmt.String() + " %>"
+	case *ast.ReturnStatement:
+		if stmt.Type == token.E_START {
+			if stmt.ReturnValue == nil {
+				return ""
+			}
+			return "<%= " + stmt.ReturnValue.String() + " %>"
+		}
+		return "<% " + stmt.String() + " %>"
+	case *ast.LetStatement:
+		return "<% " + stmt.String() + " %>"
+	case *ast.BlockStatement:
+		return fastBlockSource(stmt)
+	default:
+		return "<% " + stmt.String() + " %>"
+	}
+}
+
+func fastPartialPlanFromCall(plan *FastRenderPlan, exp *ast.CallExpression, line int) (*FastPartialPlan, bool) {
+	if exp == nil || exp.Block != nil || exp.ChainCallee != nil || len(exp.Arguments) == 0 || len(exp.Arguments) > 2 {
+		return nil, false
+	}
+	ident, ok := exp.Function.(*ast.Identifier)
+	if !ok || ident.Callee != nil || ident.Value != "partial" {
+		return nil, false
+	}
+	name, ok := exp.Arguments[0].(*ast.StringLiteral)
+	if !ok {
+		return nil, false
+	}
+	partial := &FastPartialPlan{Name: name.Value, Line: line}
+	if len(exp.Arguments) == 2 {
+		data, ok := fastPartialDataPlanFromExpression(plan, exp.Arguments[1], line)
+		if !ok {
+			return nil, false
+		}
+		partial.Data = data
+	}
+	return partial, true
+}
+
+func fastPartialDataPlanFromExpression(plan *FastRenderPlan, expr ast.Expression, line int) ([]FastPartialDataPair, bool) {
+	hash, ok := expr.(*ast.HashLiteral)
+	if !ok {
+		return nil, false
+	}
+	keys := append([]ast.Expression(nil), hash.Order...)
+	if len(keys) == 0 {
+		for key := range hash.Pairs {
+			keys = append(keys, key)
+		}
+		sort.Slice(keys, func(i, j int) bool {
+			return keys[i].String() < keys[j].String()
+		})
+	}
+	data := make([]FastPartialDataPair, 0, len(keys))
+	for _, keyExpr := range keys {
+		key, ok := fastPartialDataKey(keyExpr)
+		if !ok || key == "layout" {
+			return nil, false
+		}
+		valueExpr := hash.Pairs[keyExpr]
+		valueLine := lineForNode(valueExpr)
+		value, ok := fastValuePlanFromExpression(plan, valueExpr, false, valueLine)
+		if !ok {
+			return nil, false
+		}
+		data = append(data, FastPartialDataPair{
+			Key:   key,
+			Value: value,
+			Line:  valueLine,
+		})
+	}
+	return data, true
+}
+
+func fastPartialDataKey(expr ast.Expression) (string, bool) {
+	switch key := expr.(type) {
+	case *ast.Identifier:
+		if key.Callee != nil || key.Value == "" {
+			return "", false
+		}
+		return key.Value, true
+	case *ast.StringLiteral:
+		return key.Value, true
+	default:
+		return "", false
+	}
+}
+
+func fastConditionalPlanFromExpression(plan *FastRenderPlan, expr *ast.IfExpression, line int) (*FastConditionalPlan, bool) {
+	if expr == nil {
+		return nil, false
+	}
+	conditional := &FastConditionalPlan{Line: line}
+	first, ok := fastValuePlanFromExpression(plan, expr.Condition, true, lineForNode(expr.Condition))
+	if !ok || !fastConditionValueSupported(first) {
+		return nil, false
+	}
+	firstSegments := []FastRenderSegment{}
+	if !appendFastStatements(plan, &firstSegments, expr.Block.Statements) {
+		return nil, false
+	}
+	conditional.Branches = append(conditional.Branches, FastConditionalBranch{
+		Condition: first,
+		Segments:  firstSegments,
+		Line:      line,
+	})
+	for _, elseIf := range expr.ElseIf {
+		if elseIf == nil {
+			return nil, false
+		}
+		condition, ok := fastValuePlanFromExpression(plan, elseIf.Condition, true, lineForNode(elseIf.Condition))
+		if !ok || !fastConditionValueSupported(condition) {
+			return nil, false
+		}
+		segments := []FastRenderSegment{}
+		if !appendFastStatements(plan, &segments, elseIf.Block.Statements) {
+			return nil, false
+		}
+		conditional.Branches = append(conditional.Branches, FastConditionalBranch{
+			Condition: condition,
+			Segments:  segments,
+			Line:      lineForToken(elseIf.TokenAble),
+		})
+	}
+	if expr.ElseBlock != nil {
+		segments := []FastRenderSegment{}
+		if !appendFastStatements(plan, &segments, expr.ElseBlock.Statements) {
+			return nil, false
+		}
+		conditional.ElseSegments = segments
+	}
+	return conditional, true
+}
+
+func fastSilentConditionalPlanFromExpression(plan *FastRenderPlan, expr *ast.IfExpression, line int) (*FastConditionalPlan, bool) {
+	conditional, ok := fastConditionalPlanFromExpressionWithAppender(plan, expr, line, appendFastSilentStatements)
+	if !ok {
+		return nil, false
+	}
+	conditional.Silent = true
+	return conditional, true
+}
+
+func fastSilentConditionalReject(plan *FastRenderPlan, expr *ast.IfExpression, line int) FastRenderReject {
+	if expr == nil || expr.Block == nil {
+		return FastRenderReject{Line: line, Reason: "script if expressions without a block are not fast-planned"}
+	}
+	condition, ok := fastValuePlanFromExpression(plan, expr.Condition, true, lineForNode(expr.Condition))
+	if !ok {
+		return fastRenderValueReject(plan, expr.Condition, "script if condition")
+	}
+	if !fastConditionValueSupported(condition) {
+		return FastRenderReject{Line: lineForNode(expr.Condition), Reason: "script if condition: unsupported literal container condition"}
+	}
+	if reject := firstFastSilentStatementReject(plan, expr.Block.Statements); reject.Reason != "" {
+		return reject
+	}
+	for _, elseIf := range expr.ElseIf {
+		if elseIf == nil || elseIf.Block == nil {
+			return FastRenderReject{Line: line, Reason: "script else-if expressions without a block are not fast-planned"}
+		}
+		condition, ok := fastValuePlanFromExpression(plan, elseIf.Condition, true, lineForNode(elseIf.Condition))
+		if !ok {
+			return fastRenderValueReject(plan, elseIf.Condition, "script else-if condition")
+		}
+		if !fastConditionValueSupported(condition) {
+			return FastRenderReject{Line: lineForNode(elseIf.Condition), Reason: "script else-if condition: unsupported literal container condition"}
+		}
+		if reject := firstFastSilentStatementReject(plan, elseIf.Block.Statements); reject.Reason != "" {
+			return reject
+		}
+	}
+	if expr.ElseBlock != nil {
+		return firstFastSilentStatementReject(plan, expr.ElseBlock.Statements)
+	}
+	return FastRenderReject{}
+}
+
+func firstFastSilentStatementReject(plan *FastRenderPlan, statements []ast.Statement) FastRenderReject {
+	for _, stmt := range statements {
+		if reject := fastSilentStatementReject(plan, stmt); reject.Reason != "" {
+			return reject
+		}
+	}
+	return FastRenderReject{}
+}
+
+func fastSilentStatementReject(plan *FastRenderPlan, stmt ast.Statement) FastRenderReject {
+	switch stmt := stmt.(type) {
+	case *ast.ExpressionStatement:
+		if _, ok := stmt.Expression.(*ast.HTMLLiteral); ok {
+			return FastRenderReject{}
+		}
+		if assign, ok := stmt.Expression.(*ast.AssignExpression); ok {
+			segments := []FastRenderSegment{}
+			if appendFastAssignExpression(plan, &segments, assign, lineForNode(stmt)) {
+				return FastRenderReject{}
+			}
+			return fastRenderValueReject(plan, assign.Value, "script assignment value")
+		}
+		if ifExpression, ok := stmt.Expression.(*ast.IfExpression); ok {
+			return fastSilentConditionalReject(plan, ifExpression, lineForNode(stmt))
+		}
+		return rejectFastRender(stmt, "script if body expression is not fast-planned: "+fastExpressionSummary(stmt.Expression))
+	case *ast.ReturnStatement:
+		if stmt.ReturnValue == nil {
+			return FastRenderReject{}
+		}
+		return fastRenderOutputReject(plan, stmt.ReturnValue, lineForNode(stmt))
+	case *ast.LetStatement:
+		return rejectFastRender(stmt, "let statements inside script if bodies are not fast-planned")
+	default:
+		return rejectFastRender(stmt, "unsupported script if body statement type for fast render")
+	}
+}
+
+func fastConditionalPlanFromExpressionWithAppender(plan *FastRenderPlan, expr *ast.IfExpression, line int, appendStatements func(*FastRenderPlan, *[]FastRenderSegment, []ast.Statement) bool) (*FastConditionalPlan, bool) {
+	if expr == nil || appendStatements == nil {
+		return nil, false
+	}
+	conditional := &FastConditionalPlan{Line: line}
+	first, ok := fastValuePlanFromExpression(plan, expr.Condition, true, lineForNode(expr.Condition))
+	if !ok || !fastConditionValueSupported(first) {
+		return nil, false
+	}
+	firstSegments := []FastRenderSegment{}
+	if !appendStatements(plan, &firstSegments, expr.Block.Statements) {
+		return nil, false
+	}
+	conditional.Branches = append(conditional.Branches, FastConditionalBranch{
+		Condition: first,
+		Segments:  firstSegments,
+		Line:      line,
+	})
+	for _, elseIf := range expr.ElseIf {
+		if elseIf == nil {
+			return nil, false
+		}
+		condition, ok := fastValuePlanFromExpression(plan, elseIf.Condition, true, lineForNode(elseIf.Condition))
+		if !ok || !fastConditionValueSupported(condition) {
+			return nil, false
+		}
+		segments := []FastRenderSegment{}
+		if !appendStatements(plan, &segments, elseIf.Block.Statements) {
+			return nil, false
+		}
+		conditional.Branches = append(conditional.Branches, FastConditionalBranch{
+			Condition: condition,
+			Segments:  segments,
+			Line:      lineForToken(elseIf.TokenAble),
+		})
+	}
+	if expr.ElseBlock != nil {
+		segments := []FastRenderSegment{}
+		if !appendStatements(plan, &segments, expr.ElseBlock.Statements) {
+			return nil, false
+		}
+		conditional.ElseSegments = segments
+	}
+	return conditional, true
+}
+
+func fastConditionValueSupported(value FastValuePlan) bool {
+	return value.Kind != FastValueArray && value.Kind != FastValueHash
+}
+
+func fastInfixOperandSupported(value FastValuePlan) bool {
+	return value.Kind != FastValueArray && value.Kind != FastValueHash
+}
+
+func fastLoopPlanFromExpression(plan *FastRenderPlan, expr *ast.ForExpression, line int) (*FastLoopPlan, bool) {
+	return fastLoopPlanFromExpressionWithOuterNames(plan, nil, expr, line)
+}
+
+func fastNestedLoopPlanFromExpression(plan *FastRenderPlan, parent *FastLoopPlan, expr *ast.ForExpression, line int) (*FastLoopPlan, bool) {
+	return fastLoopPlanFromExpressionWithOuterNames(plan, fastLoopOuterNames(parent), expr, line)
+}
+
+func fastLoopPlanFromExpressionWithOuterNames(plan *FastRenderPlan, outerNames []string, expr *ast.ForExpression, line int) (*FastLoopPlan, bool) {
+	if expr == nil || expr.Block == nil {
+		return nil, false
+	}
+	iterable, ok := fastValuePlanFromExpression(plan, expr.Iterable, false, lineForNode(expr.Iterable))
+	if !ok || iterable.Value == "nil" || !fastLoopIterableValueSupported(iterable) {
+		return nil, false
+	}
+	loop := &FastLoopPlan{
+		IterableName:      iterable.Value,
+		IterableNameIndex: iterable.NameIndex,
+		Iterable:          iterable,
+		KeyName:           expr.KeyName,
+		ValueName:         expr.ValueName,
+		OuterNames:        append([]string(nil), outerNames...),
+		Line:              line,
+	}
+	if !appendFastLoopStatements(plan, loop, &loop.Parts, expr.Block.Statements) {
+		return nil, false
+	}
+	return loop, true
+}
+
+func fastLoopIterableValueSupported(value FastValuePlan) bool {
+	switch value.Kind {
+	case FastValueName, FastValuePath, FastValueCall, FastValueArray, FastValueHash:
+		return true
+	default:
+		return false
+	}
+}
+
+func appendFastLoopStatements(plan *FastRenderPlan, loop *FastLoopPlan, parts *[]FastLoopPart, statements []ast.Statement) bool {
+	for _, stmt := range statements {
+		if !appendFastLoopStatement(plan, loop, parts, stmt) {
+			return false
+		}
+	}
+	return true
+}
+
+func appendFastLoopStatement(plan *FastRenderPlan, loop *FastLoopPlan, parts *[]FastLoopPart, stmt ast.Statement) bool {
+	switch stmt := stmt.(type) {
+	case *ast.ExpressionStatement:
+		switch expr := stmt.Expression.(type) {
+		case *ast.HTMLLiteral:
+			appendFastLoopStatic(plan, loop, parts, expr.Value)
+			return true
+		case *ast.BreakExpression:
+			appendFastLoopControlPart(parts, FastLoopPartBreak, lineForNode(stmt))
+			return true
+		case *ast.ContinueExpression:
+			appendFastLoopControlPart(parts, FastLoopPartContinue, lineForNode(stmt))
+			return true
+		case *ast.IfExpression:
+			conditional, ok := fastSilentLoopConditionalPlanFromExpression(plan, loop, expr, lineForNode(stmt))
+			if !ok {
+				return false
+			}
+			*parts = append(*parts, FastLoopPart{
+				Kind:        FastLoopPartConditional,
+				Conditional: conditional,
+				Line:        lineForNode(stmt),
+			})
+			return true
+		default:
+			return false
+		}
+	case *ast.ReturnStatement:
+		if stmt.Type != token.E_START {
+			return false
+		}
+		return appendFastLoopOutputParts(plan, loop, parts, stmt.ReturnValue, lineForNode(stmt))
+	case *ast.LetStatement:
+		return appendFastLoopLetStatement(plan, loop, parts, stmt)
+	default:
+		return false
+	}
+}
+
+func appendFastLoopLetStatement(plan *FastRenderPlan, loop *FastLoopPlan, parts *[]FastLoopPart, stmt *ast.LetStatement) bool {
+	if stmt == nil || stmt.Name == nil || stmt.Name.Callee != nil || stmt.Name.Value == "" || stmt.Value == nil {
+		return false
+	}
+	value, ok := fastValuePlanFromLoopOperand(plan, loop, stmt.Value, false, lineForNode(stmt.Value))
+	if !ok {
+		return false
+	}
+	*parts = append(*parts, FastLoopPart{
+		Kind:      FastLoopPartLet,
+		Value:     stmt.Name.Value,
+		NameIndex: plan.bindName(stmt.Name.Value),
+		ValuePlan: value,
+		Line:      lineForNode(stmt),
+	})
+	plan.NameCount++
+	return true
+}
+
+func appendFastLoopOutputParts(plan *FastRenderPlan, loop *FastLoopPlan, parts *[]FastLoopPart, expr ast.Expression, line int) bool {
+	switch expr := expr.(type) {
+	case *ast.StringLiteral:
+		value := template.HTMLEscapeString(expr.Value)
+		appendFastLoopStatic(plan, loop, parts, value)
+		return true
+	case *ast.HTMLLiteral:
+		appendFastLoopStatic(plan, loop, parts, expr.Value)
+		return true
+	case *ast.IntegerLiteral:
+		value := fmt.Sprint(expr.Value)
+		appendFastLoopStatic(plan, loop, parts, value)
+		return true
+	case *ast.FloatLiteral:
+		value := fmt.Sprint(expr.Value)
+		appendFastLoopStatic(plan, loop, parts, value)
+		return true
+	case *ast.Boolean:
+		value := fmt.Sprint(expr.Value)
+		appendFastLoopStatic(plan, loop, parts, value)
+		return true
+	case *ast.BreakExpression:
+		appendFastLoopControlPart(parts, FastLoopPartBreak, line)
+		return true
+	case *ast.ContinueExpression:
+		appendFastLoopControlPart(parts, FastLoopPartContinue, line)
+		return true
+	case *ast.IfExpression:
+		conditional, ok := fastLoopConditionalPlanFromExpression(plan, loop, expr, line)
+		if !ok {
+			return false
+		}
+		*parts = append(*parts, FastLoopPart{
+			Kind:        FastLoopPartConditional,
+			Conditional: conditional,
+			Line:        line,
+		})
+		return true
+	case *ast.ForExpression:
+		nested, ok := fastNestedLoopPlanFromExpression(plan, loop, expr, line)
+		if !ok {
+			return false
+		}
+		*parts = append(*parts, FastLoopPart{
+			Kind: FastLoopPartLoop,
+			Loop: nested,
+			Line: line,
+		})
+		return true
+	case *ast.Identifier:
+		identParts := identifierParts(expr)
+		if len(identParts) == 1 && identParts[0] == loop.KeyName {
+			*parts = append(*parts, FastLoopPart{Kind: FastLoopPartKey, Line: line})
+			return true
+		}
+		if len(identParts) == 1 && identParts[0] == loop.ValueName {
+			*parts = append(*parts, FastLoopPart{Kind: FastLoopPartValue, Line: line})
+			return true
+		}
+		if len(identParts) > 1 && identParts[0] == loop.ValueName {
+			if len(identParts) == 2 {
+				*parts = append(*parts, FastLoopPart{
+					Kind:     FastLoopPartValueProperty,
+					Value:    identParts[1],
+					Receiver: loop.ValueName,
+					Full:     loop.ValueName + "." + identParts[1],
+					Line:     line,
+				})
+				return true
+			}
+			value := FastValuePlan{Kind: FastValuePath, Value: loop.ValueName, NameIndex: -1, Line: line}
+			receiver := loop.ValueName
+			for _, property := range identParts[1:] {
+				full := receiver + "." + property
+				value.Path = append(value.Path, fastPropertyStep(property, receiver, full, line, false))
+				receiver = full
+			}
+			*parts = append(*parts, FastLoopPart{Kind: FastLoopPartValuePath, ValuePlan: value, Line: line})
+			return true
+		}
+		if len(identParts) > 0 && fastLoopHasOuterName(loop, identParts[0]) {
+			value, ok := fastValuePlanFromExpression(plan, expr, false, line)
+			if !ok {
+				return false
+			}
+			*parts = append(*parts, FastLoopPart{Kind: FastLoopPartValuePath, ValuePlan: value, Line: line})
+			return true
+		}
+	case *ast.CallExpression:
+		if blockCall, ok := fastLoopBlockCallPlanFromExpression(plan, loop, expr, line); ok {
+			*parts = append(*parts, FastLoopPart{
+				Kind:      FastLoopPartBlockCall,
+				Value:     blockCall.Name,
+				BlockCall: blockCall,
+				Line:      line,
+			})
+			return true
+		}
+		if partial, ok := fastPartialPlanFromCall(plan, expr, line); ok {
+			*parts = append(*parts, FastLoopPart{
+				Kind:    FastLoopPartPartial,
+				Value:   partial.Name,
+				Partial: partial,
+				Line:    line,
+			})
+			return true
+		}
+		if value, ok := fastValuePlanFromLoopCall(loop, expr, line); ok {
+			*parts = append(*parts, FastLoopPart{Kind: FastLoopPartValuePath, ValuePlan: value, Line: line})
+			return true
+		}
+		if root, ok := fastLoopExpressionRootName(expr); ok && fastLoopHasOuterName(loop, root) {
+			value, ok := fastValuePlanFromExpression(plan, expr, false, line)
+			if !ok {
+				return false
+			}
+			*parts = append(*parts, FastLoopPart{Kind: FastLoopPartValuePath, ValuePlan: value, Line: line})
+			return true
+		}
+		if call, ok := fastLoopCallPlanFromExpression(plan, loop, expr, line); ok {
+			*parts = append(*parts, FastLoopPart{
+				Kind:  FastLoopPartCall,
+				Value: call.Name,
+				Call:  call,
+				Line:  line,
+			})
+			return true
+		}
+		return false
+	}
+	switch expr.(type) {
+	case *ast.PrefixExpression, *ast.InfixExpression:
+		if value, ok := fastValuePlanFromLoopOperand(plan, loop, expr, false, line); ok {
+			*parts = append(*parts, FastLoopPart{Kind: FastLoopPartValuePath, ValuePlan: value, Line: line})
+			return true
+		}
+	}
+	value, ok := fastValuePlanFromLoopOperand(plan, loop, expr, false, line)
+	if !ok {
+		return false
+	}
+	*parts = append(*parts, FastLoopPart{Kind: FastLoopPartValuePath, ValuePlan: value, Line: line})
+	return true
+}
+
+func appendFastLoopControlPart(parts *[]FastLoopPart, kind FastLoopPartKind, line int) {
+	*parts = append(*parts, FastLoopPart{Kind: kind, Line: line})
+}
+
+func appendFastLoopStatic(plan *FastRenderPlan, loop *FastLoopPlan, parts *[]FastLoopPart, value string) {
+	if value == "" {
+		return
+	}
+	last := len(*parts) - 1
+	if last >= 0 && (*parts)[last].Kind == FastLoopPartStatic {
+		(*parts)[last].Value += value
+	} else {
+		*parts = append(*parts, FastLoopPart{
+			Kind:  FastLoopPartStatic,
+			Value: value,
+		})
+	}
+	if plan != nil {
+		plan.StaticSize += len(value)
+	}
+	if loop != nil {
+		loop.StaticSize += len(value)
+	}
+}
+
+func fastLoopConditionalPlanFromExpression(plan *FastRenderPlan, loop *FastLoopPlan, expr *ast.IfExpression, line int) (*FastLoopConditionalPlan, bool) {
+	if expr == nil || expr.Block == nil {
+		return nil, false
+	}
+	conditional := &FastLoopConditionalPlan{Line: line}
+	first, ok := fastValuePlanFromLoopCondition(plan, loop, expr.Condition, lineForNode(expr.Condition))
+	if !ok || !fastConditionValueSupported(first) {
+		return nil, false
+	}
+	firstParts := []FastLoopPart{}
+	if !appendFastLoopStatements(plan, loop, &firstParts, expr.Block.Statements) {
+		return nil, false
+	}
+	conditional.Branches = append(conditional.Branches, FastLoopConditionalBranch{
+		Condition: first,
+		Parts:     firstParts,
+		Line:      line,
+	})
+	for _, elseIf := range expr.ElseIf {
+		if elseIf == nil || elseIf.Block == nil {
+			return nil, false
+		}
+		condition, ok := fastValuePlanFromLoopCondition(plan, loop, elseIf.Condition, lineForNode(elseIf.Condition))
+		if !ok || !fastConditionValueSupported(condition) {
+			return nil, false
+		}
+		branchParts := []FastLoopPart{}
+		if !appendFastLoopStatements(plan, loop, &branchParts, elseIf.Block.Statements) {
+			return nil, false
+		}
+		conditional.Branches = append(conditional.Branches, FastLoopConditionalBranch{
+			Condition: condition,
+			Parts:     branchParts,
+			Line:      lineForToken(elseIf.TokenAble),
+		})
+	}
+	if expr.ElseBlock != nil {
+		elseParts := []FastLoopPart{}
+		if !appendFastLoopStatements(plan, loop, &elseParts, expr.ElseBlock.Statements) {
+			return nil, false
+		}
+		conditional.ElseParts = elseParts
+	}
+	return conditional, true
+}
+
+func fastSilentLoopConditionalPlanFromExpression(plan *FastRenderPlan, loop *FastLoopPlan, expr *ast.IfExpression, line int) (*FastLoopConditionalPlan, bool) {
+	conditional, ok := fastLoopConditionalPlanFromExpression(plan, loop, expr, line)
+	if !ok {
+		return nil, false
+	}
+	conditional.Silent = true
+	return conditional, true
+}
+
+func fastValuePlanFromLoopCondition(plan *FastRenderPlan, loop *FastLoopPlan, expr ast.Expression, line int) (FastValuePlan, bool) {
+	if prefix, ok := expr.(*ast.PrefixExpression); ok {
+		return fastValuePlanFromLoopPrefix(plan, loop, prefix, line)
+	}
+	if infix, ok := expr.(*ast.InfixExpression); ok {
+		return fastValuePlanFromLoopInfix(plan, loop, infix, line)
+	}
+	return fastValuePlanFromLoopOperand(plan, loop, expr, true, line)
+}
+
+func fastValuePlanFromLoopInfix(plan *FastRenderPlan, loop *FastLoopPlan, expr *ast.InfixExpression, line int) (FastValuePlan, bool) {
+	if expr != nil && expr.Operator == "+" {
+		return fastValuePlanFromLoopConcat(plan, loop, expr, line)
+	}
+	if expr == nil || !fastInfixOperator(expr.Operator) {
+		return FastValuePlan{}, false
+	}
+	left, ok := fastValuePlanFromLoopOperand(plan, loop, expr.Left, true, lineForNode(expr.Left))
+	if !ok {
+		return FastValuePlan{}, false
+	}
+	right, ok := fastValuePlanFromLoopOperand(plan, loop, expr.Right, true, lineForNode(expr.Right))
+	if !ok {
+		return FastValuePlan{}, false
+	}
+	if !fastInfixOperandSupported(left) || !fastInfixOperandSupported(right) {
+		return FastValuePlan{}, false
+	}
+	return FastValuePlan{
+		Kind:     FastValueInfix,
+		Operator: expr.Operator,
+		Left:     &left,
+		Right:    &right,
+		Line:     line,
+	}, true
+}
+
+func fastValuePlanFromLoopPrefix(plan *FastRenderPlan, loop *FastLoopPlan, expr *ast.PrefixExpression, line int) (FastValuePlan, bool) {
+	if expr == nil || expr.Operator != "!" || expr.Right == nil {
+		return FastValuePlan{}, false
+	}
+	right, ok := fastValuePlanFromLoopOperand(plan, loop, expr.Right, true, lineForNode(expr.Right))
+	if !ok {
+		return FastValuePlan{}, false
+	}
+	return FastValuePlan{
+		Kind:     FastValuePrefix,
+		Operator: expr.Operator,
+		Right:    &right,
+		Line:     line,
+	}, true
+}
+
+func fastValuePlanFromLoopConcat(plan *FastRenderPlan, loop *FastLoopPlan, expr *ast.InfixExpression, line int) (FastValuePlan, bool) {
+	if expr == nil || expr.Operator != "+" {
+		return FastValuePlan{}, false
+	}
+	left, ok := fastValuePlanFromLoopOperand(plan, loop, expr.Left, false, lineForNode(expr.Left))
+	if !ok {
+		return FastValuePlan{}, false
+	}
+	right, ok := fastValuePlanFromLoopOperand(plan, loop, expr.Right, false, lineForNode(expr.Right))
+	if !ok {
+		return FastValuePlan{}, false
+	}
+	return FastValuePlan{
+		Kind:     FastValueConcat,
+		Operator: expr.Operator,
+		Left:     &left,
+		Right:    &right,
+		Line:     line,
+	}, true
+}
+
+func fastInfixOperator(operator string) bool {
+	switch operator {
+	case "-", "*", "/", "==", "!=", "<", ">", "<=", ">=", "&&", "||":
+		return true
+	default:
+		return false
+	}
+}
+
+func fastValuePlanFromLoopOperand(plan *FastRenderPlan, loop *FastLoopPlan, expr ast.Expression, nullOnMissing bool, line int) (FastValuePlan, bool) {
+	if loop == nil {
+		return FastValuePlan{}, false
+	}
+	switch expr := expr.(type) {
+	case *ast.ArrayLiteral:
+		return fastValuePlanFromLoopArrayLiteral(plan, loop, expr, line)
+	case *ast.HashLiteral:
+		return fastValuePlanFromLoopHashLiteral(plan, loop, expr, line)
+	}
+	if call, ok := expr.(*ast.CallExpression); ok {
+		if value, ok := fastValuePlanFromLoopCall(loop, call, line); ok {
+			return value, true
+		}
+		if planned, ok := fastLoopCallPlanFromExpression(plan, loop, call, line); ok {
+			return FastValuePlan{
+				Kind: FastValueCall,
+				Call: planned,
+				Line: line,
+			}, true
+		}
+	}
+	if prefix, ok := expr.(*ast.PrefixExpression); ok {
+		return fastValuePlanFromLoopPrefix(plan, loop, prefix, line)
+	}
+	if infix, ok := expr.(*ast.InfixExpression); ok {
+		return fastValuePlanFromLoopInfix(plan, loop, infix, line)
+	}
+	if root, ok := fastLoopExpressionRootName(expr); ok {
+		if root == loop.KeyName {
+			if isFastLoopKeyIdentifier(loop, expr) {
+				return FastValuePlan{Kind: FastValueLoopKey, Value: loop.KeyName, Line: line}, true
+			}
+			return FastValuePlan{}, false
+		}
+		if root == loop.ValueName {
+			return fastValuePlanFromLoopExpression(loop, expr, line)
+		}
+		if fastLoopHasOuterName(loop, root) {
+			return fastValuePlanFromExpression(plan, expr, nullOnMissing, line)
+		}
+	}
+	return fastValuePlanFromExpression(plan, expr, nullOnMissing, line)
+}
+
+func fastValuePlanFromLoopArrayLiteral(plan *FastRenderPlan, loop *FastLoopPlan, expr *ast.ArrayLiteral, line int) (FastValuePlan, bool) {
+	if expr == nil {
+		return FastValuePlan{}, false
+	}
+	elements := make([]FastValuePlan, 0, len(expr.Elements))
+	for _, elementExpr := range expr.Elements {
+		value, ok := fastValuePlanFromLoopOperand(plan, loop, elementExpr, false, lineForNode(elementExpr))
+		if !ok {
+			return FastValuePlan{}, false
+		}
+		elements = append(elements, value)
+	}
+	return FastValuePlan{
+		Kind:     FastValueArray,
+		Elements: elements,
+		Line:     line,
+	}, true
+}
+
+func fastValuePlanFromLoopHashLiteral(plan *FastRenderPlan, loop *FastLoopPlan, expr *ast.HashLiteral, line int) (FastValuePlan, bool) {
+	if expr == nil {
+		return FastValuePlan{}, false
+	}
+	keys := append([]ast.Expression(nil), expr.Order...)
+	if len(keys) == 0 {
+		for key := range expr.Pairs {
+			keys = append(keys, key)
+		}
+		sort.Slice(keys, func(i, j int) bool {
+			return keys[i].String() < keys[j].String()
+		})
+	}
+	pairs := make([]FastValuePair, 0, len(keys))
+	for _, keyExpr := range keys {
+		key, ok := fastPartialDataKey(keyExpr)
+		if !ok {
+			return FastValuePlan{}, false
+		}
+		valueExpr := expr.Pairs[keyExpr]
+		value, ok := fastValuePlanFromLoopOperand(plan, loop, valueExpr, false, lineForNode(valueExpr))
+		if !ok {
+			return FastValuePlan{}, false
+		}
+		pairs = append(pairs, FastValuePair{
+			Key:   key,
+			Value: value,
+			Line:  lineForNode(valueExpr),
+		})
+	}
+	return FastValuePlan{
+		Kind:  FastValueHash,
+		Pairs: pairs,
+		Line:  line,
+	}, true
+}
+
+func fastLoopCallPlanFromExpression(plan *FastRenderPlan, loop *FastLoopPlan, exp *ast.CallExpression, line int) (*FastCallPlan, bool) {
+	if plan == nil || loop == nil || exp == nil || exp.Block != nil || exp.ChainCallee != nil {
+		return nil, false
+	}
+	ident, ok := exp.Function.(*ast.Identifier)
+	if !ok || ident.Callee != nil || ident.Value == "" || ident.Value == "nil" || ident.Value == "partial" {
+		return nil, false
+	}
+	call := &FastCallPlan{
+		Name:      ident.Value,
+		NameIndex: plan.bindName(ident.Value),
+		Line:      line,
+	}
+	for _, arg := range exp.Arguments {
+		value, ok := fastValuePlanFromLoopCallArgument(plan, loop, arg, line)
+		if !ok {
+			return nil, false
+		}
+		call.Args = append(call.Args, value)
+	}
+	return call, true
+}
+
+func fastLoopBlockCallPlanFromExpression(plan *FastRenderPlan, loop *FastLoopPlan, exp *ast.CallExpression, line int) (*FastBlockCallPlan, bool) {
+	if plan == nil || loop == nil || exp == nil || exp.Block == nil || exp.ChainCallee != nil {
+		return nil, false
+	}
+	ident, ok := exp.Function.(*ast.Identifier)
+	if !ok || !fastPlainHelperIdentifier(ident) || ident.Value == "nil" {
+		return nil, false
+	}
+	if !fastBlockCanRenderFromSource(exp.Block) {
+		return nil, false
+	}
+	call := &FastBlockCallPlan{
+		Name:        ident.Value,
+		NameIndex:   plan.bindName(ident.Value),
+		Block:       exp.Block,
+		BlockSource: fastBlockSource(exp.Block),
+		Line:        line,
+	}
+	for _, arg := range exp.Arguments {
+		value, ok := fastValuePlanFromLoopCallArgument(plan, loop, arg, lineForNode(arg))
+		if !ok {
+			return nil, false
+		}
+		call.Args = append(call.Args, value)
+	}
+	return call, true
+}
+
+func fastPlainHelperIdentifier(ident *ast.Identifier) bool {
+	if ident == nil || ident.Callee != nil || ident.Value == "" {
+		return false
+	}
+	return len(identifierParts(ident)) == 1
+}
+
+func fastValuePlanFromLoopCallArgument(plan *FastRenderPlan, loop *FastLoopPlan, expr ast.Expression, line int) (FastValuePlan, bool) {
+	return fastValuePlanFromLoopOperand(plan, loop, expr, false, line)
+}
+
+func fastLoopOuterNames(parent *FastLoopPlan) []string {
+	if parent == nil {
+		return nil
+	}
+	names := append([]string(nil), parent.OuterNames...)
+	names = appendFastLoopOuterName(names, parent.KeyName)
+	names = appendFastLoopOuterName(names, parent.ValueName)
+	return names
+}
+
+func appendFastLoopOuterName(names []string, name string) []string {
+	if name == "" || name == "_" {
+		return names
+	}
+	for _, existing := range names {
+		if existing == name {
+			return names
+		}
+	}
+	return append(names, name)
+}
+
+func fastLoopHasOuterName(loop *FastLoopPlan, name string) bool {
+	if loop == nil || name == "" {
+		return false
+	}
+	for _, outer := range loop.OuterNames {
+		if outer == name {
+			return true
+		}
+	}
+	return false
+}
+
+func fastLoopExpressionRootName(expr ast.Expression) (string, bool) {
+	switch expr := expr.(type) {
+	case *ast.Identifier:
+		parts := identifierParts(expr)
+		if len(parts) == 0 {
+			return "", false
+		}
+		return parts[0], true
+	case *ast.IndexExpression:
+		return fastLoopExpressionRootName(expr.Left)
+	case *ast.CallExpression:
+		return fastLoopExpressionRootName(expr.Function)
+	default:
+		return "", false
+	}
+}
+
+func isFastLoopKeyIdentifier(loop *FastLoopPlan, expr ast.Expression) bool {
+	ident, ok := expr.(*ast.Identifier)
+	if !ok || ident.Callee != nil {
+		return false
+	}
+	parts := identifierParts(ident)
+	return len(parts) == 1 && parts[0] == loop.KeyName
+}
+
+func fastValuePlanFromLoopIndex(loop *FastLoopPlan, expr ast.Expression, line int) (FastValuePlan, bool) {
+	index, ok := expr.(*ast.IndexExpression)
+	if !ok {
+		return FastValuePlan{}, false
+	}
+	value, ok := fastValuePlanFromLoopExpressionWithMethod(loop, index.Left, line, false)
+	if !ok {
+		return FastValuePlan{}, false
+	}
+	indexStep, ok := fastIndexStepFromExpression(index.Index, line)
+	if !ok {
+		return FastValuePlan{}, false
+	}
+	value.Path = append(value.Path, indexStep)
+	if index.Callee != nil && !appendFastReceiverCallee(&value, index.Callee, lastChainPart(index.Left), line) {
+		return FastValuePlan{}, false
+	}
+	return value, true
+}
+
+func fastValuePlanFromLoopCall(loop *FastLoopPlan, exp *ast.CallExpression, line int) (FastValuePlan, bool) {
+	if exp == nil || exp.Block != nil || len(exp.Arguments) != 0 {
+		return FastValuePlan{}, false
+	}
+	value, ok := fastValuePlanFromLoopExpressionWithMethod(loop, exp.Function, line, true)
+	if !ok {
+		return FastValuePlan{}, false
+	}
+	value.Path = append(value.Path, FastPathStep{Kind: FastPathStepCall, Value: callExpressionName(exp), Line: line})
+	if exp.ChainCallee != nil && !appendFastReceiverCallee(&value, exp.ChainCallee, lastChainPart(exp.Function), line) {
+		return FastValuePlan{}, false
+	}
+	return value, true
+}
+
+func fastValuePlanFromLoopExpression(loop *FastLoopPlan, expr ast.Expression, line int) (FastValuePlan, bool) {
+	return fastValuePlanFromLoopExpressionWithMethod(loop, expr, line, false)
+}
+
+func fastValuePlanFromLoopExpressionWithMethod(loop *FastLoopPlan, expr ast.Expression, line int, markLastPropertyAsMethod bool) (FastValuePlan, bool) {
+	switch expr := expr.(type) {
+	case *ast.Identifier:
+		parts := identifierParts(expr)
+		if len(parts) == 0 || parts[0] != loop.ValueName {
+			return FastValuePlan{}, false
+		}
+		value := FastValuePlan{Kind: FastValuePath, Value: loop.ValueName, NameIndex: -1, Line: line}
+		receiver := loop.ValueName
+		for i, property := range parts[1:] {
+			full := receiver + "." + property
+			method := markLastPropertyAsMethod && i == len(parts[1:])-1
+			value.Path = append(value.Path, fastPropertyStep(property, receiver, full, line, method))
+			receiver = full
+		}
+		return value, true
+	case *ast.IndexExpression:
+		return fastValuePlanFromLoopIndex(loop, expr, line)
+	case *ast.CallExpression:
+		return fastValuePlanFromLoopCall(loop, expr, line)
+	default:
+		return FastValuePlan{}, false
+	}
+}
+
+func lineForNode(node ast.Node) int {
+	if node == nil {
+		return 1
+	}
+	if line := node.T().LineNumber; line > 0 {
+		return line
+	}
+	return 1
+}
+
+func lineForToken(tokenable ast.TokenAble) int {
+	if line := tokenable.T().LineNumber; line > 0 {
+		return line
+	}
+	return 1
+}

--- a/VM/compiler/fast_plan_ast_edges_test.go
+++ b/VM/compiler/fast_plan_ast_edges_test.go
@@ -1,0 +1,434 @@
+package compiler
+
+import (
+	"testing"
+
+	"github.com/gobuffalo/plush/v5/VM/code"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/gobuffalo/plush/v5/ast"
+	"github.com/gobuffalo/plush/v5/parser"
+	"github.com/gobuffalo/plush/v5/token"
+	"github.com/stretchr/testify/require"
+)
+
+func parseFast_Test_Expression(t *testing.T, input string) ast.Expression {
+	t.Helper()
+	program, err := parser.Parse("<%= " + input + " %>")
+	require.NoError(t, err)
+	require.Len(t, program.Statements, 1)
+	stmt, ok := program.Statements[0].(*ast.ReturnStatement)
+	require.True(t, ok)
+	require.NotNil(t, stmt.ReturnValue)
+	return stmt.ReturnValue
+}
+
+func compilerFast_Test_Return(expr ast.Expression) *ast.ReturnStatement {
+	return &ast.ReturnStatement{Type: token.E_START, ReturnValue: expr}
+}
+
+func Test_Fast_Render_AST_Program_And_Static_Edges(t *testing.T) {
+	require.Nil(t, fastRenderPlanFromProgram(nil))
+	require.Nil(t, fastRenderPlanFromProgram(&ast.Program{Statements: []ast.Statement{
+		&ast.ExpressionStatement{Expression: &ast.HTMLLiteral{Value: "static"}},
+	}}))
+
+	plan := &FastRenderPlan{}
+	segments := []FastRenderSegment{}
+	require.False(t, appendFastStatement(plan, &segments, &ast.ReturnStatement{
+		Type:        token.RETURN,
+		ReturnValue: &ast.StringLiteral{Value: "nope"},
+	}))
+	require.False(t, appendFastStatement(plan, &segments, &ast.ExpressionStatement{
+		Expression: &ast.IntegerLiteral{Value: 7},
+	}))
+
+	appendFastStatic(plan, &segments, "")
+	require.Empty(t, segments)
+
+	require.True(t, appendFastOutputExpression(plan, &segments, &ast.StringLiteral{Value: "<x>"}, 1))
+	require.True(t, appendFastOutputExpression(plan, &segments, &ast.HTMLLiteral{Value: "<b>"}, 1))
+	require.True(t, appendFastOutputExpression(plan, &segments, &ast.IntegerLiteral{Value: 7}, 1))
+	require.True(t, appendFastOutputExpression(plan, &segments, &ast.FloatLiteral{Value: 1.5}, 1))
+	require.True(t, appendFastOutputExpression(plan, &segments, &ast.Boolean{Value: true}, 1))
+	require.Len(t, segments, 1)
+	require.Equal(t, "&lt;x&gt;<b>71.5true", segments[0].Value)
+
+	require.False(t, appendFastOutputExpression(plan, &segments, &ast.ForExpression{}, 1))
+	require.False(t, appendFastOutputExpression(plan, &segments, &ast.IfExpression{}, 1))
+	require.False(t, appendFastOutputExpression(plan, &segments, &ast.CallExpression{
+		Function: &ast.StringLiteral{Value: "not-callable"},
+	}, 1))
+}
+
+func Test_Fast_Render_AST_Feature_Scan_Edges(t *testing.T) {
+	require.Equal(t, bytecodeFeatures{}, scanInstructionFeatures(code.Instructions{255}, nil, nil))
+
+	constants := []object.Object{&object.String{Value: "partial"}}
+	instructions := code.Instructions{}
+	instructions = append(instructions, code.Make(code.OpHole, 0)...)
+	instructions = append(instructions, code.Make(code.OpWriteNameCall, 0, 0)...)
+	features := scanInstructionFeatures(instructions, constants, nil)
+	require.True(t, features.HasHoles)
+	require.True(t, features.HasPartials)
+
+	features = scanInstructionFeatures(code.Make(code.OpCall, 0), constants, map[int]string{0: "partial"})
+	require.True(t, features.HasPartials)
+
+	fn := &object.CompiledFunction{Instructions: code.Make(code.OpHole, 0)}
+	nested := &object.CompiledFunction{Instructions: code.Make(code.OpWriteName, 0)}
+	features = bytecodeFeaturesFromInstructions(nil, []object.Object{constants[0], fn, nested}, nil)
+	require.True(t, features.HasHoles)
+	require.True(t, features.HasPartials)
+}
+
+func Test_Fast_Render_AST_Value_Plan_Edges(t *testing.T) {
+	plan := &FastRenderPlan{}
+
+	value, ok := fastValuePlanFromIdentifier(plan, nil, false, 2)
+	require.False(t, ok)
+	require.Equal(t, FastValuePlan{}, value)
+
+	value, ok = fastValuePlanFromIdentifier(plan, &ast.Identifier{Value: "nil"}, false, 2)
+	require.True(t, ok)
+	require.Equal(t, FastValueName, value.Kind)
+	require.Equal(t, -1, value.NameIndex)
+	require.True(t, value.NullOnMissing)
+
+	value, ok = fastValuePlanFromIdentifier(plan, &ast.Identifier{Value: "robot.Name.Echo"}, false, 2)
+	require.True(t, ok)
+	require.Equal(t, FastValuePath, value.Kind)
+	require.Len(t, value.Path, 2)
+
+	_, ok = fastValuePlanFromIndexExpression(plan, &ast.IndexExpression{
+		Left:  &ast.StringLiteral{Value: "not-path"},
+		Index: &ast.IntegerLiteral{Value: 0},
+	}, false, 3)
+	require.False(t, ok)
+
+	_, ok = fastValuePlanFromIndexExpression(plan, &ast.IndexExpression{
+		Left:  &ast.Identifier{Value: "items"},
+		Index: &ast.Identifier{Value: "dynamic"},
+	}, false, 3)
+	require.False(t, ok)
+	_, ok = fastValuePlanFromIndexExpression(plan, &ast.IndexExpression{
+		Left:   &ast.Identifier{Value: "items"},
+		Index:  &ast.IntegerLiteral{Value: 0},
+		Callee: &ast.StringLiteral{Value: "bad"},
+	}, false, 3)
+	require.False(t, ok)
+
+	_, ok = fastValuePlanFromCallExpression(plan, &ast.CallExpression{
+		Function: &ast.Identifier{Value: "helper"},
+		Block:    &ast.BlockStatement{},
+	}, false, 4)
+	require.False(t, ok)
+
+	_, ok = fastValuePlanFromCallExpression(plan, &ast.CallExpression{
+		Function:  &ast.Identifier{Value: "partial"},
+		Arguments: []ast.Expression{&ast.StringLiteral{Value: "row"}},
+	}, false, 4)
+	require.False(t, ok)
+
+	_, ok = fastValuePlanFromCallExpression(plan, &ast.CallExpression{
+		Function: &ast.StringLiteral{Value: "not-path"},
+	}, false, 4)
+	require.False(t, ok)
+
+	_, ok = fastValuePlanFromCallExpression(plan, &ast.CallExpression{
+		Function: &ast.Identifier{Value: "robot.Name"},
+		ChainCallee: &ast.CallExpression{
+			Function:  &ast.Identifier{Value: "Echo"},
+			Arguments: []ast.Expression{&ast.StringLiteral{Value: "bad"}},
+		},
+	}, false, 4)
+	require.False(t, ok)
+
+	_, ok = fastValuePlanFromCallExpression(plan, &ast.CallExpression{
+		Function:    &ast.Identifier{Value: "robot"},
+		ChainCallee: &ast.StringLiteral{Value: "bad"},
+	}, false, 4)
+	require.False(t, ok)
+
+	path := FastValuePlan{Kind: FastValuePath, Value: "robot"}
+	require.False(t, appendFastReceiverCallee(&path, &ast.StringLiteral{Value: "bad"}, "robot", 5))
+	require.False(t, appendFastReceiverCallee(&path, &ast.IndexExpression{
+		Left:  &ast.StringLiteral{Value: "bad"},
+		Index: &ast.IntegerLiteral{Value: 0},
+	}, "robot", 5))
+	require.True(t, appendFastReceiverCallee(&path, &ast.IndexExpression{
+		Left:  &ast.Identifier{Value: "robot"},
+		Index: &ast.IntegerLiteral{Value: 0},
+	}, "robot", 5))
+	require.False(t, appendFastReceiverCallee(&path, &ast.CallExpression{
+		Function: &ast.StringLiteral{Value: "bad"},
+	}, "robot", 5))
+}
+
+func Test_Fast_Render_AST_Partial_And_Conditional_Edges(t *testing.T) {
+	plan := &FastRenderPlan{}
+
+	partial, ok := fastPartialPlanFromCall(plan, nil, 1)
+	require.False(t, ok)
+	require.Nil(t, partial)
+
+	partial, ok = fastPartialPlanFromCall(plan, &ast.CallExpression{
+		Function:  &ast.Identifier{Value: "partial"},
+		Arguments: []ast.Expression{&ast.IntegerLiteral{Value: 1}},
+	}, 1)
+	require.False(t, ok)
+	require.Nil(t, partial)
+
+	_, ok = fastPartialDataPlanFromExpression(plan, &ast.IntegerLiteral{Value: 1}, 1)
+	require.False(t, ok)
+	_, ok = fastPartialDataPlanFromExpression(plan, &ast.HashLiteral{
+		Order: []ast.Expression{&ast.StringLiteral{Value: "layout"}},
+		Pairs: map[ast.Expression]ast.Expression{
+			&ast.StringLiteral{Value: "layout"}: &ast.StringLiteral{Value: "app"},
+		},
+	}, 1)
+	require.False(t, ok)
+	_, ok = fastPartialDataKey(&ast.Identifier{Value: ""})
+	require.False(t, ok)
+	_, ok = fastPartialDataKey(&ast.IntegerLiteral{Value: 1})
+	require.False(t, ok)
+	key := &ast.StringLiteral{Value: "label"}
+	data, ok := fastPartialDataPlanFromExpression(plan, &ast.HashLiteral{
+		Pairs: map[ast.Expression]ast.Expression{
+			key: &ast.StringLiteral{Value: "ok"},
+		},
+	}, 1)
+	require.True(t, ok)
+	require.Len(t, data, 1)
+
+	conditional, ok := fastConditionalPlanFromExpression(plan, nil, 1)
+	require.False(t, ok)
+	require.Nil(t, conditional)
+
+	conditional, ok = fastConditionalPlanFromExpression(plan, &ast.IfExpression{
+		Condition: &ast.Identifier{Value: "ok"},
+		Block: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: &ast.IntegerLiteral{Value: 1}},
+		}},
+	}, 1)
+	require.False(t, ok)
+	require.Nil(t, conditional)
+
+	conditional, ok = fastConditionalPlanFromExpression(plan, &ast.IfExpression{
+		Condition: &ast.Identifier{Value: "ok"},
+		Block: &ast.BlockStatement{Statements: []ast.Statement{
+			compilerFast_Test_Return(&ast.StringLiteral{Value: "yes"}),
+		}},
+		ElseIf: []*ast.ElseIfExpression{nil},
+	}, 1)
+	require.False(t, ok)
+	require.Nil(t, conditional)
+
+	conditional, ok = fastConditionalPlanFromExpression(plan, &ast.IfExpression{
+		Condition: &ast.Identifier{Value: "ok"},
+		Block: &ast.BlockStatement{Statements: []ast.Statement{
+			compilerFast_Test_Return(&ast.StringLiteral{Value: "yes"}),
+		}},
+		ElseIf: []*ast.ElseIfExpression{{Condition: &ast.HashLiteral{}, Block: &ast.BlockStatement{Statements: []ast.Statement{
+			compilerFast_Test_Return(&ast.StringLiteral{Value: "else-if"}),
+		}}}},
+	}, 1)
+	require.False(t, ok)
+	require.Nil(t, conditional)
+	conditional, ok = fastConditionalPlanFromExpression(plan, &ast.IfExpression{
+		Condition: &ast.Identifier{Value: "ok"},
+		Block: &ast.BlockStatement{Statements: []ast.Statement{
+			compilerFast_Test_Return(&ast.StringLiteral{Value: "yes"}),
+		}},
+		ElseIf: []*ast.ElseIfExpression{{Condition: &ast.Identifier{Value: "ok2"}, Block: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: &ast.IntegerLiteral{Value: 1}},
+		}}}},
+	}, 1)
+	require.False(t, ok)
+	require.Nil(t, conditional)
+	conditional, ok = fastConditionalPlanFromExpression(plan, &ast.IfExpression{
+		Condition: &ast.Identifier{Value: "ok"},
+		Block: &ast.BlockStatement{Statements: []ast.Statement{
+			compilerFast_Test_Return(&ast.StringLiteral{Value: "yes"}),
+		}},
+		ElseBlock: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: &ast.IntegerLiteral{Value: 1}},
+		}},
+	}, 1)
+	require.False(t, ok)
+	require.Nil(t, conditional)
+}
+
+func Test_Fast_Render_AST_Loop_Edge_Branches(t *testing.T) {
+	plan := &FastRenderPlan{}
+	loop := &FastLoopPlan{KeyName: "i", ValueName: "product"}
+
+	gotLoop, ok := fastLoopPlanFromExpression(plan, nil, 1)
+	require.False(t, ok)
+	require.Nil(t, gotLoop)
+	gotLoop, ok = fastLoopPlanFromExpression(plan, &ast.ForExpression{Iterable: &ast.Identifier{Value: "items"}}, 1)
+	require.False(t, ok)
+	require.Nil(t, gotLoop)
+	gotLoop, ok = fastLoopPlanFromExpression(plan, &ast.ForExpression{Iterable: &ast.Identifier{Value: "nil"}, Block: &ast.BlockStatement{}}, 1)
+	require.False(t, ok)
+	require.Nil(t, gotLoop)
+	gotLoop, ok = fastLoopPlanFromExpression(plan, &ast.ForExpression{
+		Iterable: &ast.Identifier{Value: "items"},
+		Block: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: &ast.IntegerLiteral{Value: 1}},
+		}},
+	}, 1)
+	require.False(t, ok)
+	require.Nil(t, gotLoop)
+
+	parts := []FastLoopPart{}
+	require.False(t, appendFastLoopStatement(plan, loop, &parts, &ast.ReturnStatement{
+		Type:        token.RETURN,
+		ReturnValue: &ast.StringLiteral{Value: "bad"},
+	}))
+	require.False(t, appendFastLoopOutputParts(plan, loop, &parts, &ast.CallExpression{
+		Function: &ast.Identifier{Value: "product.Name"},
+		Block:    &ast.BlockStatement{},
+	}, 1))
+	require.False(t, appendFastLoopOutputParts(plan, loop, &parts, &ast.IfExpression{
+		Condition: &ast.HashLiteral{},
+		Block: &ast.BlockStatement{Statements: []ast.Statement{
+			compilerFast_Test_Return(&ast.StringLiteral{Value: "bad"}),
+		}},
+	}, 1))
+	require.True(t, appendFastLoopOutputParts(plan, loop, &parts, &ast.Identifier{Value: "other"}, 1))
+
+	parts = nil
+	appendFastLoopStatic(nil, nil, &parts, "")
+	require.Empty(t, parts)
+	require.True(t, appendFastLoopOutputParts(plan, loop, &parts, &ast.StringLiteral{Value: "<x>"}, 1))
+	require.True(t, appendFastLoopOutputParts(plan, loop, &parts, &ast.HTMLLiteral{Value: "<b>"}, 1))
+	require.True(t, appendFastLoopOutputParts(plan, loop, &parts, &ast.IntegerLiteral{Value: 7}, 1))
+	require.True(t, appendFastLoopOutputParts(plan, loop, &parts, &ast.FloatLiteral{Value: 1.5}, 1))
+	require.True(t, appendFastLoopOutputParts(plan, loop, &parts, &ast.Boolean{Value: false}, 1))
+	require.Equal(t, "&lt;x&gt;<b>71.5false", parts[0].Value)
+
+	condition, ok := fastLoopConditionalPlanFromExpression(plan, loop, nil, 1)
+	require.False(t, ok)
+	require.Nil(t, condition)
+	condition, ok = fastLoopConditionalPlanFromExpression(plan, loop, &ast.IfExpression{
+		Condition: &ast.Identifier{Value: "product.Name"},
+		Block: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: &ast.IntegerLiteral{Value: 1}},
+		}},
+	}, 1)
+	require.False(t, ok)
+	require.Nil(t, condition)
+	condition, ok = fastLoopConditionalPlanFromExpression(plan, loop, &ast.IfExpression{
+		Condition: &ast.Identifier{Value: "product.Name"},
+		Block: &ast.BlockStatement{Statements: []ast.Statement{
+			compilerFast_Test_Return(&ast.StringLiteral{Value: "yes"}),
+		}},
+		ElseIf: []*ast.ElseIfExpression{{Condition: &ast.HashLiteral{}, Block: &ast.BlockStatement{Statements: []ast.Statement{
+			compilerFast_Test_Return(&ast.StringLiteral{Value: "else-if"}),
+		}}}},
+	}, 1)
+	require.False(t, ok)
+	require.Nil(t, condition)
+	condition, ok = fastLoopConditionalPlanFromExpression(plan, loop, &ast.IfExpression{
+		Condition: &ast.Identifier{Value: "product.Name"},
+		Block: &ast.BlockStatement{Statements: []ast.Statement{
+			compilerFast_Test_Return(&ast.StringLiteral{Value: "yes"}),
+		}},
+		ElseIf: []*ast.ElseIfExpression{{Condition: &ast.Identifier{Value: "product.Name"}, Block: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: &ast.IntegerLiteral{Value: 1}},
+		}}}},
+	}, 1)
+	require.False(t, ok)
+	require.Nil(t, condition)
+	condition, ok = fastLoopConditionalPlanFromExpression(plan, loop, &ast.IfExpression{
+		Condition: &ast.Identifier{Value: "product.Name"},
+		Block: &ast.BlockStatement{Statements: []ast.Statement{
+			compilerFast_Test_Return(&ast.StringLiteral{Value: "yes"}),
+		}},
+		ElseBlock: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: &ast.IntegerLiteral{Value: 1}},
+		}},
+	}, 1)
+	require.False(t, ok)
+	require.Nil(t, condition)
+
+	value, ok := fastValuePlanFromLoopOperand(plan, nil, &ast.Identifier{Value: "product"}, false, 1)
+	require.False(t, ok)
+	require.Equal(t, FastValuePlan{}, value)
+	value, ok = fastValuePlanFromLoopOperand(plan, loop, &ast.Identifier{Value: "i.Name"}, false, 1)
+	require.False(t, ok)
+	require.Equal(t, FastValuePlan{}, value)
+	_, ok = fastValuePlanFromLoopInfix(plan, loop, &ast.InfixExpression{
+		Left:     &ast.Identifier{Value: "product.Name"},
+		Operator: "??",
+		Right:    &ast.StringLiteral{Value: "x"},
+	}, 1)
+	require.False(t, ok)
+	_, ok = fastValuePlanFromLoopInfix(plan, loop, &ast.InfixExpression{
+		Left:     &ast.Identifier{Value: "product.Name"},
+		Operator: "==",
+		Right:    &ast.HashLiteral{},
+	}, 1)
+	require.False(t, ok)
+	value, ok = fastValuePlanFromLoopOperand(plan, loop, &ast.InfixExpression{
+		Left:     &ast.Identifier{Value: "product.Name"},
+		Operator: "==",
+		Right:    &ast.StringLiteral{Value: "x"},
+	}, false, 1)
+	require.True(t, ok)
+	require.Equal(t, FastValueInfix, value.Kind)
+	loopCallPlan, ok := fastLoopCallPlanFromExpression(plan, loop, &ast.CallExpression{
+		Function:  &ast.Identifier{Value: "label"},
+		Arguments: []ast.Expression{&ast.HashLiteral{}},
+	}, 1)
+	require.True(t, ok)
+	require.NotNil(t, loopCallPlan)
+	require.Len(t, loopCallPlan.Args, 1)
+	require.Equal(t, FastValueHash, loopCallPlan.Args[0].Kind)
+
+	root, ok := fastLoopExpressionRootName(&ast.Identifier{Value: "."})
+	require.False(t, ok)
+	require.Empty(t, root)
+	root, ok = fastLoopExpressionRootName(&ast.IndexExpression{Left: &ast.Identifier{Value: "product"}, Index: &ast.IntegerLiteral{Value: 0}})
+	require.True(t, ok)
+	require.Equal(t, "product", root)
+
+	_, ok = fastValuePlanFromLoopIndex(loop, &ast.IndexExpression{Left: &ast.Identifier{Value: "product.Name"}, Index: &ast.Identifier{Value: "bad"}}, 1)
+	require.False(t, ok)
+	_, ok = fastValuePlanFromLoopIndex(loop, &ast.IndexExpression{
+		Left:   &ast.Identifier{Value: "product.Name"},
+		Index:  &ast.IntegerLiteral{Value: 0},
+		Callee: &ast.StringLiteral{Value: "bad"},
+	}, 1)
+	require.False(t, ok)
+	_, ok = fastValuePlanFromLoopCall(loop, &ast.CallExpression{Block: &ast.BlockStatement{}}, 1)
+	require.False(t, ok)
+	_, ok = fastValuePlanFromLoopCall(loop, &ast.CallExpression{
+		Function:  &ast.Identifier{Value: "product.Name"},
+		Arguments: []ast.Expression{&ast.StringLiteral{Value: "bad"}},
+	}, 1)
+	require.False(t, ok)
+	_, ok = fastValuePlanFromLoopCall(loop, &ast.CallExpression{Function: &ast.StringLiteral{Value: "bad"}}, 1)
+	require.False(t, ok)
+	_, ok = fastValuePlanFromLoopCall(loop, &ast.CallExpression{
+		Function:    &ast.Identifier{Value: "product.Name"},
+		ChainCallee: &ast.StringLiteral{Value: "bad"},
+	}, 1)
+	require.False(t, ok)
+	_, ok = fastValuePlanFromLoopExpressionWithMethod(loop, &ast.StringLiteral{Value: "bad"}, 1, false)
+	require.False(t, ok)
+	value, ok = fastValuePlanFromLoopExpressionWithMethod(loop, &ast.IndexExpression{
+		Left:  &ast.Identifier{Value: "product.Name"},
+		Index: &ast.IntegerLiteral{Value: 0},
+	}, 1, false)
+	require.True(t, ok)
+	require.Equal(t, FastValuePath, value.Kind)
+
+	expr := parseFast_Test_Expression(t, `product.Name()`)
+	call, ok := expr.(*ast.CallExpression)
+	require.True(t, ok)
+	value, ok = fastValuePlanFromLoopCall(loop, call, 1)
+	require.True(t, ok)
+	require.Equal(t, FastValuePath, value.Kind)
+	require.NotEmpty(t, value.Path)
+}

--- a/VM/compiler/fast_plan_bytecode.go
+++ b/VM/compiler/fast_plan_bytecode.go
@@ -1,0 +1,283 @@
+package compiler
+
+import (
+	"html/template"
+
+	"github.com/gobuffalo/plush/v5/VM/code"
+	"github.com/gobuffalo/plush/v5/VM/object"
+)
+
+// fastRenderPlanFromInstructions is the narrower fallback planner. It recovers
+// fast render segments from already-optimized bytecode when the AST planner did
+// not produce a plan.
+func fastRenderPlanFromInstructions(instructions code.Instructions, constants []object.Object, lineNumbers map[int]int) *FastRenderPlan {
+	plan := &FastRenderPlan{}
+	hasDynamic := false
+
+	for i := 0; i < len(instructions); {
+		op := code.Opcode(instructions[i])
+		def, err := code.Lookup(instructions[i])
+		if err != nil {
+			return nil
+		}
+		operands, read := code.ReadOperands(def, instructions[i+1:])
+		nextPos := i + 1 + read
+
+		switch op {
+		case code.OpWriteHTML:
+			value, ok := htmlConstantValue(constants, operands[0])
+			if !ok {
+				return nil
+			}
+			plan.appendStatic(value)
+		case code.OpWriteString:
+			value, ok := stringConstantValue(constants, operands[0])
+			if !ok {
+				return nil
+			}
+			plan.appendStatic(template.HTMLEscapeString(value))
+		case code.OpWriteConstant:
+			value, ok := staticConstantOutput(constants, operands[0])
+			if !ok {
+				return nil
+			}
+			plan.appendStatic(value)
+		case code.OpWriteName, code.OpWriteNameOrNull:
+			name, ok := stringConstantValue(constants, operands[0])
+			if !ok {
+				return nil
+			}
+			if name != "nil" {
+				hasDynamic = true
+				plan.Segments = append(plan.Segments, FastRenderSegment{
+					Kind:          FastRenderSegmentName,
+					Value:         name,
+					NameIndex:     plan.bindName(name),
+					NullOnMissing: op == code.OpWriteNameOrNull,
+					Line:          lineNumberAt(lineNumbers, i),
+				})
+				plan.NameCount++
+			}
+		case code.OpWriteNameProperty:
+			base, ok := stringConstantValue(constants, operands[0])
+			if !ok {
+				return nil
+			}
+			property, ok := stringConstantValue(constants, operands[1])
+			if !ok {
+				return nil
+			}
+			if base != "nil" {
+				hasDynamic = true
+				plan.Segments = append(plan.Segments, FastRenderSegment{
+					Kind:      FastRenderSegmentProperty,
+					Value:     base,
+					NameIndex: plan.bindName(base),
+					Property:  property,
+					Receiver:  base,
+					Full:      base + "." + property,
+					Line:      lineNumberAt(lineNumbers, i),
+				})
+				plan.NameCount++
+			}
+		case code.OpGetName:
+			loop, writeEnd, ok := fastLoopPlanAt(instructions, nextPos, constants, lineNumbers)
+			if !ok {
+				return nil
+			}
+			iterable, ok := stringConstantValue(constants, operands[0])
+			if !ok || iterable == "nil" {
+				return nil
+			}
+			hasDynamic = true
+			loop.IterableName = iterable
+			loop.IterableNameIndex = plan.bindName(iterable)
+			plan.Segments = append(plan.Segments, FastRenderSegment{
+				Kind: FastRenderSegmentLoop,
+				Loop: loop,
+				Line: loop.Line,
+			})
+			i = writeEnd
+			continue
+		default:
+			return nil
+		}
+
+		i = nextPos
+	}
+
+	if !hasDynamic {
+		return nil
+	}
+	return plan
+}
+
+func fastLoopPlanAt(instructions code.Instructions, pos int, constants []object.Object, lineNumbers map[int]int) (*FastLoopPlan, int, bool) {
+	op, operands, read, ok := instructionAt(instructions, pos)
+	if !ok || op != code.OpFor || len(operands) != 4 || operands[3] != 0 {
+		return nil, 0, false
+	}
+	writePos := pos + 1 + read
+	writeOp, _, writeRead, ok := instructionAt(instructions, writePos)
+	if !ok || writeOp != code.OpWrite {
+		return nil, 0, false
+	}
+
+	keyName, ok := stringConstantValue(constants, operands[1])
+	if !ok {
+		return nil, 0, false
+	}
+	valueName, ok := stringConstantValue(constants, operands[2])
+	if !ok {
+		return nil, 0, false
+	}
+	fn, ok := compiledFunctionConstant(constants, operands[0])
+	if !ok {
+		return nil, 0, false
+	}
+	loop, ok := fastLoopPlanFromFunction(fn, constants, keyName, valueName)
+	if !ok {
+		return nil, 0, false
+	}
+	loop.Line = lineNumberAt(lineNumbers, pos)
+	return loop, writePos + 1 + writeRead, true
+}
+
+func instructionAt(instructions code.Instructions, pos int) (code.Opcode, []int, int, bool) {
+	if pos < 0 || pos >= len(instructions) {
+		return 0, nil, 0, false
+	}
+	op := code.Opcode(instructions[pos])
+	def, err := code.Lookup(instructions[pos])
+	if err != nil {
+		return 0, nil, 0, false
+	}
+	operands, read := code.ReadOperands(def, instructions[pos+1:])
+	return op, operands, read, true
+}
+
+func compiledFunctionConstant(constants []object.Object, index int) (*object.CompiledFunction, bool) {
+	if index < 0 || index >= len(constants) {
+		return nil, false
+	}
+	fn, ok := constants[index].(*object.CompiledFunction)
+	return fn, ok
+}
+
+func fastLoopPlanFromFunction(fn *object.CompiledFunction, constants []object.Object, keyName, valueName string) (*FastLoopPlan, bool) {
+	if fn == nil || fn.NumParameters < 2 {
+		return nil, false
+	}
+
+	loop := &FastLoopPlan{KeyName: keyName, ValueName: valueName}
+	for i := 0; i < len(fn.Instructions); {
+		op, operands, read, ok := instructionAt(fn.Instructions, i)
+		if !ok {
+			return nil, false
+		}
+
+		switch op {
+		case code.OpReturn:
+			return loop, true
+		case code.OpWriteHTML:
+			value, ok := htmlConstantValue(constants, operands[0])
+			if !ok {
+				return nil, false
+			}
+			loop.appendStatic(value)
+		case code.OpWriteString:
+			value, ok := stringConstantValue(constants, operands[0])
+			if !ok {
+				return nil, false
+			}
+			loop.appendStatic(template.HTMLEscapeString(value))
+		case code.OpWriteConstant:
+			value, ok := staticConstantOutput(constants, operands[0])
+			if !ok {
+				return nil, false
+			}
+			loop.appendStatic(value)
+		case code.OpWriteLocal:
+			switch operands[0] {
+			case 0:
+				loop.Parts = append(loop.Parts, FastLoopPart{Kind: FastLoopPartKey, Line: lineNumberAt(fn.LineNumbers, i)})
+			case 1:
+				loop.Parts = append(loop.Parts, FastLoopPart{Kind: FastLoopPartValue, Line: lineNumberAt(fn.LineNumbers, i)})
+			default:
+				return nil, false
+			}
+		case code.OpWriteLocalProperty:
+			if operands[0] != 1 {
+				return nil, false
+			}
+			property, ok := stringConstantValue(constants, operands[1])
+			if !ok {
+				return nil, false
+			}
+			loop.Parts = append(loop.Parts, FastLoopPart{
+				Kind:     FastLoopPartValueProperty,
+				Value:    property,
+				Receiver: valueName,
+				Full:     valueName + "." + property,
+				Line:     lineNumberAt(fn.LineNumbers, i),
+			})
+		default:
+			return nil, false
+		}
+
+		i += 1 + read
+	}
+	return nil, false
+}
+
+func lineNumberAt(lineNumbers map[int]int, pos int) int {
+	if lineNumbers == nil {
+		return 1
+	}
+	if line := lineNumbers[pos]; line > 0 {
+		return line
+	}
+	return 1
+}
+
+func (p *FastRenderPlan) appendStatic(value string) {
+	if value == "" {
+		return
+	}
+	last := len(p.Segments) - 1
+	if last >= 0 && p.Segments[last].Kind == FastRenderSegmentStatic {
+		p.Segments[last].Value += value
+	} else {
+		p.Segments = append(p.Segments, FastRenderSegment{
+			Kind:  FastRenderSegmentStatic,
+			Value: value,
+		})
+	}
+	p.StaticSize += len(value)
+}
+
+func (p *FastRenderPlan) bindName(name string) int {
+	for i, bound := range p.Bindings {
+		if bound == name {
+			return i
+		}
+	}
+	p.Bindings = append(p.Bindings, name)
+	return len(p.Bindings) - 1
+}
+
+func (p *FastLoopPlan) appendStatic(value string) {
+	if value == "" {
+		return
+	}
+	last := len(p.Parts) - 1
+	if last >= 0 && p.Parts[last].Kind == FastLoopPartStatic {
+		p.Parts[last].Value += value
+	} else {
+		p.Parts = append(p.Parts, FastLoopPart{
+			Kind:  FastLoopPartStatic,
+			Value: value,
+		})
+	}
+	p.StaticSize += len(value)
+}

--- a/VM/compiler/fast_script_plan_test.go
+++ b/VM/compiler/fast_script_plan_test.go
@@ -1,0 +1,182 @@
+package compiler
+
+import (
+	"testing"
+
+	"github.com/gobuffalo/plush/v5/parser"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Fast_Render_Plan_Literal_Lets_And_Path_Loops(t *testing.T) {
+	input := `<% let title = "Default" %><title><%= title %></title><%= for (item) in menu.Items { %><%= item.Name %>;<% } %>`
+	program, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	plan := compiler.Bytecode().FastRenderPlan
+	require.NotNil(t, plan)
+	require.Len(t, plan.Segments, 5)
+	require.Equal(t, FastRenderSegmentLet, plan.Segments[0].Kind)
+	require.Equal(t, FastValueString, plan.Segments[0].ValuePlan.Kind)
+	require.Equal(t, FastRenderSegmentLoop, plan.Segments[4].Kind)
+	require.Equal(t, FastValuePath, plan.Segments[4].Loop.Iterable.Kind)
+	require.Equal(t, "menu", plan.Segments[4].Loop.Iterable.Value)
+	require.Len(t, plan.Segments[4].Loop.Iterable.Path, 1)
+	require.Equal(t, "Items", plan.Segments[4].Loop.Iterable.Path[0].Value)
+}
+
+func Test_Fast_Render_Plan_Loop_Let_With_Helper_And_Arithmetic_Arg(t *testing.T) {
+	input := `<%= for (_, product) in products { %><% let categorySeo = replace(category.CategorySeoUrl, "-outofstock", "", 0 - 1) %><%= categorySeo %>:<%= product.Name %>;<% } %>`
+	program, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Empty(t, bytecode.FastReject)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+
+	loop := bytecode.FastRenderPlan.Segments[0].Loop
+	require.NotNil(t, loop)
+	require.GreaterOrEqual(t, len(loop.Parts), 4)
+	require.Equal(t, FastLoopPartLet, loop.Parts[0].Kind)
+	require.Equal(t, "categorySeo", loop.Parts[0].Value)
+	require.Equal(t, FastValueCall, loop.Parts[0].ValuePlan.Kind)
+	require.NotNil(t, loop.Parts[0].ValuePlan.Call)
+	require.Equal(t, "replace", loop.Parts[0].ValuePlan.Call.Name)
+	require.Len(t, loop.Parts[0].ValuePlan.Call.Args, 4)
+	require.Equal(t, FastValueInfix, loop.Parts[0].ValuePlan.Call.Args[3].Kind)
+	require.Equal(t, "-", loop.Parts[0].ValuePlan.Call.Args[3].Operator)
+
+	require.Equal(t, FastLoopPartValuePath, loop.Parts[1].Kind)
+	require.Equal(t, FastValueName, loop.Parts[1].ValuePlan.Kind)
+	require.Equal(t, "categorySeo", loop.Parts[1].ValuePlan.Value)
+}
+
+func Test_Fast_Render_Plan_Prefix_Condition_And_Loop_Concat(t *testing.T) {
+	input := `<%= if (!userSignedIn) { %>Guest<% } else { %>User<% } %><%= for (item) in menu.Items { %><%= item.Name + " x " + item.Count %>;<% } %>`
+	program, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	plan := compiler.Bytecode().FastRenderPlan
+	require.NotNil(t, plan)
+	require.Len(t, plan.Segments, 2)
+	require.Equal(t, FastRenderSegmentConditional, plan.Segments[0].Kind)
+	require.NotNil(t, plan.Segments[0].Conditional)
+	require.Len(t, plan.Segments[0].Conditional.Branches, 1)
+	require.Equal(t, FastValuePrefix, plan.Segments[0].Conditional.Branches[0].Condition.Kind)
+	require.Equal(t, "!", plan.Segments[0].Conditional.Branches[0].Condition.Operator)
+
+	require.Equal(t, FastRenderSegmentLoop, plan.Segments[1].Kind)
+	require.NotNil(t, plan.Segments[1].Loop)
+	require.Len(t, plan.Segments[1].Loop.Parts, 2)
+	require.Equal(t, FastLoopPartValuePath, plan.Segments[1].Loop.Parts[0].Kind)
+	require.Equal(t, FastValueConcat, plan.Segments[1].Loop.Parts[0].ValuePlan.Kind)
+	require.Equal(t, "+", plan.Segments[1].Loop.Parts[0].ValuePlan.Operator)
+	require.Equal(t, FastLoopPartStatic, plan.Segments[1].Loop.Parts[1].Kind)
+	require.Equal(t, ";", plan.Segments[1].Loop.Parts[1].Value)
+}
+
+func Test_Fast_Render_Plan_Nested_Loop_Tracks_Outer_Names(t *testing.T) {
+	input := `<%= for (i, row) in rows { %><%= for (j, col) in row { %><%= i %>,<%= j %>:<%= col %>;<% } %><% } %>`
+	program, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	plan := compiler.Bytecode().FastRenderPlan
+	require.NotNil(t, plan)
+	require.Len(t, plan.Segments, 1)
+	require.Equal(t, FastRenderSegmentLoop, plan.Segments[0].Kind)
+
+	outer := plan.Segments[0].Loop
+	require.NotNil(t, outer)
+	require.Len(t, outer.Parts, 1)
+	require.Equal(t, FastLoopPartLoop, outer.Parts[0].Kind)
+
+	inner := outer.Parts[0].Loop
+	require.NotNil(t, inner)
+	require.ElementsMatch(t, []string{"i", "row"}, inner.OuterNames)
+	require.Len(t, inner.Parts, 6)
+	require.Equal(t, FastLoopPartValuePath, inner.Parts[0].Kind)
+	require.Equal(t, FastValueName, inner.Parts[0].ValuePlan.Kind)
+	require.Equal(t, "i", inner.Parts[0].ValuePlan.Value)
+	require.Equal(t, FastLoopPartKey, inner.Parts[2].Kind)
+	require.Equal(t, FastLoopPartValue, inner.Parts[4].Kind)
+}
+
+func Test_Fast_Render_Plan_Silent_Script_If(t *testing.T) {
+	input := `<% if (show) { %>hidden<%= touch(name) %><% } else { %><%= touch("else") %><% } %>done`
+	program, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	plan := compiler.Bytecode().FastRenderPlan
+	require.NotNil(t, plan)
+	require.Len(t, plan.Segments, 2)
+
+	conditional := plan.Segments[0].Conditional
+	require.NotNil(t, conditional)
+	require.True(t, conditional.Silent)
+	require.Len(t, conditional.Branches, 1)
+	require.Len(t, conditional.Branches[0].Segments, 2)
+	require.Equal(t, FastRenderSegmentStatic, conditional.Branches[0].Segments[0].Kind)
+	require.Equal(t, FastRenderSegmentCall, conditional.Branches[0].Segments[1].Kind)
+	require.Len(t, conditional.ElseSegments, 1)
+	require.Equal(t, FastRenderSegmentCall, conditional.ElseSegments[0].Kind)
+	require.Equal(t, FastRenderSegmentStatic, plan.Segments[1].Kind)
+}
+
+func Test_Fast_Render_Plan_Silent_Script_If_Inside_Loop(t *testing.T) {
+	input := `<%= for (_, item) in items { %><% if (item.Hidden) { %><%= touch(item.Name) %><% } %><%= item.Name %><% } %>`
+	program, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	plan := compiler.Bytecode().FastRenderPlan
+	require.NotNil(t, plan)
+	require.Len(t, plan.Segments, 1)
+
+	loop := plan.Segments[0].Loop
+	require.NotNil(t, loop)
+	require.Len(t, loop.Parts, 2)
+	require.Equal(t, FastLoopPartConditional, loop.Parts[0].Kind)
+	require.True(t, loop.Parts[0].Conditional.Silent)
+	require.Len(t, loop.Parts[0].Conditional.Branches, 1)
+	require.Len(t, loop.Parts[0].Conditional.Branches[0].Parts, 1)
+	require.Equal(t, FastLoopPartCall, loop.Parts[0].Conditional.Branches[0].Parts[0].Kind)
+	require.Equal(t, FastLoopPartValueProperty, loop.Parts[1].Kind)
+}
+
+func Test_Fast_Render_Plan_Silent_Script_If_Allows_Assignments(t *testing.T) {
+	input := `<% if (show) { name = "changed" } %><%= name %>`
+	program, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan, bytecode.FastReject)
+	require.Empty(t, bytecode.FastReject)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 2)
+	conditional := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentConditional, conditional.Kind)
+	require.NotNil(t, conditional.Conditional)
+	require.True(t, conditional.Conditional.Silent)
+	require.Len(t, conditional.Conditional.Branches, 1)
+	require.Len(t, conditional.Conditional.Branches[0].Segments, 1)
+	require.Equal(t, FastRenderSegmentAssign, conditional.Conditional.Branches[0].Segments[0].Kind)
+}

--- a/VM/compiler/optimizer.go
+++ b/VM/compiler/optimizer.go
@@ -1,0 +1,232 @@
+package compiler
+
+import (
+	"html/template"
+
+	"github.com/gobuffalo/plush/v5/VM/code"
+	"github.com/gobuffalo/plush/v5/VM/object"
+)
+
+// optimizeScope performs bytecode peephole rewrites for render hot paths, such
+// as replacing OpGetName+OpWrite with OpWriteName. It also remaps jumps and
+// metadata so errors, call names, and property access stay attached to the
+// correct instruction after bytes are removed.
+func optimizeScope(
+	instructions code.Instructions,
+	callNames map[int]string,
+	lineNumbers map[int]int,
+	properties map[int]object.PropertyAccess,
+	constants []object.Object,
+) (code.Instructions, map[int]string, map[int]int, map[int]object.PropertyAccess) {
+	type instruction struct {
+		oldPos   int
+		op       code.Opcode
+		operands []int
+		width    int
+	}
+
+	parsed := []instruction{}
+	for i := 0; i < len(instructions); {
+		op := code.Opcode(instructions[i])
+		def, err := code.Lookup(byte(op))
+		if err != nil {
+			parsed = append(parsed, instruction{oldPos: i, op: op, width: 1})
+			i++
+			continue
+		}
+		operands, read := code.ReadOperands(def, instructions[i+1:])
+		parsed = append(parsed, instruction{oldPos: i, op: op, operands: operands, width: 1 + read})
+		i += 1 + read
+	}
+
+	jumpTargets := map[int]bool{}
+	for _, ins := range parsed {
+		switch ins.op {
+		case code.OpJump, code.OpJumpNotTruthy:
+			if len(ins.operands) > 0 {
+				jumpTargets[ins.operands[0]] = true
+			}
+		}
+	}
+
+	remove := map[int]bool{}
+	replace := map[int]code.Instructions{}
+	removedTarget := map[int]int{}
+	for i := 0; i < len(parsed)-1; i++ {
+		current := parsed[i]
+		next := parsed[i+1]
+		if current.op == code.OpNull && next.op == code.OpPop {
+			replace[current.oldPos] = code.Make(code.OpPop)
+			remove[next.oldPos] = true
+			removedTarget[next.oldPos] = current.oldPos
+			i++
+			continue
+		}
+		if next.op == code.OpWrite {
+			if jumpTargets[next.oldPos] {
+				continue
+			}
+			if replacement, ok := writeReplacement(current.op, current.operands, constants); ok {
+				replace[current.oldPos] = replacement
+				remove[next.oldPos] = true
+				removedTarget[next.oldPos] = current.oldPos
+				i++
+				continue
+			}
+		}
+	}
+	if len(remove) == 0 && len(replace) == 0 {
+		return instructions, callNames, lineNumbers, properties
+	}
+
+	oldToNew := map[int]int{}
+	removedBytes := make([]int, len(instructions)+1)
+	out := code.Instructions{}
+	removedSoFar := 0
+	for _, ins := range parsed {
+		for pos := ins.oldPos; pos <= ins.oldPos+ins.width && pos < len(removedBytes); pos++ {
+			removedBytes[pos] = removedSoFar
+		}
+		if remove[ins.oldPos] {
+			removedSoFar += ins.width
+			continue
+		}
+
+		oldToNew[ins.oldPos] = len(out)
+		if replacement, ok := replace[ins.oldPos]; ok {
+			out = append(out, replacement...)
+			continue
+		}
+		out = append(out, instructions[ins.oldPos:ins.oldPos+ins.width]...)
+	}
+	removedBytes[len(instructions)] = removedSoFar
+
+	mapTarget := func(pos int) int {
+		if newPos, ok := oldToNew[pos]; ok {
+			return newPos
+		}
+		if target, ok := removedTarget[pos]; ok {
+			return oldToNew[target]
+		}
+		if pos >= len(removedBytes) {
+			return len(out)
+		}
+		return pos - removedBytes[pos]
+	}
+
+	for i := 0; i < len(out); {
+		op := code.Opcode(out[i])
+		def, err := code.Lookup(byte(op))
+		if err != nil {
+			i++
+			continue
+		}
+		operands, read := code.ReadOperands(def, out[i+1:])
+		switch op {
+		case code.OpJump, code.OpJumpNotTruthy:
+			copied := append([]int(nil), operands...)
+			copied[0] = mapTarget(copied[0])
+			replacement := code.Make(op, copied...)
+			copy(out[i:i+len(replacement)], replacement)
+		}
+		i += 1 + read
+	}
+
+	return out,
+		remapStringMap(callNames, oldToNew, remove),
+		remapIntMap(lineNumbers, oldToNew, remove),
+		remapPropertyMap(properties, oldToNew, remove)
+}
+
+func writeReplacement(op code.Opcode, operands []int, constants []object.Object) (code.Instructions, bool) {
+	if len(operands) == 0 {
+		return nil, false
+	}
+	switch op {
+	case code.OpConstant:
+		return code.Make(constantWriteOpcode(operands[0], constants), operands[0]), true
+	case code.OpGetName:
+		return code.Make(code.OpWriteName, operands[0]), true
+	case code.OpGetNameOrNull:
+		return code.Make(code.OpWriteNameOrNull, operands[0]), true
+	case code.OpGetLocal:
+		return code.Make(code.OpWriteLocal, operands[0]), true
+	case code.OpGetGlobal:
+		return code.Make(code.OpWriteGlobal, operands[0]), true
+	case code.OpCall:
+		return code.Make(code.OpWriteCall, operands[0]), true
+	}
+	return nil, false
+}
+
+func constantWriteOpcode(index int, constants []object.Object) code.Opcode {
+	if index < 0 || index >= len(constants) {
+		return code.OpWriteConstant
+	}
+	switch obj := constants[index].(type) {
+	case *object.String:
+		return code.OpWriteString
+	case *object.Native:
+		if _, ok := obj.Value.(template.HTML); ok {
+			return code.OpWriteHTML
+		}
+	}
+	return code.OpWriteConstant
+}
+
+func remapStringMap(input map[int]string, oldToNew map[int]int, remove map[int]bool) map[int]string {
+	if len(input) == 0 {
+		return nil
+	}
+	out := map[int]string{}
+	for pos, value := range input {
+		if remove[pos] {
+			continue
+		}
+		if newPos, ok := oldToNew[pos]; ok {
+			out[newPos] = value
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func remapIntMap(input map[int]int, oldToNew map[int]int, remove map[int]bool) map[int]int {
+	if len(input) == 0 {
+		return nil
+	}
+	out := map[int]int{}
+	for pos, value := range input {
+		if remove[pos] {
+			continue
+		}
+		if newPos, ok := oldToNew[pos]; ok {
+			out[newPos] = value
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func remapPropertyMap(input map[int]object.PropertyAccess, oldToNew map[int]int, remove map[int]bool) map[int]object.PropertyAccess {
+	if len(input) == 0 {
+		return nil
+	}
+	out := map[int]object.PropertyAccess{}
+	for pos, value := range input {
+		if remove[pos] {
+			continue
+		}
+		if newPos, ok := oldToNew[pos]; ok {
+			out[newPos] = value
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/VM/compiler/optimizer_test.go
+++ b/VM/compiler/optimizer_test.go
@@ -1,0 +1,192 @@
+package compiler
+
+import (
+	"html/template"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5/VM/code"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Optimizer_Write_Replacement_Opcodes(t *testing.T) {
+	constants := []object.Object{
+		&object.String{Value: "text"},
+		&object.Native{Value: template.HTML("<b>")},
+		&object.Integer{Value: 3},
+	}
+
+	tests := []struct {
+		name     string
+		op       code.Opcode
+		operands []int
+		expected code.Instructions
+		ok       bool
+	}{
+		{"missing operands", code.OpGetName, nil, nil, false},
+		{"string constant", code.OpConstant, []int{0}, code.Make(code.OpWriteString, 0), true},
+		{"html constant", code.OpConstant, []int{1}, code.Make(code.OpWriteHTML, 1), true},
+		{"other constant", code.OpConstant, []int{2}, code.Make(code.OpWriteConstant, 2), true},
+		{"bad constant index", code.OpConstant, []int{99}, code.Make(code.OpWriteConstant, 99), true},
+		{"name", code.OpGetName, []int{4}, code.Make(code.OpWriteName, 4), true},
+		{"name or null", code.OpGetNameOrNull, []int{5}, code.Make(code.OpWriteNameOrNull, 5), true},
+		{"local", code.OpGetLocal, []int{6}, code.Make(code.OpWriteLocal, 6), true},
+		{"global", code.OpGetGlobal, []int{7}, code.Make(code.OpWriteGlobal, 7), true},
+		{"call", code.OpCall, []int{2}, code.Make(code.OpWriteCall, 2), true},
+		{"unsupported", code.OpTrue, []int{1}, nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := writeReplacement(tt.op, tt.operands, constants)
+			require.Equal(t, tt.ok, ok)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func Test_Optimize_Scope_Remaps_Jump_And_Metadata(t *testing.T) {
+	constants := []object.Object{&object.String{Value: "text"}}
+	instructions := code.Instructions{}
+	instructions = append(instructions, code.Make(code.OpJump, 7)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 0)...)
+	instructions = append(instructions, code.Make(code.OpWrite)...)
+	instructions = append(instructions, code.Make(code.OpPop)...)
+
+	optimized, callNames, lineNumbers, properties := optimizeScope(
+		instructions,
+		map[int]string{0: "jump", 3: "constant", 6: "removed"},
+		map[int]int{0: 1, 3: 2, 6: 3},
+		map[int]object.PropertyAccess{3: {Receiver: "x", Full: "x.y"}},
+		constants,
+	)
+
+	def, err := code.Lookup(byte(code.OpJump))
+	require.NoError(t, err)
+	operands, _ := code.ReadOperands(def, optimized[1:])
+	require.Equal(t, []int{6}, operands)
+	require.True(t, instructionContainsOpcode(optimized, code.OpWriteString))
+	require.False(t, instructionContainsOpcode(optimized, code.OpWrite))
+
+	require.Equal(t, map[int]string{0: "jump", 3: "constant"}, callNames)
+	require.Equal(t, map[int]int{0: 1, 3: 2}, lineNumbers)
+	require.Equal(t, map[int]object.PropertyAccess{3: {Receiver: "x", Full: "x.y"}}, properties)
+}
+
+func Test_Optimize_Scope_Does_Not_Fuse_Shared_Branch_Write_Target(t *testing.T) {
+	constants := []object.Object{
+		&object.String{Value: "good"},
+		&object.String{Value: "bad"},
+	}
+	instructions := code.Instructions{}
+	instructions = append(instructions, code.Make(code.OpTrue)...)
+	instructions = append(instructions, code.Make(code.OpJumpNotTruthy, 10)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 0)...)
+	instructions = append(instructions, code.Make(code.OpJump, 13)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 1)...)
+	instructions = append(instructions, code.Make(code.OpWrite)...)
+
+	optimized, _, _, _ := optimizeScope(instructions, nil, nil, nil, constants)
+	require.Equal(t, instructions, optimized)
+}
+
+func Test_Optimize_Scope_Noop_And_Empty_Remaps(t *testing.T) {
+	instructions := code.Make(code.OpTrue)
+	optimized, callNames, lineNumbers, properties := optimizeScope(instructions, nil, nil, nil, nil)
+	require.Equal(t, code.Instructions(instructions), optimized)
+	require.Nil(t, callNames)
+	require.Nil(t, lineNumbers)
+	require.Nil(t, properties)
+
+	require.Nil(t, remapStringMap(nil, nil, nil))
+	require.Nil(t, remapIntMap(nil, nil, nil))
+	require.Nil(t, remapPropertyMap(nil, nil, nil))
+
+	require.Nil(t, remapStringMap(map[int]string{1: "removed"}, nil, map[int]bool{1: true}))
+	require.Nil(t, remapIntMap(map[int]int{1: 7}, nil, map[int]bool{1: true}))
+	require.Nil(t, remapPropertyMap(map[int]object.PropertyAccess{1: {Receiver: "x"}}, nil, map[int]bool{1: true}))
+}
+
+func Test_Optimize_Scope_Remaps_Unknown_Opcode_And_Out_Of_Range_Jump(t *testing.T) {
+	instructions := code.Instructions{255}
+	instructions = append(instructions, code.Make(code.OpNull)...)
+	instructions = append(instructions, code.Make(code.OpPop)...)
+	instructions = append(instructions, code.Make(code.OpJump, 999)...)
+
+	optimized, _, _, _ := optimizeScope(instructions, nil, nil, nil, nil)
+
+	require.Equal(t, byte(255), optimized[0])
+	require.True(t, instructionContainsOpcode(optimized, code.OpPop))
+
+	def, err := code.Lookup(byte(code.OpJump))
+	require.NoError(t, err)
+	jumpPos := 2
+	operands, _ := code.ReadOperands(def, optimized[jumpPos+1:])
+	require.Equal(t, []int{len(optimized)}, operands)
+}
+
+func Test_Optimize_Scope_Remaps_Jump_Target_Inside_Instruction(t *testing.T) {
+	instructions := code.Instructions{}
+	instructions = append(instructions, code.Make(code.OpNull)...)
+	instructions = append(instructions, code.Make(code.OpPop)...)
+	instructions = append(instructions, code.Make(code.OpJump, 4)...)
+
+	optimized, _, _, _ := optimizeScope(instructions, nil, nil, nil, nil)
+
+	def, err := code.Lookup(byte(code.OpJump))
+	require.NoError(t, err)
+	operands, _ := code.ReadOperands(def, optimized[2:])
+	require.Equal(t, []int{3}, operands)
+}
+
+func Test_Static_Constant_Output_Helpers(t *testing.T) {
+	constants := []object.Object{
+		&object.String{Value: "<text>"},
+		&object.Native{Value: template.HTML("<b>")},
+		&object.Integer{Value: 7},
+		&object.Float{Value: 1.5},
+		object.TrueObject,
+		object.NullObject,
+		&object.Native{Value: "plain native"},
+	}
+
+	value, ok := stringConstantValue(constants, 0)
+	require.True(t, ok)
+	require.Equal(t, "<text>", value)
+	_, ok = stringConstantValue(constants, 1)
+	require.False(t, ok)
+	_, ok = stringConstantValue(constants, 99)
+	require.False(t, ok)
+
+	value, ok = htmlConstantValue(constants, 1)
+	require.True(t, ok)
+	require.Equal(t, "<b>", value)
+	_, ok = htmlConstantValue(constants, 0)
+	require.False(t, ok)
+	_, ok = htmlConstantValue(constants, 6)
+	require.False(t, ok)
+	_, ok = htmlConstantValue(constants, -1)
+	require.False(t, ok)
+
+	tests := []struct {
+		index    int
+		expected string
+		ok       bool
+	}{
+		{0, "&lt;text&gt;", true},
+		{1, "<b>", true},
+		{2, "7", true},
+		{3, "1.5", true},
+		{4, "true", true},
+		{5, "", true},
+		{6, "", false},
+		{99, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			value, ok := staticConstantOutput(constants, tt.index)
+			require.Equal(t, tt.ok, ok)
+			require.Equal(t, tt.expected, value)
+		})
+	}
+}

--- a/VM/compiler/symbol_table.go
+++ b/VM/compiler/symbol_table.go
@@ -1,0 +1,129 @@
+package compiler
+
+type SymbolScope string
+
+const (
+	LocalScope    SymbolScope = "LOCAL"
+	GlobalScope   SymbolScope = "GLOBAL"
+	BuiltinScope  SymbolScope = "BUILTIN"
+	FreeScope     SymbolScope = "FREE"
+	FunctionScope SymbolScope = "FUNCTION"
+)
+
+type Symbol struct {
+	Name  string
+	Scope SymbolScope
+	Index int
+}
+
+type SymbolTable struct {
+	Outer *SymbolTable
+
+	store          map[string]Symbol
+	numDefinitions int
+
+	FreeSymbols []Symbol
+
+	inlineBlock bool
+}
+
+func NewEnclosedSymbolTable(outer *SymbolTable) *SymbolTable {
+	s := NewSymbolTable()
+	s.Outer = outer
+	return s
+}
+
+func NewInlineBlockSymbolTable(outer *SymbolTable) *SymbolTable {
+	s := NewEnclosedSymbolTable(outer)
+	s.inlineBlock = true
+	return s
+}
+
+func NewSymbolTable() *SymbolTable {
+	return &SymbolTable{
+		store:       map[string]Symbol{},
+		FreeSymbols: []Symbol{},
+	}
+}
+
+func (s *SymbolTable) Define(name string) Symbol {
+	symbol := Symbol{Name: name}
+	if s.Outer == nil && !s.inlineBlock {
+		symbol.Index = s.numDefinitions
+		symbol.Scope = GlobalScope
+		s.numDefinitions++
+		s.store[name] = symbol
+		return symbol
+	}
+
+	if s.inlineBlock {
+		owner := s.localDefinitionOwner()
+		if owner != nil && owner.Outer != nil {
+			symbol.Index = owner.numDefinitions
+			owner.numDefinitions++
+		} else {
+			symbol.Index = s.numDefinitions
+			s.numDefinitions++
+		}
+		symbol.Scope = LocalScope
+		s.store[name] = symbol
+		return symbol
+	}
+
+	symbol.Index = s.numDefinitions
+	symbol.Scope = LocalScope
+	s.store[name] = symbol
+	s.numDefinitions++
+	return symbol
+}
+
+func (s *SymbolTable) localDefinitionOwner() *SymbolTable {
+	for owner := s.Outer; owner != nil; owner = owner.Outer {
+		if !owner.inlineBlock {
+			return owner
+		}
+	}
+	return nil
+}
+
+func (s *SymbolTable) Resolve(name string) (Symbol, bool) {
+	obj, ok := s.store[name]
+	if !ok && s.Outer != nil {
+		obj, ok = s.Outer.Resolve(name)
+		if !ok {
+			return obj, ok
+		}
+
+		if s.inlineBlock {
+			return obj, ok
+		}
+
+		if obj.Scope == GlobalScope || obj.Scope == BuiltinScope {
+			return obj, ok
+		}
+
+		free := s.defineFree(obj)
+		return free, true
+	}
+	return obj, ok
+}
+
+func (s *SymbolTable) DefineBuiltin(index int, name string) Symbol {
+	symbol := Symbol{Name: name, Index: index, Scope: BuiltinScope}
+	s.store[name] = symbol
+	return symbol
+}
+
+func (s *SymbolTable) DefineFunctionName(name string) Symbol {
+	symbol := Symbol{Name: name, Index: 0, Scope: FunctionScope}
+	s.store[name] = symbol
+	return symbol
+}
+
+func (s *SymbolTable) defineFree(original Symbol) Symbol {
+	s.FreeSymbols = append(s.FreeSymbols, original)
+
+	symbol := Symbol{Name: original.Name, Index: len(s.FreeSymbols) - 1, Scope: FreeScope}
+	s.store[original.Name] = symbol
+	return symbol
+}

--- a/VM/compiler/symbol_table_test.go
+++ b/VM/compiler/symbol_table_test.go
@@ -1,0 +1,196 @@
+package compiler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Symbol_Table_Define_And_Resolve(t *testing.T) {
+	global := NewSymbolTable()
+
+	a := global.Define("a")
+	require.Equal(t, Symbol{Name: "a", Scope: GlobalScope, Index: 0}, a)
+	b := global.Define("b")
+	require.Equal(t, Symbol{Name: "b", Scope: GlobalScope, Index: 1}, b)
+
+	firstLocal := NewEnclosedSymbolTable(global)
+	c := firstLocal.Define("c")
+	require.Equal(t, Symbol{Name: "c", Scope: LocalScope, Index: 0}, c)
+	d := firstLocal.Define("d")
+	require.Equal(t, Symbol{Name: "d", Scope: LocalScope, Index: 1}, d)
+
+	secondLocal := NewEnclosedSymbolTable(firstLocal)
+	e := secondLocal.Define("e")
+	require.Equal(t, Symbol{Name: "e", Scope: LocalScope, Index: 0}, e)
+	f := secondLocal.Define("f")
+	require.Equal(t, Symbol{Name: "f", Scope: LocalScope, Index: 1}, f)
+
+	tests := []struct {
+		table    *SymbolTable
+		name     string
+		expected Symbol
+	}{
+		{global, "a", Symbol{Name: "a", Scope: GlobalScope, Index: 0}},
+		{global, "b", Symbol{Name: "b", Scope: GlobalScope, Index: 1}},
+		{firstLocal, "a", Symbol{Name: "a", Scope: GlobalScope, Index: 0}},
+		{firstLocal, "b", Symbol{Name: "b", Scope: GlobalScope, Index: 1}},
+		{firstLocal, "c", Symbol{Name: "c", Scope: LocalScope, Index: 0}},
+		{firstLocal, "d", Symbol{Name: "d", Scope: LocalScope, Index: 1}},
+		{secondLocal, "a", Symbol{Name: "a", Scope: GlobalScope, Index: 0}},
+		{secondLocal, "b", Symbol{Name: "b", Scope: GlobalScope, Index: 1}},
+		{secondLocal, "e", Symbol{Name: "e", Scope: LocalScope, Index: 0}},
+		{secondLocal, "f", Symbol{Name: "f", Scope: LocalScope, Index: 1}},
+	}
+
+	for _, tt := range tests {
+		actual, ok := tt.table.Resolve(tt.name)
+		require.Truef(t, ok, "expected to resolve %q", tt.name)
+		require.Equal(t, tt.expected, actual)
+	}
+}
+
+func Test_Symbol_Table_Define_Resolve_Builtins(t *testing.T) {
+	global := NewSymbolTable()
+	firstLocal := NewEnclosedSymbolTable(global)
+	secondLocal := NewEnclosedSymbolTable(firstLocal)
+
+	expected := []Symbol{
+		{Name: "a", Scope: BuiltinScope, Index: 0},
+		{Name: "c", Scope: BuiltinScope, Index: 1},
+		{Name: "e", Scope: BuiltinScope, Index: 2},
+		{Name: "f", Scope: BuiltinScope, Index: 3},
+	}
+
+	for i, symbol := range expected {
+		global.DefineBuiltin(i, symbol.Name)
+	}
+
+	for _, table := range []*SymbolTable{global, firstLocal, secondLocal} {
+		for _, symbol := range expected {
+			actual, ok := table.Resolve(symbol.Name)
+			require.Truef(t, ok, "expected to resolve builtin %q", symbol.Name)
+			require.Equal(t, symbol, actual)
+		}
+	}
+}
+
+func Test_Symbol_Table_Resolve_Free(t *testing.T) {
+	global := NewSymbolTable()
+	global.Define("a")
+	global.Define("b")
+
+	firstLocal := NewEnclosedSymbolTable(global)
+	firstLocal.Define("c")
+	firstLocal.Define("d")
+
+	secondLocal := NewEnclosedSymbolTable(firstLocal)
+	secondLocal.Define("e")
+	secondLocal.Define("f")
+
+	tests := []struct {
+		table       *SymbolTable
+		expected    []Symbol
+		freeSymbols []Symbol
+	}{
+		{
+			table: firstLocal,
+			expected: []Symbol{
+				{Name: "a", Scope: GlobalScope, Index: 0},
+				{Name: "b", Scope: GlobalScope, Index: 1},
+				{Name: "c", Scope: LocalScope, Index: 0},
+				{Name: "d", Scope: LocalScope, Index: 1},
+			},
+			freeSymbols: []Symbol{},
+		},
+		{
+			table: secondLocal,
+			expected: []Symbol{
+				{Name: "a", Scope: GlobalScope, Index: 0},
+				{Name: "b", Scope: GlobalScope, Index: 1},
+				{Name: "c", Scope: FreeScope, Index: 0},
+				{Name: "d", Scope: FreeScope, Index: 1},
+				{Name: "e", Scope: LocalScope, Index: 0},
+				{Name: "f", Scope: LocalScope, Index: 1},
+			},
+			freeSymbols: []Symbol{
+				{Name: "c", Scope: LocalScope, Index: 0},
+				{Name: "d", Scope: LocalScope, Index: 1},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		for _, symbol := range tt.expected {
+			actual, ok := tt.table.Resolve(symbol.Name)
+			require.Truef(t, ok, "expected to resolve %q", symbol.Name)
+			require.Equal(t, symbol, actual)
+		}
+		require.Equal(t, tt.freeSymbols, tt.table.FreeSymbols)
+	}
+}
+
+func Test_Symbol_Table_Resolve_Unresolvable_Free(t *testing.T) {
+	global := NewSymbolTable()
+	global.Define("a")
+
+	firstLocal := NewEnclosedSymbolTable(global)
+	firstLocal.Define("c")
+
+	secondLocal := NewEnclosedSymbolTable(firstLocal)
+	secondLocal.Define("e")
+	secondLocal.Define("f")
+
+	expected := []Symbol{
+		{Name: "a", Scope: GlobalScope, Index: 0},
+		{Name: "c", Scope: FreeScope, Index: 0},
+		{Name: "e", Scope: LocalScope, Index: 0},
+		{Name: "f", Scope: LocalScope, Index: 1},
+	}
+
+	for _, symbol := range expected {
+		actual, ok := secondLocal.Resolve(symbol.Name)
+		require.Truef(t, ok, "expected to resolve %q", symbol.Name)
+		require.Equal(t, symbol, actual)
+	}
+
+	_, ok := secondLocal.Resolve("b")
+	require.False(t, ok)
+	_, ok = secondLocal.Resolve("d")
+	require.False(t, ok)
+}
+
+func Test_Symbol_Table_Function_Name_And_Shadowing(t *testing.T) {
+	global := NewSymbolTable()
+	fn := global.DefineFunctionName("a")
+	require.Equal(t, Symbol{Name: "a", Scope: FunctionScope, Index: 0}, fn)
+
+	actual, ok := global.Resolve("a")
+	require.True(t, ok)
+	require.Equal(t, fn, actual)
+
+	shadow := global.Define("a")
+	require.Equal(t, Symbol{Name: "a", Scope: GlobalScope, Index: 0}, shadow)
+
+	actual, ok = global.Resolve("a")
+	require.True(t, ok)
+	require.Equal(t, shadow, actual)
+}
+
+func Test_Inline_Block_Symbol_Table_Uses_Function_Local_Owner(t *testing.T) {
+	global := NewSymbolTable()
+	fn := NewEnclosedSymbolTable(global)
+	param := fn.Define("value")
+
+	inline := NewInlineBlockSymbolTable(fn)
+	local := inline.Define("inside")
+
+	require.Equal(t, Symbol{Name: "value", Scope: LocalScope, Index: 0}, param)
+	require.Equal(t, Symbol{Name: "inside", Scope: LocalScope, Index: 1}, local)
+	require.Equal(t, 2, fn.numDefinitions)
+
+	actual, ok := inline.Resolve("value")
+	require.True(t, ok)
+	require.Equal(t, param, actual)
+	require.Empty(t, inline.FreeSymbols)
+}

--- a/VM/compiler/types.go
+++ b/VM/compiler/types.go
@@ -1,0 +1,267 @@
+package compiler
+
+import (
+	"sync/atomic"
+
+	"github.com/gobuffalo/plush/v5/VM/code"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/gobuffalo/plush/v5/ast"
+)
+
+type Bytecode struct {
+	Instructions    code.Instructions
+	CallNames       map[int]string
+	LocalNames      map[int]string
+	LineNumbers     map[int]int
+	Properties      map[int]object.PropertyAccess
+	PropertyCaches  []object.InlineCacheSlot
+	CallCaches      []object.InlineCacheSlot
+	NumLocals       int
+	NumGlobals      int
+	Constants       []object.Object
+	GlobalNames     map[int]string
+	Static          bool
+	StaticOutput    string
+	FastRenderPlan  *FastRenderPlan
+	FastRejectLine  int
+	FastReject      string
+	FastDiagnostics atomic.Value
+	HasHoles        bool
+	HasPartials     bool
+}
+
+type FastRenderReject struct {
+	Line   int
+	Reason string
+}
+
+type FastRenderSegmentKind uint8
+
+const (
+	FastRenderSegmentStatic FastRenderSegmentKind = iota
+	FastRenderSegmentName
+	FastRenderSegmentProperty
+	FastRenderSegmentLoop
+	FastRenderSegmentValue
+	FastRenderSegmentCall
+	FastRenderSegmentBlockCall
+	FastRenderSegmentConditional
+	FastRenderSegmentPartial
+	FastRenderSegmentLet
+	FastRenderSegmentAssign
+)
+
+type FastRenderSegment struct {
+	Kind          FastRenderSegmentKind
+	Value         string
+	NameIndex     int
+	NullOnMissing bool
+	Property      string
+	Receiver      string
+	Full          string
+	Line          int
+	Loop          *FastLoopPlan
+	ValuePlan     FastValuePlan
+	Call          *FastCallPlan
+	BlockCall     *FastBlockCallPlan
+	Conditional   *FastConditionalPlan
+	Partial       *FastPartialPlan
+	PropertyCache object.InlineCacheSlot
+	CallCache     object.InlineCacheSlot
+	OutputCache   object.InlineCacheSlot
+}
+
+type FastRenderPlan struct {
+	Bindings   []string
+	Segments   []FastRenderSegment
+	StaticSize int
+	NameCount  int
+	// Prepared caches the VM-side mixed/static-name/simple plan built from this
+	// compiler plan. BindingPrepared caches interned context IDs for stable
+	// contexts. See VM/FAST_PATHS.md for the full fast path map.
+	Prepared        atomic.Value
+	BindingPrepared atomic.Value
+}
+
+type FastLoopPartKind uint8
+
+const (
+	FastLoopPartStatic FastLoopPartKind = iota
+	FastLoopPartKey
+	FastLoopPartValue
+	FastLoopPartValueProperty
+	FastLoopPartValuePath
+	FastLoopPartCall
+	FastLoopPartConditional
+	FastLoopPartLoop
+	FastLoopPartBreak
+	FastLoopPartContinue
+	FastLoopPartBlockCall
+	FastLoopPartPartial
+	FastLoopPartLet
+)
+
+type FastLoopPart struct {
+	Kind          FastLoopPartKind
+	Value         string
+	NameIndex     int
+	Receiver      string
+	Full          string
+	Line          int
+	ValuePlan     FastValuePlan
+	Call          *FastCallPlan
+	BlockCall     *FastBlockCallPlan
+	Partial       *FastPartialPlan
+	Conditional   *FastLoopConditionalPlan
+	Loop          *FastLoopPlan
+	PropertyCache object.InlineCacheSlot
+}
+
+type FastLoopPlan struct {
+	IterableName      string
+	IterableNameIndex int
+	Iterable          FastValuePlan
+	KeyName           string
+	ValueName         string
+	OuterNames        []string
+	Parts             []FastLoopPart
+	StaticSize        int
+	Line              int
+}
+
+type FastValueKind uint8
+
+const (
+	FastValueInvalid FastValueKind = iota
+	FastValueName
+	FastValueString
+	FastValueInteger
+	FastValueFloat
+	FastValueBool
+	FastValuePath
+	FastValueLoopKey
+	FastValueInfix
+	FastValueCall
+	FastValuePrefix
+	FastValueConcat
+	FastValueArray
+	FastValueHash
+)
+
+type FastPathStepKind uint8
+
+const (
+	FastPathStepProperty FastPathStepKind = iota
+	FastPathStepIndexInteger
+	FastPathStepIndexString
+	FastPathStepCall
+)
+
+type FastValuePlan struct {
+	Kind          FastValueKind
+	Value         string
+	NameIndex     int
+	NullOnMissing bool
+	IntValue      int64
+	FloatValue    float64
+	BoolValue     bool
+	Operator      string
+	Left          *FastValuePlan
+	Right         *FastValuePlan
+	Call          *FastCallPlan
+	Elements      []FastValuePlan
+	Pairs         []FastValuePair
+	Path          []FastPathStep
+	Line          int
+}
+
+type FastValuePair struct {
+	Key   string
+	Value FastValuePlan
+	Line  int
+}
+
+type FastPathStep struct {
+	Kind          FastPathStepKind
+	Value         string
+	Index         int
+	Receiver      string
+	Full          string
+	Method        bool
+	Line          int
+	PropertyCache object.InlineCacheSlot
+	CallCache     object.InlineCacheSlot
+}
+
+type FastCallPlan struct {
+	Name      string
+	NameIndex int
+	Args      []FastValuePlan
+	Line      int
+	Cache     object.InlineCacheSlot
+}
+
+type FastBlockCallPlan struct {
+	Name          string
+	NameIndex     int
+	Args          []FastValuePlan
+	Block         *ast.BlockStatement
+	BlockSource   string
+	BlockBytecode *Bytecode
+	Line          int
+	Cache         object.InlineCacheSlot
+}
+
+type FastPartialPlan struct {
+	Name string
+	Data []FastPartialDataPair
+	Line int
+}
+
+type FastPartialDataPair struct {
+	Key   string
+	Value FastValuePlan
+	Line  int
+}
+
+type FastConditionalBranch struct {
+	Condition FastValuePlan
+	Segments  []FastRenderSegment
+	Line      int
+}
+
+type FastConditionalPlan struct {
+	Branches     []FastConditionalBranch
+	ElseSegments []FastRenderSegment
+	Line         int
+	Silent       bool
+}
+
+type FastLoopConditionalBranch struct {
+	Condition FastValuePlan
+	Parts     []FastLoopPart
+	Line      int
+}
+
+type FastLoopConditionalPlan struct {
+	Branches  []FastLoopConditionalBranch
+	ElseParts []FastLoopPart
+	Line      int
+	Silent    bool
+}
+
+type EmittedInstruction struct {
+	Opcode   code.Opcode
+	Position int
+}
+
+type CompilationScope struct {
+	instructions        code.Instructions
+	callNames           map[int]string
+	localNames          map[int]string
+	lineNumbers         map[int]int
+	properties          map[int]object.PropertyAccess
+	numLocals           int
+	lastInstruction     EmittedInstruction
+	previousInstruction EmittedInstruction
+}

--- a/VM/object/builtins.go
+++ b/VM/object/builtins.go
@@ -1,0 +1,119 @@
+package object
+
+import "fmt"
+
+var Builtins = []struct {
+	Name    string
+	Builtin *Builtin
+}{
+	{
+		"len",
+		&Builtin{Fn: func(args ...Object) Object {
+			if len(args) != 1 {
+				return NewError("wrong number of arguments. got=%d, want=1", len(args))
+			}
+
+			switch arg := args[0].(type) {
+			case *Array:
+				return &Integer{Value: int64(len(arg.Elements))}
+			case *String:
+				return &Integer{Value: int64(len(arg.Value))}
+			default:
+				return NewError("argument to `len` not supported, got %s", args[0].Type())
+			}
+		}},
+	},
+	{
+		"puts",
+		&Builtin{Fn: func(args ...Object) Object {
+			for _, arg := range args {
+				fmt.Println(arg.Inspect())
+			}
+
+			return nil
+		}},
+	},
+	{
+		"first",
+		&Builtin{Fn: func(args ...Object) Object {
+			if len(args) != 1 {
+				return NewError("wrong number of arguments. got=%d, want=1", len(args))
+			}
+			if args[0].Type() != ARRAY_OBJ {
+				return NewError("argument to `first` must be ARRAY, got %s", args[0].Type())
+			}
+
+			arr := args[0].(*Array)
+			if len(arr.Elements) > 0 {
+				return arr.Elements[0]
+			}
+
+			return nil
+		}},
+	},
+	{
+		"last",
+		&Builtin{Fn: func(args ...Object) Object {
+			if len(args) != 1 {
+				return NewError("wrong number of arguments. got=%d, want=1", len(args))
+			}
+			if args[0].Type() != ARRAY_OBJ {
+				return NewError("argument to `last` must be ARRAY, got %s", args[0].Type())
+			}
+
+			arr := args[0].(*Array)
+			if len(arr.Elements) > 0 {
+				return arr.Elements[len(arr.Elements)-1]
+			}
+
+			return nil
+		}},
+	},
+	{
+		"rest",
+		&Builtin{Fn: func(args ...Object) Object {
+			if len(args) != 1 {
+				return NewError("wrong number of arguments. got=%d, want=1", len(args))
+			}
+			if args[0].Type() != ARRAY_OBJ {
+				return NewError("argument to `rest` must be ARRAY, got %s", args[0].Type())
+			}
+
+			arr := args[0].(*Array)
+			if len(arr.Elements) > 0 {
+				newElements := make([]Object, len(arr.Elements)-1)
+				copy(newElements, arr.Elements[1:])
+				return &Array{Elements: newElements}
+			}
+
+			return nil
+		}},
+	},
+	{
+		"push",
+		&Builtin{Fn: func(args ...Object) Object {
+			if len(args) != 2 {
+				return NewError("wrong number of arguments. got=%d, want=2", len(args))
+			}
+			if args[0].Type() != ARRAY_OBJ {
+				return NewError("argument to `push` must be ARRAY, got %s", args[0].Type())
+			}
+
+			arr := args[0].(*Array)
+			newElements := make([]Object, len(arr.Elements)+1)
+			copy(newElements, arr.Elements)
+			newElements[len(newElements)-1] = args[1]
+
+			return &Array{Elements: newElements}
+		}},
+	},
+}
+
+func GetBuiltinByName(name string) *Builtin {
+	for _, def := range Builtins {
+		if def.Name == name {
+			return def.Builtin
+		}
+	}
+	return nil
+}

--- a/VM/object/object.go
+++ b/VM/object/object.go
@@ -1,0 +1,405 @@
+package object
+
+import (
+	"bytes"
+	"fmt"
+	"hash/fnv"
+	"html/template"
+	"math"
+	"reflect"
+	"strings"
+	"sync/atomic"
+
+	"github.com/gobuffalo/plush/v5/VM/code"
+	"github.com/gobuffalo/plush/v5/ast"
+)
+
+type BuiltinFunction func(args ...Object) Object
+
+type ObjectType string
+
+const (
+	NULL_OBJ  = "NULL"
+	ERROR_OBJ = "ERROR"
+
+	INTEGER_OBJ = "INTEGER"
+	FLOAT_OBJ   = "FLOAT"
+	BOOLEAN_OBJ = "BOOLEAN"
+	STRING_OBJ  = "STRING"
+
+	BUILTIN_OBJ  = "BUILTIN"
+	FUNCTION_OBJ = "FUNCTION"
+
+	ARRAY_OBJ = "ARRAY"
+	HASH_OBJ  = "HASH"
+
+	COMPILED_FUNCTION_OBJ = "COMPILED_FUNCTION"
+	CLOSURE_OBJ           = "CLOSURE"
+
+	NATIVE_OBJ  = "NATIVE"
+	CONTROL_OBJ = "CONTROL"
+)
+
+type Object interface {
+	Type() ObjectType
+	Inspect() string
+}
+
+type Integer struct {
+	Value int64
+}
+
+func (i *Integer) Type() ObjectType { return INTEGER_OBJ }
+func (i *Integer) Inspect() string  { return fmt.Sprintf("%d", i.Value) }
+func (i *Integer) HashKey() HashKey {
+	return HashKey{Type: i.Type(), Value: uint64(i.Value)}
+}
+
+type Float struct {
+	Value float64
+}
+
+func (f *Float) Type() ObjectType { return FLOAT_OBJ }
+func (f *Float) Inspect() string  { return fmt.Sprintf("%v", f.Value) }
+
+type Boolean struct {
+	Value bool
+}
+
+func (b *Boolean) Type() ObjectType { return BOOLEAN_OBJ }
+func (b *Boolean) Inspect() string  { return fmt.Sprintf("%t", b.Value) }
+func (b *Boolean) HashKey() HashKey {
+	if b.Value {
+		return HashKey{Type: b.Type(), Value: 1}
+	}
+	return HashKey{Type: b.Type(), Value: 0}
+}
+
+type Null struct{}
+
+func (n *Null) Type() ObjectType { return NULL_OBJ }
+func (n *Null) Inspect() string  { return "null" }
+
+var (
+	NullObject  = &Null{}
+	TrueObject  = &Boolean{Value: true}
+	FalseObject = &Boolean{Value: false}
+)
+
+type Error struct {
+	Message string
+}
+
+func (e *Error) Type() ObjectType { return ERROR_OBJ }
+func (e *Error) Inspect() string  { return "ERROR: " + e.Message }
+
+type String struct {
+	Value string
+}
+
+func (s *String) Type() ObjectType { return STRING_OBJ }
+func (s *String) Inspect() string  { return s.Value }
+func (s *String) HashKey() HashKey {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(s.Value))
+
+	return HashKey{Type: s.Type(), Value: h.Sum64()}
+}
+
+type Builtin struct {
+	Fn BuiltinFunction
+}
+
+func (b *Builtin) Type() ObjectType { return BUILTIN_OBJ }
+func (b *Builtin) Inspect() string  { return "builtin function" }
+
+type FunctionLiteral struct {
+	Parameters []*ast.Identifier
+	Body       *ast.BlockStatement
+}
+
+func (f *FunctionLiteral) Type() ObjectType { return FUNCTION_OBJ }
+func (f *FunctionLiteral) Inspect() string {
+	var out bytes.Buffer
+
+	params := []string{}
+	for _, p := range f.Parameters {
+		params = append(params, p.String())
+	}
+
+	out.WriteString("fn")
+	out.WriteString("(")
+	out.WriteString(strings.Join(params, ", "))
+	out.WriteString(") {\n")
+	if f.Body != nil {
+		out.WriteString(f.Body.String())
+	}
+	out.WriteString("\n}")
+
+	return out.String()
+}
+
+type Array struct {
+	Elements []Object
+}
+
+func (ao *Array) Type() ObjectType { return ARRAY_OBJ }
+func (ao *Array) Inspect() string {
+	elements := make([]string, 0, len(ao.Elements))
+	for _, e := range ao.Elements {
+		elements = append(elements, e.Inspect())
+	}
+
+	return "[" + strings.Join(elements, ", ") + "]"
+}
+
+type HashKey struct {
+	Type  ObjectType
+	Value uint64
+}
+
+type Hashable interface {
+	HashKey() HashKey
+}
+
+type HashPair struct {
+	Key   Object
+	Value Object
+}
+
+type Hash struct {
+	Pairs map[HashKey]HashPair
+}
+
+func (h *Hash) Type() ObjectType { return HASH_OBJ }
+func (h *Hash) Inspect() string {
+	var out bytes.Buffer
+
+	pairs := []string{}
+	for _, pair := range h.Pairs {
+		pairs = append(pairs, fmt.Sprintf("%s: %s",
+			pair.Key.Inspect(), pair.Value.Inspect()))
+	}
+
+	out.WriteString("{")
+	out.WriteString(strings.Join(pairs, ", "))
+	out.WriteString("}")
+
+	return out.String()
+}
+
+type CompiledFunction struct {
+	Instructions   code.Instructions
+	CallNames      map[int]string
+	LocalNames     map[int]string
+	LineNumbers    map[int]int
+	Properties     map[int]PropertyAccess
+	PropertyCaches []InlineCacheSlot
+	CallCaches     []InlineCacheSlot
+	NumLocals      int
+	NumParameters  int
+}
+
+func (cf *CompiledFunction) Type() ObjectType { return COMPILED_FUNCTION_OBJ }
+func (cf *CompiledFunction) Inspect() string {
+	return fmt.Sprintf("CompiledFunction[%p]", cf)
+}
+
+type PropertyAccess struct {
+	Receiver string
+	Full     string
+	Method   bool
+}
+
+type InlineCacheSlot struct {
+	value atomic.Value
+}
+
+func NewInlineCacheSlots(size int) []InlineCacheSlot {
+	if size <= 0 {
+		return nil
+	}
+	return make([]InlineCacheSlot, size)
+}
+
+func (s *InlineCacheSlot) Load() interface{} {
+	if s == nil {
+		return nil
+	}
+	return s.value.Load()
+}
+
+func (s *InlineCacheSlot) Store(value interface{}) {
+	if s == nil || value == nil {
+		return
+	}
+	s.value.Store(value)
+}
+
+type Closure struct {
+	Fn   *CompiledFunction
+	Free []Object
+}
+
+func (c *Closure) Type() ObjectType { return CLOSURE_OBJ }
+func (c *Closure) Inspect() string  { return fmt.Sprintf("Closure[%p]", c) }
+
+type Native struct {
+	Value interface{}
+}
+
+func (n *Native) Type() ObjectType { return NATIVE_OBJ }
+func (n *Native) Inspect() string  { return fmt.Sprint(n.Value) }
+
+type ControlKind string
+
+const (
+	ControlBreak    ControlKind = "break"
+	ControlContinue ControlKind = "continue"
+)
+
+type Control struct {
+	Kind  ControlKind
+	Value []Object
+}
+
+func (c *Control) Type() ObjectType { return CONTROL_OBJ }
+func (c *Control) Inspect() string  { return string(c.Kind) }
+
+func NewError(format string, a ...interface{}) *Error {
+	return &Error{Message: fmt.Sprintf(format, a...)}
+}
+
+func Wrap(v interface{}) Object {
+	switch v := v.(type) {
+	case nil:
+		return NullObject
+	case Object:
+		return v
+	case int:
+		return &Integer{Value: int64(v)}
+	case int8:
+		return &Integer{Value: int64(v)}
+	case int16:
+		return &Integer{Value: int64(v)}
+	case int32:
+		return &Integer{Value: int64(v)}
+	case int64:
+		return &Integer{Value: v}
+	case uint:
+		if uint64(v) <= uint64(math.MaxInt64) {
+			return &Integer{Value: int64(v)}
+		}
+		return &Native{Value: v}
+	case uint8:
+		return &Integer{Value: int64(v)}
+	case uint16:
+		return &Integer{Value: int64(v)}
+	case uint32:
+		return &Integer{Value: int64(v)}
+	case uint64:
+		if v <= uint64(math.MaxInt64) {
+			return &Integer{Value: int64(v)}
+		}
+		return &Native{Value: v}
+	case float32:
+		return &Float{Value: float64(v)}
+	case float64:
+		return &Float{Value: v}
+	case bool:
+		if v {
+			return TrueObject
+		}
+		return FalseObject
+	case string:
+		return &String{Value: v}
+	case []Object:
+		return &Array{Elements: v}
+	case []interface{}:
+		elements := make([]Object, 0, len(v))
+		for _, el := range v {
+			elements = append(elements, Wrap(el))
+		}
+		return &Array{Elements: elements}
+	default:
+		return wrapReflect(v)
+	}
+}
+
+func wrapReflect(v interface{}) Object {
+	rv := reflect.ValueOf(v)
+	if !rv.IsValid() {
+		return NullObject
+	}
+	if rv.Kind() == reflect.Ptr && rv.IsNil() {
+		return NullObject
+	}
+
+	switch rv.Kind() {
+	case reflect.Slice, reflect.Array:
+		return &Native{Value: v}
+	case reflect.Map:
+		return &Native{Value: v}
+	default:
+		return &Native{Value: v}
+	}
+}
+
+func ToGo(obj Object) interface{} {
+	switch obj := obj.(type) {
+	case nil:
+		return nil
+	case *Null:
+		return nil
+	case *Integer:
+		return int(obj.Value)
+	case *Float:
+		return obj.Value
+	case *Boolean:
+		return obj.Value
+	case *String:
+		return obj.Value
+	case *Array:
+		out := make([]interface{}, 0, len(obj.Elements))
+		for _, el := range obj.Elements {
+			out = append(out, ToGo(el))
+		}
+		return out
+	case *Hash:
+		out := map[string]interface{}{}
+		for _, pair := range obj.Pairs {
+			out[hashKeyString(pair.Key)] = ToGo(pair.Value)
+		}
+		return out
+	case *Native:
+		return obj.Value
+	default:
+		return obj
+	}
+}
+
+func hashKeyString(key Object) string {
+	switch key := key.(type) {
+	case *String:
+		return key.Value
+	case *Integer:
+		return key.Inspect()
+	case *Boolean:
+		return key.Inspect()
+	default:
+		return key.Inspect()
+	}
+}
+
+func IsNull(obj Object) bool {
+	if obj == nil {
+		return true
+	}
+	_, ok := obj.(*Null)
+	return ok
+}
+
+func IsHTML(obj Object) bool {
+	_, ok := ToGo(obj).(template.HTML)
+	return ok
+}

--- a/VM/object/object_test.go
+++ b/VM/object/object_test.go
@@ -1,0 +1,153 @@
+package object
+
+import (
+	"math"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5/ast"
+	"github.com/gobuffalo/plush/v5/token"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Function_Literal(t *testing.T) {
+	fn := &FunctionLiteral{
+		Parameters: []*ast.Identifier{
+			{
+				TokenAble: ast.TokenAble{Token: token.Token{Type: token.IDENT, Literal: "x"}},
+				Value:     "x",
+			},
+		},
+		Body: &ast.BlockStatement{},
+	}
+
+	require.Equal(t, ObjectType(FUNCTION_OBJ), fn.Type())
+	require.Equal(t, "fn(x) {\n\n}", fn.Inspect())
+}
+
+func Test_Wrap_Preserves_Large_Uint_64(t *testing.T) {
+	obj := Wrap(uint64(math.MaxUint64))
+
+	native, ok := obj.(*Native)
+	require.Truef(t, ok, "expected large uint64 to stay native, got %T", obj)
+	require.Equal(t, uint64(math.MaxUint64), native.Value)
+}
+
+func Test_String_Hash_Key(t *testing.T) {
+	hello1 := &String{Value: "Hello World"}
+	hello2 := &String{Value: "Hello World"}
+	diff1 := &String{Value: "My name is johnny"}
+	diff2 := &String{Value: "My name is johnny"}
+
+	require.Equal(t, hello1.HashKey(), hello2.HashKey())
+	require.Equal(t, diff1.HashKey(), diff2.HashKey())
+	require.NotEqual(t, hello1.HashKey(), diff1.HashKey())
+}
+
+func Test_Boolean_Hash_Key(t *testing.T) {
+	true1 := &Boolean{Value: true}
+	true2 := &Boolean{Value: true}
+	false1 := &Boolean{Value: false}
+	false2 := &Boolean{Value: false}
+
+	require.Equal(t, true1.HashKey(), true2.HashKey())
+	require.Equal(t, false1.HashKey(), false2.HashKey())
+	require.NotEqual(t, true1.HashKey(), false1.HashKey())
+}
+
+func Test_Integer_Hash_Key(t *testing.T) {
+	one1 := &Integer{Value: 1}
+	one2 := &Integer{Value: 1}
+	two1 := &Integer{Value: 2}
+	two2 := &Integer{Value: 2}
+
+	require.Equal(t, one1.HashKey(), one2.HashKey())
+	require.Equal(t, two1.HashKey(), two2.HashKey())
+	require.NotEqual(t, one1.HashKey(), two1.HashKey())
+}
+
+func Test_VM_Builtins(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []Object
+		expected Object
+	}{
+		{
+			name:     "len",
+			args:     []Object{&String{Value: "hello"}},
+			expected: &Integer{Value: 5},
+		},
+		{
+			name:     "len",
+			args:     []Object{&Array{Elements: []Object{&Integer{Value: 1}, &Integer{Value: 2}}}},
+			expected: &Integer{Value: 2},
+		},
+		{
+			name:     "first",
+			args:     []Object{&Array{Elements: []Object{&Integer{Value: 1}, &Integer{Value: 2}}}},
+			expected: &Integer{Value: 1},
+		},
+		{
+			name:     "last",
+			args:     []Object{&Array{Elements: []Object{&Integer{Value: 1}, &Integer{Value: 2}}}},
+			expected: &Integer{Value: 2},
+		},
+		{
+			name:     "rest",
+			args:     []Object{&Array{Elements: []Object{&Integer{Value: 1}, &Integer{Value: 2}}}},
+			expected: &Array{Elements: []Object{&Integer{Value: 2}}},
+		},
+		{
+			name:     "push",
+			args:     []Object{&Array{Elements: []Object{}}, &Integer{Value: 1}},
+			expected: &Array{Elements: []Object{&Integer{Value: 1}}},
+		},
+	}
+
+	for _, tt := range tests {
+		builtin := GetBuiltinByName(tt.name)
+		require.NotNil(t, builtin)
+		require.Equal(t, tt.expected, builtin.Fn(tt.args...))
+	}
+}
+
+func Test_VM_Builtin_Errors(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []Object
+		expected string
+	}{
+		{
+			name:     "len",
+			args:     []Object{&Integer{Value: 1}},
+			expected: "argument to `len` not supported, got INTEGER",
+		},
+		{
+			name:     "len",
+			args:     []Object{&String{Value: "one"}, &String{Value: "two"}},
+			expected: "wrong number of arguments. got=2, want=1",
+		},
+		{
+			name:     "first",
+			args:     []Object{&Integer{Value: 1}},
+			expected: "argument to `first` must be ARRAY, got INTEGER",
+		},
+		{
+			name:     "last",
+			args:     []Object{&Integer{Value: 1}},
+			expected: "argument to `last` must be ARRAY, got INTEGER",
+		},
+		{
+			name:     "push",
+			args:     []Object{&Integer{Value: 1}, &Integer{Value: 1}},
+			expected: "argument to `push` must be ARRAY, got INTEGER",
+		},
+	}
+
+	for _, tt := range tests {
+		builtin := GetBuiltinByName(tt.name)
+		require.NotNil(t, builtin)
+		result, ok := builtin.Fn(tt.args...).(*Error)
+		require.Truef(t, ok, "expected error object for builtin %s", tt.name)
+		require.Equal(t, tt.expected, result.Message)
+	}
+}

--- a/VM/plush/compiled_template_test.go
+++ b/VM/plush/compiled_template_test.go
@@ -1,0 +1,38 @@
+package plush_test
+
+import (
+	"fmt"
+	"testing"
+
+	rootplush "github.com/gobuffalo/plush/v5"
+	vmplush "github.com/gobuffalo/plush/v5/VM/plush"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Compiled_Template_Render(t *testing.T) {
+	tmpl, err := vmplush.Compile(`<p><%= greet(name) %></p>`)
+	require.NoError(t, err)
+
+	out, err := tmpl.Render(rootplush.NewContextWith(map[string]interface{}{
+		"name": "Mido",
+		"greet": func(name string) string {
+			return "hi " + name
+		},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "<p>hi Mido</p>", out)
+}
+
+func Test_Compiled_Template_Render_Reuses_Bytecode_With_Fresh_Contexts(t *testing.T) {
+	tmpl, err := vmplush.Compile(`<%= for (i, item) in items { %><%= prefix %>-<%= i %>:<%= item %>;<% } %>`)
+	require.NoError(t, err)
+
+	for i := 0; i < 3; i++ {
+		out, err := tmpl.Render(rootplush.NewContextWith(map[string]interface{}{
+			"prefix": fmt.Sprintf("run%d", i),
+			"items":  []string{"a", "b"},
+		}))
+		require.NoError(t, err)
+		require.Equal(t, fmt.Sprintf("run%d-0:a;run%d-1:b;", i, i), out)
+	}
+}

--- a/VM/plush/concurrency_test.go
+++ b/VM/plush/concurrency_test.go
@@ -1,0 +1,153 @@
+package plush_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	rootplush "github.com/gobuffalo/plush/v5"
+	vmplush "github.com/gobuffalo/plush/v5/VM/plush"
+	"github.com/gobuffalo/plush/v5/helpers/meta"
+	"github.com/gobuffalo/plush/v5/templatecache/inmemory"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Phase_15_Concurrent_VM_Renders_With_Separate_Contexts(t *testing.T) {
+	input := `<% let local = name %><%= name %>:<%= local %>:<%= for (i, item) in items { %><%= name %>-<%= i %>-<%= item %>;<% } %>`
+
+	runConcurrentChecks(t, 32, func(i int) error {
+		name := fmt.Sprintf("n%d", i)
+		out, err := vmplush.Render(input, rootplush.NewContextWith(map[string]interface{}{
+			"name":  name,
+			"items": []string{"a", "b"},
+		}))
+		if err != nil {
+			return err
+		}
+		expected := fmt.Sprintf("%s:%s:%s-0-a;%s-1-b;", name, name, name, name)
+		if out != expected {
+			return fmt.Errorf("render %d output mismatch: want %q, got %q", i, expected, out)
+		}
+		return nil
+	})
+}
+
+func Test_Phase_15_Concurrent_Compiled_Template_Shared_Bytecode(t *testing.T) {
+	tmpl, err := vmplush.Compile(`<% let local = name %><%= local %>|<%= suffix %>|<%= for (i, item) in items { %><%= local %>:<%= item %>;<% } %>`)
+	require.NoError(t, err)
+
+	runConcurrentChecks(t, 32, func(i int) error {
+		name := fmt.Sprintf("user%d", i)
+		suffix := fmt.Sprintf("s%d", i)
+		out, err := tmpl.Render(rootplush.NewContextWith(map[string]interface{}{
+			"name":   name,
+			"suffix": suffix,
+			"items":  []string{"x", "y"},
+		}))
+		if err != nil {
+			return err
+		}
+		expected := fmt.Sprintf("%s|%s|%s:x;%s:y;", name, suffix, name, name)
+		if out != expected {
+			return fmt.Errorf("compiled render %d output mismatch: want %q, got %q", i, expected, out)
+		}
+		return nil
+	})
+}
+
+func Test_Phase_15_Repeated_Compiled_Template_Does_Not_Leak_Globals_Or_Locals(t *testing.T) {
+	tmpl, err := vmplush.Compile(`<% let global = name %><% let make = fn(value) { let local = value + suffix; return local } %><%= global %>|<%= make(name) %>`)
+	require.NoError(t, err)
+
+	for i := 0; i < 10; i++ {
+		name := fmt.Sprintf("n%d", i)
+		suffix := fmt.Sprintf("-s%d", i)
+		out, err := tmpl.Render(rootplush.NewContextWith(map[string]interface{}{
+			"name":   name,
+			"suffix": suffix,
+		}))
+		require.NoError(t, err)
+		require.Equal(t, fmt.Sprintf("%s|%s%s", name, name, suffix), out)
+	}
+}
+
+func Test_Phase_15_Concurrent_VM_Hole_Rendering(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	rootplush.PlushCacheSetup(cache)
+	defer rootplush.ClearTemplateCache()
+
+	input := `<%H value %>|<%= value %>`
+
+	runConcurrentChecks(t, 16, func(i int) error {
+		value := fmt.Sprintf("hole%d", i)
+		ctx := rootplush.NewContextWith(map[string]interface{}{
+			"value": value,
+		})
+		ctx.Set(meta.TemplateFileKey, fmt.Sprintf("phase15-holes-%d.plush", i))
+
+		out, err := vmplush.Render(input, ctx)
+		if err != nil {
+			return err
+		}
+		expected := fmt.Sprintf("%s|%s", value, value)
+		if out != expected {
+			return fmt.Errorf("hole render %d output mismatch: want %q, got %q", i, expected, out)
+		}
+		return nil
+	})
+}
+
+func Test_Phase_15_Concurrent_Root_Render_Mode_VM_Bytecode_Cache_Access(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	rootplush.PlushCacheSetup(cache)
+	defer rootplush.ClearTemplateCache()
+
+	previous := rootplush.SetRenderMode(rootplush.RenderModeVM)
+	defer rootplush.SetRenderMode(previous)
+
+	input := `<%= name %>|<%= for (i, item) in items { %><%= name %>:<%= item %>;<% } %>`
+
+	runConcurrentChecks(t, 32, func(i int) error {
+		name := fmt.Sprintf("cached%d", i)
+		ctx := rootplush.NewContextWith(map[string]interface{}{
+			"name":  name,
+			"items": []string{"a", "b"},
+		})
+		ctx.Set(meta.TemplateFileKey, "phase15-cache.plush")
+
+		out, err := rootplush.Render(input, ctx)
+		if err != nil {
+			return err
+		}
+		expected := fmt.Sprintf("%s|%s:a;%s:b;", name, name, name)
+		if out != expected {
+			return fmt.Errorf("cached render %d output mismatch: want %q, got %q", i, expected, out)
+		}
+		return nil
+	})
+
+	entry, ok := cache.Get(rootplush.GenerateASTKey("phase15-cache.plush"))
+	require.True(t, ok)
+	require.NotNil(t, entry.VMBytecode)
+}
+
+func runConcurrentChecks(t *testing.T, count int, fn func(int) error) {
+	t.Helper()
+
+	var wg sync.WaitGroup
+	errs := make(chan error, count)
+	for i := 0; i < count; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- fn(i)
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}

--- a/VM/plush/parity_basic_test.go
+++ b/VM/plush/parity_basic_test.go
@@ -1,0 +1,41 @@
+package plush_test
+
+import (
+	"html/template"
+	"testing"
+)
+
+func Test_Parity_Basic_HTML_And_Interpolation(t *testing.T) {
+	compareRender(t, `<p>Hello <%= name %></p>`, contextWith(map[string]interface{}{
+		"name": "mark",
+	}))
+}
+
+func Test_Parity_Basic_Spacing_And_Show_No_Show(t *testing.T) {
+	compareRender(t, `<%= greet %> <%= name %>`, contextWith(map[string]interface{}{
+		"greet": "hi",
+		"name":  "mark",
+	}))
+	compareRender(t, `<%= "shown" %><% "notshown" %>`, emptyContext)
+}
+
+func Test_Parity_Basic_Escaping(t *testing.T) {
+	compareRender(t, `<%= html %>`, contextWith(map[string]interface{}{
+		"html": `<strong>safe?</strong>`,
+	}))
+}
+
+func Test_Parity_Basic_HTML_Escape_Helpers(t *testing.T) {
+	compareRender(t, `<%= escapedHTML() %>|<%= unescapedHTML() %>|<%= raw("<b>unsafe</b>") %>`, contextWith(map[string]interface{}{
+		"escapedHTML": func() string {
+			return "<b>unsafe</b>"
+		},
+		"unescapedHTML": func() template.HTML {
+			return "<b>unsafe</b>"
+		},
+	}))
+}
+
+func Test_Parity_Basic_Escape_Expression(t *testing.T) {
+	compareRender(t, `C:\\<%= "temp" %>`, emptyContext)
+}

--- a/VM/plush/parity_budget_test.go
+++ b/VM/plush/parity_budget_test.go
@@ -1,0 +1,187 @@
+package plush_test
+
+import (
+	"errors"
+	"testing"
+
+	rootplush "github.com/gobuffalo/plush/v5"
+	vmplush "github.com/gobuffalo/plush/v5/VM/plush"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Parity_Budget_Enough_Budget(t *testing.T) {
+	compareRender(t, `<%= for (i,v) in items { %><%= v %><% } %>`, func() hctx.Context {
+		ctx := rootplush.NewContextWith(map[string]interface{}{
+			"items": []string{"a", "b"},
+		})
+		ctx.WithBudget(rootplush.NewBudget(100))
+		return ctx
+	})
+}
+
+type phase11BudgetGreeter struct{}
+
+func (phase11BudgetGreeter) Greet() string {
+	return "hi"
+}
+
+type phase11BudgetStats struct {
+	Count int
+}
+
+type phase11BudgetRobot struct {
+	Name  string
+	Stats phase11BudgetStats
+}
+
+func Test_Parity_Phase_11_Budget_Work_Counters(t *testing.T) {
+	costs := rootplush.ZeroCosts()
+	costs.LoopIteration = 2
+	costs.HelperCall = 3
+	costs.ConditionCheck = 5
+	costs.Assignment = 7
+
+	result := compareBudgetRender(t, `<% let message = "start" %><% message = "next" %><%= if (ok) { %><%= for (i,v) in items { %><%= helper(v) %><% } %><% } %><%= message %>`, 100, costs, func() map[string]interface{} {
+		return map[string]interface{}{
+			"ok":    true,
+			"items": []string{"a", "b"},
+			"helper": func(value string) string {
+				return value
+			},
+		}
+	})
+
+	require.Equal(t, "abnext", result.vmOut)
+	require.Equal(t, int64(29), result.vmStats.TotalUsed)
+	require.Equal(t, int64(4), result.vmStats.LoopIterations)
+	require.Equal(t, int64(6), result.vmStats.FunctionCalls)
+	require.Equal(t, int64(5), result.vmStats.ConditionChecks)
+	require.Equal(t, int64(14), result.vmStats.Assignments)
+	require.Equal(t, int64(6), result.vmStats.ByFunction["helper"])
+}
+
+func Test_Parity_Phase_11_Function_Cost_Overrides(t *testing.T) {
+	costs := rootplush.ZeroCosts()
+	costs.HelperCall = 1
+	costs.FunctionCosts = map[string]int64{
+		"expensive": 7,
+		"add":       5,
+		"Greet":     3,
+	}
+
+	result := compareBudgetRender(t, `<% let add = fn(x) { return x + 1 } %><%= expensive() %>|<%= add(2) %>|<%= greeter.Greet() %>`, 100, costs, func() map[string]interface{} {
+		return map[string]interface{}{
+			"expensive": func() string { return "x" },
+			"greeter":   phase11BudgetGreeter{},
+		}
+	})
+
+	require.Equal(t, "x|3|hi", result.vmOut)
+	require.Equal(t, int64(15), result.vmStats.TotalUsed)
+	require.Equal(t, int64(15), result.vmStats.FunctionCalls)
+	require.Equal(t, int64(7), result.vmStats.ByFunction["expensive"])
+	require.Equal(t, int64(5), result.vmStats.ByFunction["add"])
+	require.Equal(t, int64(3), result.vmStats.ByFunction["Greet"])
+}
+
+func Test_Parity_Phase_11_Object_Traversal_Budget(t *testing.T) {
+	costs := rootplush.ZeroCosts()
+	costs.ObjectTraversal = 2
+
+	result := compareBudgetRender(t, `<%= robot.Name %>|<%= robots[0].Stats.Count %>`, 100, costs, func() map[string]interface{} {
+		return map[string]interface{}{
+			"robot":  phase11BudgetRobot{Name: "Bender"},
+			"robots": []phase11BudgetRobot{{Stats: phase11BudgetStats{Count: 3}}},
+		}
+	})
+
+	require.Equal(t, "Bender|3", result.vmOut)
+	require.Equal(t, int64(6), result.vmStats.TotalUsed)
+	require.Equal(t, int64(6), result.vmStats.ObjectTraversals)
+}
+
+func Test_Parity_Phase_11_Sub_Render_Budget(t *testing.T) {
+	costs := rootplush.ZeroCosts()
+	costs.SubRender = 11
+
+	result := compareBudgetRender(t, `<%= partial("child.plush") %>`, 100, costs, func() map[string]interface{} {
+		return map[string]interface{}{
+			"name": "mark",
+			"partialFeeder": func(name string) (string, error) {
+				require.Equal(t, "child.plush", name)
+				return `<%= name %>`, nil
+			},
+		}
+	})
+
+	require.Equal(t, "mark", result.vmOut)
+	require.Equal(t, int64(11), result.vmStats.TotalUsed)
+	require.Equal(t, int64(11), result.vmStats.SubRenders)
+}
+
+func Test_Parity_Phase_11_Budget_Exceeded(t *testing.T) {
+	costs := rootplush.ZeroCosts()
+	costs.FunctionCosts = map[string]int64{"expensive": 7}
+
+	result := compareBudgetRender(t, `<%= expensive() %>`, 6, costs, func() map[string]interface{} {
+		return map[string]interface{}{
+			"expensive": func() string { return "x" },
+		}
+	})
+
+	require.ErrorIs(t, result.vmErr, rootplush.ErrBudgetExceeded)
+	require.Equal(t, int64(7), result.vmStats.TotalUsed)
+	require.Equal(t, int64(7), result.vmStats.FunctionCalls)
+	require.Equal(t, int64(7), result.vmStats.ByFunction["expensive"])
+}
+
+type budgetRenderResult struct {
+	interpreterOut   string
+	interpreterErr   error
+	interpreterStats rootplush.BudgetStats
+	vmOut            string
+	vmErr            error
+	vmStats          rootplush.BudgetStats
+}
+
+func compareBudgetRender(t *testing.T, input string, limit int64, costs rootplush.BudgetCosts, data func() map[string]interface{}) budgetRenderResult {
+	t.Helper()
+
+	interpreterOut, interpreterErr, interpreterStats := renderInterpreterWithBudget(input, limit, costs, data)
+	vmOut, vmErr, vmStats := renderVMWithBudget(input, limit, costs, data)
+
+	if errors.Is(interpreterErr, rootplush.ErrBudgetExceeded) || errors.Is(vmErr, rootplush.ErrBudgetExceeded) {
+		require.ErrorIs(t, interpreterErr, rootplush.ErrBudgetExceeded)
+		require.ErrorIs(t, vmErr, rootplush.ErrBudgetExceeded)
+	} else {
+		require.Equalf(t, errorString(interpreterErr), errorString(vmErr), "error mismatch\ninterpreter: %q\nvm:          %q", errorString(interpreterErr), errorString(vmErr))
+	}
+	require.Equalf(t, interpreterOut, vmOut, "output mismatch\ninterpreter: %q\nvm:          %q", interpreterOut, vmOut)
+	require.Equal(t, interpreterStats, vmStats)
+
+	return budgetRenderResult{
+		interpreterOut:   interpreterOut,
+		interpreterErr:   interpreterErr,
+		interpreterStats: interpreterStats,
+		vmOut:            vmOut,
+		vmErr:            vmErr,
+		vmStats:          vmStats,
+	}
+}
+
+func renderInterpreterWithBudget(input string, limit int64, costs rootplush.BudgetCosts, data func() map[string]interface{}) (string, error, rootplush.BudgetStats) {
+	budget := rootplush.NewBudgetWithCosts(limit, costs)
+	ctx := rootplush.NewContextWith(data())
+	ctx.WithBudget(budget)
+	out, err := rootplush.Render(input, ctx)
+	return out, err, budget.Stats()
+}
+
+func renderVMWithBudget(input string, limit int64, costs rootplush.BudgetCosts, data func() map[string]interface{}) (string, error, rootplush.BudgetStats) {
+	budget := rootplush.NewBudgetWithCosts(limit, costs)
+	ctx := rootplush.NewContextWith(data())
+	ctx.WithBudget(budget)
+	out, err := vmplush.Render(input, ctx)
+	return out, err, budget.Stats()
+}

--- a/VM/plush/parity_conditions_test.go
+++ b/VM/plush/parity_conditions_test.go
@@ -1,0 +1,116 @@
+package plush_test
+
+import "testing"
+
+type parityTruthUser struct {
+	Name  string
+	Image *string
+}
+
+func Test_Parity_Conditions_Unknown_As_Nil(t *testing.T) {
+	compareRender(t, `<%= paths == nil %>`, emptyContext)
+	compareRender(t, `<%= nil == paths %>`, emptyContext)
+	compareRender(t, `<%= !paths %>`, emptyContext)
+	compareRender(t, `<%= if (paths) { %>yes<% } else { %>no<% } %>`, emptyContext)
+}
+
+func Test_Parity_Conditions_String_Truthiness(t *testing.T) {
+	compareRender(t, `<%= if (username && username != "") { return "hi" } else { return "bye" } %>`, contextWith(map[string]interface{}{
+		"username": "",
+	}))
+	compareRender(t, `<%= if (username && username != "") { return "hi" } else { return "bye" } %>`, contextWith(map[string]interface{}{
+		"username": "mark",
+	}))
+}
+
+func Test_Parity_Conditions_Assignment_Inside_If_Scope(t *testing.T) {
+	input := `<p><%= if (username && username != "") { username = "hi" } else { username = "bye" } %><%= username %></p>`
+
+	compareRender(t, input, contextWith(map[string]interface{}{
+		"username": "",
+	}))
+	compareRender(t, input, contextWith(map[string]interface{}{
+		"username": "foo",
+	}))
+}
+
+func Test_Parity_Conditions_Unknown_Assignment_Inside_If_Errors(t *testing.T) {
+	compareBothRenderError(t, `<p><%= if (username && username != "") { username = "hi" } else { username = "bye" } %><%= username %></p>`, emptyContext)
+}
+
+func Test_Parity_Conditions_Block_Scope_Declare_Does_Not_Overwrite_Outer(t *testing.T) {
+	compareRender(t, `<p><% let username = "Hello World" %><%= if (username && username != "") {
+		let username = "hi"
+		username = "hi"
+	} else {
+		let username = "bye"
+		username = "1"
+	} %><%= username %></p>`, emptyContext)
+}
+
+func Test_Parity_Conditions_Nested_Block_Scope_Overwrite_Outer(t *testing.T) {
+	compareRender(t, `<p><% let username = "Hello World" %><%= if (username && username != "") {
+		username = "hi"
+		if (username == "hi") {
+			username = "hi2"
+		}
+	} else {
+		let username = "bye"
+		username = "1"
+	} %><%= username %></p>`, emptyContext)
+}
+
+func Test_Parity_Conditions_Nil_Pointer_Truthiness(t *testing.T) {
+	compareRender(t, `<%= user.Name %>:<%= if (user.Image) { return "has image" } else { return "no image" } %>`, contextWith(map[string]interface{}{
+		"user": parityTruthUser{Name: "Garn"},
+	}))
+
+	image := "bicep.png"
+	compareRender(t, `<%= user.Name %>:<%= if (user.Image) { return "has image" } else { return "no image" } %>`, contextWith(map[string]interface{}{
+		"user": parityTruthUser{Name: "Scrinch", Image: &image},
+	}))
+}
+
+func Test_Parity_Conditions_Logical_Unknown_Short_Circuit(t *testing.T) {
+	compareRender(t, `<%= if (names && len(names) >= 1) { %>yes<% } else { %>no<% } %>`, emptyContext)
+	compareRender(t, `<%= paths || pages %>`, contextWith(map[string]interface{}{
+		"paths": "cart",
+	}))
+	compareRender(t, `<%= pages || paths %>`, contextWith(map[string]interface{}{
+		"paths": "cart",
+	}))
+	compareRender(t, `<%= paths && pages %>`, contextWith(map[string]interface{}{
+		"paths": "cart",
+	}))
+}
+
+func Test_Parity_Conditions_Complex_Or_With_Unknown_Middle(t *testing.T) {
+	compareRender(t, `<%= if (paths == "cart" || (page && page.PageTitle != "cafe") || paths == "cart") { %>hi<% } %>`, contextWith(map[string]interface{}{
+		"path":  "cart",
+		"paths": "cart",
+	}))
+}
+
+func Test_Parity_Conditions_Direct_Unknown_Still_Errors(t *testing.T) {
+	_, interpreterErr := renderInterpreter(`<%= pages %>`, emptyContext)
+	_, vmErr := renderVM(`<%= pages %>`, emptyContext)
+
+	if interpreterErr == nil {
+		t.Fatal("expected interpreter error")
+	}
+	if vmErr == nil {
+		t.Fatal("expected VM error")
+	}
+}
+
+func Test_Parity_Conditions_Invalid_Int_Bool_Comparison_Errors(t *testing.T) {
+	_, interpreterErr := renderInterpreter(`<% let test = 1 %><%= if (test != true) { return "good"} %>`, emptyContext)
+	_, vmErr := renderVM(`<% let test = 1 %><%= if (test != true) { return "good"} %>`, emptyContext)
+
+	if interpreterErr == nil {
+		t.Fatal("expected interpreter error")
+	}
+	if vmErr == nil {
+		t.Fatal("expected VM error")
+	}
+}

--- a/VM/plush/parity_errors_test.go
+++ b/VM/plush/parity_errors_test.go
@@ -1,0 +1,148 @@
+package plush_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+	"github.com/stretchr/testify/require"
+)
+
+type phase13Robot struct {
+	Name    string
+	Friends []phase13Robot
+	hidden  string
+}
+
+func (r phase13Robot) GetFriends() []phase13Robot {
+	return r.Friends
+}
+
+func Test_Parity_Phase_13_Exact_Runtime_Errors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		data  map[string]interface{}
+	}{
+		{name: "unknown identifier", input: `<%= missing %>`},
+		{name: "unknown function", input: `<%= missing() %>`},
+		{name: "unknown struct field", input: `<%= robot.Missing %>`, data: phase13Data()},
+		{name: "unknown method", input: `<%= robot.Missing() %>`, data: phase13Data()},
+		{name: "call field as method", input: `<%= robot.Name() %>`, data: phase13Data()},
+		{name: "unknown chained method", input: `<%= robot.Name.Missing() %>`, data: phase13Data()},
+		{name: "unexported field", input: `<%= robot.hidden %>`, data: phase13Data()},
+		{name: "invalid helper argument", input: `<%= one("x") %>`, data: map[string]interface{}{
+			"one": func(int) string { return "" },
+		}},
+		{name: "helper returned error", input: `<%= fail() %>`, data: map[string]interface{}{
+			"fail": func() (string, error) { return "", fmt.Errorf("helper boom") },
+		}},
+		{name: "map key type", input: `<%= lookup["bad"] %>`, data: map[string]interface{}{
+			"lookup": map[int]string{1: "one"},
+		}},
+		{name: "slice index type", input: `<%= items["bad"] %>`, data: map[string]interface{}{
+			"items": []string{"a"},
+		}},
+		{name: "slice out of bounds", input: `<%= items[3] %>`, data: map[string]interface{}{
+			"items": []string{"a"},
+		}},
+		{name: "invalid assignment", input: `<% missing = "x" %>`},
+		{name: "division by zero", input: `<%= 10 / 0 %>`},
+		{name: "break outside loop", input: `<% break %>`},
+		{name: "continue outside loop", input: `<% continue %>`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			compareExactRenderError(t, tt.input, contextWith(tt.data))
+		})
+	}
+}
+
+func Test_Parity_Phase_13_Line_Numbers(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		data  map[string]interface{}
+		line  string
+	}{
+		{
+			name: "unknown on line 2",
+			input: `<p>
+<%= f.Foo %>
+</p>`,
+			line: "line 2:",
+		},
+		{
+			name: "for iterable on line 2",
+			input: `
+<%= for (n) in numbers.Foo { %>
+<%= n %>
+<% } %>`,
+			line: "line 2:",
+		},
+		{
+			name: "inside loop on line 3",
+			input: `
+<%= for (n) in numbers { %>
+<%= n.Foo %>
+<% } %>`,
+			data: map[string]interface{}{"numbers": []int{1}},
+			line: "line 3:",
+		},
+		{
+			name: "missing keyword on line 6",
+			input: `
+
+
+
+
+<%=  (n) in numbers { %>
+<%= n %>
+<% } %>`,
+			data: map[string]interface{}{"numbers": []int{1}},
+			line: "line 6:",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, interpreterErr := renderInterpreter(tt.input, contextWith(tt.data))
+			_, vmErr := renderVM(tt.input, contextWith(tt.data))
+			require.Error(t, interpreterErr)
+			require.Error(t, vmErr)
+			require.Equal(t, interpreterErr.Error(), vmErr.Error())
+			require.Contains(t, vmErr.Error(), tt.line)
+		})
+	}
+}
+
+func Test_Parity_Phase_13_Parser_And_EOF_Syntax_Errors(t *testing.T) {
+	compareExactRenderError(t, `<% let = %>`, emptyContext)
+	compareBothRenderError(t, `<%= if true %>bad<% } %>`, emptyContext)
+	compareBothRenderError(t, `<%= foo("unterminated) %>`, contextWith(map[string]interface{}{
+		"foo": func(string) string { return "" },
+	}))
+}
+
+func phase13Data() map[string]interface{} {
+	return map[string]interface{}{
+		"robot": phase13Robot{
+			Name:    "bender",
+			Friends: []phase13Robot{{Name: "fry"}},
+			hidden:  "secret",
+		},
+	}
+}
+
+func compareExactRenderError(t *testing.T, input string, factory func() hctx.Context) {
+	t.Helper()
+
+	interpreterOut, interpreterErr := renderInterpreter(input, factory)
+	vmOut, vmErr := renderVM(input, factory)
+
+	require.Error(t, interpreterErr, "expected interpreter error, got output %q", interpreterOut)
+	require.Error(t, vmErr, "expected VM error, got output %q", vmOut)
+	require.Equal(t, interpreterOut, vmOut)
+	require.Equal(t, interpreterErr.Error(), vmErr.Error())
+}

--- a/VM/plush/parity_functions_test.go
+++ b/VM/plush/parity_functions_test.go
@@ -1,0 +1,162 @@
+package plush_test
+
+import (
+	"errors"
+	"html/template"
+	"testing"
+)
+
+type parityPointerArgSection struct {
+	Name string
+}
+
+func Test_Parity_Functions_Helper_Call(t *testing.T) {
+	compareRender(t, `<%= greet(name) %>`, contextWith(map[string]interface{}{
+		"name": "mark",
+		"greet": func(name string) string {
+			return "hello " + name
+		},
+	}))
+}
+
+func Test_Parity_Functions_Helper_Call_With_Value_For_Pointer_Arg(t *testing.T) {
+	compareRender(t, `<%= render_section(section) %>`, contextWith(map[string]interface{}{
+		"section": parityPointerArgSection{Name: "hero"},
+		"render_section": func(section *parityPointerArgSection) string {
+			return section.Name
+		},
+	}))
+}
+
+func Test_Parity_Functions_User_Function(t *testing.T) {
+	compareRender(t, `<% let add = fn(x) { return x + 2 } %><%= add(3) %>`, emptyContext)
+}
+
+func Test_Parity_Functions_Unknown_Function_Errors(t *testing.T) {
+	compareBothRenderError(t, `<p><%= f() %></p>`, emptyContext)
+}
+
+func Test_Parity_Functions_Helper_Error_Return(t *testing.T) {
+	compareBothRenderError(t, `<p><%= fail() %></p>`, contextWith(map[string]interface{}{
+		"fail": func() (string, error) {
+			return "hi", errors.New("oops")
+		},
+	}))
+}
+
+func Test_Parity_Functions_Nil_Arg(t *testing.T) {
+	compareRender(t, `<%= lookup(nil, "k") %><%= lookup(one, "k") %>`, contextWith(map[string]interface{}{
+		"one": map[string]string{
+			"k": "test",
+		},
+		"lookup": func(values map[string]string, key string) string {
+			if values == nil {
+				return ""
+			}
+			return values[key]
+		},
+	}))
+}
+
+func Test_Parity_Functions_Undefined_Arg_Errors(t *testing.T) {
+	compareBothRenderError(t, `<%= foo(bar) %>`, contextWith(map[string]interface{}{
+		"foo": func(string) {},
+	}))
+}
+
+func Test_Parity_Functions_Early_Return(t *testing.T) {
+	compareRender(t, `<%
+let numberify = fn(arg) {
+	if (arg == "one") {
+		return 1 + 1
+	}
+	if (arg == "two") {
+		return 44
+	}
+	return "unsupported"
+} %><%= numberify("one") %>`, emptyContext)
+}
+
+type paritySecretData struct {
+	Secret   bool
+	GiveHint bool
+	String   string
+}
+
+type parityGreeter struct{}
+
+func (parityGreeter) Greet(name string) string {
+	return "hi " + name + "!"
+}
+
+func Test_Parity_Functions_Nested_Return_With_Default_Helper(t *testing.T) {
+	input := `<%
+let print = fn(obj) {
+	if (obj.Secret) {
+		if (obj.GiveHint) {
+			return truncate(obj.String, {size: 12, trail: "****"})
+		}
+		return "**********"
+	}
+	return obj.String
+}
+%>You are: <%= print(data) %>.`
+
+	cases := []map[string]interface{}{
+		{"data": paritySecretData{Secret: true, String: "your royal highness"}},
+		{"data": paritySecretData{Secret: true, GiveHint: true, String: "your royal highness"}},
+		{"data": paritySecretData{Secret: false, String: "your royal highness"}},
+	}
+
+	for _, data := range cases {
+		compareRender(t, input, contextWith(data))
+	}
+}
+
+func Test_Parity_Functions_Method_Call_On_Callee(t *testing.T) {
+	compareRender(t, `<p><%= g.Greet("mark") %></p>`, contextWith(map[string]interface{}{
+		"g": parityGreeter{},
+	}))
+}
+
+func Test_Parity_Functions_Optional_Map_Arg(t *testing.T) {
+	compareRender(t, `<%= foo() %>|<%= bar({a: "A"}) %>`, contextWith(map[string]interface{}{
+		"foo": func(opts map[string]interface{}) string {
+			return "foo"
+		},
+		"bar": func(opts map[string]interface{}) string {
+			return opts["a"].(string)
+		},
+	}))
+}
+
+func Test_Parity_Functions_Dash_In_Helper(t *testing.T) {
+	compareRender(t, `<%= my-helper() %>`, contextWith(map[string]interface{}{
+		"my-helper": func() string {
+			return "hello"
+		},
+	}))
+}
+
+func Test_Parity_Functions_Closure(t *testing.T) {
+	input := `<% let newAdder = fn(x) { return fn(y) { return x + y } } %><% let addTwo = newAdder(2) %><%= addTwo(3) %>`
+	out, err := renderVM(input, emptyContext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "5" {
+		t.Fatalf("expected VM closure output %q, got %q", "5", out)
+	}
+}
+
+func Test_Parity_Functions_Recursion(t *testing.T) {
+	compareRender(t, `<% let countdown = fn(x) { if (x == 0) { return 0 } return countdown(x - 1) } %><%= countdown(3) %>`, emptyContext)
+}
+
+func Test_Parity_Functions_Backtick_String(t *testing.T) {
+	compareRender(t, "<%= raw(`CREATE VIEW x AS SELECT \"name\" FROM things`) %>", contextWith(map[string]interface{}{
+		"raw": func(value string) template.HTML {
+			return template.HTML(value)
+		},
+	}))
+}

--- a/VM/plush/parity_harness_test.go
+++ b/VM/plush/parity_harness_test.go
@@ -1,0 +1,69 @@
+package plush_test
+
+import (
+	"testing"
+
+	rootplush "github.com/gobuffalo/plush/v5"
+	vmplush "github.com/gobuffalo/plush/v5/VM/plush"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+	"github.com/stretchr/testify/require"
+)
+
+type contextFactory func() hctx.Context
+
+func emptyContext() hctx.Context {
+	return rootplush.NewContext()
+}
+
+func contextWith(data map[string]interface{}) contextFactory {
+	return func() hctx.Context {
+		return rootplush.NewContextWith(data)
+	}
+}
+
+func compareRender(t *testing.T, input string, factory contextFactory) {
+	t.Helper()
+
+	interpreterOut, interpreterErr := renderInterpreter(input, factory)
+	vmOut, vmErr := renderVM(input, factory)
+
+	require.Equalf(t, errorString(interpreterErr), errorString(vmErr), "error mismatch\ninterpreter: %q\nvm:          %q", errorString(interpreterErr), errorString(vmErr))
+	require.Equalf(t, interpreterOut, vmOut, "output mismatch\ninterpreter: %q\nvm:          %q", interpreterOut, vmOut)
+}
+
+func compareRenderError(t *testing.T, input string, factory contextFactory) {
+	t.Helper()
+
+	interpreterOut, interpreterErr := renderInterpreter(input, factory)
+	vmOut, vmErr := renderVM(input, factory)
+
+	require.Error(t, interpreterErr, "expected interpreter error, got output %q", interpreterOut)
+	require.Error(t, vmErr, "expected VM error, got output %q", vmOut)
+	require.Equalf(t, interpreterOut, vmOut, "error output mismatch\ninterpreter: %q\nvm:          %q", interpreterOut, vmOut)
+	require.Equalf(t, interpreterErr.Error(), vmErr.Error(), "error mismatch\ninterpreter: %q\nvm:          %q", interpreterErr.Error(), vmErr.Error())
+}
+
+func compareBothRenderError(t *testing.T, input string, factory contextFactory) {
+	t.Helper()
+
+	interpreterOut, interpreterErr := renderInterpreter(input, factory)
+	vmOut, vmErr := renderVM(input, factory)
+
+	require.Error(t, interpreterErr, "expected interpreter error, got output %q", interpreterOut)
+	require.Error(t, vmErr, "expected VM error, got output %q", vmOut)
+}
+
+func renderInterpreter(input string, factory contextFactory) (string, error) {
+	return rootplush.Render(input, factory())
+}
+
+func renderVM(input string, factory contextFactory) (string, error) {
+	return vmplush.Render(input, factory())
+}
+
+func errorString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/VM/plush/parity_helpers_test.go
+++ b/VM/plush/parity_helpers_test.go
@@ -1,0 +1,226 @@
+package plush_test
+
+import (
+	"errors"
+	"fmt"
+	"html/template"
+	"testing"
+
+	rootplush "github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Parity_Phase_6_Helper_Invocation_Matrix(t *testing.T) {
+	t.Run("context and positional args", func(t *testing.T) {
+		compareRender(t, `<%= greet(name) %>`, contextWith(map[string]interface{}{
+			"name": "mark",
+			"greet": func(name string) string {
+				return "hi " + name
+			},
+		}))
+	})
+
+	t.Run("variable arg expression", func(t *testing.T) {
+		compareRender(t, `<%= greet(first + last) %>`, contextWith(map[string]interface{}{
+			"first": "ma",
+			"last":  "rk",
+			"greet": func(name string) string {
+				return "hi " + name
+			},
+		}))
+	})
+
+	t.Run("variadic helpers", func(t *testing.T) {
+		compareRender(t, `<%= count(1, 2, 3) %>|<%= prefix("a", "b", "c") %>|<%= empty() %>|<%= fixed(4) %>`, contextWith(map[string]interface{}{
+			"count": func(values ...int) int {
+				return len(values)
+			},
+			"prefix": func(first string, rest ...string) string {
+				return first + fmt.Sprint(len(rest))
+			},
+			"empty": func(values ...int) int {
+				return len(values)
+			},
+			"fixed": func(first int, rest ...int) int {
+				return first + len(rest)
+			},
+		}))
+	})
+
+	t.Run("variadic wrong type errors", func(t *testing.T) {
+		compareBothRenderError(t, `<%= count(1, 2, "bad") %>`, contextWith(map[string]interface{}{
+			"count": func(values ...int) int {
+				return len(values)
+			},
+		}))
+	})
+
+	t.Run("nil args", func(t *testing.T) {
+		compareRender(t, `<%= lookup(nil, "k") %><%= lookup(one, "k") %>`, contextWith(map[string]interface{}{
+			"one": map[string]string{"k": "test"},
+			"lookup": func(values map[string]string, key string) string {
+				if values == nil {
+					return ""
+				}
+				return values[key]
+			},
+		}))
+	})
+}
+
+func Test_Parity_Phase_6_Helper_Return_Matrix(t *testing.T) {
+	t.Run("no return", func(t *testing.T) {
+		compareRender(t, `<%= remember("x") %><%= value %>`, contextWith(map[string]interface{}{
+			"value": "",
+			"remember": func(value string) {
+			},
+		}))
+	})
+
+	t.Run("single return", func(t *testing.T) {
+		compareRender(t, `<%= greet() %>`, contextWith(map[string]interface{}{
+			"greet": func() string {
+				return "hello"
+			},
+		}))
+	})
+
+	t.Run("value error success", func(t *testing.T) {
+		compareRender(t, `<%= greet() %>`, contextWith(map[string]interface{}{
+			"greet": func() (string, error) {
+				return "hello", nil
+			},
+		}))
+	})
+
+	t.Run("value error failure", func(t *testing.T) {
+		compareBothRenderError(t, `<%= fail() %>`, contextWith(map[string]interface{}{
+			"fail": func() (string, error) {
+				return "hidden", errors.New("phase6 failure")
+			},
+		}))
+	})
+}
+
+func Test_Parity_Phase_6_Optional_Injection_Matrix(t *testing.T) {
+	t.Run("map injection", func(t *testing.T) {
+		compareRender(t, `<%= foo() %>|<%= bar({name: "mark"}) %>`, contextWith(map[string]interface{}{
+			"foo": func(opts map[string]interface{}) string {
+				return fmt.Sprint(len(opts))
+			},
+			"bar": func(opts map[string]interface{}) string {
+				return opts["name"].(string)
+			},
+		}))
+	})
+
+	t.Run("plush helper context", func(t *testing.T) {
+		compareRender(t, `<%= blockCheck() { return "block" } %>|<%= blockCheck() %>`, contextWith(map[string]interface{}{
+			"blockCheck": func(help rootplush.HelperContext) string {
+				if help.HasBlock() {
+					body, _ := help.Block()
+					return body
+				}
+				return "no block"
+			},
+		}))
+	})
+
+	t.Run("hctx helper context", func(t *testing.T) {
+		compareRender(t, `<%= blockCheck() { return "block" } %>|<%= blockCheck() %>`, contextWith(map[string]interface{}{
+			"blockCheck": func(help hctx.HelperContext) string {
+				if help.HasBlock() {
+					body, _ := help.Block()
+					return body
+				}
+				return "no block"
+			},
+		}))
+	})
+}
+
+func Test_Parity_Phase_6_Helper_Context_Block_With_And_Render(t *testing.T) {
+	t.Run("block with child context", func(t *testing.T) {
+		compareRender(t, `<%= wrap({name: "mark"}) { return prefix + name } %><%= name %>`, contextWith(map[string]interface{}{
+			"name":   "outer",
+			"prefix": "hi ",
+			"wrap": func(data map[string]interface{}, help rootplush.HelperContext) (template.HTML, error) {
+				ctx := help.New()
+				for k, v := range data {
+					ctx.Set(k, v)
+				}
+				body, err := help.BlockWith(ctx)
+				return template.HTML(body), err
+			},
+		}))
+	})
+
+	t.Run("render with current context", func(t *testing.T) {
+		compareRender(t, `<%= renderSnippet() %>`, contextWith(map[string]interface{}{
+			"name": "mark",
+			"renderSnippet": func(help rootplush.HelperContext) (template.HTML, error) {
+				body, err := help.Render(`<strong><%= name %></strong>`)
+				return template.HTML(body), err
+			},
+		}))
+	})
+}
+
+func Test_Parity_Phase_6_Helper_Block_Scope_Behavior(t *testing.T) {
+	t.Run("assignment updates outer scope", func(t *testing.T) {
+		compareRender(t, `<% let value = "before" %><%= run() { value = "after" } %><%= value %>`, contextWith(map[string]interface{}{
+			"run": func(help rootplush.HelperContext) string {
+				body, _ := help.Block()
+				return body
+			},
+		}))
+	})
+
+	t.Run("local let does not leak", func(t *testing.T) {
+		compareBothRenderError(t, `<%= run() { let inner = "secret" } %><%= inner %>`, contextWith(map[string]interface{}{
+			"run": func(help rootplush.HelperContext) string {
+				body, _ := help.Block()
+				return body
+			},
+		}))
+	})
+}
+
+func Test_Parity_Phase_6_Method_Calls_And_Helper_Return_Chains(t *testing.T) {
+	compareRender(t, `<%= greeter.Greet("mark") %>|<%= makeGreeter().Greet("mido") %>|<%= makeName().Echo() %>`, contextWith(map[string]interface{}{
+		"greeter": phase6Greeter{},
+		"makeGreeter": func() phase6Greeter {
+			return phase6Greeter{}
+		},
+		"makeName": func() phase6Name {
+			return phase6Name("plush")
+		},
+	}))
+}
+
+type phase6Greeter struct{}
+
+func (phase6Greeter) Greet(name string) string {
+	return "hi " + name
+}
+
+type phase6Name string
+
+func (n phase6Name) Echo() string {
+	return string(n)
+}
+
+func Test_Parity_Phase_6_Unknown_Helper_Errors(t *testing.T) {
+	compareBothRenderError(t, `<%= missingHelper() %>`, emptyContext)
+}
+
+func Test_Parity_Phase_6_Helper_Error_Contains_Returned_Error(t *testing.T) {
+	_, err := renderVM(`<%= fail() %>`, contextWith(map[string]interface{}{
+		"fail": func() (string, error) {
+			return "", errors.New("phase6 returned error")
+		},
+	}))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "phase6 returned error")
+}

--- a/VM/plush/parity_holes_test.go
+++ b/VM/plush/parity_holes_test.go
@@ -1,0 +1,120 @@
+package plush_test
+
+import (
+	"html/template"
+	"testing"
+
+	rootplush "github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+	"github.com/gobuffalo/plush/v5/helpers/meta"
+)
+
+func holeContext(data map[string]interface{}) contextFactory {
+	return func() hctx.Context {
+		ctx := contextWith(data)()
+		ctx.Set(meta.TemplateFileKey, "phase10.plush")
+		return ctx
+	}
+}
+
+func Test_Parity_Holes_No_Filename_Returns_Skeleton(t *testing.T) {
+	compareRender(t, `<%H "hello" %>`, emptyContext)
+}
+
+func Test_Parity_Holes_Simple(t *testing.T) {
+	compareRender(t, `<%H "hello" %>`, holeContext(nil))
+}
+
+func Test_Parity_Holes_Error_In_Hole(t *testing.T) {
+	compareRender(t, `<%H missing_helper" %><%H "ok" %>`, holeContext(nil))
+}
+
+func Test_Parity_Holes_Positions_And_Counts(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "multiple holes at end",
+			input: `<%= "x" %><%H "a" %><%H "b" %><%H "c" %>`,
+		},
+		{
+			name:  "holes at start",
+			input: `<%H "a" %><%H "b" %><%= "x" %>`,
+		},
+		{
+			name:  "hole at start and end",
+			input: `<%H "start" %>middle<%H "end" %>`,
+		},
+		{
+			name:  "empty holes",
+			input: `<%H "" %>foo<%H  %>`,
+		},
+		{
+			name:  "literal marker preserved",
+			input: `<PLUSH_HOLE_0><%H "start" %><%H "end" %>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			compareRender(t, tt.input, holeContext(nil))
+		})
+	}
+}
+
+func Test_Parity_Holes_Many(t *testing.T) {
+	input := ""
+	for i := 0; i < 100; i++ {
+		input += `<%H "x" %>`
+	}
+	compareRender(t, input, holeContext(nil))
+}
+
+func Test_Parity_Holes_Inside_If_Blocks(t *testing.T) {
+	compareRender(t, `<%= if (a == "22") { %><%H "testing" %><% } else { %><%H "dddd" %><% } %>`, holeContext(map[string]interface{}{
+		"a": "22",
+	}))
+	compareRender(t, `<%H if (number > 0){ %><%= "NUMBER" %><% } else { %><%= number %><%  }%>`, holeContext(map[string]interface{}{
+		"number": 3,
+	}))
+}
+
+func Test_Parity_Holes_Loop_Body(t *testing.T) {
+	compareRender(t, `<%= for (i,v) in items { %><%H "testing" %><%= v %><% } %>`, holeContext(map[string]interface{}{
+		"items": []string{"a", "b", "c"},
+	}))
+	compareRender(t, `<%H for (i,v) in items { %><%= v %><% } %>`, holeContext(map[string]interface{}{
+		"items": []string{"a", "b", "c"},
+	}))
+}
+
+func Test_Parity_Holes_Inside_Helper_Block(t *testing.T) {
+	compareRender(t, `<%= wrap() { %><%H "inside" %><% } %>`, holeContext(map[string]interface{}{
+		"wrap": func(help rootplush.HelperContext) (template.HTML, error) {
+			body, err := help.Block()
+			return template.HTML("<span>" + body + "</span>"), err
+		},
+	}))
+}
+
+func Test_Parity_Holes_Inside_Partial(t *testing.T) {
+	compareRender(t, `<%= partial("hole.plush") %>`, holeContext(map[string]interface{}{
+		"partialFeeder": func(name string) (string, error) {
+			return `<span><%H "inside" %></span>`, nil
+		},
+	}))
+}
+
+func Test_Parity_Holes_Recursive_Partial(t *testing.T) {
+	compareRender(t, `<%= partial("index.plush") %>`, holeContext(map[string]interface{}{
+		"number": 3,
+		"partialFeeder": func(string) (string, error) {
+			return `<%=
+		if (number > 0) { %><%
+			let number = number - 1 %><%=
+			partial("index.plush") %><%H number %>, <%
+		} %>`, nil
+		},
+	}))
+}

--- a/VM/plush/parity_loops_test.go
+++ b/VM/plush/parity_loops_test.go
@@ -1,0 +1,164 @@
+package plush_test
+
+import (
+	"strings"
+	"testing"
+)
+
+type parityLoopMenu struct {
+	Items []parityLoopItem
+}
+
+type parityLoopItem struct {
+	Name  string
+	Count int
+}
+
+func Test_Parity_Loops_Array_Return(t *testing.T) {
+	compareRender(t, `<%= for (i,v) in ["a", "b", "c"] { return v } %>`, emptyContext)
+}
+
+func Test_Parity_Loops_Context_Slice(t *testing.T) {
+	compareRender(t, `<%= for (i,v) in items { %><%= i %>:<%= v %>;<% } %>`, contextWith(map[string]interface{}{
+		"items": []string{"a", "b"},
+	}))
+}
+
+func Test_Parity_Loops_Key_Only(t *testing.T) {
+	compareRender(t, `<%= for (v) in ["a", "b", "c"] {%><%=v%><%} %>`, emptyContext)
+}
+
+func Test_Parity_Loops_Key_Value_And_Outer_Same_Identifier(t *testing.T) {
+	compareRender(t, `<%= for (i,v) in ["a", "b", "c"] {%><%=i%><%=v%><%} %>`, emptyContext)
+	compareRender(t, `<% let i = 10000 %><%= for (i,v) in ["a", "b", "c"] {%><%=i%><%=v%><%} %><%= i %>`, emptyContext)
+}
+
+func Test_Parity_Loops_Update_Outer_Binding(t *testing.T) {
+	compareRender(t, `<% let varTest = "" %><% for (i,v) in ["a", "b", "c"] {varTest = v} %><%= varTest %>`, emptyContext)
+}
+
+func Test_Parity_Loops_Continue(t *testing.T) {
+	compareRender(t, `<%= for (i,v) in [1, 2, 3] { if (v == 2) { continue } return v } %>`, emptyContext)
+}
+
+func Test_Parity_Loops_Break(t *testing.T) {
+	compareRender(t, `<%= for (i,v) in [1, 2, 3] { if (v == 2) { break } return v } %>`, emptyContext)
+}
+
+func Test_Parity_Loops_Continue_Output_Accumulation(t *testing.T) {
+	compareRender(t, `<%= for (i,v) in [1, 2, 3, 4] {
+		%>Start<%
+		if (v == 1 || v == 3) {
+			%>Odd<%
+			continue
+		}
+		return v
+	} %>`, emptyContext)
+}
+
+func Test_Parity_Loops_Continue_No_Output(t *testing.T) {
+	compareRender(t, `<%= for (i,v) in [1, 2, 3] {
+		continue
+		return v
+	} %>`, emptyContext)
+}
+
+func Test_Parity_Loops_Break_Output_Accumulation(t *testing.T) {
+	compareRender(t, `<%= for (i,v) in [1, 2, 3, 4] {
+		%>Start<%
+		if (v == 3) {
+			%>Stop<%
+			break
+		}
+		return v
+	} %>`, emptyContext)
+}
+
+func Test_Parity_Loops_Break_First_Value_With_Output(t *testing.T) {
+	compareRender(t, `<%= for (i,v) in [1, 2, 3] {
+		if (v == 1) {
+			%><%=v%><%
+			break
+		}
+		return v
+	} %>`, emptyContext)
+}
+
+func Test_Parity_Loops_Single_Entry_Map(t *testing.T) {
+	compareRender(t, `<%= for (k,v) in myMap { %><%= k + ":" + v%><% } %>`, contextWith(map[string]interface{}{
+		"myMap": map[string]string{
+			"a": "A",
+		},
+	}))
+}
+
+func Test_Parity_Loops_Map_Contains_Entries(t *testing.T) {
+	input := `<%= for (k,v) in myMap { %><%= k + ":" + v%>;<% } %>`
+	factory := contextWith(map[string]interface{}{
+		"myMap": map[string]string{
+			"a": "A",
+			"b": "B",
+		},
+	})
+
+	interpreterOut, interpreterErr := renderInterpreter(input, factory)
+	vmOut, vmErr := renderVM(input, factory)
+	if interpreterErr != nil || vmErr != nil {
+		t.Fatalf("unexpected errors\ninterpreter: %v\nvm: %v", interpreterErr, vmErr)
+	}
+	for _, fragment := range []string{"a:A;", "b:B;"} {
+		if !strings.Contains(interpreterOut, fragment) {
+			t.Fatalf("interpreter output %q missing %q", interpreterOut, fragment)
+		}
+		if !strings.Contains(vmOut, fragment) {
+			t.Fatalf("VM output %q missing %q", vmOut, fragment)
+		}
+	}
+}
+
+func Test_Parity_Loops_Nested_Slices(t *testing.T) {
+	compareRender(t, `<%= for (i,row) in rows { %><%= for (j,col) in row { %><%= i %>,<%= j %>:<%= col %>;<% } %><% } %>`, contextWith(map[string]interface{}{
+		"rows": [][]string{{"a", "b"}, {"c"}},
+	}))
+}
+
+func Test_Parity_Loops_Nested_Flash_Style_Condition(t *testing.T) {
+	compareRender(t, `<%= for (k, messages) in flash { %><%= for (msg) in messages { %><%= if (len(messages) && messages[0] != "skip") { %><%= k %>:<%= msg %>;<% } %><% } %><% } %>`, contextWith(map[string]interface{}{
+		"flash": map[string][]string{"notice": {"Hello", "Bye"}},
+	}))
+	compareRender(t, `<%= for (k, messages) in flash { %><%= for (msg) in messages { %><%= if (len(messages) && messages[0] != "skip") { %><%= k %>:<%= msg %>;<% } %><% } %><% } %>`, contextWith(map[string]interface{}{
+		"flash": map[string][]string{"notice": {"skip", "Bye"}},
+	}))
+}
+
+func Test_Parity_Loops_Iterator_Helpers(t *testing.T) {
+	compareRender(t, `<%= for (v) in range(3,5) { %><%=v%><% } %>|<%= for (v) in between(3,6) { %><%=v%><% } %>|<%= for (v) in until(3) { %><%=v%><% } %>`, emptyContext)
+}
+
+func Test_Parity_Loops_Nil_Iterable(t *testing.T) {
+	compareRender(t, `<%= for (i,v) in nil { return v } %>`, emptyContext)
+	compareBothRenderError(t, `<%= for (i,v) in nilValue { return v } %>`, contextWith(map[string]interface{}{
+		"nilValue": nil,
+	}))
+}
+
+func Test_Parity_Loops_Missing_Map_Key_Iterable(t *testing.T) {
+	compareRender(t, `<%= for (k, v) in flash["errors"] { %><%= k %>:<%= v %><% } %>`, contextWith(map[string]interface{}{
+		"flash": map[string][]string{},
+	}))
+}
+
+func Test_Parity_Loops_Prefix_Condition_And_Struct_Field_Concat(t *testing.T) {
+	compareRender(t, `<%= if (!userSignedIn) { %>Guest<% } else { %>User<% } %><%= for (item) in menu.Items { %><%= item.Name + " x " + item.Count %>;<% } %>`, contextWith(map[string]interface{}{
+		"userSignedIn": false,
+		"menu": parityLoopMenu{Items: []parityLoopItem{
+			{Name: "One", Count: 2},
+			{Name: "Two", Count: 3},
+		}},
+	}))
+}
+
+func Test_Parity_Loops_Iterator_Scope_Does_Not_Leak(t *testing.T) {
+	compareBothRenderError(t, `<%= for (i,v) in ["a"] { %><%= i %>:<%= v %><% } %><%= i %>`, emptyContext)
+	compareBothRenderError(t, `<%= for (i,v) in ["a"] { %><%= i %>:<%= v %><% } %><%= v %>`, emptyContext)
+}

--- a/VM/plush/parity_math_test.go
+++ b/VM/plush/parity_math_test.go
@@ -1,0 +1,182 @@
+package plush_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type parityNumericStats struct {
+	Count uint64
+}
+
+type parityNumericRobot struct {
+	Count uint32
+	Stats parityNumericStats
+}
+
+func (r parityNumericRobot) MethodCount() uint32 {
+	return r.Count
+}
+
+func Test_Parity_Math_Integer_Operators(t *testing.T) {
+	tests := []string{
+		`<%= 1 + 3 %>`,
+		`<%= 3 - 1 %>`,
+		`<%= 10 / 2 %>`,
+		`<%= 10 * 2 %>`,
+		`<%= 10 > 2 %>`,
+		`<%= 10 >= 2 %>`,
+		`<%= 10 >= 10 %>`,
+		`<%= 2 <= 2 %>`,
+		`<%= 10 < 2 %>`,
+		`<%= 10 <= 2 %>`,
+		`<%= 2 == 2 %>`,
+		`<%= 1 != 2 %>`,
+	}
+
+	for _, input := range tests {
+		compareRender(t, input, emptyContext)
+	}
+}
+
+func Test_Parity_Math_Float_Operators(t *testing.T) {
+	tests := []string{
+		`<%= 1.0 + 3.0 %>`,
+		`<%= 3.0 - 1.0 %>`,
+		`<%= 10.0 / 2.0 %>`,
+		`<%= 10.0 * 2.0 %>`,
+		`<%= 10.0 > 2.0 %>`,
+		`<%= 10.0 >= 2.0 %>`,
+		`<%= 10.0 >= 10.0 %>`,
+		`<%= 2.0 <= 2.0 %>`,
+		`<%= 10.0 < 2.0 %>`,
+		`<%= 10.0 <= 2.0 %>`,
+		`<%= 2.0 == 2.0 %>`,
+		`<%= 1.0 != 2.0 %>`,
+	}
+
+	for _, input := range tests {
+		compareRender(t, input, emptyContext)
+	}
+}
+
+func Test_Parity_Math_String_Operators(t *testing.T) {
+	tests := []string{
+		`<%= "a" + "b" %>`,
+		`<%= "a" + "b" + "c" %>`,
+		`<%= "a" != "b" %>`,
+		`<%= "a" == "a" %>`,
+		`<%= "a" == "b" %>`,
+		`<%= "a" > "b" %>`,
+		`<%= "a" >= "b" %>`,
+		`<%= "a" <= "b" %>`,
+	}
+
+	for _, input := range tests {
+		compareRender(t, input, emptyContext)
+	}
+}
+
+func Test_Parity_Math_Undefined_Equality_Operators(t *testing.T) {
+	compareRender(t, `<%= undefined == 3 %>`, emptyContext)
+	compareRender(t, `<%= undefined != 3 %>`, emptyContext)
+	compareRender(t, `<%= 3 == unknown %>`, emptyContext)
+	compareRender(t, `<%= 3 != unknown %>`, emptyContext)
+}
+
+func Test_Parity_Math_Undefined_Arithmetic_Operators_Error(t *testing.T) {
+	compareBothRenderError(t, `<%= undefined + 3 %>`, emptyContext)
+	compareBothRenderError(t, `<%= 3 + unknown %>`, emptyContext)
+	compareBothRenderError(t, `<%= undefined > 3 %>`, emptyContext)
+}
+
+func Test_Parity_Math_String_Int_Concat(t *testing.T) {
+	compareRender(t, `<%= "a" + 1 %>`, emptyContext)
+}
+
+func Test_Parity_Math_Bool_Concat(t *testing.T) {
+	compareRender(t, `<%= true + 1 %>`, emptyContext)
+}
+
+func Test_Parity_Math_Division_By_Zero_Errors(t *testing.T) {
+	compareBothRenderError(t, `<%= 10 / 0 %>`, emptyContext)
+	compareBothRenderError(t, `<%= 10.5 / 0.0 %>`, emptyContext)
+}
+
+func Test_Parity_Math_Renders_Many_Numeric_Types(t *testing.T) {
+	compareRender(t, `<%= i32 %> <%= u32 %> <%= i8 %>`, contextWith(map[string]interface{}{
+		"i32": int32(1),
+		"u32": uint32(2),
+		"i8":  int8(3),
+	}))
+}
+
+func Test_Parity_Math_Safe_Mixed_Numeric_Comparisons(t *testing.T) {
+	ctx := contextWith(map[string]interface{}{
+		"i32":     int32(0),
+		"i32v":    int32(3),
+		"neg":     int32(-1),
+		"u32":     uint32(0),
+		"u32v":    uint32(3),
+		"u64":     uint64(0),
+		"u64one":  uint64(1),
+		"u64max":  uint64(math.MaxUint64),
+		"f32":     float32(3.5),
+		"f32i":    float32(3),
+		"f64":     float64(3.5),
+		"f64i":    float64(3),
+		"counts":  map[string]uint32{"active": 0},
+		"values":  []uint32{0},
+		"robot":   parityNumericRobot{Count: 0, Stats: parityNumericStats{Count: 0}},
+		"robots":  []parityNumericRobot{{Count: 1, Stats: parityNumericStats{Count: 0}}},
+		"counter": func() uint32 { return 0 },
+	})
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{`<%= i32 == 0 %>`, "true"},
+		{`<%= u32 == 0 %>`, "true"},
+		{`<%= u64 == 0 %>`, "true"},
+		{`<%= u64one > 0 %>`, "true"},
+		{`<%= u64max > 0 %>`, "true"},
+		{`<%= neg < 0 %>`, "true"},
+		{`<%= neg < u64 %>`, "true"},
+		{`<%= neg == u64 %>`, "false"},
+		{`<%= u32v == 3 %>`, "true"},
+		{`<%= f32 == 3.5 %>`, "true"},
+		{`<%= f64 > 3 %>`, "true"},
+		{`<%= f32i == 3 %>`, "true"},
+		{`<%= f64i == i32v %>`, "true"},
+		{`<%= u32v == 3.0 %>`, "true"},
+		{`<%= u64one == 1.0 %>`, "true"},
+		{`<%= robot.Count == 0 %>`, "true"},
+		{`<%= robots[0].Stats.Count == 0 %>`, "true"},
+		{`<%= counts["active"] == 0 %>`, "true"},
+		{`<%= values[0] == 0 %>`, "true"},
+		{`<%= counter() == 0 %>`, "true"},
+		{`<%= robot.MethodCount() == 0 %>`, "true"},
+		{`<%= robot.Count + 1 %>`, "1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			requireBothRender(t, tt.input, tt.expected, ctx)
+		})
+	}
+}
+
+func requireBothRender(t *testing.T, input, expected string, factory contextFactory) {
+	t.Helper()
+
+	interpreterOut, interpreterErr := renderInterpreter(input, factory)
+	require.NoError(t, interpreterErr)
+	require.Equal(t, expected, interpreterOut)
+
+	vmOut, vmErr := renderVM(input, factory)
+	require.NoError(t, vmErr)
+	require.Equal(t, expected, vmOut)
+}

--- a/VM/plush/parity_optional_if_test.go
+++ b/VM/plush/parity_optional_if_test.go
@@ -1,0 +1,127 @@
+package plush_test
+
+import "testing"
+
+type phase9Robot struct {
+	Name string
+}
+
+func Test_Parity_Phase_9_Optional_If_Parentheses(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+		factory  contextFactory
+	}{
+		{
+			name:     "literal true",
+			input:    `<%= if true { %>yes<% } %>`,
+			expected: "yes",
+			factory:  emptyContext,
+		},
+		{
+			name:     "identifier truthy",
+			input:    `<%= if name { %><%= name %><% } %>`,
+			expected: "mark",
+			factory: contextWith(map[string]interface{}{
+				"name": "mark",
+			}),
+		},
+		{
+			name:     "bang identifier",
+			input:    `<%= if !name { %>empty<% } %>`,
+			expected: "empty",
+			factory: contextWith(map[string]interface{}{
+				"name": "",
+			}),
+		},
+		{
+			name:     "equality",
+			input:    `<%= if name == "mark" { %>yes<% } %>`,
+			expected: "yes",
+			factory: contextWith(map[string]interface{}{
+				"name": "mark",
+			}),
+		},
+		{
+			name:     "or expression",
+			input:    `<%= if name == "mark" || admin { %>yes<% } %>`,
+			expected: "yes",
+			factory: contextWith(map[string]interface{}{
+				"name":  "ringo",
+				"admin": true,
+			}),
+		},
+		{
+			name:     "grouped expression with or",
+			input:    `<%= if (name == "mark") || admin { %>yes<% } %>`,
+			expected: "yes",
+			factory: contextWith(map[string]interface{}{
+				"name":  "ringo",
+				"admin": true,
+			}),
+		},
+		{
+			name:     "else if literal",
+			input:    `<%= if false { %>no<% } else if true { %>yes<% } %>`,
+			expected: "yes",
+			factory:  emptyContext,
+		},
+		{
+			name:     "else if expression",
+			input:    `<%= if false { %>no<% } else if name == "mark" { %>yes<% } %>`,
+			expected: "yes",
+			factory: contextWith(map[string]interface{}{
+				"name": "mark",
+			}),
+		},
+		{
+			name:     "indexed struct field",
+			input:    `<%= if robots[0].Name == "mark" { %>yes<% } %>`,
+			expected: "yes",
+			factory: contextWith(map[string]interface{}{
+				"robots": []phase9Robot{{Name: "mark"}},
+			}),
+		},
+		{
+			name:     "indexed array compare identifier",
+			input:    `<%= if robots[0] == mark { %>yes<% } %>`,
+			expected: "yes",
+			factory: contextWith(map[string]interface{}{
+				"robots": []string{"mark"},
+				"mark":   "mark",
+			}),
+		},
+		{
+			name:     "indexed map compare string",
+			input:    `<%= if robots["TESTING"] == "mark" { %>yes<% } %>`,
+			expected: "yes",
+			factory: contextWith(map[string]interface{}{
+				"robots": map[string]string{"TESTING": "mark"},
+			}),
+		},
+		{
+			name:     "old if syntax still works",
+			input:    `<%= if (true) { %>yes<% } %>`,
+			expected: "yes",
+			factory:  emptyContext,
+		},
+		{
+			name:     "old else if syntax still works",
+			input:    `<%= if (false) { %>no<% } else if (true) { %>yes<% } %>`,
+			expected: "yes",
+			factory:  emptyContext,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requireBothRender(t, tt.input, tt.expected, tt.factory)
+		})
+	}
+}
+
+func Test_Parity_Phase_9_Optional_If_Parentheses_Errors(t *testing.T) {
+	compareBothRenderError(t, `<%= if { %>bad<% } %>`, emptyContext)
+	compareBothRenderError(t, `<%= if true %>bad<% } %>`, emptyContext)
+}

--- a/VM/plush/parity_output_test.go
+++ b/VM/plush/parity_output_test.go
@@ -1,0 +1,171 @@
+package plush_test
+
+import (
+	"fmt"
+	"html/template"
+	"testing"
+	"time"
+)
+
+type phase7HTMLer struct {
+	value string
+}
+
+func (h phase7HTMLer) HTML() template.HTML {
+	return template.HTML(h.value)
+}
+
+type phase7InterfaceValue struct {
+	value interface{}
+}
+
+func (v phase7InterfaceValue) Interface() interface{} {
+	return v.value
+}
+
+type phase7Stringer string
+
+func (s phase7Stringer) String() string {
+	return string(s)
+}
+
+func Test_Parity_Phase_7_Escaping_And_HTML_Safety(t *testing.T) {
+	ctx := contextWith(map[string]interface{}{
+		"unsafe":          `<strong>"x"</strong>`,
+		"safeHTML":        template.HTML(`<strong>"x"</strong>`),
+		"htmler":          phase7HTMLer{value: `<em>x</em>`},
+		"interfaceHTML":   phase7InterfaceValue{value: template.HTML(`<i>x</i>`)},
+		"interfaceString": phase7InterfaceValue{value: `<i>x</i>`},
+		"rawStringer":     phase7Stringer(`<b>stringer</b>`),
+	})
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "normal string literal escapes",
+			input:    `<%= "<script>alert('x')</script>" %>`,
+			expected: `&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt;`,
+		},
+		{
+			name:     "injected variable escapes",
+			input:    `<%= unsafe %>`,
+			expected: `&lt;strong&gt;&#34;x&#34;&lt;/strong&gt;`,
+		},
+		{
+			name:     "template html remains raw",
+			input:    `<%= safeHTML %>`,
+			expected: `<strong>"x"</strong>`,
+		},
+		{
+			name:     "htmler remains raw",
+			input:    `<%= htmler %>`,
+			expected: `<em>x</em>`,
+		},
+		{
+			name:     "interface unwraps html",
+			input:    `<%= interfaceHTML %>`,
+			expected: `<i>x</i>`,
+		},
+		{
+			name:     "interface unwraps escaped string",
+			input:    `<%= interfaceString %>`,
+			expected: `&lt;i&gt;x&lt;/i&gt;`,
+		},
+		{
+			name:     "fmt stringer matches interpreter",
+			input:    `<%= rawStringer %>`,
+			expected: `<b>stringer</b>`,
+		},
+		{
+			name:     "raw helper remains raw",
+			input:    `<%= raw("<u>x</u>") %>`,
+			expected: `<u>x</u>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requireBothRender(t, tt.input, tt.expected, ctx)
+		})
+	}
+}
+
+func Test_Parity_Phase_7_Time_Formatting(t *testing.T) {
+	tm := time.Date(2013, time.February, 3, 0, 0, 0, 0, time.UTC)
+
+	requireBothRender(t, `<%= tm %>|<%= ptr %>`, "February 03, 2013 00:00:00 +0000|February 03, 2013 00:00:00 +0000", contextWith(map[string]interface{}{
+		"tm":  tm,
+		"ptr": &tm,
+	}))
+
+	requireBothRender(t, `<%= tm %>|<%= ptr %>`, "2013-03-Feb|2013-03-Feb", contextWith(map[string]interface{}{
+		"tm":          tm,
+		"ptr":         &tm,
+		"TIME_FORMAT": "2006-02-Jan",
+	}))
+}
+
+func Test_Parity_Phase_7_Numbers_Bools_Arrays_And_Nil(t *testing.T) {
+	ctx := contextWith(map[string]interface{}{
+		"i":       int32(1),
+		"u":       uint32(2),
+		"f":       float32(3.5),
+		"truthy":  true,
+		"falsy":   false,
+		"strings": []string{"a", "<b>"},
+		"mixed":   []interface{}{"x", template.HTML("<y>"), 7, false, nil},
+	})
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "numbers render like interpreter",
+			input:    `<%= i %>|<%= u %>|<%= f %>|<%= 4 %>|<%= 5.25 %>`,
+			expected: `1|2|3.5|4|5.25`,
+		},
+		{
+			name:     "bools render like interpreter",
+			input:    `<%= truthy %>|<%= falsy %>|<%= true %>|<%= false %>`,
+			expected: `true|false|true|false`,
+		},
+		{
+			name:     "array literal writes elements",
+			input:    `<%= ["a", "<b>", 3, false, nil] %>`,
+			expected: `a&lt;b&gt;3false`,
+		},
+		{
+			name:     "native string slice writes elements",
+			input:    `<%= strings %>`,
+			expected: `a&lt;b&gt;`,
+		},
+		{
+			name:     "native interface slice writes elements",
+			input:    `<%= mixed %>`,
+			expected: `x<y>7false`,
+		},
+		{
+			name:     "nil renders empty",
+			input:    `<%= nil %>`,
+			expected: ``,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requireBothRender(t, tt.input, tt.expected, ctx)
+		})
+	}
+}
+
+func Test_Parity_Phase_7_Interface_Stringer_Ordering(t *testing.T) {
+	value := phase7InterfaceValue{value: phase7Stringer(fmt.Sprintf("<%s>", "wrapped"))}
+	requireBothRender(t, `<%= value %>`, "<wrapped>", contextWith(map[string]interface{}{
+		"value": value,
+	}))
+}

--- a/VM/plush/parity_partials_test.go
+++ b/VM/plush/parity_partials_test.go
@@ -1,0 +1,342 @@
+package plush_test
+
+import (
+	"fmt"
+	"html/template"
+	"strings"
+	"testing"
+
+	rootplush "github.com/gobuffalo/plush/v5"
+	vmplush "github.com/gobuffalo/plush/v5/VM/plush"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+	"github.com/gobuffalo/plush/v5/helpers/meta"
+	"github.com/gobuffalo/plush/v5/templatecache/inmemory"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Parity_Partials_Simple(t *testing.T) {
+	compareRender(t, `<%= partial("hello.plush") %>`, contextWith(map[string]interface{}{
+		"partialFeeder": func(name string) (string, error) {
+			return `<p>Hello</p>`, nil
+		},
+	}))
+}
+
+func Test_Parity_Phase_12_Nested_Partial_Path_Metadata(t *testing.T) {
+	gg := meta.TemplateFileKey
+	partials := map[string]string{
+		"partials/code-1.plush.html": `<%= partial("testing/code-2.plush.html") %>`,
+		"testing/code-2.plush.html":  `<%= partial("testing/code-3.plush.html") %>`,
+		"testing/code-3.plush.html":  `CODE3 PRINT <%= ` + gg + ` %>`,
+	}
+
+	compareRender(t, `<%= partial("partials/code-1.plush.html") %>`, func() hctx.Context {
+		ctx := rootplush.NewContext()
+		ctx.Set("partialFeeder", func(name string) (string, error) {
+			return partials[name], nil
+		})
+		ctx.Set(meta.TemplateBaseFileNameKey, "path/product_listing")
+		ctx.Set(meta.TemplateFileKey, "/fake/templates/path/product_listing.html")
+		ctx.Set(meta.TemplateExtensionKey, "html")
+		return ctx
+	})
+}
+
+func Test_Parity_Phase_12_Partials_Data_Recursion_Layout_And_Yield(t *testing.T) {
+	compareRender(t, `<%= partial("card", {name: "Mido", layout: "shell"}) %>`, contextWith(map[string]interface{}{
+		"partialFeeder": func(name string) (string, error) {
+			if name == "shell" {
+				return `<main><%= yield %></main>`, nil
+			}
+			return `<p>Hello <%= name %></p>`, nil
+		},
+	}))
+
+	compareRender(t, `<%= partial("count") %><%= number %>`, contextWith(map[string]interface{}{
+		"number": 3,
+		"partialFeeder": func(string) (string, error) {
+			return `<%= if (number > 0) { %><% let number = number - 1 %><%= partial("count") %><%= number %>, <% } %>`, nil
+		},
+	}))
+}
+
+func Test_Parity_Partials_Data_Map_Values(t *testing.T) {
+	compareRender(t, `<%= partial("row", {name: first, title: robot.Name}) %>|<%= partial("row", {name: second, title: "literal"}) %>|<%= name %>`, contextWith(map[string]interface{}{
+		"name":   "Outer",
+		"first":  "Mido",
+		"second": "Fry",
+		"robot": struct {
+			Name string
+		}{Name: "Bender"},
+		"partialFeeder": func(string) (string, error) {
+			return `<span><%= name %>:<%= title %></span>`, nil
+		},
+	}))
+}
+
+func Test_Parity_Partials_Data_Map_Helper_Call_Value(t *testing.T) {
+	compareRender(t, `<%= partial("row", {label: label(product.Name, prefix)}) %>|<%= product.Name %>`, contextWith(map[string]interface{}{
+		"product": struct {
+			Name string
+		}{Name: "<Bender>"},
+		"prefix": "robot",
+		"label": func(name string, prefix string) string {
+			return prefix + ":" + name
+		},
+		"partialFeeder": func(string) (string, error) {
+			return `<span><%= label %></span>`, nil
+		},
+	}))
+}
+
+func Test_Parity_Phase_12_Partial_Java_Script_Escaping(t *testing.T) {
+	compareRender(t, `<%= partial("index.html") %>|<%= partial("index.js") %>|<%= partial("index") %>`, contextWith(map[string]interface{}{
+		"contentType": "application/javascript",
+		"partialFeeder": func(string) (string, error) {
+			return `alert('\'Hello\'');`, nil
+		},
+	}))
+
+	compareRender(t, `<%= partial("js_having_html_partial.js") %>|<%= partial("js_having_js_partial.js") %>`, contextWith(map[string]interface{}{
+		"contentType": "application/javascript",
+		"partialFeeder": func(name string) (string, error) {
+			switch name {
+			case "js_having_html_partial.js":
+				return `alert('<%= partial("t1.html") %>');`, nil
+			case "js_having_js_partial.js":
+				return `alert('<%= partial("t1.js") %>');`, nil
+			case "t1.html":
+				return `<div><%= partial("p1.html") %></div>`, nil
+			case "t1.js":
+				return `<div><%= partial("p1.js") %></div>`, nil
+			case "p1.html", "p1.js":
+				return `<span>FORM</span>`, nil
+			default:
+				return "", fmt.Errorf("unknown partial %s", name)
+			}
+		},
+	}))
+}
+
+func Test_Parity_Phase_12_Partial_No_Default_Helper_Override(t *testing.T) {
+	compareRender(t, `<%= partial("index") %>`, contextWith(map[string]interface{}{
+		"truncate": func(s string, opts hctx.Map) string {
+			return s
+		},
+		"partialFeeder": func(string) (string, error) {
+			return `<%= truncate("xxxxxxxxxxxaaaaaaaaaa", {size: 10}) %>`, nil
+		},
+	}))
+}
+
+func Test_Parity_Phase_12_Partial_Feeder_Errors(t *testing.T) {
+	compareBothRenderError(t, `<%= partial("missing") %>`, contextWith(map[string]interface{}{
+		"partialFeeder": func(name string) (string, error) {
+			return "", fmt.Errorf("missing %s", name)
+		},
+	}))
+
+	compareBothRenderError(t, `<%= partial("bad") %>`, contextWith(map[string]interface{}{
+		"partialFeeder": func(string) (string, error) {
+			return `<%= missing </div>`, nil
+		},
+	}))
+}
+
+func Test_Phase_12_VM_Plush_Cache_Hole_Skeleton_For_Plush_Filenames(t *testing.T) {
+	for _, filename := range []string{"phase12.plush", "phase12.plush.html"} {
+		t.Run(filename, func(t *testing.T) {
+			cache := inmemory.NewMemoryCache()
+			rootplush.PlushCacheSetup(cache)
+			defer rootplush.ClearTemplateCache()
+
+			ctx := rootplush.NewContextWith(map[string]interface{}{
+				"items": []string{"a", "b"},
+			})
+			ctx.Set(meta.TemplateFileKey, filename)
+
+			input := `<% let suffix = "1" %><%= items[0] %><%H suffix %><%= items[1] %>`
+			out, err := vmplush.Render(input, ctx)
+			require.NoError(t, err)
+			require.Equal(t, "a1b", out)
+			requireCacheKey(t, cache, rootplush.GenerateASTKey(filename))
+			requireCacheKey(t, cache, "full:"+filename)
+
+			out, err = vmplush.Render(`<% let suffix = "2" %><%= items[0] %><%H suffix %><%= items[1] %>`, ctx)
+			require.NoError(t, err)
+			require.Equal(t, "a2b", out)
+		})
+	}
+}
+
+func Test_Phase_12_VM_Plush_Non_Plush_Filename_Does_Not_Use_Hole_Cache(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	rootplush.PlushCacheSetup(cache)
+	defer rootplush.ClearTemplateCache()
+
+	ctx := rootplush.NewContext()
+	ctx.Set(meta.TemplateFileKey, "phase12.txt")
+
+	out, err := vmplush.Render(`<%= "a" %><%H "hole" %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "a<PLUSH_HOLE_0>", out)
+
+	out, err = vmplush.Render(`<%= "b" %><%H "hole" %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "b<PLUSH_HOLE_0>", out)
+}
+
+func Test_VM_Bytecode_Caches_HTML_Template_Filenames(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	rootplush.PlushCacheSetup(cache)
+	defer rootplush.ClearTemplateCache()
+
+	filename := "bytecode-cache.html"
+	require.False(t, rootplush.IsPlushTemplateFile(filename))
+	require.True(t, rootplush.IsVMBytecodeCacheableTemplateFile(filename))
+
+	ctx := rootplush.NewContext()
+	ctx.Set(meta.TemplateFileKey, filename)
+
+	out, err := vmplush.Render(`<%= "old" %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "old", out)
+	requireCacheKey(t, cache, rootplush.GenerateASTKey(filename))
+
+	out, err = vmplush.Render(`<%= "new" %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "new", out)
+}
+
+func Test_Phase_12_VM_Plush_Cache_Uses_Current_URL_In_Full_Key(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	rootplush.PlushCacheSetup(cache)
+	defer rootplush.ClearTemplateCache()
+
+	ctx := rootplush.NewContext()
+	ctx.Set(meta.TemplateFileKey, "phase12-url.plush")
+	ctx.Set(meta.TemplateCurrentUrlKey, "/products/123?ignored=true")
+
+	out, err := vmplush.Render(`<%= "x" %><%H "hole" %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "xhole", out)
+	requireCacheKey(t, cache, "full:phase12-url.plush|url:products_123")
+}
+
+func Test_Phase_12_VM_Plush_Caches_Bytecode_By_AST_Key(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	rootplush.PlushCacheSetup(cache)
+	defer rootplush.ClearTemplateCache()
+
+	filename := "phase12-bytecode.plush"
+	ctx := rootplush.NewContext()
+	ctx.Set(meta.TemplateFileKey, filename)
+
+	out, err := vmplush.Render(`<%= "old" %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "old", out)
+	requireCacheKey(t, cache, rootplush.GenerateASTKey(filename))
+
+	out, err = vmplush.Render(`<%= "new" %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "new", out)
+
+	cache.Delete(rootplush.GenerateASTKey(filename))
+	out, err = vmplush.Render(`<%= "new" %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "new", out)
+}
+
+func Test_Phase_12_VM_Plush_Caches_Bytecode_Without_AST_Or_Source(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	rootplush.PlushCacheSetup(cache)
+	defer rootplush.ClearTemplateCache()
+
+	filename := "phase12-bytecode-only.plush"
+	ctx := rootplush.NewContext()
+	ctx.Set(meta.TemplateFileKey, filename)
+
+	out, err := vmplush.Render(`<%= "old" %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "old", out)
+
+	key := rootplush.GenerateASTKey(filename)
+	entry, ok := cache.Get(key)
+	require.True(t, ok)
+	require.NotNil(t, entry.VMBytecode)
+	require.Nil(t, entry.Program)
+	require.Empty(t, entry.Input)
+
+	out, err = vmplush.Render(`<%= "new" %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "new", out)
+	entry, ok = cache.Get(key)
+	require.True(t, ok)
+	require.Nil(t, entry.Program)
+
+	out, err = rootplush.Render(`<%= "new" %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "new", out)
+	entry, ok = cache.Get(key)
+	require.True(t, ok)
+	require.NotNil(t, entry.Program)
+	require.NotNil(t, entry.VMBytecode)
+	require.Empty(t, entry.Input)
+}
+
+func Test_Phase_12_VM_Plush_Uses_Existing_Interpreter_AST_Cache(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	rootplush.PlushCacheSetup(cache)
+	defer rootplush.ClearTemplateCache()
+
+	filename := "phase12-interpreter-ast.plush"
+	ctx := rootplush.NewContext()
+	ctx.Set(meta.TemplateFileKey, filename)
+
+	out, err := rootplush.Render(`<%= "ast" %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "ast", out)
+
+	key := rootplush.GenerateASTKey(filename)
+	entry, ok := cache.Get(key)
+	require.True(t, ok)
+	require.NotNil(t, entry.Program)
+	require.Nil(t, entry.VMBytecode)
+	require.Empty(t, entry.Input)
+
+	out, err = vmplush.Render(`<%= "new" %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "new", out)
+
+	entry, ok = cache.Get(key)
+	require.True(t, ok)
+	require.Nil(t, entry.Program)
+	require.NotNil(t, entry.VMBytecode)
+	require.Empty(t, entry.Input)
+}
+
+func requireCacheKey(t *testing.T, cache *inmemory.MemoryCache, key string) {
+	t.Helper()
+	_, ok := cache.Get(key)
+	require.True(t, ok, "expected cache key %q", key)
+}
+
+func Test_Parity_Phase_12_Metadata_Normalization(t *testing.T) {
+	compareRender(t, `<%= partial("child.plush.html") %>`, contextWith(map[string]interface{}{
+		"partialFeeder": func(name string) (string, error) {
+			require.True(t, strings.HasSuffix(name, ".plush.html"))
+			return `<%= filename() %>`, nil
+		},
+	}))
+}
+
+func Test_Parity_Phase_12_Partial_Safe_Yield_HTML(t *testing.T) {
+	compareRender(t, `<%= partial("body", {layout: "layout"}) %>`, contextWith(map[string]interface{}{
+		"partialFeeder": func(name string) (string, error) {
+			if name == "layout" {
+				return `<section><%= yield %></section>`, nil
+			}
+			return string(template.HTML(`<strong>safe</strong>`)), nil
+		},
+	}))
+}

--- a/VM/plush/parity_root_tests_test.go
+++ b/VM/plush/parity_root_tests_test.go
@@ -1,0 +1,592 @@
+package plush_test
+
+import (
+	"bytes"
+	"database/sql"
+	"errors"
+	"fmt"
+	"html/template"
+	"strings"
+	"testing"
+	"time"
+
+	rootplush "github.com/gobuffalo/plush/v5"
+	vmplush "github.com/gobuffalo/plush/v5/VM/plush"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Parity_Root_Plush_Render_Cases(t *testing.T) {
+	compareRender(t, `<p>Hi</p>`, emptyContext)
+	compareRender(t, `<p><%= "mark" %></p>`, emptyContext)
+	compareRender(t, `<p><%= name %></p>`, contextWith(map[string]interface{}{"name": "Mark"}))
+	compareBothRenderError(t, `<p><%= name %></p>`, emptyContext)
+	compareRender(t, `<% let add = fn(x) { return x + 2; }; %><%= add(2) %>`, emptyContext)
+}
+
+func Test_Parity_Root_Variadic_Helper_Cases(t *testing.T) {
+	compareRender(t, `<%= foo(1, 2, 3) %>`, contextWith(map[string]interface{}{
+		"foo": func(args ...int) int { return len(args) },
+	}))
+	compareRender(t, `<%= foo("hello") %>`, contextWith(map[string]interface{}{
+		"foo": func(s string, args ...interface{}) string { return s },
+	}))
+	compareRender(t, `<%= foo() %>`, contextWith(map[string]interface{}{
+		"foo": func(args ...int) int { return len(args) },
+	}))
+	compareRender(t, `<%= foo(1) %>`, contextWith(map[string]interface{}{
+		"foo": func(a int, args ...int) int { return a + len(args) },
+	}))
+	compareExactRenderError(t, `<%= foo(1, 2, "test") %>`, contextWith(map[string]interface{}{
+		"foo": func(args ...int) int { return len(args) },
+	}))
+}
+
+func Test_Parity_Root_Hash_Index_Cases(t *testing.T) {
+	compareRender(t, `<%= m["first"]%>`, contextWith(map[string]interface{}{
+		"m": map[interface{}]bool{"first": true},
+	}))
+	compareExactRenderError(t, `<%= m["first"]%>`, contextWith(map[string]interface{}{
+		"m": map[int]bool{0: true},
+	}))
+	compareRender(t, `<%= m["first"] + " " + m["last"] %>|<%= a[0+1] %>`, contextWith(map[string]interface{}{
+		"m": map[string]string{"first": "Mark", "last": "Bates"},
+		"a": []string{"john", "paul"},
+	}))
+	compareRender(t, `<%= m["a"] %>`, contextWith(map[string]interface{}{
+		"m": map[string]string{"a": "A"},
+	}))
+	compareRender(t, `<%= m.MyMap[key] %>`, contextWith(map[string]interface{}{
+		"m": struct {
+			MyMap map[string]string
+		}{MyMap: map[string]string{"a": "A"}},
+		"key": "a",
+	}))
+	compareRender(t, `<%= debug(m.MyMap[key]) %>`, contextWith(map[string]interface{}{
+		"m": struct {
+			MyMap map[string]string
+		}{MyMap: map[string]string{"a": "A"}},
+		"key": "a",
+	}))
+}
+
+func Test_Parity_Root_If_Condition_Table(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		success bool
+	}{
+		{"if_else_true", `<%= if (true) { return "good"} else { return "bad"} %>`, true},
+		{"if_else_false", `<%= if (false) { return "good"} else { return "bad"} %>`, true},
+		{"missing_output_marker", `<%  if (true) { return "good"} else { return "bad"} %>`, true},
+		{"value_from_template_html", `<%= if (true) { %>good<% } %>`, true},
+		{"if_false", `<%= if (false) { return "good"} %>`, true},
+		{"if_bang_false", `<%= if (!false) { return "good"} %>`, true},
+		{"bool_true_is_true", `<%= if (true == true) { return "good"} else { return "bad"} %>`, true},
+		{"bool_true_is_not_true", `<%= if (true != true) { return "good"} else { return "bad"} %>`, true},
+		{"let_var_is_false", `<% let test = true %><%= if (test == false) { return "good"} %>`, true},
+		{"let_var_is_true", `<% let test = true %><%= if (test == true) { return "good"} %>`, true},
+		{"let_var_is_not_true", `<% let test = true %><%= if (test != true) { return "good"} %>`, true},
+		{"let_var_is_not_bool", `<% let test = 1 %><%= if (test != true) { return "good"} %>`, false},
+		{"let_var_is_1", `<% let test = 1 %><%= if (test == 1) { return "good"} %>`, true},
+		{"logical_false_and_true", `<%= if (false && true) { %>good<% } %>`, true},
+		{"logical_true_and_true", `<%= if (2 == 2 && 1 == 1) { %>good<% } %>`, true},
+		{"logical_false_or_true", `<%= if (false || true) { %>good<% } %>`, true},
+		{"logical_false_or_false", `<%= if (1 == 2 || 2 == 1) { %>good<% } %>`, true},
+		{"nil_and", `<%= if (names && len(names) >= 1) { %>good<% } %>`, true},
+		{"nil_and_else", `<%= if (names && len(names) >= 1) { %>good<% } else { %>else<% } %>`, true},
+		{"nil", `<%= if (names) { %>good<% } %>`, true},
+		{"not_nil", `<%= if (!names) { %>good<% } %>`, true},
+		{"compare_equal_to", `<%= if (1 == 2) { %>good<% } %>`, true},
+		{"compare_not_equal_to", `<%= if (1 != 2) { %>good<% } %>`, true},
+		{"compare_less_than", `<%= if (1 < 2) { %>good<% } %>`, true},
+		{"compare_less_than_equal_to", `<%= if (1 <= 2) { %>good<% } %>`, true},
+		{"compare_greater_than", `<%= if (1 > 2) { %>good<% } %>`, true},
+		{"compare_greater_than_equal_to", `<%= if (1 >= 2) { %>good<% } %>`, true},
+		{"if_match_foo_bar", `<%= if ("foo" ~= "bar") { %>good<% } %>`, true},
+		{"if_match_foo_prefix", `<%= if ("foo" ~= "^fo") { %>good<% } %>`, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.success {
+				compareRender(t, tt.input, emptyContext)
+				return
+			}
+			compareExactRenderError(t, tt.input, emptyContext)
+		})
+	}
+}
+
+func Test_Parity_Root_Condition_Only_Table(t *testing.T) {
+	ctxEmpty := emptyContext
+	ctxWithPaths := contextWith(map[string]interface{}{"paths": "cart"})
+
+	tests := []struct {
+		name    string
+		input   string
+		factory contextFactory
+	}{
+		{"unknown_equal_to_nil", `<%= paths == nil %>`, ctxEmpty},
+		{"nil_equal_to_unknown", `<%= nil == paths %>`, ctxEmpty},
+		{"not_set_identifier", `<%= !paths %>`, ctxWithPaths},
+		{"not_unknown_identifier", `<%= !pages %>`, ctxWithPaths},
+		{"set_or_unknown", `<%= paths || pages %>`, ctxWithPaths},
+		{"unknown_or_set", `<%= pages || paths %>`, ctxWithPaths},
+		{"set_or_unknown_equal", `<%= paths || pages == "cart" %>`, ctxWithPaths},
+		{"unknown_equal_or_set", `<%= pages == "cart" || paths %>`, ctxWithPaths},
+		{"equal_or_unknown", `<%= paths == "cart" || pages %>`, ctxWithPaths},
+		{"unknown_or_equal", `<%= pages || paths == "cart" %>`, ctxWithPaths},
+		{"equal_or_unknown_equal", `<%= paths == "cart" || pages == "cart" %>`, ctxWithPaths},
+		{"unknown_equal_or_equal", `<%= pages == "cart" || paths == "cart" %>`, ctxWithPaths},
+		{"set_and_unknown", `<%= paths && pages %>`, ctxWithPaths},
+		{"unknown_and_set", `<%= pages && paths %>`, ctxWithPaths},
+		{"set_and_unknown_equal", `<%= paths && pages == "cart" %>`, ctxWithPaths},
+		{"unknown_equal_and_set", `<%= pages == "cart" && paths %>`, ctxWithPaths},
+		{"equal_and_unknown", `<%= paths == "cart" && pages %>`, ctxWithPaths},
+		{"unknown_and_equal", `<%= pages && paths == "cart" %>`, ctxWithPaths},
+		{"equal_and_unknown_equal", `<%= paths == "cart" && pages == "cart" %>`, ctxWithPaths},
+		{"unknown_equal_and_equal", `<%= pages == "cart" && paths == "cart" %>`, ctxWithPaths},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			compareRender(t, tt.input, tt.factory)
+		})
+	}
+}
+
+func Test_Parity_Root_If_Scope_And_Else_If_Cases(t *testing.T) {
+	input := `<p><%= if (state == "foo") { %>hi foo<% } else if (state == "bar") { %>hi bar<% } else if (state == "fizz") { %>hi fizz<% } else { %>hi buzz<% } %></p>`
+	for _, state := range []string{"foo", "bar", "fizz", "buzz"} {
+		t.Run("state_"+state, func(t *testing.T) {
+			compareRender(t, input, contextWith(map[string]interface{}{"state": state}))
+		})
+	}
+
+	stringTruthy := `<p><%= if (username && username != "") { return "hi" } else { return "bye" } %></p>`
+	compareRender(t, stringTruthy, contextWith(map[string]interface{}{"username": ""}))
+	compareRender(t, stringTruthy, contextWith(map[string]interface{}{"username": "foo"}))
+
+	updateInput := `<p><%= if (username && username != "") { username = "hi" } else { username= "bye" } %><%= username %></p>`
+	compareRender(t, updateInput, contextWith(map[string]interface{}{"username": ""}))
+	compareRender(t, updateInput, contextWith(map[string]interface{}{"username": "foo"}))
+	compareExactRenderError(t, updateInput, emptyContext)
+
+	compareRender(t, `<p><% let username = "Hello World" %><%= if (username && username != "") {
+		let username = "hi"
+		username = "hi"
+	} else {
+		let username = "bye"
+		username = "1"
+	 }%><%= username %></p>`, emptyContext)
+
+	compareRender(t, `<p><% let username = "Hello World" %><%= if (username && username != "") {
+		let username = "hi"
+		username = "hi"
+		if (username == "hi"){
+			username = "hi2"
+		}
+	} else {
+		let username = "bye"
+		username = "1"
+	 }%><%= username %></p>`, emptyContext)
+
+	compareRender(t, `<p><% let username = "Hello World" %><%= if (username && username != "") {
+		username = "hi"
+		if (username == "hi"){
+			username = "hi2"
+		}
+	} else {
+		let username = "bye"
+		username = "1"
+	 }%><%= username %></p>`, emptyContext)
+
+	compareRender(t, `<%= if ( paths == "cart" || (page && page.PageTitle != "cafe") || paths == "cart") { %>hi<%} %>`, contextWith(map[string]interface{}{
+		"path":  "cart",
+		"paths": "cart",
+	}))
+}
+
+func Test_Parity_Root_Variable_Assignment_Index_And_Append_Cases(t *testing.T) {
+	compareRender(t, `<% let foo = "bar" %>
+  <%= for (a) in myArray { %>
+<%= foo %>
+    <% if (foo != "baz") { %>
+      <% foo = "baz" %>
+    <% } %>
+  <% } %>
+<% } %>`, contextWith(map[string]interface{}{
+		"myArray": []string{"a", "b"},
+	}))
+
+	successes := []string{
+		`<p><% let h = {"a": "A"} %><%= h["a"] %></p>`,
+		`<p><% let h = {"a": "A"} %><% h["a"] = "C" %><%= h["a"] %></p>`,
+		`<p><% let h = {"a": "A"} %><% h["b"] = "D" %><%= h["b"] %></p>`,
+		`<p><% let h = {"a": "A"} %><% h["b"] = 3 %><%= h["b"] %></p>`,
+		`<p><% let h = {"a": "A"} %><% h["b"] = 3 %><%= h["c"] %></p>`,
+		`<p><% let a = [1, 2, "three", "four", 3.75] %><% a[0] = 3 %><%= a[0] %></p>`,
+		`<p><% let a = [1, 2, "three", "four", 3.75] %><% a[4] = 3 %><%= a[4] + 2 %></p>`,
+		`<% let a = [1,"22",33] %><% a = a + 1 %><%= a %>`,
+		`<% let a = [1,2,"HelloWorld"] %><% a = a + 2.2 %><%= a %>`,
+	}
+	for _, input := range successes {
+		t.Run(input, func(t *testing.T) {
+			compareRender(t, input, emptyContext)
+		})
+	}
+
+	errors := []string{
+		`<p><% let a = [1, 2, "three", "four", 3.75] %><% a["b"] = 3 %><%= a["c"] %></p>`,
+		`<p><% let a = [1, 2, "three", "four", 3.75] %><% a[5] = 3 %><%= a[4] + 2 %></p>`,
+		`<p><% let a = [1, 2, "three", "four", 3.75] %><%= a[5] %></p>`,
+	}
+	for _, input := range errors {
+		t.Run(input, func(t *testing.T) {
+			compareBothRenderError(t, input, emptyContext)
+		})
+	}
+
+	type item struct {
+		P string
+	}
+	compareBothRenderError(t, `<p><% let a = myArray %></p><% a[0] = "HELLO WORLD" %>`, contextWith(map[string]interface{}{
+		"myArray": []item{{P: "t"}},
+	}))
+	compareRender(t, `<p><% let a = myArray %></p><% a[0] = "HELLO WORLD" %>`, contextWith(map[string]interface{}{
+		"myArray": []interface{}{item{P: "t"}, item{P: "g"}},
+	}))
+	compareBothRenderError(t, `<% let a = myArray %><% a = a + 1 %><%= a %>`, contextWith(map[string]interface{}{
+		"myArray": []string{"a", "b"},
+	}))
+	compareRender(t, `<% let a = myArray %><% a = a + 1 %><%= a %>`, contextWith(map[string]interface{}{
+		"myArray": []interface{}{"a", "b"},
+	}))
+}
+
+func Test_Parity_Root_Function_Call_And_Block_Cases(t *testing.T) {
+	compareRender(t, `<p><%= f() %></p>`, contextWith(map[string]interface{}{
+		"f": func() string { return "hi!" },
+	}))
+	compareRender(t, `<p><%= f("mark") %></p>`, contextWith(map[string]interface{}{
+		"f": func(s string) string { return fmt.Sprintf("hi %s!", s) },
+	}))
+	compareRender(t, `<p><%= f(name) %></p>`, contextWith(map[string]interface{}{
+		"f":    func(s string) string { return fmt.Sprintf("hi %s!", s) },
+		"name": "mark",
+	}))
+	compareRender(t, `<p><%= f({name: name}) %></p>`, contextWith(map[string]interface{}{
+		"f":    func(m map[string]interface{}) string { return fmt.Sprintf("hi %s!", m["name"]) },
+		"name": "mark",
+	}))
+	compareBothRenderError(t, `<p><%= f({name: name) %></p>`, contextWith(map[string]interface{}{
+		"f":    func(m map[string]interface{}) string { return fmt.Sprintf("hi %s!", m["name"]) },
+		"name": "mark",
+	}))
+	compareExactRenderError(t, `<p><%= f() %></p>`, contextWith(map[string]interface{}{
+		"f": func() (string, error) { return "hi!", errors.New("oops") },
+	}))
+	compareRender(t, `<p><%= f() { %>hello<% } %></p>`, contextWith(map[string]interface{}{
+		"f": func(h rootplush.HelperContext) string {
+			s, _ := h.Block()
+			return s
+		},
+	}))
+	compareRender(t, `<p><% let i = "hello-world" %><%= f() { i = "bye" } %><%= i %></p>`, contextWith(map[string]interface{}{
+		"f": func(h rootplush.HelperContext) string {
+			s, _ := h.Block()
+			return s
+		},
+	}))
+	compareBothRenderError(t, `<p><%= f() { let i = "hello-world" } %><%= i %></p>`, contextWith(map[string]interface{}{
+		"f": func(h rootplush.HelperContext) string {
+			s, _ := h.Block()
+			return s
+		},
+	}))
+	compareRender(t, `<%= foo() %>|<%= bar({a: "A"}) %>`, contextWith(map[string]interface{}{
+		"foo": func(opts map[string]interface{}, help rootplush.HelperContext) string { return "foo" },
+		"bar": func(opts map[string]interface{}) string { return opts["a"].(string) },
+	}))
+}
+
+func Test_Parity_Root_Helper_Block_With_Data_Cases(t *testing.T) {
+	type data map[string]interface{}
+	tests := []struct {
+		name string
+		in   string
+	}{
+		{name: "default data", in: `<%= foo() {return bar + name} %>`},
+		{name: "override name", in: `<%= foo({name: "mark"}) {return bar + name} %>`},
+		{name: "local data does not leak", in: `<%= foo({name: "mark", bbb: "hello-world"}) {return bar + name} %><%= bbb %>`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			factory := contextWith(map[string]interface{}{
+				"name": "unknown",
+				"bar":  "BAR",
+				"foo": func(d data, help rootplush.HelperContext) (string, error) {
+					c := help.New()
+					if n, ok := d["name"]; ok {
+						c.Set("name", n)
+					}
+					if n, ok := d["bbb"]; ok {
+						c.Set("bbb", n)
+					}
+					return help.BlockWith(c)
+				},
+			})
+			if strings.Contains(tt.in, `<%= bbb %>`) {
+				compareExactRenderError(t, tt.in, factory)
+				return
+			}
+			compareRender(t, tt.in, factory)
+		})
+	}
+}
+
+func Test_Parity_Root_For_Cases(t *testing.T) {
+	tests := []struct {
+		input     string
+		factory   contextFactory
+		wantError bool
+	}{
+		{input: `<% for (i,v) in ["a", "b", "c"] {return v} %>`, factory: emptyContext},
+		{input: `<% let varTest = "" %><% for (i,v) in ["a", "b", "c"] {varTest =  v} %><%= varTest %>`, factory: emptyContext},
+		{input: `<%= for (k,v) in myMap { %><%= k + ":" + v%><% } %> <%= k %>`, factory: contextWith(map[string]interface{}{"myMap": map[string]string{"a": "A"}}), wantError: true},
+		{input: `<%= for (k,v) in myMap { %><%= k + ":" + v%><% } %> <%= v %>`, factory: contextWith(map[string]interface{}{"myMap": map[string]string{"a": "A"}}), wantError: true},
+		{input: `<%= for (i,v) in ["a", "b", "c"] {return v} %>`, factory: emptyContext},
+		{input: `<%= for (i,v) in [1, 2, 3,4,5,6,7,8,9,10] {
+		continue
+		return v
+		} %>`, factory: emptyContext},
+		{input: `<%= for (i,v) in [1, 2, 3,4,5,6,7,8,9,10] {
+		break
+		return v
+		} %>`, factory: emptyContext},
+		{input: `<%= for (v) in ["a", "b", "c"] {%><%=v%><%} %>`, factory: emptyContext},
+		{input: `<%= for (v) in range(3,5) { %><%=v%><% } %>`, factory: emptyContext},
+		{input: `<%= for (v) in between(3,6) { %><%=v%><% } %>`, factory: emptyContext},
+		{input: `<%= for (v) in until(3) { %><%=v%><% } %>`, factory: emptyContext},
+		{input: `<%= for (i,v) in ["a", "b", "c"] {%><%=i%><%=v%><%} %>`, factory: emptyContext},
+		{input: `<%   let i = 10000 %><%= for (i,v) in ["a", "b", "c"] {%><%=i%><%=v%><%} %><%= i %>`, factory: emptyContext},
+		{input: `<%= for (i,v) in ["a", "b", "c"] {%><%=i%><%=v%><%} %><%= i %>`, factory: emptyContext, wantError: true},
+		{input: ` <%= for (i,v) in ["a", "b", "c"] {%><%=i%><%=v%><%} %><%= v %>`, factory: emptyContext, wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if tt.wantError {
+				compareBothRenderError(t, tt.input, tt.factory)
+				return
+			}
+			compareRender(t, tt.input, tt.factory)
+		})
+	}
+
+	mapLoop := `<%= for (k,v) in myMap { %><%= k + ":" + v%><% } %>`
+	factory := contextWith(map[string]interface{}{
+		"myMap": map[string]string{"a": "A", "b": "B"},
+	})
+	interpreterOut, interpreterErr := renderInterpreter(mapLoop, factory)
+	vmOut, vmErr := renderVM(mapLoop, factory)
+	require.NoError(t, interpreterErr)
+	require.NoError(t, vmErr)
+	for _, fragment := range []string{"a:A", "b:B"} {
+		require.Contains(t, interpreterOut, fragment)
+		require.Contains(t, vmOut, fragment)
+	}
+}
+
+func Test_Parity_Root_Return_Exit_Cases(t *testing.T) {
+	inputs := []string{
+		`<%
+		let numberify = fn(arg) {
+			if (arg == "one") {
+				return 1+1;
+			}
+			if (arg == "two") {
+				return 44;
+			}
+			if (arg == "three") {
+				return 2;
+			}
+			return "unsupported"
+		} %>
+		<%= numberify("one") %>`,
+		`<%
+		let numberify = fn(arg) {
+			if (arg == "one") {
+				return 1;
+			}
+			if (arg == "two") {
+				return 445;
+			}
+			if (arg == "three") {
+				return 3;
+			}
+			return "unsupported"
+		} %>
+		<%= numberify("two") %>`,
+		`<%
+		let numberify = fn(arg) {
+			if (arg == "one") {
+				return 1;
+			}
+			if (arg == "two") {
+				return 445;
+			}
+			if (arg == "three") {
+				return 3;
+			}
+			return "default value"
+		} %>
+		<%= numberify("six") %>`,
+	}
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			compareRender(t, input, emptyContext)
+		})
+	}
+}
+
+func Test_Parity_Root_Struct_Edge_Cases(t *testing.T) {
+	type list struct {
+		N    int
+		Next *list
+	}
+	input := `Current number is <%= p.N %>.<%= if (p.Next) { %>  Next up is <%= p.Next.N %>.<% } %>`
+	first := &list{N: 0}
+	last := first
+	for i := 0; i < 5; i++ {
+		last.Next = &list{N: i + 1}
+		last = last.Next
+	}
+	for p := first; p != nil; p = p.Next {
+		p := p
+		t.Run(fmt.Sprintf("list_%d", p.N), func(t *testing.T) {
+			compareRender(t, input, contextWith(map[string]interface{}{"p": p}))
+		})
+	}
+
+	type imageUser struct {
+		Name  string
+		Image *string
+	}
+	compareRender(t, `<%= user.Name %>: <%= user.Image %>`, contextWith(map[string]interface{}{
+		"user": imageUser{Name: "Garn Clapstick"},
+	}))
+	image := "bicep.png"
+	compareRender(t, `<%= user.Name %>: <%= user.Image %>`, contextWith(map[string]interface{}{
+		"user": imageUser{Name: "Scrinch Archipeligo", Image: &image},
+	}))
+
+	type bornPerson struct {
+		born time.Time
+	}
+	funcPerson := bornPerson{born: time.Date(1993, time.January, 11, 0, 0, 0, 0, time.UTC)}
+	compareRender(t, `<%= nour.GetBorn().Format("Jan 2, 2006") %>`, contextWith(map[string]interface{}{
+		"nour": rootParityBornPerson(funcPerson),
+	}))
+}
+
+type rootParityBornPerson struct {
+	born time.Time
+}
+
+func (p rootParityBornPerson) GetBorn() time.Time {
+	return p.born
+}
+
+func Test_Parity_Root_Quote_And_Error_Type_Cases(t *testing.T) {
+	for _, input := range []string{
+		`<%= foo("asdf) %>`,
+		`<%= foo("test) %>".`,
+		`<%= title("Running Migrations) %>(default "./migrations")`,
+	} {
+		t.Run(input, func(t *testing.T) {
+			compareBothRenderError(t, input, contextWith(map[string]interface{}{
+				"foo":   func(string) {},
+				"title": func(string) string { return "" },
+			}))
+		})
+	}
+
+	ctxFactory := contextWith(map[string]interface{}{
+		"sqlError": func() error {
+			return sql.ErrNoRows
+		},
+	})
+	_, interpreterErr := renderInterpreter(`<%= sqlError() %>`, ctxFactory)
+	_, vmErr := renderVM(`<%= sqlError() %>`, ctxFactory)
+	require.True(t, errors.Is(interpreterErr, sql.ErrNoRows))
+	require.True(t, errors.Is(vmErr, sql.ErrNoRows))
+}
+
+func Test_Parity_Root_Script_Execution(t *testing.T) {
+	const script = `let x = "foo"
+
+let a = 1
+let b = 2
+let c = a + b
+
+out(c)
+
+if (c == 3) {
+  out("hi")
+}
+
+let x = fn(f) {
+  f()
+}
+
+x(fn() {
+  out("asdfasdf")
+})`
+
+	rootBuffer := &bytes.Buffer{}
+	rootCtx := rootplush.NewContextWith(map[string]interface{}{
+		"out": func(i interface{}) {
+			rootBuffer.WriteString(fmt.Sprint(i))
+		},
+	})
+	require.NoError(t, rootplush.RunScript(script, rootCtx))
+
+	vmBuffer := &bytes.Buffer{}
+	vmCtx := rootplush.NewContextWith(map[string]interface{}{
+		"out": func(i interface{}) {
+			vmBuffer.WriteString(fmt.Sprint(i))
+		},
+	})
+	require.NoError(t, vmplush.RunScript(script, vmCtx))
+	require.Equal(t, rootBuffer.String(), vmBuffer.String())
+	require.Equal(t, "3hiasdfasdf", vmBuffer.String())
+}
+
+func Test_Parity_Root_Backtick_And_Quote_Helper_Case(t *testing.T) {
+	input := "<%= raw(`" + `CREATE MATERIALIZED VIEW view_papers AS
+	SELECT papers.created_at,
+	   papers.updated_at,
+	   papers.id,
+	   papers.name,
+	   (   setweight(to_tsvector(papers.name::text), 'A'::"char") ||
+		   setweight(to_tsvector(papers.author_name), 'B'::"char")
+	   ) || setweight(to_tsvector(papers.description), 'C'::"char")
+	   AS paper_vector
+	  FROM
+	  ( SELECT papers.id, string_agg(categories.code, ',') as categories
+	   FROM papers
+	   LEFT JOIN paper_categories ON paper_categories.paper_id=papers.id LEFT JOIN (select * from categories order by weight asc) categories ON categories.id=paper_categories.category_id
+	   GROUP BY papers.id
+	  ) a
+	  LEFT JOIN papers on a.id=papers.id
+	 WHERE (papers.doc_status = ANY (ARRAY[1, 3])) AND papers.status = 1
+   WITH DATA` + "`) %>"
+
+	compareRender(t, input, contextWith(map[string]interface{}{
+		"raw": func(arg string) template.HTML {
+			return template.HTML(arg)
+		},
+	}))
+}

--- a/VM/plush/parity_struct_access_test.go
+++ b/VM/plush/parity_struct_access_test.go
@@ -1,0 +1,366 @@
+package plush_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type parityEchoName string
+
+func (n parityEchoName) Echo() string {
+	return string(n)
+}
+
+func (n parityEchoName) String() string {
+	return string(n)
+}
+
+type parityRobot struct {
+	Name parityEchoName
+}
+
+type parityStringRobot struct {
+	Name string
+}
+
+type parityAvatar string
+
+func (a parityAvatar) URL() string {
+	return string(a)
+}
+
+type parityRobotProfile struct {
+	Names []parityEchoName
+}
+
+type parityRobotStats struct {
+	Label string
+}
+
+type parityNestedRobot struct {
+	Name     parityEchoName
+	Avatar   parityAvatar
+	Profile  parityRobotProfile
+	Stats    []parityRobotStats
+	Metadata map[string]parityRobot
+	Friends  []parityRobot
+}
+
+func (r parityNestedRobot) GetFriends() []parityRobot {
+	return r.Friends
+}
+
+type parityAccessNode struct {
+	N    string
+	Next *parityAccessNode
+}
+
+type parityAccessRobot struct {
+	Name    parityEchoName
+	Avatar  parityAvatar
+	Next    *parityAccessNode
+	Friends []parityAccessRobot
+	Map     map[string]parityAccessRobot
+	Nested  parityAccessNested
+}
+
+func (r parityAccessRobot) GetFriends() []parityAccessRobot {
+	return r.Friends
+}
+
+type parityAccessNested struct {
+	Map map[string]parityAccessBucket
+}
+
+type parityAccessBucket struct {
+	Items []parityAccessRobot
+}
+
+type parityRobotFactory struct {
+	values []parityAccessRobot
+}
+
+func (f parityRobotFactory) Robots() []parityAccessRobot {
+	return f.values
+}
+
+type parityFunctionReturnFactory struct {
+	robot parityFunctionReturnRobot
+}
+
+func (f parityFunctionReturnFactory) Robots() parityFunctionReturnRobot {
+	return f.robot
+}
+
+type parityFunctionReturnRobot struct {
+	name parityEchoName
+}
+
+func (r parityFunctionReturnRobot) Name() parityEchoName {
+	return r.name
+}
+
+type parityPointerMethodRobot struct {
+	name string
+}
+
+func (r *parityPointerMethodRobot) Name() string {
+	return r.name
+}
+
+type parityArrayHolder struct {
+	Items [2]parityAccessRobot
+}
+
+type parityAccessPerson struct {
+	born time.Time
+}
+
+func (p parityAccessPerson) GetBorn() time.Time {
+	return p.born
+}
+
+func Test_Parity_Struct_Access_Field(t *testing.T) {
+	compareRender(t, `<%= robot.Name %>`, contextWith(map[string]interface{}{
+		"robot": parityStringRobot{Name: "bender"},
+	}))
+}
+
+func Test_Parity_Struct_Access_Nested_Method(t *testing.T) {
+	compareRender(t, `<%= robot.Name.Echo() %>`, contextWith(map[string]interface{}{
+		"robot": parityRobot{Name: "bender"},
+	}))
+}
+
+func Test_Parity_Struct_Access_Slice_Start(t *testing.T) {
+	compareVMRender(t, `<%= robots[0].Name.Echo() %>`, "bender", contextWith(map[string]interface{}{
+		"robots": []parityRobot{{Name: "bender"}},
+	}))
+}
+
+func Test_Parity_Struct_Access_Nested_Field(t *testing.T) {
+	compareVMRender(t, `<%= robot.Profile.Names[1].Echo() %>`, "flexo", contextWith(map[string]interface{}{
+		"robot": parityNestedRobot{
+			Profile: parityRobotProfile{Names: []parityEchoName{"bender", "flexo"}},
+		},
+	}))
+}
+
+func Test_Parity_Struct_Access_Nested_Slice_Field(t *testing.T) {
+	compareRender(t, `<%= robots[0].Stats[1].Label %>`, contextWith(map[string]interface{}{
+		"robots": []parityNestedRobot{{
+			Stats: []parityRobotStats{{Label: "first"}, {Label: "second"}},
+		}},
+	}))
+}
+
+func Test_Parity_Struct_Access_Nested_Map_Slice_Method(t *testing.T) {
+	compareVMRender(t, `<%= robot.Metadata["owner"].Name.Echo() %>`, "fry", contextWith(map[string]interface{}{
+		"robot": parityNestedRobot{
+			Metadata: map[string]parityRobot{
+				"owner": {Name: "fry"},
+			},
+		},
+	}))
+}
+
+func Test_Parity_Struct_Access_Typed_Map_String_Index(t *testing.T) {
+	requireBothRender(t, `<%= labels["status"] %>|<%= counts["active"] %>|<%= robots["bender"].Name %>`, `&lt;ok&gt;|7|Bender`, contextWith(map[string]interface{}{
+		"labels": map[string]string{"status": "<ok>"},
+		"counts": map[string]uint32{"active": 7},
+		"robots": map[string]parityStringRobot{
+			"bender": {Name: "Bender"},
+		},
+	}))
+}
+
+func Test_Parity_Struct_Access_Typed_Interface_Map_String_Index(t *testing.T) {
+	requireBothRender(t, `<%= labels["status"] %>`, `&lt;ok&gt;`, contextWith(map[string]interface{}{
+		"labels": map[interface{}]string{"status": "<ok>"},
+	}))
+}
+
+func Test_Parity_Struct_Access_Method_Return_Index(t *testing.T) {
+	compareVMRender(t, `<%= robot.GetFriends()[0].Name.Echo() %>`, "leela", contextWith(map[string]interface{}{
+		"robot": parityNestedRobot{
+			Friends: []parityRobot{{Name: "leela"}},
+		},
+	}))
+}
+
+func Test_Parity_Struct_Access_Method_On_Nested_Field(t *testing.T) {
+	compareRender(t, `<%= robot.Avatar.URL() %>`, contextWith(map[string]interface{}{
+		"robot": parityNestedRobot{
+			Avatar: "bender.jpg",
+		},
+	}))
+}
+
+func Test_Parity_Struct_Access_Method_Return_Native_Chain(t *testing.T) {
+	requireBothRender(t, `<%= nour.GetBorn().Format("Jan 2, 2006") %>`, "Jan 11, 1993", contextWith(map[string]interface{}{
+		"nour": parityAccessPerson{
+			born: time.Date(1993, time.January, 11, 0, 0, 0, 0, time.UTC),
+		},
+	}))
+}
+
+func Test_Parity_Struct_Access_Nested_Function_Returns(t *testing.T) {
+	compareVMRender(t, `<%= factory().Robots().Name().Echo() %>`, "nested", contextWith(map[string]interface{}{
+		"factory": func() parityFunctionReturnFactory {
+			return parityFunctionReturnFactory{
+				robot: parityFunctionReturnRobot{name: "nested"},
+			}
+		},
+	}))
+}
+
+func Test_Parity_Struct_Access_Phase_5_Matrix(t *testing.T) {
+	robot := parityAccessRobot{
+		Name:   "bender",
+		Avatar: "bender.jpg",
+		Next: &parityAccessNode{
+			N:    "one",
+			Next: &parityAccessNode{N: "two"},
+		},
+		Friends: []parityAccessRobot{
+			{Name: "fry"},
+			{Name: "leela"},
+		},
+		Map: map[string]parityAccessRobot{
+			"owner": {Name: "fry"},
+		},
+		Nested: parityAccessNested{
+			Map: map[string]parityAccessBucket{
+				"team": {Items: []parityAccessRobot{{Name: "amy"}}},
+			},
+		},
+	}
+	robots := []parityAccessRobot{robot}
+
+	ctx := contextWith(map[string]interface{}{
+		"robot":     robot,
+		"robots":    robots,
+		"key":       "owner",
+		"nestedKey": "team",
+		"getRobot": func() parityAccessRobot {
+			return robot
+		},
+		"getRobots": func() []parityAccessRobot {
+			return []parityAccessRobot{{Name: "scruffy"}}
+		},
+		"factory": func() parityRobotFactory {
+			return parityRobotFactory{values: []parityAccessRobot{{Name: "factory"}}}
+		},
+	})
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{`<%= robot.Name %>`, "bender"},
+		{`<%= robot.Name.Echo() %>`, "bender"},
+		{`<%= robot.Avatar.URL() %>`, "bender.jpg"},
+		{`<%= robot.Next.N %>`, "one"},
+		{`<%= robot.Next.Next.N %>`, "two"},
+		{`<%= robots[0].Name %>`, "bender"},
+		{`<%= robots[0].Name.Echo() %>`, "bender"},
+		{`<%= robots[0].Avatar.URL() %>`, "bender.jpg"},
+		{`<%= robots[0].Friends[1].Name %>`, "leela"},
+		{`<%= robots[0].Friends[1].Name.Echo() %>`, "leela"},
+		{`<%= robot.Map[key].Name %>`, "fry"},
+		{`<%= robot.Map[key].Name.Echo() %>`, "fry"},
+		{`<%= robot.Nested.Map[nestedKey].Items[0].Name %>`, "amy"},
+		{`<%= robot.Nested.Map[nestedKey].Items[0].Name.Echo() %>`, "amy"},
+		{`<%= getRobot().Name %>`, "bender"},
+		{`<%= getRobot().Name.Echo() %>`, "bender"},
+		{`<%= getRobots()[0].Name %>`, "scruffy"},
+		{`<%= getRobots()[0].Name.Echo() %>`, "scruffy"},
+		{`<%= robot.GetFriends()[0].Name %>`, "fry"},
+		{`<%= robot.GetFriends()[0].Name.Echo() %>`, "fry"},
+		{`<%= factory().Robots()[0].Name.Echo() %>`, "factory"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			compareVMRender(t, tt.input, tt.expected, ctx)
+		})
+	}
+}
+
+func Test_Parity_Struct_Access_Reflection_Compatibility(t *testing.T) {
+	ctx := contextWith(map[string]interface{}{
+		"structRobot": parityPointerMethodRobot{name: "struct"},
+		"ptrRobot":    &parityPointerMethodRobot{name: "ptr"},
+		"nilRobot": parityAccessRobot{
+			Next: nil,
+			Map:  map[string]parityAccessRobot{},
+		},
+	})
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{`<%= structRobot.Name() %>`, "struct"},
+		{`<%= ptrRobot.Name() %>`, "ptr"},
+		{`<%= nilRobot.Next.N %>`, ""},
+		{`<%= nilRobot.Map["missing"].Name %>`, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			requireBothRender(t, tt.input, tt.expected, ctx)
+		})
+	}
+}
+
+func Test_Parity_Struct_Access_Typed_Collections(t *testing.T) {
+	ctx := contextWith(map[string]interface{}{
+		"holder": parityArrayHolder{
+			Items: [2]parityAccessRobot{{Name: "zero"}, {Name: "one"}},
+		},
+		"lookup": map[int]string{1: "one"},
+		"items":  []parityAccessRobot{{Name: "zero"}},
+	})
+
+	compareVMRender(t, `<%= holder.Items[1].Name %>`, "one", ctx)
+	compareBothRenderError(t, `<%= lookup["bad"] %>`, ctx)
+	compareBothRenderError(t, `<%= items["bad"].Name %>`, ctx)
+	compareBothRenderError(t, `<%= items[2].Name %>`, ctx)
+}
+
+func Test_Parity_Struct_Access_Errors(t *testing.T) {
+	type privatePeople struct {
+		FirstName string
+	}
+	type privateEmployee struct {
+		employee []privatePeople
+	}
+
+	ctx := contextWith(map[string]interface{}{
+		"departments": map[string]privateEmployee{
+			"HR": {employee: []privatePeople{{FirstName: "John"}}},
+		},
+		"robot": parityAccessRobot{
+			Name:    "bender",
+			Friends: []parityAccessRobot{{Name: "fry"}},
+		},
+	})
+
+	compareBothRenderError(t, `<%= departments["HR"].employee[0].FirstName %>`, ctx)
+	compareBothRenderError(t, `<%= robot.Missing %>`, ctx)
+	compareBothRenderError(t, `<%= robot.Missing() %>`, ctx)
+	compareBothRenderError(t, `<%= robot.Name() %>`, ctx)
+	compareBothRenderError(t, `<%= robot.Name.Missing() %>`, ctx)
+	compareBothRenderError(t, `<%= robot.GetFriends()[9].Name %>`, ctx)
+}
+
+func compareVMRender(t *testing.T, input, expected string, factory contextFactory) {
+	t.Helper()
+
+	out, err := renderVM(input, factory)
+	require.NoError(t, err)
+	require.Equal(t, expected, out)
+}

--- a/VM/plush/parity_syntax_test.go
+++ b/VM/plush/parity_syntax_test.go
@@ -1,0 +1,52 @@
+package plush_test
+
+import "testing"
+
+func Test_Parity_Syntax_Current_Parenthesized_If(t *testing.T) {
+	compareRender(t, `<%= if (enabled) { %>yes<% } else { %>no<% } %>`, contextWith(map[string]interface{}{
+		"enabled": true,
+	}))
+}
+
+func Test_Parity_Syntax_Current_Else_If(t *testing.T) {
+	compareRender(t, `<%= if (first) { %>first<% } else if (second) { %>second<% } else { %>none<% } %>`, contextWith(map[string]interface{}{
+		"first":  false,
+		"second": true,
+	}))
+}
+
+func Test_Parity_Syntax_Context_Shadows_VM_Builtins(t *testing.T) {
+	compareRender(t, `<%= first %>|<%= if (first) { %>yes<% } else { %>no<% } %>`, contextWith(map[string]interface{}{
+		"first": false,
+	}))
+}
+
+func Test_Parity_Syntax_Comments(t *testing.T) {
+	inputs := []string{
+		`
+		<%# this is a comment %>
+		Hi
+		`,
+		`
+		<% <%# this is a comment %> %>
+		Hi
+		`,
+		`
+		<%# this is
+		a block comment %>
+		Hi
+		`,
+		`
+		<% <%# this is
+		a block comment %> %>
+		Hi`,
+	}
+
+	for _, input := range inputs {
+		compareRender(t, input, emptyContext)
+	}
+}
+
+func Test_Parity_Syntax_Regex_Match(t *testing.T) {
+	compareRender(t, `<%= if ("foo" ~= "^fo") { %>good<% } else { %>bad<% } %>`, emptyContext)
+}

--- a/VM/plush/parity_trim_tags_test.go
+++ b/VM/plush/parity_trim_tags_test.go
@@ -1,0 +1,87 @@
+package plush_test
+
+import (
+	"html/template"
+	"testing"
+
+	rootplush "github.com/gobuffalo/plush/v5"
+)
+
+func Test_Parity_Phase_8_Trim_Tags(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+		factory  contextFactory
+	}{
+		{
+			name:     "issue newline example",
+			input:    "<pre>\n<%- \"Hello\" %>\n</pre>",
+			expected: "<pre>Hello</pre>",
+			factory:  emptyContext,
+		},
+		{
+			name:     "issue inline spaces example",
+			input:    `<pre> <%- "Hello" %> </pre>`,
+			expected: "<pre>Hello</pre>",
+			factory:  emptyContext,
+		},
+		{
+			name:     "middle of document",
+			input:    "<p>A</p>\n<%- \"B\" %>\n<p>C</p>",
+			expected: "<p>A</p>B<p>C</p>",
+			factory:  emptyContext,
+		},
+		{
+			name:     "raw html safety unchanged",
+			input:    `<%- raw("<b>x</b>") %>`,
+			expected: "<b>x</b>",
+			factory:  emptyContext,
+		},
+		{
+			name:     "inside if",
+			input:    "<%= if (true) { %>\n<%- \"yes\" %>\n<% } %>",
+			expected: "yes",
+			factory:  emptyContext,
+		},
+		{
+			name:     "inside for",
+			input:    "<%= for (i,v) in items { %>\n<%- v %>\n<% } %>",
+			expected: "ab",
+			factory: contextWith(map[string]interface{}{
+				"items": []string{"a", "b"},
+			}),
+		},
+		{
+			name:     "inside helper block",
+			input:    "<%= wrap() { %>\n<%- \"x\" %>\n<% } %>",
+			expected: "<span>x</span>",
+			factory: contextWith(map[string]interface{}{
+				"wrap": func(help rootplush.HelperContext) (template.HTML, error) {
+					body, err := help.Block()
+					return template.HTML("<span>" + body + "</span>"), err
+				},
+			}),
+		},
+		{
+			name:     "inside partial",
+			input:    `<%= partial("row.plush") %>`,
+			expected: "<span>x</span>",
+			factory: contextWith(map[string]interface{}{
+				"partialFeeder": func(string) (string, error) {
+					return "<span>\n<%- \"x\" %>\n</span>", nil
+				},
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requireBothRender(t, tt.input, tt.expected, tt.factory)
+		})
+	}
+}
+
+func Test_Phase_8_Old_Eval_Whitespace_Behavior_Unchanged(t *testing.T) {
+	requireBothRender(t, "<pre>\n<%= \"Hello\" %>\n</pre>", "<pre>\nHello\n</pre>", emptyContext)
+}

--- a/VM/plush/parity_variables_test.go
+++ b/VM/plush/parity_variables_test.go
@@ -1,0 +1,115 @@
+package plush_test
+
+import "testing"
+
+type parityCategory struct {
+	Products []parityProduct
+}
+
+type parityProduct struct {
+	Name []string
+}
+
+func Test_Parity_Variables_Let_And_Assign(t *testing.T) {
+	compareRender(t, `<% let message = "hello" %><% message = "bye" %><%= message %>`, emptyContext)
+}
+
+func Test_Parity_Variables_Fast_Local_Let_Helper_Call(t *testing.T) {
+	compareRender(t, `<% let message = greet(name) %><%= wrap(message) %>|<%= message %>`, contextWith(map[string]interface{}{
+		"name":    "Mido",
+		"message": "outer",
+		"greet": func(name string) string {
+			return "hi " + name
+		},
+		"wrap": func(value string) string {
+			return "[" + value + "]"
+		},
+	}))
+}
+
+func Test_Parity_Variables_Unknown_Assignment_Errors(t *testing.T) {
+	compareBothRenderError(t, `<% foo = "baz" %>`, emptyContext)
+}
+
+func Test_Parity_Variables_Identifiers_With_Digits(t *testing.T) {
+	compareRender(t, `<%= my123greet %> <%= name3 %>`, contextWith(map[string]interface{}{
+		"my123greet": "hi",
+		"name3":      "mark",
+	}))
+}
+
+func Test_Parity_Variables_Identifier_Ending_In_Number_Loop(t *testing.T) {
+	compareRender(t, `<%= for (n) in myvar1 { return n } %>`, contextWith(map[string]interface{}{
+		"myvar1": []string{"john", "paul"},
+	}))
+}
+
+func Test_Parity_Variables_Array_And_Hash_Index(t *testing.T) {
+	compareRender(t, `<% let h = {"name": "mark"} %><% let a = ["m", "e"] %><%= h["name"] %><%= a[1] %>`, emptyContext)
+}
+
+func Test_Parity_Variables_Hash_Index_Assignment_And_Missing_Key(t *testing.T) {
+	compareRender(t, `<p><% let h = {"a": "A"} %><% h["a"] = "C" %><%= h["a"] %>:<%= h["missing"] %></p>`, emptyContext)
+}
+
+func Test_Parity_Variables_Array_Index_Assignment(t *testing.T) {
+	compareRender(t, `<p><% let a = [1, 2, "three"] %><% a[0] = 3 %><%= a[0] %></p>`, emptyContext)
+}
+
+func Test_Parity_Variables_Array_Append(t *testing.T) {
+	compareRender(t, `<% let a = [1, "two"] %><% a = a + 3 %><%= a %>`, emptyContext)
+}
+
+func Test_Parity_Variables_Native_Slice_Index_Assignment(t *testing.T) {
+	type item struct {
+		Name string
+	}
+
+	compareBothRenderError(t, `<% let a = myArray %><% a[0] = "HELLO WORLD" %>`, contextWith(map[string]interface{}{
+		"myArray": []item{{Name: "t"}},
+	}))
+}
+
+func Test_Parity_Variables_Native_Interface_Slice_Assignment(t *testing.T) {
+	type item struct {
+		Name string
+	}
+
+	compareRender(t, `<% let a = myArray %><% a[0] = "HELLO WORLD" %><%= a %>`, contextWith(map[string]interface{}{
+		"myArray": []interface{}{item{Name: "t"}, item{Name: "g"}},
+	}))
+}
+
+func Test_Parity_Variables_Native_Slice_Append_Success(t *testing.T) {
+	compareRender(t, `<% let a = myArray %><% a = a + 1 %><%= a %>`, contextWith(map[string]interface{}{
+		"myArray": []interface{}{"a", "b"},
+	}))
+	compareRender(t, `<% let a = myInts %><% a = a + 3 %><%= a[2] %>`, contextWith(map[string]interface{}{
+		"myInts": []int{1, 2},
+	}))
+	compareRender(t, `<% let a = myStrings %><% a = a + "c" %><%= a[2] %>`, contextWith(map[string]interface{}{
+		"myStrings": []string{"a", "b"},
+	}))
+}
+
+func Test_Parity_Variables_Native_Typed_Slice_Append_Error(t *testing.T) {
+	compareBothRenderError(t, `<% let a = myArray %><% a = a + 1 %><%= a %>`, contextWith(map[string]interface{}{
+		"myArray": []string{"a", "b"},
+	}))
+}
+
+func Test_Parity_Variables_Access_Callee_Array(t *testing.T) {
+	compareRender(t, `<% let a = product_listing.Products[0].Name[0] %><%= a %>`, contextWith(map[string]interface{}{
+		"product_listing": parityCategory{
+			Products: []parityProduct{
+				{Name: []string{"Buffalo"}},
+			},
+		},
+	}))
+}
+
+func Test_Parity_Variables_Access_Callee_Array_Out_Of_Bounds(t *testing.T) {
+	compareBothRenderError(t, `<% let a = product_listing.Products[0].Name[0] %><%= a %>`, contextWith(map[string]interface{}{
+		"product_listing": parityCategory{},
+	}))
+}

--- a/VM/plush/plush.go
+++ b/VM/plush/plush.go
@@ -1,0 +1,58 @@
+package plush
+
+import (
+	"fmt"
+
+	rootplush "github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/vm"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+)
+
+type Template = vm.Template
+type FastWriter = vm.FastWriter
+type FastArgs = vm.FastArgs
+type FastHelperFunc = vm.FastHelperFunc
+
+var ErrFastUnsupported = vm.ErrFastUnsupported
+
+func init() {
+	rootplush.RegisterVMRenderer(Render)
+}
+
+func Compile(input string) (*Template, error) {
+	return vm.Compile(input)
+}
+
+// Render renders a Plush template through the compiled VM path.
+//
+// The root github.com/gobuffalo/plush/v5.Render function remains
+// interpreter-backed by default. This package is the opt-in compiled renderer.
+func Render(input string, ctx hctx.Context) (string, error) {
+	return vm.Render(input, ctx)
+}
+
+// RunScript executes a pure Plush script through the compiled VM path.
+func RunScript(input string, ctx hctx.Context) error {
+	ctx = ctx.New()
+	ctx.Set("print", func(i interface{}) {
+		fmt.Print(i)
+	})
+	ctx.Set("println", func(i interface{}) {
+		fmt.Println(i)
+	})
+
+	_, err := Render("<% "+input+" %>", ctx)
+	return err
+}
+
+// SetFastHelper registers an optional custom fast writer for a helper name on
+// this context. The normal helper should still be present in the context for
+// correctness and fallback; returning ErrFastUnsupported from the fast helper
+// tells the VM to use the normal helper call path.
+func SetFastHelper(ctx hctx.Context, name string, helper FastHelperFunc) {
+	vm.SetFastHelper(ctx, name, helper)
+}
+
+func ClearFastHelper(ctx hctx.Context, name string) {
+	vm.ClearFastHelper(ctx, name)
+}

--- a/VM/plush/plush_test.go
+++ b/VM/plush/plush_test.go
@@ -1,0 +1,158 @@
+package plush_test
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	rootplush "github.com/gobuffalo/plush/v5"
+	vmplush "github.com/gobuffalo/plush/v5/VM/plush"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Render_Uses_Compiled_VM_Path(t *testing.T) {
+	ctx := rootplush.NewContextWith(map[string]interface{}{
+		"name": "mark",
+	})
+
+	out, err := vmplush.Render(`<p><%= name %></p>`, ctx)
+	if err != nil {
+		t.Fatalf("Render returned error: %s", err)
+	}
+	if out != "<p>mark</p>" {
+		t.Fatalf("wrong output: %q", out)
+	}
+}
+
+func Test_Root_Render_And_VM_Render_Coexist(t *testing.T) {
+	input := `<%= name %>`
+
+	rootOut, rootErr := rootplush.Render(input, rootplush.NewContextWith(map[string]interface{}{
+		"name": "root",
+	}))
+	if rootErr != nil {
+		t.Fatalf("root Render returned error: %s", rootErr)
+	}
+
+	vmOut, vmErr := vmplush.Render(input, rootplush.NewContextWith(map[string]interface{}{
+		"name": "vm",
+	}))
+	if vmErr != nil {
+		t.Fatalf("VM Render returned error: %s", vmErr)
+	}
+
+	if rootOut != "root" {
+		t.Fatalf("root renderer output changed: %q", rootOut)
+	}
+	if vmOut != "vm" {
+		t.Fatalf("VM renderer output wrong: %q", vmOut)
+	}
+}
+
+func Test_Set_Fast_Helper_Custom_Fast_Render_And_Fallback(t *testing.T) {
+	fallbackCalls := 0
+	ctx := rootplush.NewContextWith(map[string]interface{}{
+		"amount": 12.5,
+		"money": func(value interface{}) string {
+			fallbackCalls++
+			return fmt.Sprintf("fallback:%v", value)
+		},
+	})
+	vmplush.SetFastHelper(ctx, "money", func(w vmplush.FastWriter, args vmplush.FastArgs) error {
+		amount, ok := args.Float64(0)
+		if !ok {
+			return vmplush.ErrFastUnsupported
+		}
+		w.WriteEscapedString(fmt.Sprintf("$%.2f", amount))
+		return nil
+	})
+
+	out, err := vmplush.Render(`<%= money(amount) %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "$12.50", out)
+	require.Zero(t, fallbackCalls)
+
+	ctx.Set("amount", "n/a")
+	out, err = vmplush.Render(`<%= money(amount) %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "fallback:n/a", out)
+	require.Equal(t, 1, fallbackCalls)
+}
+
+func Test_Set_Fast_Helper_Custom_Bytecode_Path(t *testing.T) {
+	fallbackCalls := 0
+	ctx := rootplush.NewContextWith(map[string]interface{}{
+		"amount": int32(7),
+		"money": func(value interface{}) string {
+			fallbackCalls++
+			return fmt.Sprintf("fallback:%v", value)
+		},
+	})
+	vmplush.SetFastHelper(ctx, "money", func(w vmplush.FastWriter, args vmplush.FastArgs) error {
+		amount, ok := args.Int64(0)
+		if !ok {
+			return vmplush.ErrFastUnsupported
+		}
+		w.WriteEscapedString(fmt.Sprintf("fast:%d", amount))
+		return nil
+	})
+
+	out, err := vmplush.Render(`<% let local = amount %><%= money(local) %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "fast:7", out)
+	require.Zero(t, fallbackCalls)
+}
+
+func Test_Clear_Fast_Helper_Removes_Custom_Fast_Render(t *testing.T) {
+	fastCalls := 0
+	fallbackCalls := 0
+	ctx := rootplush.NewContextWith(map[string]interface{}{
+		"name": "plush",
+		"label": func(value interface{}) string {
+			fallbackCalls++
+			return fmt.Sprintf("fallback:%v", value)
+		},
+	})
+	vmplush.SetFastHelper(ctx, "label", func(w vmplush.FastWriter, args vmplush.FastArgs) error {
+		fastCalls++
+		value, ok := args.String(0)
+		if !ok {
+			return vmplush.ErrFastUnsupported
+		}
+		w.WriteEscapedString("fast:" + value)
+		return nil
+	})
+
+	out, err := vmplush.Render(`<%= label(name) %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "fast:plush", out)
+	require.Equal(t, 1, fastCalls)
+	require.Zero(t, fallbackCalls)
+
+	vmplush.ClearFastHelper(ctx, "label")
+	out, err = vmplush.Render(`<%= label(name) %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "fallback:plush", out)
+	require.Equal(t, 1, fastCalls)
+	require.Equal(t, 1, fallbackCalls)
+}
+
+func Test_Run_Script_Installs_Print_Helpers(t *testing.T) {
+	ctx := rootplush.NewContext()
+	originalStdout := os.Stdout
+	reader, writer, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = writer
+	t.Cleanup(func() {
+		os.Stdout = originalStdout
+	})
+
+	err = vmplush.RunScript(`print("hello"); println(" world")`, ctx)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	output, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.Equal(t, "hello world\n", string(output))
+}

--- a/VM/plush/render_mode_test.go
+++ b/VM/plush/render_mode_test.go
@@ -1,0 +1,252 @@
+package plush_test
+
+import (
+	"testing"
+
+	rootplush "github.com/gobuffalo/plush/v5"
+	_ "github.com/gobuffalo/plush/v5/VM/plush"
+	"github.com/gobuffalo/plush/v5/helpers/meta"
+	"github.com/gobuffalo/plush/v5/templatecache/inmemory"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Root_Render_Mode_VM_Uses_Registered_VM_Renderer(t *testing.T) {
+	previous := rootplush.SetRenderMode(rootplush.RenderModeVM)
+	defer rootplush.SetRenderMode(previous)
+
+	out, err := rootplush.Render(`<%= "vm" %>`, rootplush.NewContext())
+	require.NoError(t, err)
+	require.Equal(t, "vm", out)
+}
+
+func Test_Root_Render_Mode_VM_Uses_Bytecode_Only_Cache(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	rootplush.PlushCacheSetup(cache)
+	defer rootplush.ClearTemplateCache()
+
+	previous := rootplush.SetRenderMode(rootplush.RenderModeVM)
+	defer rootplush.SetRenderMode(previous)
+
+	filename := "render-mode-vm.plush"
+	ctx := rootplush.NewContext()
+	ctx.Set(meta.TemplateFileKey, filename)
+
+	out, err := rootplush.Render(`<%= "vm-cache" %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "vm-cache", out)
+
+	entry, ok := cache.Get(rootplush.GenerateASTKey(filename))
+	require.True(t, ok)
+	require.NotNil(t, entry.VMBytecode)
+	require.Nil(t, entry.Program)
+	require.Empty(t, entry.Input)
+}
+
+func Test_Root_Render_Mode_VM_Bytecode_Cache_Invalidates_When_Source_Changes(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	rootplush.PlushCacheSetup(cache)
+	defer rootplush.ClearTemplateCache()
+
+	previous := rootplush.SetRenderMode(rootplush.RenderModeVM)
+	defer rootplush.SetRenderMode(previous)
+
+	filename := "render-mode-vm-source-change.plush"
+	ctx := rootplush.NewContext()
+	ctx.Set(meta.TemplateFileKey, filename)
+
+	out, err := rootplush.Render(`<%= "first" %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "first", out)
+
+	out, err = rootplush.Render(`<%= "second" %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "second", out)
+
+	diagnostics, ok := rootplush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, rootplush.VMBytecodeCacheMissStore, diagnostics.VMBytecodeCache)
+}
+
+func Test_Root_Render_Mode_VM_Bytecode_Cache_Uses_Full_Template_Path(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	rootplush.PlushCacheSetup(cache)
+	defer rootplush.ClearTemplateCache()
+
+	previous := rootplush.SetRenderMode(rootplush.RenderModeVM)
+	defer rootplush.SetRenderMode(previous)
+
+	first := "/templates/client-1/index.plush"
+	second := "/templates/client-2/index.plush"
+
+	firstCtx := rootplush.NewContext()
+	firstCtx.Set(meta.TemplateFileKey, first)
+	out, err := rootplush.Render(`<%= "one" %>`, firstCtx)
+	require.NoError(t, err)
+	require.Equal(t, "one", out)
+
+	secondCtx := rootplush.NewContext()
+	secondCtx.Set(meta.TemplateFileKey, second)
+	out, err = rootplush.Render(`<%= "two" %>`, secondCtx)
+	require.NoError(t, err)
+	require.Equal(t, "two", out)
+
+	firstKey := rootplush.GenerateASTKey(first)
+	secondKey := rootplush.GenerateASTKey(second)
+	require.NotEqual(t, firstKey, secondKey)
+	_, ok := cache.Get(firstKey)
+	require.True(t, ok)
+	_, ok = cache.Get(secondKey)
+	require.True(t, ok)
+}
+
+func Test_Root_Render_Mode_VM_Punch_Hole_Cache_Invalidates_When_Source_Changes(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	rootplush.PlushCacheSetup(cache)
+	defer rootplush.ClearTemplateCache()
+
+	previous := rootplush.SetRenderMode(rootplush.RenderModeVM)
+	defer rootplush.SetRenderMode(previous)
+
+	filename := "render-mode-vm-hole-source-change.plush"
+	ctx := rootplush.NewContext()
+	ctx.Set(meta.TemplateFileKey, filename)
+
+	out, err := rootplush.Render(`A<%H "hole" %>B`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "AholeB", out)
+
+	out, err = rootplush.Render(`C<%H "hole" %>D`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "CholeD", out)
+}
+
+func Test_Root_Render_Mode_VM_Writes_Diagnostics_To_Context(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	rootplush.PlushCacheSetup(cache)
+	defer rootplush.ClearTemplateCache()
+
+	previous := rootplush.SetRenderMode(rootplush.RenderModeVM)
+	defer rootplush.SetRenderMode(previous)
+
+	filename := "render-mode-vm-diagnostics.plush"
+	ctx := rootplush.NewContext()
+	ctx.Set(meta.TemplateFileKey, filename)
+	ctx.Set("name", "mido")
+
+	out, err := rootplush.Render(`<%= name %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "mido", out)
+
+	diagnostics, ok := rootplush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, rootplush.RenderModeNameVM, diagnostics.Mode)
+	require.Equal(t, filename, diagnostics.TemplateFilename)
+	require.Equal(t, rootplush.VMBytecodeCacheMissStore, diagnostics.VMBytecodeCache)
+	require.NotZero(t, diagnostics.EngineDuration)
+
+	out, err = rootplush.Render(`<%= name %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "mido", out)
+
+	diagnostics, ok = rootplush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, rootplush.RenderModeNameVM, diagnostics.Mode)
+	require.Equal(t, filename, diagnostics.TemplateFilename)
+	require.Equal(t, rootplush.VMBytecodeCacheHit, diagnostics.VMBytecodeCache)
+	require.NotZero(t, diagnostics.EngineDuration)
+}
+
+func Test_Root_Render_Mode_VM_Generic_Fallback_Uses_Interpreter(t *testing.T) {
+	previousMode := rootplush.SetRenderMode(rootplush.RenderModeVM)
+	defer rootplush.SetRenderMode(previousMode)
+	previousFallback := rootplush.SetVMGenericFallback(true)
+	defer rootplush.SetVMGenericFallback(previousFallback)
+
+	ctx := rootplush.NewContext()
+	out, err := rootplush.Render(`<% let forceBytecode = fn() { return "x" } %><% let title = "Products" %><%= title %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "Products", out)
+
+	diagnostics, ok := rootplush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, rootplush.RenderModeNameVM, diagnostics.Mode)
+	require.Equal(t, rootplush.RenderFastPathInterpreterFallback, diagnostics.FastPath)
+}
+
+func Test_Root_Render_Mode_VM_Generic_Fallback_Keeps_Bytecode_Cache(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	rootplush.PlushCacheSetup(cache)
+	defer rootplush.ClearTemplateCache()
+
+	previousMode := rootplush.SetRenderMode(rootplush.RenderModeVM)
+	defer rootplush.SetRenderMode(previousMode)
+	previousFallback := rootplush.SetVMGenericFallback(true)
+	defer rootplush.SetVMGenericFallback(previousFallback)
+
+	filename := "render-mode-vm-fallback-cache.plush"
+	ctx := rootplush.NewContext()
+	ctx.Set(meta.TemplateFileKey, filename)
+
+	input := `<% let forceBytecode = fn() { return "x" } %><% let title = "Products" %><%= title %>`
+	out, err := rootplush.Render(input, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "Products", out)
+	diagnostics, ok := rootplush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, rootplush.VMBytecodeCacheMissStore, diagnostics.VMBytecodeCache)
+
+	out, err = rootplush.Render(input, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "Products", out)
+	diagnostics, ok = rootplush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, rootplush.VMBytecodeCacheHit, diagnostics.VMBytecodeCache)
+	require.Equal(t, rootplush.RenderFastPathInterpreterFallback, diagnostics.FastPath)
+}
+
+func Test_Root_Render_Mode_VM_Generic_Fallback_Renders_Partials_With_Interpreter(t *testing.T) {
+	previousMode := rootplush.SetRenderMode(rootplush.RenderModeVM)
+	defer rootplush.SetRenderMode(previousMode)
+	previousFallback := rootplush.SetVMGenericFallback(true)
+	defer rootplush.SetVMGenericFallback(previousFallback)
+
+	ctx := rootplush.NewContext()
+	ctx.Set("partial", rootplush.PartialHelper)
+	ctx.Set("partialFeeder", func(name string) (string, error) {
+		require.Equal(t, "row.plush", name)
+		return `<% let title = "Row" %><%= title %>`, nil
+	})
+	ctx.Set(meta.TemplateFileKey, "render-mode-vm-fallback-partial.plush")
+
+	out, err := rootplush.Render(`<% let forceBytecode = fn() { return "x" } %><%= partial("row.plush", {}) %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "Row", out)
+
+	diagnostics, ok := rootplush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, rootplush.RenderFastPathInterpreterFallback, diagnostics.FastPath)
+	require.Zero(t, diagnostics.VMHotspots.PartialCalls)
+}
+
+func Test_Root_Render_Mode_Interpreter_Still_Uses_AST_Cache(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	rootplush.PlushCacheSetup(cache)
+	defer rootplush.ClearTemplateCache()
+
+	previous := rootplush.SetRenderMode(rootplush.RenderModeInterpreter)
+	defer rootplush.SetRenderMode(previous)
+
+	filename := "render-mode-interpreter.plush"
+	ctx := rootplush.NewContext()
+	ctx.Set(meta.TemplateFileKey, filename)
+
+	out, err := rootplush.Render(`<%= "interpreter-cache" %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "interpreter-cache", out)
+
+	entry, ok := cache.Get(rootplush.GenerateASTKey(filename))
+	require.True(t, ok)
+	require.NotNil(t, entry.Program)
+	require.Nil(t, entry.VMBytecode)
+	require.Empty(t, entry.Input)
+}

--- a/VM/plush/render_mode_test.go
+++ b/VM/plush/render_mode_test.go
@@ -2,6 +2,7 @@ package plush_test
 
 import (
 	"testing"
+	"time"
 
 	rootplush "github.com/gobuffalo/plush/v5"
 	_ "github.com/gobuffalo/plush/v5/VM/plush"
@@ -132,8 +133,12 @@ func Test_Root_Render_Mode_VM_Writes_Diagnostics_To_Context(t *testing.T) {
 	ctx := rootplush.NewContext()
 	ctx.Set(meta.TemplateFileKey, filename)
 	ctx.Set("name", "mido")
+	ctx.Set("slow", func() string {
+		time.Sleep(20 * time.Millisecond)
+		return ""
+	})
 
-	out, err := rootplush.Render(`<%= name %>`, ctx)
+	out, err := rootplush.Render(`<%= slow() %><%= name %>`, ctx)
 	require.NoError(t, err)
 	require.Equal(t, "mido", out)
 
@@ -144,7 +149,7 @@ func Test_Root_Render_Mode_VM_Writes_Diagnostics_To_Context(t *testing.T) {
 	require.Equal(t, rootplush.VMBytecodeCacheMissStore, diagnostics.VMBytecodeCache)
 	require.NotZero(t, diagnostics.EngineDuration)
 
-	out, err = rootplush.Render(`<%= name %>`, ctx)
+	out, err = rootplush.Render(`<%= slow() %><%= name %>`, ctx)
 	require.NoError(t, err)
 	require.Equal(t, "mido", out)
 

--- a/VM/vm/benchmark_test.go
+++ b/VM/vm/benchmark_test.go
@@ -1,0 +1,757 @@
+package vm
+
+import (
+	"fmt"
+	"html/template"
+	"strings"
+	"testing"
+
+	rootplush "github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+	"github.com/gobuffalo/plush/v5/helpers/meta"
+	"github.com/gobuffalo/plush/v5/templatecache/inmemory"
+)
+
+var benchmarkSink string
+
+type benchmarkScenario struct {
+	name  string
+	input string
+	ctx   func() hctx.Context
+	reuse bool
+}
+
+type benchmarkRobot struct {
+	Name    benchmarkName
+	Enabled bool
+	Stock   uint32
+	Friends []benchmarkRobot
+}
+
+func (r benchmarkRobot) GetFriends() []benchmarkRobot {
+	return r.Friends
+}
+
+type benchmarkName string
+
+func (n benchmarkName) Echo() string {
+	return string(n)
+}
+
+type benchmarkProduct struct {
+	Name     string
+	Count    int
+	Category benchmarkCategory
+}
+
+type benchmarkCatalog struct {
+	Products []benchmarkStoreProduct
+}
+
+type benchmarkStoreProduct struct {
+	Name    string
+	Stock   uint32
+	Friends []benchmarkStoreFriend
+}
+
+type benchmarkStoreFriend struct {
+	Name string
+}
+
+type benchmarkCategory struct {
+	Label string
+}
+
+func benchmarkScenarios() []benchmarkScenario {
+	return []benchmarkScenario{
+		{
+			name:  "static_html",
+			input: `<section><h1>Hello</h1><p>Static content</p></section>`,
+			ctx:   benchmarkEmptyContext,
+			reuse: true,
+		},
+		{
+			name:  "variable_interpolation",
+			input: `<p>Hello <%= name %></p><p><%= title %></p>`,
+			ctx: func() hctx.Context {
+				return rootplush.NewContextWith(map[string]interface{}{"name": "Mido", "title": "Engineer"})
+			},
+			reuse: true,
+		},
+		{
+			name:  "helper_heavy",
+			input: `<%= greet(name) %><%= greet(name) %><%= greet(name) %><%= greet(name) %><%= greet(name) %>`,
+			ctx: func() hctx.Context {
+				return rootplush.NewContextWith(map[string]interface{}{
+					"name": "Mido",
+					"greet": func(name string) string {
+						return "hi " + name
+					},
+				})
+			},
+			reuse: true,
+		},
+		{
+			name:  "name_lookup_heavy",
+			input: strings.Repeat(`<%= name %>|`, 40),
+			ctx: func() hctx.Context {
+				return rootplush.NewContextWith(map[string]interface{}{"name": "Mido"})
+			},
+			reuse: true,
+		},
+		{
+			name:  "static_output_heavy",
+			input: `<section>` + strings.Repeat(`<p>Static VM output paragraph.</p>`, 80) + `</section>`,
+			ctx:   benchmarkEmptyContext,
+			reuse: true,
+		},
+		{
+			name:  "regex_match",
+			input: `<%= name ~= "^Mi.*o$" %><%= name ~= "^Mi.*o$" %><%= name ~= "^Mi.*o$" %>`,
+			ctx: func() hctx.Context {
+				return rootplush.NewContextWith(map[string]interface{}{"name": "Mido"})
+			},
+			reuse: true,
+		},
+		{
+			name:  "mixed_numeric_operators",
+			input: `<%= i32 == 0 %>|<%= u32 == 0 %>|<%= u64one == 1.0 %>|<%= f32i == 3 %>|<%= f64i == i32v %>|<%= robot.Stock == 3.0 %>`,
+			ctx: func() hctx.Context {
+				return rootplush.NewContextWith(map[string]interface{}{
+					"i32":    int32(0),
+					"i32v":   int32(3),
+					"u32":    uint32(0),
+					"u64one": uint64(1),
+					"f32i":   float32(3),
+					"f64i":   float64(3),
+					"robot":  benchmarkRobot{Stock: uint32(3)},
+				})
+			},
+			reuse: true,
+		},
+		{
+			name:  "loop_heavy",
+			input: `<%= for (i, item) in items { %><%= i %>:<%= item %>;<% } %>`,
+			ctx: func() hctx.Context {
+				items := make([]string, 100)
+				for i := range items {
+					items[i] = fmt.Sprintf("item-%d", i)
+				}
+				return rootplush.NewContextWith(map[string]interface{}{"items": items})
+			},
+			reuse: true,
+		},
+		{
+			name:  "loop_struct_property",
+			input: `<%= for (i, product) in products { %><%= product.Name %>;<% } %>`,
+			ctx: func() hctx.Context {
+				products := make([]benchmarkRobot, 100)
+				for i := range products {
+					products[i] = benchmarkRobot{Name: benchmarkName(fmt.Sprintf("product-%d", i))}
+				}
+				return rootplush.NewContextWith(map[string]interface{}{"products": products})
+			},
+			reuse: true,
+		},
+		{
+			name:  "loop_concat_output",
+			input: `<%= for (i, product) in products { %><%= product.Name + " x " + product.Count %>;<% } %>`,
+			ctx: func() hctx.Context {
+				products := make([]benchmarkProduct, 100)
+				for i := range products {
+					products[i] = benchmarkProduct{
+						Name:  fmt.Sprintf("product-%d", i),
+						Count: i + 1,
+					}
+				}
+				return rootplush.NewContextWith(map[string]interface{}{"products": products})
+			},
+			reuse: true,
+		},
+		{
+			name:  "nested_flash_loop",
+			input: `<%= for (k, messages) in flash { %><%= for (msg) in messages { %><%= if (len(messages) && messages[0] != "skip") { %><%= k %>:<%= msg %>;<% } %><% } %><% } %>`,
+			ctx: func() hctx.Context {
+				return rootplush.NewContextWith(map[string]interface{}{
+					"flash": map[string][]string{
+						"notice": {"Hello", "Bye", "Ready"},
+					},
+				})
+			},
+			reuse: true,
+		},
+		{
+			name:  "nested_struct_property",
+			input: `<%= product.Category.Label %>:<%= product.Name %>`,
+			ctx: func() hctx.Context {
+				return rootplush.NewContextWith(map[string]interface{}{
+					"product": benchmarkProduct{
+						Name:     "Bender",
+						Category: benchmarkCategory{Label: "Robot"},
+					},
+				})
+			},
+			reuse: true,
+		},
+		{
+			name:  "loop_nested_struct_property",
+			input: `<%= for (i, product) in products { %><%= product.Category.Label %>:<%= product.Name %>;<% } %>`,
+			ctx: func() hctx.Context {
+				products := make([]benchmarkProduct, 100)
+				for i := range products {
+					products[i] = benchmarkProduct{
+						Name:     fmt.Sprintf("product-%d", i),
+						Category: benchmarkCategory{Label: "robot"},
+					}
+				}
+				return rootplush.NewContextWith(map[string]interface{}{"products": products})
+			},
+			reuse: true,
+		},
+		{
+			name:  "loop_helper_call",
+			input: `<%= for (i, product) in products { %><%= label(product.Name, prefix) %>;<% } %>`,
+			ctx: func() hctx.Context {
+				products := make([]benchmarkRobot, 100)
+				for i := range products {
+					products[i] = benchmarkRobot{Name: benchmarkName(fmt.Sprintf("product-%d", i))}
+				}
+				return rootplush.NewContextWith(map[string]interface{}{
+					"prefix":   "product",
+					"products": products,
+					"label": func(name benchmarkName, prefix string) string {
+						return prefix + ":" + name.Echo()
+					},
+				})
+			},
+			reuse: true,
+		},
+		{
+			name:  "loop_helper_call_string",
+			input: `<%= for (i, product) in products { %><%= label(product.Name, prefix) %>;<% } %>`,
+			ctx: func() hctx.Context {
+				products := make([]benchmarkProduct, 100)
+				for i := range products {
+					products[i] = benchmarkProduct{Name: fmt.Sprintf("product-%d", i)}
+				}
+				return rootplush.NewContextWith(map[string]interface{}{
+					"prefix":   "product",
+					"products": products,
+					"label": func(name string, prefix string) string {
+						return prefix + ":" + name
+					},
+				})
+			},
+			reuse: true,
+		},
+		{
+			name:  "loop_helper_call_int",
+			input: `<%= for (i, product) in products { %><%= label(i, suffix) %>;<% } %>`,
+			ctx: func() hctx.Context {
+				products := make([]benchmarkProduct, 100)
+				for i := range products {
+					products[i] = benchmarkProduct{Name: fmt.Sprintf("product-%d", i)}
+				}
+				return rootplush.NewContextWith(map[string]interface{}{
+					"suffix":   "items",
+					"products": products,
+					"label": func(index int, suffix string) string {
+						return fmt.Sprintf("%d:%s", index, suffix)
+					},
+				})
+			},
+			reuse: true,
+		},
+		{
+			name:  "loop_conditional",
+			input: `<%= for (i, product) in products { %><%= if product.Enabled { %><%= product.Name %><% } else { %>hidden<% } %>;<% } %>`,
+			ctx: func() hctx.Context {
+				products := make([]benchmarkRobot, 100)
+				for i := range products {
+					products[i] = benchmarkRobot{
+						Name:    benchmarkName(fmt.Sprintf("product-%d", i)),
+						Enabled: i%2 == 0,
+					}
+				}
+				return rootplush.NewContextWith(map[string]interface{}{"products": products})
+			},
+			reuse: true,
+		},
+		{
+			name:  "loop_infix_conditional",
+			input: `<%= for (i, product) in products { %><%= if product.Stock > min && i != 0 { %><%= product.Name %><% } else { %>hidden<% } %>;<% } %>`,
+			ctx: func() hctx.Context {
+				products := make([]benchmarkRobot, 100)
+				for i := range products {
+					products[i] = benchmarkRobot{
+						Name:  benchmarkName(fmt.Sprintf("product-%d", i)),
+						Stock: uint32(i % 5),
+					}
+				}
+				return rootplush.NewContextWith(map[string]interface{}{
+					"min":      uint64(2),
+					"products": products,
+				})
+			},
+			reuse: true,
+		},
+		{
+			name:  "struct_chain_heavy",
+			input: `<%= robot.Name.Echo() %>|<%= robot.GetFriends()[0].Name.Echo() %>|<%= robot.GetFriends()[1].Name.Echo() %>`,
+			ctx: func() hctx.Context {
+				return rootplush.NewContextWith(map[string]interface{}{
+					"robot": benchmarkRobot{
+						Name: benchmarkName("bender"),
+						Friends: []benchmarkRobot{
+							{Name: benchmarkName("fry")},
+							{Name: benchmarkName("leela")},
+						},
+					},
+				})
+			},
+			reuse: true,
+		},
+		{
+			name:  "nested_access",
+			input: `<%= robots[0].Name %>|<%= robots[1].Name %>`,
+			ctx: func() hctx.Context {
+				return rootplush.NewContextWith(map[string]interface{}{
+					"robots": []benchmarkRobot{
+						{Name: benchmarkName("bender")},
+						{Name: benchmarkName("fry")},
+					},
+				})
+			},
+			reuse: true,
+		},
+		{
+			name:  "typed_map_access",
+			input: `<%= labels["status"] %>|<%= counts["active"] %>|<%= robots["bender"].Name %>`,
+			ctx: func() hctx.Context {
+				return rootplush.NewContextWith(map[string]interface{}{
+					"labels": map[string]string{"status": "ready"},
+					"counts": map[string]uint32{"active": 7},
+					"robots": map[string]benchmarkRobot{
+						"bender": {Name: benchmarkName("Bender")},
+					},
+				})
+			},
+			reuse: true,
+		},
+		{
+			name:  "partial_heavy",
+			input: `<%= partial("row.plush") %><%= partial("row.plush") %><%= partial("row.plush") %>`,
+			ctx: func() hctx.Context {
+				return rootplush.NewContextWith(map[string]interface{}{
+					"name": "Mido",
+					"partialFeeder": func(string) (string, error) {
+						return `<span><%= name %></span>`, nil
+					},
+				})
+			},
+			reuse: true,
+		},
+		{
+			name:  "partial_data_map",
+			input: `<%= partial("row.plush", {name: first, title: robot.Name}) %><%= partial("row.plush", {name: second, title: "literal"}) %><%= partial("row.plush", {name: third, title: robot.Name}) %>`,
+			ctx: func() hctx.Context {
+				return rootplush.NewContextWith(map[string]interface{}{
+					"first":  "Mido",
+					"second": "Fry",
+					"third":  "Leela",
+					"robot":  benchmarkRobot{Name: benchmarkName("Bender")},
+					"partialFeeder": func(string) (string, error) {
+						return `<span><%= name %>:<%= title %></span>`, nil
+					},
+				})
+			},
+			reuse: true,
+		},
+		{
+			name:  "partial_data_helper_map",
+			input: `<%= partial("row.plush", {label: label(product.Name, prefix)}) %><%= partial("row.plush", {label: label(product.Name, prefix)}) %><%= partial("row.plush", {label: label(product.Name, prefix)}) %>`,
+			ctx: func() hctx.Context {
+				return rootplush.NewContextWith(map[string]interface{}{
+					"product": benchmarkProduct{Name: "Bender"},
+					"prefix":  "robot",
+					"label": func(name string, prefix string) string {
+						return prefix + ":" + name
+					},
+					"partialFeeder": func(string) (string, error) {
+						return `<span><%= label %></span>`, nil
+					},
+				})
+			},
+			reuse: true,
+		},
+		{
+			name:  "partial_simple_access",
+			input: `<%= partial("row.plush") %><%= partial("row.plush") %><%= partial("row.plush") %>`,
+			ctx: func() hctx.Context {
+				return rootplush.NewContextWith(map[string]interface{}{
+					"robot":  benchmarkRobot{Name: benchmarkName("Bender")},
+					"labels": map[string]string{"status": "ready"},
+					"count":  uint32(1),
+					"partialFeeder": func(string) (string, error) {
+						return `<span><%= robot.Name %>:<%= labels["status"] %>:<%= count == 1 %></span>`, nil
+					},
+				})
+			},
+			reuse: true,
+		},
+		{
+			name:  "punch_hole",
+			input: `<%= "a" %><%H "hole" %><%= "b" %><%H "hole2" %>`,
+			ctx:   benchmarkEmptyContext,
+		},
+		{
+			name:  "whitespace_trim",
+			input: "a \n <%- \"b\" %> \n c",
+			ctx:   benchmarkEmptyContext,
+			reuse: true,
+		},
+		{
+			name:  "optional_parentheses",
+			input: `<%= if enabled { %>yes<% } else if fallback { %>fallback<% } else { %>no<% } %>`,
+			ctx: func() hctx.Context {
+				return rootplush.NewContextWith(map[string]interface{}{"enabled": false, "fallback": true})
+			},
+			reuse: true,
+		},
+		{
+			name:  "conditional_simple_access",
+			input: `<%= if robot.Stock > min { %><%= robot.Name %><% } else if fallback { %><%= labels["status"] %>:<%= count == 1 %><% } else { %>no<% } %>`,
+			ctx: func() hctx.Context {
+				return rootplush.NewContextWith(map[string]interface{}{
+					"robot":    benchmarkRobot{Name: benchmarkName("Bender"), Stock: 0},
+					"min":      uint32(0),
+					"fallback": true,
+					"labels":   map[string]string{"status": "ready"},
+					"count":    uint32(1),
+				})
+			},
+			reuse: true,
+		},
+		{
+			name: "realistic_mixed",
+			input: `<article>
+<h1><%= title %></h1>
+<%= if user.Name { %><p><%= greet(user.Name) %></p><% } %>
+<ul><%= for (i, item) in items { %><li><%= i %>: <%= item.Name.Echo() %></li><% } %></ul>
+</article>`,
+			ctx: func() hctx.Context {
+				return rootplush.NewContextWith(map[string]interface{}{
+					"title": "Robots",
+					"user":  benchmarkRobot{Name: benchmarkName("Mido")},
+					"items": []benchmarkRobot{
+						{Name: benchmarkName("bender")},
+						{Name: benchmarkName("fry")},
+						{Name: benchmarkName("leela")},
+					},
+					"greet": func(name benchmarkName) template.HTML {
+						return template.HTML("hello " + name.Echo())
+					},
+				})
+			},
+			reuse: true,
+		},
+		{
+			name: "generic_storefront_shape",
+			input: `<% let title = "Products" %>
+<%= wrap({class: "grid"}) { %>
+<h2><%= title %></h2>
+<%= if (!hidden) { %>
+<%= for (_, product) in catalog.Products { %>
+<article>
+<h3><%= product.Name %></h3>
+<%= if (product.Stock > 0) { %><span><%= product.Stock %></span><% } else { %><span>sold out</span><% } %>
+<ul><%= for (_, friend) in product.Friends { %><%= if (friend.Name == "stop") { %><%= break %><% } %><li><%= friend.Name %></li><% } %></ul>
+</article>
+<% } %>
+<% } %>
+<% } %>`,
+			ctx: func() hctx.Context {
+				return rootplush.NewContextWith(map[string]interface{}{
+					"hidden": false,
+					"catalog": benchmarkCatalog{Products: []benchmarkStoreProduct{
+						{Name: "Bender", Stock: 3, Friends: []benchmarkStoreFriend{{Name: "Fry"}, {Name: "Leela"}}},
+						{Name: "Zoidberg", Stock: 0, Friends: []benchmarkStoreFriend{{Name: "Hermes"}, {Name: "stop"}, {Name: "Amy"}}},
+						{Name: "Nibbler", Stock: 1, Friends: []benchmarkStoreFriend{{Name: "Mido"}}},
+					}},
+					"wrap": func(data map[string]interface{}, help rootplush.HelperContext) (template.HTML, error) {
+						body, err := help.Block()
+						if err != nil {
+							return "", err
+						}
+						return template.HTML(`<section class="` + fmt.Sprint(data["class"]) + `">` + body + `</section>`), nil
+					},
+				})
+			},
+			reuse: true,
+		},
+	}
+}
+
+func benchmarkEmptyContext() hctx.Context {
+	return rootplush.NewContext()
+}
+
+func BenchmarkRenderOneShot(b *testing.B) {
+	for _, scenario := range benchmarkScenarios() {
+		b.Run(scenario.name+"/interpreter", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				out, err := rootplush.Render(scenario.input, scenario.ctx())
+				if err != nil {
+					b.Skipf("interpreter does not support this benchmark scenario: %v", err)
+				}
+				benchmarkSink = out
+			}
+		})
+		b.Run(scenario.name+"/vm", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				out, err := Render(scenario.input, scenario.ctx())
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchmarkSink = out
+			}
+		})
+	}
+}
+
+func BenchmarkRenderCompiledReuse(b *testing.B) {
+	for _, scenario := range benchmarkScenarios() {
+		if !scenario.reuse {
+			continue
+		}
+		b.Run(scenario.name+"/vm_reused_bytecode", func(b *testing.B) {
+			tmpl, err := Compile(scenario.input)
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				out, err := tmpl.Render(scenario.ctx())
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchmarkSink = out
+			}
+		})
+	}
+}
+
+func BenchmarkRenderReusedContextMatrix(b *testing.B) {
+	for _, scenario := range benchmarkScenarios() {
+		if !scenario.reuse {
+			continue
+		}
+
+		b.Run(scenario.name+"/interpreter_parsed_reused_context", func(b *testing.B) {
+			tmpl, err := rootplush.NewTemplate(scenario.input)
+			if err != nil {
+				b.Skipf("interpreter does not support this benchmark scenario: %v", err)
+			}
+			ctx := scenario.ctx()
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				out, _, err := tmpl.Exec(ctx)
+				if err != nil {
+					b.Skipf("interpreter does not support this benchmark scenario: %v", err)
+				}
+				benchmarkSink = out
+			}
+		})
+
+		b.Run(scenario.name+"/vm_compiled_reused_context", func(b *testing.B) {
+			tmpl, err := Compile(scenario.input)
+			if err != nil {
+				b.Fatal(err)
+			}
+			ctx := scenario.ctx()
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				out, err := tmpl.Render(ctx)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchmarkSink = out
+			}
+		})
+	}
+}
+
+func BenchmarkRenderCachedFilename(b *testing.B) {
+	for _, scenario := range benchmarkScenarios() {
+		if !scenario.reuse {
+			continue
+		}
+		b.Run(scenario.name+"/vm_cached_render", func(b *testing.B) {
+			cache := inmemory.NewMemoryCache()
+			rootplush.PlushCacheSetup(cache)
+			filename := "bench-" + scenario.name + ".plush"
+			warmCtx := scenario.ctx()
+			warmCtx.Set(meta.TemplateFileKey, filename)
+			if _, err := Render(scenario.input, warmCtx); err != nil {
+				b.Fatal(err)
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				ctx := scenario.ctx()
+				ctx.Set(meta.TemplateFileKey, filename)
+				out, err := Render(scenario.input, ctx)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchmarkSink = out
+			}
+		})
+	}
+}
+
+func BenchmarkRenderSourceBytecodeCache(b *testing.B) {
+	scenarios := []benchmarkScenario{
+		{
+			name:  "variable_snippet",
+			input: `<script>window.store = "<%= storeURL %>"; window.page = "<%= page %>";</script>`,
+			ctx: func() hctx.Context {
+				return rootplush.NewContextWith(map[string]interface{}{
+					"storeURL": "devstorev1.com",
+					"page":     "product",
+				})
+			},
+			reuse: true,
+		},
+		{
+			name:  "helper_snippet",
+			input: `<%= assetTag("app.js") %><%= assetTag("app.css") %><%= assetTag(name + ".js") %>`,
+			ctx: func() hctx.Context {
+				return rootplush.NewContextWith(map[string]interface{}{
+					"name": "product",
+					"assetTag": func(name string) template.HTML {
+						return template.HTML(`<script src="/assets/` + name + `"></script>`)
+					},
+				})
+			},
+			reuse: true,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		b.Run(scenario.name+"/interpreter_no_filename", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				out, err := rootplush.Render(scenario.input, scenario.ctx())
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchmarkSink = out
+			}
+		})
+
+		b.Run(scenario.name+"/vm_no_filename_uncached", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				clearSourceBytecodeCacheForTest()
+				out, err := Render(scenario.input, scenario.ctx())
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchmarkSink = out
+			}
+		})
+		clearSourceBytecodeCacheForTest()
+
+		b.Run(scenario.name+"/vm_no_filename_source_cache", func(b *testing.B) {
+			warmCtx := scenario.ctx()
+			if _, err := Render(scenario.input, warmCtx); err != nil {
+				b.Fatal(err)
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				out, err := Render(scenario.input, scenario.ctx())
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchmarkSink = out
+			}
+		})
+		clearSourceBytecodeCacheForTest()
+	}
+}
+
+func BenchmarkRenderModeMatrix(b *testing.B) {
+	for _, scenario := range benchmarkScenarios() {
+		if !scenario.reuse {
+			continue
+		}
+
+		b.Run(scenario.name+"/interpreter_uncached", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				out, err := rootplush.Render(scenario.input, scenario.ctx())
+				if err != nil {
+					b.Skipf("interpreter does not support this benchmark scenario: %v", err)
+				}
+				benchmarkSink = out
+			}
+		})
+
+		b.Run(scenario.name+"/interpreter_ast_cache", func(b *testing.B) {
+			cache := inmemory.NewMemoryCache()
+			rootplush.PlushCacheSetup(cache)
+			filename := "bench-interpreter-" + scenario.name + ".plush"
+			warmCtx := scenario.ctx()
+			warmCtx.Set(meta.TemplateFileKey, filename)
+			out, err := rootplush.Render(scenario.input, warmCtx)
+			if err != nil {
+				b.Skipf("interpreter does not support this benchmark scenario: %v", err)
+			}
+			benchmarkSink = out
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				ctx := scenario.ctx()
+				ctx.Set(meta.TemplateFileKey, filename)
+				out, err := rootplush.Render(scenario.input, ctx)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchmarkSink = out
+			}
+		})
+
+		b.Run(scenario.name+"/vm_uncached", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				out, err := Render(scenario.input, scenario.ctx())
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchmarkSink = out
+			}
+		})
+
+		b.Run(scenario.name+"/vm_bytecode_cache", func(b *testing.B) {
+			cache := inmemory.NewMemoryCache()
+			rootplush.PlushCacheSetup(cache)
+			filename := "bench-vm-" + scenario.name + ".plush"
+			warmCtx := scenario.ctx()
+			warmCtx.Set(meta.TemplateFileKey, filename)
+			if _, err := Render(scenario.input, warmCtx); err != nil {
+				b.Fatal(err)
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				ctx := scenario.ctx()
+				ctx.Set(meta.TemplateFileKey, filename)
+				out, err := Render(scenario.input, ctx)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchmarkSink = out
+			}
+		})
+	}
+}

--- a/VM/vm/binding_context_helpers_test.go
+++ b/VM/vm/binding_context_helpers_test.go
@@ -1,0 +1,275 @@
+package vm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+	"github.com/stretchr/testify/require"
+)
+
+type vmBindingIDContext struct {
+	*idLookupTestContext
+	internIDs int
+}
+
+func (c *vmBindingIDContext) InternIDs(keys []string, ids []int) {
+	c.internIDs++
+	for i, key := range keys {
+		ids[i] = c.InternID(key)
+	}
+}
+
+type vmFallbackContext struct {
+	context.Context
+	values map[string]interface{}
+	has    int
+	value  int
+}
+
+func newVMFallbackContext(values map[string]interface{}) *vmFallbackContext {
+	return &vmFallbackContext{Context: context.Background(), values: values}
+}
+
+func (c *vmFallbackContext) New() hctx.Context {
+	return newVMFallbackContext(c.values)
+}
+
+func (c *vmFallbackContext) Has(key string) bool {
+	c.has++
+	_, ok := c.values[key]
+	return ok
+}
+
+func (c *vmFallbackContext) Value(key interface{}) interface{} {
+	c.value++
+	if key, ok := key.(string); ok {
+		return c.values[key]
+	}
+	return nil
+}
+
+func (c *vmFallbackContext) Set(key string, value interface{}) {
+	c.values[key] = value
+}
+
+func (c *vmFallbackContext) Update(key string, value interface{}) bool {
+	if _, ok := c.values[key]; !ok {
+		return false
+	}
+	c.values[key] = value
+	return true
+}
+
+func Test_VM_Fill_Fast_Render_Binding_I_Ds_Branches(t *testing.T) {
+	var inline [8]int
+	var ids []int
+	fillFastRenderBindingIDs(nil, nil, &inline, &ids)
+	require.Nil(t, ids)
+
+	lookup := newIDLookupTestContext(map[string]interface{}{})
+	fillFastRenderBindingIDs([]string{"a", "b"}, lookup, &inline, &ids)
+	require.Nil(t, ids)
+	require.Equal(t, lookup.stringToID["a"], inline[0])
+	require.Equal(t, lookup.stringToID["b"], inline[1])
+
+	manyNames := make([]string, 9)
+	for i := range manyNames {
+		manyNames[i] = fmt.Sprintf("n%d", i)
+	}
+	fillFastRenderBindingIDs(manyNames, lookup, &inline, &ids)
+	require.Len(t, ids, len(manyNames))
+	require.Equal(t, lookup.stringToID["n8"], ids[8])
+
+	binder := &vmBindingIDContext{idLookupTestContext: newIDLookupTestContext(map[string]interface{}{})}
+	inline = [8]int{}
+	ids = nil
+	fillFastRenderBindingIDs([]string{"x", "y"}, binder, &inline, &ids)
+	require.Equal(t, 1, binder.internIDs)
+	require.Equal(t, binder.stringToID["x"], inline[0])
+
+	fillFastRenderBindingIDs(manyNames, binder, &inline, &ids)
+	require.Equal(t, 2, binder.internIDs)
+	require.Len(t, ids, len(manyNames))
+}
+
+func Test_VM_Fast_Render_Bindings_Value_Branches(t *testing.T) {
+	require.Nil(t, newFastRenderBindingPlan(nil, plush.NewContext()))
+	require.Nil(t, newFastRenderBindingPlan(&compiler.FastRenderPlan{}, plush.NewContext()))
+	require.Nil(t, newFastRenderBindingPlan(&compiler.FastRenderPlan{Bindings: []string{"name"}}, newVMFallbackContext(map[string]interface{}{"name": "fallback"})))
+
+	ctx := newIDLookupTestContext(map[string]interface{}{"a": "A", "b": "B"})
+	plan := &compiler.FastRenderPlan{Bindings: []string{"a", "b"}}
+	bindings := newFastRenderBindings(plan, ctx)
+
+	value, ok := bindings.value(-1)
+	require.False(t, ok)
+	require.Nil(t, value)
+
+	value, ok = bindings.value(99)
+	require.False(t, ok)
+	require.Nil(t, value)
+
+	value, ok = bindings.value(0)
+	require.True(t, ok)
+	require.Equal(t, "A", value)
+
+	bindings.localOK = []bool{true}
+	bindings.localVals = []interface{}{"local"}
+	value, ok = bindings.value(0)
+	require.True(t, ok)
+	require.Equal(t, "local", value)
+
+	fallback := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"name"}}, plush.NewContextWith(map[string]interface{}{"name": "fallback"}))
+	value, ok = fallback.value(0)
+	require.True(t, ok)
+	require.Equal(t, "fallback", value)
+
+	bigPlan := &compiler.FastRenderPlan{Bindings: []string{"a", "b", "c", "d", "e", "f", "g", "h", "i"}}
+	bigCtx := plush.NewContextWith(map[string]interface{}{"i": "I"})
+	prepared := newFastRenderBindingPlan(bigPlan, bigCtx)
+	require.NotNil(t, prepared)
+	bigBindings := newFastRenderBindingsWithPlan(bigPlan, bigCtx, prepared)
+	require.NotNil(t, bigBindings.ids)
+	value, ok = bigBindings.value(8)
+	require.True(t, ok)
+	require.Equal(t, "I", value)
+
+	mismatch := newFastRenderBindingsWithPlan(&compiler.FastRenderPlan{Bindings: []string{"i"}}, bigCtx, prepared)
+	value, ok = mismatch.value(0)
+	require.True(t, ok)
+	require.Equal(t, "I", value)
+}
+
+func Test_VM_Context_Value_Branches(t *testing.T) {
+	machine := newRuntimeHelperTestVM(nil)
+	value, ok := machine.contextValue("missing")
+	require.False(t, ok)
+	require.Nil(t, value)
+
+	lookup := newLookupTestContext(map[string]interface{}{"name": "lookup"})
+	machine.ctx = lookup
+	value, ok = machine.contextValue("name")
+	require.True(t, ok)
+	require.Equal(t, "lookup", value)
+	require.Equal(t, 1, lookup.lookup)
+
+	machine.ctx = plush.NewContextWith(map[string]interface{}{"name": "ctx"})
+	value, ok = machine.contextValue("name")
+	require.True(t, ok)
+	require.Equal(t, "ctx", value)
+
+	value, ok = machine.contextValue("missing")
+	require.False(t, ok)
+	require.Nil(t, value)
+
+	fallback := newVMFallbackContext(map[string]interface{}{"name": "fallback"})
+	machine.ctx = fallback
+	value, ok = machine.contextValue("name")
+	require.True(t, ok)
+	require.Equal(t, "fallback", value)
+	require.Equal(t, 1, fallback.has)
+	require.Equal(t, 1, fallback.value)
+
+	value, ok = machine.contextValue("missing")
+	require.False(t, ok)
+	require.Nil(t, value)
+	require.Equal(t, 2, fallback.has)
+
+	machine.ctx = nil
+	value, ok = machine.contextValueByNameIndex(0)
+	require.False(t, ok)
+	require.Nil(t, value)
+
+	idLookup := newIDLookupTestContext(map[string]interface{}{"name": "id"})
+	machine.ctx = idLookup
+	value, ok = machine.contextValueByNameIndex(0)
+	require.True(t, ok)
+	require.Equal(t, "id", value)
+	require.Equal(t, 1, idLookup.lookupID)
+
+	value, ok = machine.contextValueByNameIndex(0)
+	require.True(t, ok)
+	require.Equal(t, "id", value)
+	require.Equal(t, 2, idLookup.lookupID)
+
+	machine.clearNameIDCache()
+	machine.ctx = plush.NewContextWith(map[string]interface{}{"name": "fallback"})
+	value, ok = machine.contextValueByNameIndex(0)
+	require.True(t, ok)
+	require.Equal(t, "fallback", value)
+
+	value, ok = fastContextValue(nil, "name")
+	require.False(t, ok)
+	require.Nil(t, value)
+
+	value, ok = fastContextValue(fallback, "name")
+	require.True(t, ok)
+	require.Equal(t, "fallback", value)
+	value, ok = fastContextValue(fallback, "missing")
+	require.False(t, ok)
+	require.Nil(t, value)
+}
+
+func Test_VM_Push_Name_And_Context_Name_I_D_Cache_Branches(t *testing.T) {
+	ctx := newIDLookupTestContext(map[string]interface{}{"name": "Mido"})
+	machine := newRuntimeHelperTestVM(ctx)
+	machine.constants = append(machine.constants, &object.String{Value: "nil"})
+
+	require.NoError(t, machine.pushName(0))
+	require.Equal(t, &object.String{Value: "Mido"}, machine.pop())
+
+	require.NoError(t, machine.pushName(5))
+	require.Same(t, Null, machine.pop())
+
+	require.ErrorContains(t, machine.pushName(3), "unknown identifier")
+
+	require.NoError(t, machine.pushNameOrNull(0))
+	require.Equal(t, &object.String{Value: "Mido"}, machine.pop())
+
+	require.NoError(t, machine.pushNameOrNull(3))
+	require.Same(t, Null, machine.pop())
+
+	require.NoError(t, machine.pushNameOrNull(5))
+	require.Same(t, Null, machine.pop())
+
+	nameConstants := make([]object.Object, 9)
+	for i := range nameConstants {
+		nameConstants[i] = &object.String{Value: fmt.Sprintf("cache_%d", i)}
+	}
+	machine.constants = nameConstants
+	machine.clearNameIDCache()
+	for i := 0; i < 8; i++ {
+		require.Equal(t, ctx.InternID(fmt.Sprintf("cache_%d", i)), machine.contextNameID(ctx, i))
+	}
+	require.Equal(t, 8, machine.nameIDCacheLen)
+
+	overflowID := machine.contextNameID(ctx, 8)
+	require.Len(t, machine.nameIDOverflow, 1)
+	require.Equal(t, overflowID, machine.contextNameID(ctx, 8))
+}
+
+func Test_VM_Fast_Line_And_Budget_Helper_Branches(t *testing.T) {
+	require.NoError(t, fastLineError(7, nil))
+	require.EqualError(t, fastLineError(0, errors.New("boom")), "line 1: boom")
+
+	require.NoError(t, spendFastTraversal(nil, 2))
+	require.NoError(t, spendFastLoop(nil, 2))
+	require.NoError(t, spendFastCondition(nil, 2))
+	require.NoError(t, spendFastFunctionCall(nil, "helper", 2))
+	require.NoError(t, spendFastSubRender(nil, 2))
+
+	require.ErrorContains(t, spendFastTraversal(plush.NewContext().WithBudget(plush.NewBudget(0)), 3), "line 3")
+	require.ErrorContains(t, spendFastLoop(plush.NewContext().WithBudget(plush.NewBudget(0)), 4), "line 4")
+	require.ErrorContains(t, spendFastCondition(plush.NewContext().WithBudget(plush.NewBudget(0)), 5), "line 5")
+	require.ErrorContains(t, spendFastFunctionCall(plush.NewContext().WithBudget(plush.NewBudget(0)), "helper", 6), "line 6")
+	require.ErrorContains(t, spendFastSubRender(plush.NewContext().WithBudget(plush.NewBudget(0)), 7), "line 7")
+
+	noBudget := newLookupTestContext(map[string]interface{}{})
+	require.Nil(t, fastBudget(noBudget))
+}

--- a/VM/vm/budget.go
+++ b/VM/vm/budget.go
@@ -1,0 +1,36 @@
+package vm
+
+import "github.com/gobuffalo/plush/v5"
+
+func (vm *VM) budget() *plush.Budget {
+	if vm.ctx == nil {
+		return nil
+	}
+	if provider, ok := vm.ctx.(interface{ Budget() *plush.Budget }); ok {
+		return provider.Budget()
+	}
+	return nil
+}
+
+func (vm *VM) spendLoop() error {
+	return vm.budget().SpendLoop()
+}
+
+func (vm *VM) spendCondition() error {
+	return vm.budget().SpendCondition()
+}
+
+func (vm *VM) spendAssignment() error {
+	return vm.budget().SpendAssignment()
+}
+
+func (vm *VM) spendFunctionCall(name string) error {
+	if name == "" {
+		name = anonymousCallName
+	}
+	return vm.budget().SpendFunctionCall(name)
+}
+
+func (vm *VM) spendTraversal(segments int) error {
+	return vm.budget().SpendObjectTraversal(segments)
+}

--- a/VM/vm/execute_for_helpers_test.go
+++ b/VM/vm/execute_for_helpers_test.go
@@ -1,0 +1,298 @@
+package vm
+
+import (
+	"html/template"
+	"sort"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/code"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/stretchr/testify/require"
+)
+
+type vmForProduct struct {
+	Name string
+}
+
+type vmForIterator struct {
+	values []interface{}
+	index  int
+}
+
+func (i *vmForIterator) Next() interface{} {
+	if i.index >= len(i.values) {
+		return nil
+	}
+	value := i.values[i.index]
+	i.index++
+	return value
+}
+
+func newExecuteForTestVM(constants ...object.Object) *VM {
+	bytecode := &compiler.Bytecode{
+		Constants:    constants,
+		Instructions: code.Make(code.OpNull),
+	}
+	return NewWithContext(bytecode, plush.NewContext())
+}
+
+func executeForClosure(instructions code.Instructions, numLocals int) *object.Closure {
+	return &object.Closure{Fn: &object.CompiledFunction{
+		Instructions: instructions,
+		NumLocals:    numLocals,
+	}}
+}
+
+func executeForInstructions(parts ...code.Instructions) code.Instructions {
+	out := code.Instructions{}
+	for _, part := range parts {
+		out = append(out, part...)
+	}
+	return out
+}
+
+func executeForReturnValueClosure() *object.Closure {
+	return executeForClosure(executeForInstructions(
+		code.Make(code.OpGetLocal, 1),
+		code.Make(code.OpReturnValue),
+	), 2)
+}
+
+func executeForWriteValueClosure() *object.Closure {
+	return executeForClosure(executeForInstructions(
+		code.Make(code.OpWriteLocal, 1),
+		code.Make(code.OpReturn),
+	), 2)
+}
+
+func Test_VM_Execute_For_Iterable_Branches(t *testing.T) {
+	block := executeForReturnValueClosure()
+
+	tests := []struct {
+		name     string
+		iterable object.Object
+		expected []interface{}
+	}{
+		{
+			name:     "nil iterable",
+			iterable: object.NullObject,
+			expected: nil,
+		},
+		{
+			name:     "string slice",
+			iterable: &object.Native{Value: []string{"a", "b"}},
+			expected: []interface{}{"a", "b"},
+		},
+		{
+			name:     "interface slice",
+			iterable: &object.Native{Value: []interface{}{"x", 2}},
+			expected: []interface{}{"x", 2},
+		},
+		{
+			name:     "object slice",
+			iterable: &object.Native{Value: []object.Object{&object.String{Value: "obj"}, &object.Integer{Value: 4}}},
+			expected: []interface{}{"obj", 4},
+		},
+		{
+			name:     "reflect slice",
+			iterable: &object.Native{Value: []int{5, 6}},
+			expected: []interface{}{5, 6},
+		},
+		{
+			name:     "pointer to slice",
+			iterable: &object.Native{Value: &[]string{"ptr"}},
+			expected: []interface{}{"ptr"},
+		},
+		{
+			name:     "array",
+			iterable: &object.Native{Value: [2]string{"aa", "bb"}},
+			expected: []interface{}{"aa", "bb"},
+		},
+		{
+			name:     "iterator",
+			iterable: &object.Native{Value: &vmForIterator{values: []interface{}{"next", 7}}},
+			expected: []interface{}{"next", 7},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := newExecuteForTestVM().executeFor(tt.iterable, block, "i", "item")
+			require.NoError(t, err)
+			array, ok := result.(*object.Array)
+			require.True(t, ok)
+			require.Len(t, array.Elements, len(tt.expected))
+			for i, expected := range tt.expected {
+				require.Equal(t, expected, object.ToGo(array.Elements[i]))
+			}
+		})
+	}
+
+	var nilSlice *[]string
+	result, err := newExecuteForTestVM().executeFor(&object.Native{Value: nilSlice}, block, "i", "item")
+	require.NoError(t, err)
+	require.Empty(t, result.(*object.Array).Elements)
+
+	_, err = newExecuteForTestVM().executeFor(&object.Native{Value: 7}, block, "i", "item")
+	require.ErrorContains(t, err, "could not iterate")
+}
+
+func Test_VM_Execute_For_Map_Break_Continue_And_Output_Branches(t *testing.T) {
+	mapResult, err := newExecuteForTestVM().executeFor(
+		&object.Native{Value: map[string]int{"b": 2, "a": 1}},
+		executeForReturnValueClosure(),
+		"k",
+		"v",
+	)
+	require.NoError(t, err)
+	mapArray := mapResult.(*object.Array)
+	got := []string{}
+	for _, element := range mapArray.Elements {
+		got = append(got, element.Inspect())
+	}
+	sort.Strings(got)
+	require.Equal(t, []string{"1", "2"}, got)
+
+	continueResult, err := newExecuteForTestVM().executeFor(
+		&object.Native{Value: []string{"a", "b"}},
+		executeForClosure(executeForInstructions(
+			code.Make(code.OpWriteLocal, 1),
+			code.Make(code.OpContinue),
+		), 2),
+		"i",
+		"item",
+	)
+	require.NoError(t, err)
+	continueArray := continueResult.(*object.Array)
+	require.Len(t, continueArray.Elements, 2)
+	require.Equal(t, template.HTML("a"), object.ToGo(continueArray.Elements[0]))
+	require.Equal(t, template.HTML("b"), object.ToGo(continueArray.Elements[1]))
+
+	breakResult, err := newExecuteForTestVM().executeFor(
+		&object.Native{Value: []string{"a", "b", "c"}},
+		executeForClosure(executeForInstructions(
+			code.Make(code.OpWriteLocal, 1),
+			code.Make(code.OpBreak),
+		), 2),
+		"i",
+		"item",
+	)
+	require.NoError(t, err)
+	breakArray := breakResult.(*object.Array)
+	require.Len(t, breakArray.Elements, 1)
+	require.Equal(t, template.HTML("a"), object.ToGo(breakArray.Elements[0]))
+
+	writeResult, err := newExecuteForTestVM().executeFor(
+		&object.Native{Value: []string{"x"}},
+		executeForWriteValueClosure(),
+		"i",
+		"item",
+	)
+	require.NoError(t, err)
+	writeArray := writeResult.(*object.Array)
+	require.Len(t, writeArray.Elements, 1)
+	require.Equal(t, template.HTML("x"), object.ToGo(writeArray.Elements[0]))
+}
+
+func Test_VM_Execute_For_Context_Write_And_Budget_Branches(t *testing.T) {
+	nameBlock := executeForClosure(executeForInstructions(
+		code.Make(code.OpGetName, 0),
+		code.Make(code.OpReturnValue),
+	), 1)
+
+	machine := newExecuteForTestVM(&object.String{Value: "item"})
+	result, err := machine.executeFor(
+		&object.Native{Value: []string{"ctx-value"}},
+		nameBlock,
+		"i",
+		"item",
+	)
+	require.NoError(t, err)
+	array := result.(*object.Array)
+	require.Len(t, array.Elements, 1)
+	require.Equal(t, "ctx-value", object.ToGo(array.Elements[0]))
+
+	budgetMachine := newExecuteForTestVM()
+	budgetMachine.ctx = plush.NewContext().WithBudget(plush.NewBudget(0))
+	result, err = budgetMachine.executeFor(
+		&object.Native{Value: []string{"blocked"}},
+		executeForReturnValueClosure(),
+		"i",
+		"item",
+	)
+	require.Error(t, err)
+	require.Empty(t, result.(*object.Array).Elements)
+}
+
+func Test_VM_Execute_For_Raw_Local_Property_Loop(t *testing.T) {
+	machine := newExecuteForTestVM(&object.String{Value: "Name"})
+	block := executeForClosure(executeForInstructions(
+		code.Make(code.OpWriteLocalProperty, 1, 0),
+		code.Make(code.OpReturn),
+	), 2)
+
+	require.True(t, loopCanUseRawValues(block))
+	require.False(t, loopNeedsContextWrites(block))
+
+	result, err := machine.executeFor(&object.Native{Value: []vmForProduct{{Name: "<bender>"}}}, block, "i", "product")
+	require.NoError(t, err)
+	array := result.(*object.Array)
+	require.Len(t, array.Elements, 1)
+	require.Equal(t, template.HTML("&lt;bender&gt;"), object.ToGo(array.Elements[0]))
+}
+
+func Test_VM_Execute_For_Raw_Local_Property_Error_And_Iterator_Branches(t *testing.T) {
+	rawNameBlock := executeForClosure(executeForInstructions(
+		code.Make(code.OpWriteLocalProperty, 1, 0),
+		code.Make(code.OpReturn),
+	), 2)
+
+	machine := newExecuteForTestVM(&object.String{Value: "Name"})
+	result, err := machine.executeFor(&object.Native{Value: []interface{}{vmForProduct{Name: "<fry>"}}}, rawNameBlock, "i", "product")
+	require.NoError(t, err)
+	array := result.(*object.Array)
+	require.Len(t, array.Elements, 1)
+	require.Equal(t, template.HTML("&lt;fry&gt;"), object.ToGo(array.Elements[0]))
+
+	result, err = machine.executeFor(&object.Native{Value: &vmForIterator{values: []interface{}{vmForProduct{Name: "<zoidberg>"}}}}, rawNameBlock, "i", "product")
+	require.NoError(t, err)
+	array = result.(*object.Array)
+	require.Len(t, array.Elements, 1)
+	require.Equal(t, template.HTML("&lt;zoidberg&gt;"), object.ToGo(array.Elements[0]))
+
+	missingBlock := executeForClosure(executeForInstructions(
+		code.Make(code.OpWriteLocalProperty, 1, 0),
+		code.Make(code.OpReturn),
+	), 2)
+	missingMachine := newExecuteForTestVM(&object.String{Value: "Missing"})
+	result, err = missingMachine.executeFor(&object.Native{Value: []string{"bad"}}, missingBlock, "i", "product")
+	require.ErrorContains(t, err, "does not have a field or method")
+	require.Empty(t, result.(*object.Array).Elements)
+
+	result, err = missingMachine.executeFor(&object.Native{Value: map[string]vmForProduct{"bad": {Name: "Bender"}}}, missingBlock, "i", "product")
+	require.ErrorContains(t, err, "does not have a field or method")
+	require.Empty(t, result.(*object.Array).Elements)
+}
+
+func Test_VM_Loop_Helper_Predicates(t *testing.T) {
+	require.False(t, loopCanUseRawValues(nil))
+	require.True(t, loopNeedsContextWrites(nil))
+
+	nameBlock := executeForClosure(executeForInstructions(
+		code.Make(code.OpGetName, 0),
+		code.Make(code.OpReturnValue),
+	), 1)
+	require.False(t, loopCanUseRawValues(nameBlock))
+	require.True(t, loopNeedsContextWrites(nameBlock))
+	require.False(t, loopCanUseRawValues(executeForClosure(code.Instructions{byte(255)}, 0)))
+
+	rawKey, rawValue := loopObjects("key", nil, true)
+	require.Equal(t, &object.Native{Value: "key"}, rawKey)
+	require.Same(t, Null, rawValue)
+
+	wrappedKey, wrappedValue := loopObjects("key", 3, false)
+	require.Equal(t, &object.String{Value: "key"}, wrappedKey)
+	require.Equal(t, &object.Integer{Value: 3}, wrappedValue)
+}

--- a/VM/vm/execution.go
+++ b/VM/vm/execution.go
@@ -1,0 +1,1316 @@
+package vm
+
+import (
+	"errors"
+	"fmt"
+	"html/template"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/code"
+	"github.com/gobuffalo/plush/v5/VM/object"
+)
+
+func (vm *VM) LastPoppedStackElem() object.Object {
+	return vm.lastPopped
+}
+
+func (vm *VM) PunchHoles() []plush.HoleMarker {
+	if vm.holes == nil {
+		return nil
+	}
+	return append([]plush.HoleMarker(nil), (*vm.holes)...)
+}
+
+func (vm *VM) ensureGlobal(index int) {
+	if index < 0 || index < len(vm.globals) {
+		return
+	}
+	globals := make([]object.Object, index+1)
+	copy(globals, vm.globals)
+	vm.globals = globals
+}
+
+func (vm *VM) globalValue(index int) object.Object {
+	if index < 0 || index >= len(vm.globals) {
+		return nil
+	}
+	return vm.globals[index]
+}
+
+func (vm *VM) Rendered() string {
+	if vm.frames[0] == nil {
+		return ""
+	}
+	if vm.halted && !object.IsNull(vm.lastPopped) {
+		return vm.renderObject(vm.lastPopped)
+	}
+	return vm.frames[0].output.String()
+}
+
+func (vm *VM) Run() error {
+	var ip int
+	var ins code.Instructions
+	var op code.Opcode
+
+	for !vm.halted && vm.currentFrame().ip < len(vm.currentFrame().Instructions())-1 {
+		vm.currentFrame().ip++
+
+		ip = vm.currentFrame().ip
+		vm.lastIP = ip
+		ins = vm.currentFrame().Instructions()
+		op = code.Opcode(ins[ip])
+
+		switch op {
+		case code.OpConstant:
+			constIndex := code.ReadUint16(ins[ip+1:])
+			vm.currentFrame().ip += 2
+			if err := vm.push(vm.constants[constIndex]); err != nil {
+				return err
+			}
+
+		case code.OpPop:
+			vm.discard()
+
+		case code.OpAdd, code.OpSub, code.OpMul, code.OpDiv:
+			if err := vm.executeBinaryOperation(op); err != nil {
+				return err
+			}
+
+		case code.OpTrue:
+			if err := vm.push(True); err != nil {
+				return err
+			}
+
+		case code.OpFalse:
+			if err := vm.push(False); err != nil {
+				return err
+			}
+
+		case code.OpEqual, code.OpNotEqual, code.OpGreaterThan,
+			code.OpGreaterEqual,
+			code.OpMatches, code.OpAnd, code.OpOr:
+			if err := vm.executeComparisonOrLogical(op); err != nil {
+				return err
+			}
+
+		case code.OpBang:
+			_ = vm.executeBangOperator()
+
+		case code.OpMinus:
+			if err := vm.executeMinusOperator(); err != nil {
+				return err
+			}
+
+		case code.OpJump:
+			pos := int(code.ReadUint16(ins[ip+1:]))
+			vm.currentFrame().ip = pos - 1
+
+		case code.OpJumpNotTruthy:
+			pos := int(code.ReadUint16(ins[ip+1:]))
+			vm.currentFrame().ip += 2
+			if err := vm.spendCondition(); err != nil {
+				return err
+			}
+
+			condition := vm.pop()
+			if !isTruthy(condition) {
+				vm.currentFrame().ip = pos - 1
+			}
+
+		case code.OpNull:
+			if err := vm.push(Null); err != nil {
+				return err
+			}
+
+		case code.OpSetGlobal:
+			globalIndex := int(code.ReadUint16(ins[ip+1:]))
+			vm.currentFrame().ip += 2
+			if err := vm.spendAssignment(); err != nil {
+				return err
+			}
+			value := vm.pop()
+			vm.ensureGlobal(globalIndex)
+			vm.globals[globalIndex] = value
+			vm.updateNamedGlobal(globalIndex, value)
+
+		case code.OpGetGlobal:
+			globalIndex := int(code.ReadUint16(ins[ip+1:]))
+			vm.currentFrame().ip += 2
+			value := vm.globalValue(globalIndex)
+			if value == nil {
+				value = vm.globalFromContext(globalIndex)
+			}
+			if value == nil {
+				value = Null
+			}
+			if err := vm.push(value); err != nil {
+				return err
+			}
+
+		case code.OpArray:
+			numElements := int(code.ReadUint16(ins[ip+1:]))
+			vm.currentFrame().ip += 2
+			array := vm.buildArray(vm.sp-numElements, vm.sp)
+			vm.sp = vm.sp - numElements
+			if err := vm.push(array); err != nil {
+				return err
+			}
+
+		case code.OpHash:
+			numElements := int(code.ReadUint16(ins[ip+1:]))
+			vm.currentFrame().ip += 2
+			hash, err := vm.buildHash(vm.sp-numElements, vm.sp)
+			if err != nil {
+				return err
+			}
+			vm.sp = vm.sp - numElements
+			if err := vm.push(hash); err != nil {
+				return err
+			}
+
+		case code.OpIndex:
+			index := vm.pop()
+			left := vm.pop()
+			if err := vm.executeIndexExpression(left, index); err != nil {
+				return err
+			}
+
+		case code.OpSetIndex:
+			value := vm.pop()
+			index := vm.pop()
+			left := vm.pop()
+			if err := vm.executeSetIndex(left, index, value); err != nil {
+				return err
+			}
+			_ = vm.push(Null)
+
+		case code.OpCall:
+			numArgs := code.ReadUint8(ins[ip+1:])
+			vm.currentFrame().ip += 1
+			if err := vm.executeCall(vm.currentCallName(ip), int(numArgs), nil, vm.currentCallCacheSlot(ip)); err != nil {
+				return err
+			}
+
+		case code.OpWriteCall:
+			numArgs := code.ReadUint8(ins[ip+1:])
+			vm.currentFrame().ip += 1
+			if err := vm.executeWriteCall(vm.currentCallName(ip), int(numArgs), vm.currentCallCacheSlot(ip)); err != nil {
+				return err
+			}
+
+		case code.OpWriteNameCall:
+			nameIndex := int(code.ReadUint16(ins[ip+1:]))
+			numArgs := code.ReadUint8(ins[ip+3:])
+			vm.currentFrame().ip += 3
+			if err := vm.executeWriteNameCall(nameIndex, int(numArgs), vm.currentCallCacheSlot(ip)); err != nil {
+				return err
+			}
+
+		case code.OpCallBlock:
+			numArgs := code.ReadUint8(ins[ip+1:])
+			blockIndex := int(code.ReadUint16(ins[ip+2:]))
+			numFree := int(code.ReadUint8(ins[ip+4:]))
+			vm.currentFrame().ip += 4
+			block, err := vm.closureFromStack(blockIndex, numFree)
+			if err != nil {
+				return err
+			}
+			if err := vm.executeCall(vm.currentCallName(ip), int(numArgs), block, vm.currentCallCacheSlot(ip)); err != nil {
+				return err
+			}
+
+		case code.OpReturnValue:
+			returnValue := vm.pop()
+			if err := vm.returnFromFrame(returnValue); err != nil {
+				return err
+			}
+
+		case code.OpReturn:
+			if err := vm.returnFromFrameValue(vm.currentFrameOutput(), false); err != nil {
+				return err
+			}
+
+		case code.OpSetLocal:
+			localIndex := code.ReadUint8(ins[ip+1:])
+			vm.currentFrame().ip += 1
+			if err := vm.spendAssignment(); err != nil {
+				return err
+			}
+			frame := vm.currentFrame()
+			vm.stack[frame.basePointer+int(localIndex)] = vm.pop()
+
+		case code.OpGetLocal:
+			localIndex := code.ReadUint8(ins[ip+1:])
+			vm.currentFrame().ip += 1
+			frame := vm.currentFrame()
+			if err := vm.push(vm.stack[frame.basePointer+int(localIndex)]); err != nil {
+				return err
+			}
+
+		case code.OpGetBuiltin:
+			builtinIndex := code.ReadUint8(ins[ip+1:])
+			vm.currentFrame().ip += 1
+			definition := object.Builtins[builtinIndex]
+			if vm.ctx != nil && vm.ctx.Has(definition.Name) {
+				if err := vm.push(object.Wrap(vm.ctx.Value(definition.Name))); err != nil {
+					return err
+				}
+				break
+			}
+			if err := vm.push(definition.Builtin); err != nil {
+				return err
+			}
+
+		case code.OpClosure:
+			constIndex := code.ReadUint16(ins[ip+1:])
+			numFree := code.ReadUint8(ins[ip+3:])
+			vm.currentFrame().ip += 3
+			if err := vm.pushClosure(int(constIndex), int(numFree)); err != nil {
+				return err
+			}
+
+		case code.OpGetFree:
+			freeIndex := code.ReadUint8(ins[ip+1:])
+			vm.currentFrame().ip += 1
+			currentClosure := vm.currentFrame().cl
+			if err := vm.push(currentClosure.Free[freeIndex]); err != nil {
+				return err
+			}
+
+		case code.OpCurrentClosure:
+			if err := vm.push(vm.currentFrame().cl); err != nil {
+				return err
+			}
+
+		case code.OpGetName:
+			nameIndex := int(code.ReadUint16(ins[ip+1:]))
+			vm.currentFrame().ip += 2
+			if err := vm.pushName(nameIndex); err != nil {
+				return err
+			}
+
+		case code.OpGetNameOrNull:
+			nameIndex := int(code.ReadUint16(ins[ip+1:]))
+			vm.currentFrame().ip += 2
+			if err := vm.pushNameOrNull(nameIndex); err != nil {
+				return err
+			}
+
+		case code.OpSetName:
+			nameIndex := int(code.ReadUint16(ins[ip+1:]))
+			vm.currentFrame().ip += 2
+			vm.setName(nameIndex, vm.pop())
+
+		case code.OpAssignName:
+			nameIndex := int(code.ReadUint16(ins[ip+1:]))
+			vm.currentFrame().ip += 2
+			if err := vm.assignName(nameIndex, vm.pop()); err != nil {
+				return err
+			}
+			_ = vm.push(Null)
+
+		case code.OpGetProperty:
+			nameIndex := int(code.ReadUint16(ins[ip+1:]))
+			vm.currentFrame().ip += 2
+			obj := vm.pop()
+			if err := vm.getProperty(obj, vm.stringConstant(nameIndex), vm.currentPropertyAccess(ip), vm.currentPropertyCacheSlot(ip)); err != nil {
+				return err
+			}
+
+		case code.OpWrite:
+			value := vm.pop()
+			vm.writeFrameOutput(vm.currentFrame(), value)
+
+		case code.OpWriteConstant:
+			constIndex := int(code.ReadUint16(ins[ip+1:]))
+			vm.currentFrame().ip += 2
+			vm.writeConstant(vm.currentFrame(), constIndex)
+
+		case code.OpWriteName:
+			nameIndex := int(code.ReadUint16(ins[ip+1:]))
+			vm.currentFrame().ip += 2
+			if err := vm.writeName(vm.currentFrame(), nameIndex, false); err != nil {
+				return err
+			}
+
+		case code.OpWriteNameOrNull:
+			nameIndex := int(code.ReadUint16(ins[ip+1:]))
+			vm.currentFrame().ip += 2
+			_ = vm.writeName(vm.currentFrame(), nameIndex, true)
+
+		case code.OpWriteLocal:
+			localIndex := code.ReadUint8(ins[ip+1:])
+			vm.currentFrame().ip += 1
+			frame := vm.currentFrame()
+			vm.writeFrameOutput(frame, vm.stack[frame.basePointer+int(localIndex)])
+
+		case code.OpWriteGlobal:
+			globalIndex := int(code.ReadUint16(ins[ip+1:]))
+			vm.currentFrame().ip += 2
+			vm.writeGlobal(vm.currentFrame(), globalIndex)
+
+		case code.OpWriteLocalProperty:
+			localIndex := code.ReadUint8(ins[ip+1:])
+			nameIndex := int(code.ReadUint16(ins[ip+2:]))
+			vm.currentFrame().ip += 3
+			if err := vm.writeLocalProperty(vm.currentFrame(), int(localIndex), nameIndex, ip); err != nil {
+				return err
+			}
+
+		case code.OpWriteGlobalProperty:
+			globalIndex := int(code.ReadUint16(ins[ip+1:]))
+			nameIndex := int(code.ReadUint16(ins[ip+3:]))
+			vm.currentFrame().ip += 4
+			if err := vm.writeGlobalProperty(vm.currentFrame(), globalIndex, nameIndex, ip); err != nil {
+				return err
+			}
+
+		case code.OpWriteNameProperty:
+			baseNameIndex := int(code.ReadUint16(ins[ip+1:]))
+			propertyNameIndex := int(code.ReadUint16(ins[ip+3:]))
+			vm.currentFrame().ip += 4
+			if err := vm.writeNameProperty(vm.currentFrame(), baseNameIndex, propertyNameIndex, ip); err != nil {
+				return err
+			}
+
+		case code.OpWriteString:
+			constIndex := int(code.ReadUint16(ins[ip+1:]))
+			vm.currentFrame().ip += 2
+			vm.writeStringConstant(vm.currentFrame(), constIndex)
+
+		case code.OpWriteHTML:
+			constIndex := int(code.ReadUint16(ins[ip+1:]))
+			vm.currentFrame().ip += 2
+			vm.writeHTMLConstant(vm.currentFrame(), constIndex)
+
+		case code.OpRenderTemplate:
+			tmpl := fmt.Sprint(object.ToGo(vm.pop()))
+			rendered, err := Render(tmpl, vm.ctx)
+			if err != nil {
+				return err
+			}
+			_ = vm.push(object.Wrap(template.HTML(rendered)))
+
+		case code.OpHole:
+			inputIndex := int(code.ReadUint16(ins[ip+1:]))
+			vm.currentFrame().ip += 2
+			vm.writeFrameOutput(vm.currentFrame(), &object.Native{
+				Value: vmHole{input: vm.stringConstant(inputIndex)},
+			})
+
+		case code.OpFor:
+			blockIndex := int(code.ReadUint16(ins[ip+1:]))
+			keyNameIndex := int(code.ReadUint16(ins[ip+3:]))
+			valueNameIndex := int(code.ReadUint16(ins[ip+5:]))
+			numFree := int(code.ReadUint8(ins[ip+7:]))
+			vm.currentFrame().ip += 7
+			block, err := vm.closureFromStack(blockIndex, numFree)
+			if err != nil {
+				return err
+			}
+			iterable := vm.pop()
+			result, err := vm.executeFor(iterable, block, vm.stringConstant(keyNameIndex), vm.stringConstant(valueNameIndex))
+			if err != nil {
+				return err
+			}
+			_ = vm.push(result)
+
+		case code.OpBreak:
+			control := &object.Control{Kind: object.ControlBreak, Value: vm.currentFrameOutputValues()}
+			if err := vm.returnFromFrame(control); err != nil {
+				return err
+			}
+
+		case code.OpContinue:
+			control := &object.Control{Kind: object.ControlContinue, Value: vm.currentFrameOutputValues()}
+			if err := vm.returnFromFrame(control); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (vm *VM) push(o object.Object) error {
+	if o == nil {
+		o = Null
+	}
+	if vm.sp >= StackSize {
+		return fmt.Errorf("stack overflow")
+	}
+
+	vm.stack[vm.sp] = o
+	vm.sp++
+	vm.markStack()
+	return nil
+}
+
+func (vm *VM) pop() object.Object {
+	o := vm.stack[vm.sp-1]
+	vm.sp--
+	vm.lastPopped = o
+	vm.stack[vm.sp] = nil
+	return o
+}
+
+func (vm *VM) markStack() {
+	if vm.sp > vm.stackMax {
+		vm.stackMax = vm.sp
+	}
+}
+
+func (vm *VM) discard() {
+	frame := vm.currentFrame()
+	stackBase := frame.basePointer + frame.cl.Fn.NumLocals
+	if vm.sp <= stackBase {
+		vm.lastPopped = Null
+		return
+	}
+	vm.pop()
+}
+
+func (vm *VM) currentFrame() *Frame {
+	return vm.frames[vm.framesIndex-1]
+}
+
+func (vm *VM) currentCallName(ip int) string {
+	frame := vm.currentFrame()
+	if frame != nil && frame.cl != nil && frame.cl.Fn != nil {
+		if name := frame.cl.Fn.CallNames[ip]; name != "" {
+			return name
+		}
+	}
+	return anonymousCallName
+}
+
+func (vm *VM) wrapRuntimeError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if strings.HasPrefix(err.Error(), "line ") {
+		return err
+	}
+	line := vm.currentLineNumber()
+	if line <= 0 {
+		line = 1
+	}
+	return fmt.Errorf("line %d: %w", line, err)
+}
+
+func (vm *VM) currentLineNumber() int {
+	frame := vm.currentFrame()
+	if frame == nil || frame.cl == nil || frame.cl.Fn == nil {
+		return 0
+	}
+	if line := frame.cl.Fn.LineNumbers[vm.lastIP]; line > 0 {
+		return line
+	}
+	return 0
+}
+
+func (vm *VM) currentPropertyAccess(ip int) object.PropertyAccess {
+	frame := vm.currentFrame()
+	if frame == nil || frame.cl == nil || frame.cl.Fn == nil {
+		return object.PropertyAccess{}
+	}
+	return frame.cl.Fn.Properties[ip]
+}
+
+func (vm *VM) currentPropertyCacheSlot(ip int) *object.InlineCacheSlot {
+	frame := vm.currentFrame()
+	if frame == nil || frame.cl == nil || frame.cl.Fn == nil {
+		return nil
+	}
+	if ip < 0 || ip >= len(frame.cl.Fn.PropertyCaches) {
+		return nil
+	}
+	return &frame.cl.Fn.PropertyCaches[ip]
+}
+
+func (vm *VM) currentCallCacheSlot(ip int) *object.InlineCacheSlot {
+	frame := vm.currentFrame()
+	if frame == nil || frame.cl == nil || frame.cl.Fn == nil {
+		return nil
+	}
+	if ip < 0 || ip >= len(frame.cl.Fn.CallCaches) {
+		return nil
+	}
+	return &frame.cl.Fn.CallCaches[ip]
+}
+
+func (vm *VM) pushFrame(f *Frame) {
+	vm.frames[vm.framesIndex] = f
+	vm.framesIndex++
+}
+
+func (vm *VM) popFrame() *Frame {
+	vm.framesIndex--
+	frame := vm.frames[vm.framesIndex]
+	vm.frames[vm.framesIndex] = nil
+	return frame
+}
+
+func (vm *VM) returnFromFrame(returnValue object.Object) error {
+	return vm.returnFromFrameValue(returnValue, true)
+}
+
+func (vm *VM) returnFromFrameValue(returnValue object.Object, combineOutput bool) error {
+	frame := vm.currentFrame()
+	writeReturn := frame != nil && frame.writeReturn
+	if combineOutput {
+		if _, isControl := returnValue.(*object.Control); !isControl {
+			returnValue = vm.combineFrameOutput(frame, returnValue)
+		}
+	}
+
+	if vm.framesIndex == 1 {
+		vm.lastPopped = returnValue
+		vm.halted = true
+		return nil
+	}
+
+	frame = vm.popFrame()
+	basePointer := frame.basePointer
+	calleeOnStack := frame.calleeOnStack
+	releaseFrame(frame)
+	vm.sp = basePointer
+	if calleeOnStack {
+		vm.sp--
+	}
+	if writeReturn {
+		vm.writeFrameOutput(vm.currentFrame(), returnValue)
+		return nil
+	}
+	return vm.push(returnValue)
+}
+
+func (vm *VM) currentFrameOutput() object.Object {
+	return vm.frameOutputObject(vm.currentFrame())
+}
+
+func (vm *VM) combineFrameOutput(frame *Frame, returnValue object.Object) object.Object {
+	if !frame.hasOutput {
+		if returnValue == nil {
+			return Null
+		}
+		return returnValue
+	}
+
+	values := []object.Object{vm.frameOutputObject(frame)}
+	if !object.IsNull(returnValue) {
+		values = append(values, returnValue)
+	}
+	return &object.Array{Elements: values}
+}
+
+func (vm *VM) frameOutputObject(frame *Frame) object.Object {
+	if frame == nil || !frame.hasOutput {
+		return Null
+	}
+	return &object.Native{Value: template.HTML(frame.output.String())}
+}
+
+func (vm *VM) currentFrameOutputValues() []object.Object {
+	frame := vm.currentFrame()
+	if frame == nil || !frame.hasOutput {
+		return nil
+	}
+	return []object.Object{vm.frameOutputObject(frame)}
+}
+
+func (vm *VM) writeFrameOutput(frame *Frame, value object.Object) {
+	if frame == nil {
+		return
+	}
+	frame.hasOutput = true
+	vm.writeObject(&frame.output, value)
+}
+
+func (vm *VM) executeBinaryOperation(op code.Opcode) error {
+	right := vm.pop()
+	left := vm.pop()
+
+	switch op {
+	case code.OpAdd:
+		return vm.executeAdd(left, right)
+	case code.OpSub, code.OpMul, code.OpDiv:
+		return vm.executeNumericOperation(op, left, right)
+	default:
+		return fmt.Errorf("unknown binary operator: %d", op)
+	}
+}
+
+func (vm *VM) executeAdd(left, right object.Object) error {
+	if left.Type() == object.ARRAY_OBJ {
+		arr := left.(*object.Array)
+		elements := append([]object.Object(nil), arr.Elements...)
+		elements = append(elements, right)
+		return vm.push(&object.Array{Elements: elements})
+	}
+
+	if handled, err := vm.executeNativeSliceAppend(left, right); handled || err != nil {
+		return err
+	}
+
+	if left.Type() == object.STRING_OBJ || right.Type() == object.STRING_OBJ {
+		return vm.push(&object.String{Value: fmt.Sprint(object.ToGo(left)) + fmt.Sprint(object.ToGo(right))})
+	}
+
+	if left.Type() == object.BOOLEAN_OBJ || right.Type() == object.BOOLEAN_OBJ {
+		return vm.push(nativeBoolToBooleanObject(isTruthy(left) && isTruthy(right)))
+	}
+
+	return vm.executeNumericOperation(code.OpAdd, left, right)
+}
+
+func (vm *VM) executeNativeSliceAppend(left, right object.Object) (bool, error) {
+	raw := object.ToGo(left)
+	if raw == nil {
+		return false, nil
+	}
+
+	rv := reflect.ValueOf(raw)
+	if rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			return false, nil
+		}
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Slice {
+		return false, nil
+	}
+
+	value := object.ToGo(right)
+	val := reflect.ValueOf(value)
+	elem := rv.Type().Elem()
+	if !val.IsValid() {
+		val = reflect.Zero(elem)
+	} else if elem.Kind() != reflect.Interface && !val.Type().AssignableTo(elem) {
+		return true, fmt.Errorf("cannot append '%v' (untyped %s constant) as %s value in assignment", value, val.Type(), elem)
+	}
+
+	appended := reflect.Append(rv, val)
+	return true, vm.push(object.Wrap(appended.Interface()))
+}
+
+func (vm *VM) executeNumericOperation(op code.Opcode, left, right object.Object) error {
+	l, lok := numericValueFromObject(left)
+	r, rok := numericValueFromObject(right)
+	if !lok || !rok {
+		return fmt.Errorf("unsupported types for binary operation: %s %s", left.Type(), right.Type())
+	}
+
+	result, err := numericOperationObject(op, l, r)
+	if err != nil {
+		return err
+	}
+	return vm.push(result)
+}
+
+func (vm *VM) executeComparisonOrLogical(op code.Opcode) error {
+	right := vm.pop()
+	left := vm.pop()
+
+	switch op {
+	case code.OpEqual:
+		result, err := compareEquality("==", left, right)
+		if err != nil {
+			return err
+		}
+		return vm.push(nativeBoolToBooleanObject(result))
+	case code.OpNotEqual:
+		result, err := compareEquality("!=", left, right)
+		if err != nil {
+			return err
+		}
+		return vm.push(nativeBoolToBooleanObject(!result))
+	case code.OpGreaterThan, code.OpGreaterEqual:
+		result, err := compareOrdered(op, left, right)
+		if err != nil {
+			return err
+		}
+		return vm.push(nativeBoolToBooleanObject(result))
+	case code.OpMatches:
+		pattern := fmt.Sprint(object.ToGo(right))
+		re, err := cachedRegex(pattern)
+		if err != nil {
+			return fmt.Errorf("couldn't compile regex %s", object.ToGo(right))
+		}
+		return vm.push(nativeBoolToBooleanObject(re.MatchString(fmt.Sprint(object.ToGo(left)))))
+	case code.OpAnd:
+		return vm.push(nativeBoolToBooleanObject(isTruthy(left) && isTruthy(right)))
+	case code.OpOr:
+		return vm.push(nativeBoolToBooleanObject(isTruthy(left) || isTruthy(right)))
+	default:
+		return fmt.Errorf("unknown comparison operator: %d", op)
+	}
+}
+
+func compareEquality(operator string, left, right object.Object) (bool, error) {
+	if object.IsNull(left) || object.IsNull(right) {
+		return object.IsNull(left) && object.IsNull(right), nil
+	}
+
+	switch left := left.(type) {
+	case *object.Boolean:
+		return left.Value == isTruthy(right), nil
+	case *object.String:
+		return left.Value == fmt.Sprint(object.ToGo(right)), nil
+	}
+
+	l, lok := numericValueFromObject(left)
+	r, rok := numericValueFromObject(right)
+	if lok && rok {
+		return compareNumericEquality(l, r), nil
+	}
+	if lok || rok {
+		return false, fmt.Errorf("unable to operate (%s) on %s and %s ", operator, plushTypeName(left), plushTypeName(right))
+	}
+
+	return reflect.DeepEqual(object.ToGo(left), object.ToGo(right)), nil
+}
+
+func cachedRegex(pattern string) (*regexp.Regexp, error) {
+	if cached, ok := regexCache.Load(pattern); ok {
+		entry := cached.(regexCacheEntry)
+		return entry.re, entry.err
+	}
+
+	re, err := regexp.Compile(pattern)
+	entry := regexCacheEntry{re: re, err: err}
+	actual, _ := regexCache.LoadOrStore(pattern, entry)
+	entry = actual.(regexCacheEntry)
+	return entry.re, entry.err
+}
+
+func compareOrdered(op code.Opcode, left, right object.Object) (bool, error) {
+	lNumeric, lok := numericValueFromObject(left)
+	rNumeric, rok := numericValueFromObject(right)
+	if lok && rok {
+		return compareNumericOrdered(op, lNumeric, rNumeric)
+	}
+	if lok || rok {
+		return false, fmt.Errorf("unable to operate (%s) on %s and %s ", orderedOperatorString(op), plushTypeName(left), plushTypeName(right))
+	}
+
+	l := fmt.Sprint(object.ToGo(left))
+	r := fmt.Sprint(object.ToGo(right))
+	switch op {
+	case code.OpGreaterThan:
+		return l > r, nil
+	case code.OpGreaterEqual:
+		return l >= r, nil
+	}
+	return false, fmt.Errorf("unknown ordered comparison: %d", op)
+}
+
+func plushTypeName(obj object.Object) string {
+	switch obj.(type) {
+	case *object.Boolean:
+		return "bool"
+	case *object.Integer:
+		return "int"
+	case *object.Float:
+		return "float64"
+	case *object.String:
+		return "string"
+	case *object.Null:
+		return "<nil>"
+	case *object.Native:
+		raw := object.ToGo(obj)
+		if raw == nil {
+			return "<nil>"
+		}
+		return reflect.TypeOf(raw).String()
+	default:
+		return fmt.Sprintf("%T", object.ToGo(obj))
+	}
+}
+
+func (vm *VM) executeBangOperator() error {
+	operand := vm.pop()
+	return vm.push(nativeBoolToBooleanObject(!isTruthy(operand)))
+}
+
+func (vm *VM) executeMinusOperator() error {
+	operand := vm.pop()
+
+	if f, ok := operand.(*object.Float); ok {
+		return vm.push(&object.Float{Value: -f.Value})
+	}
+
+	value, ok := toInt(operand)
+	if !ok {
+		return fmt.Errorf("unsupported type for negation: %s", operand.Type())
+	}
+
+	return vm.push(&object.Integer{Value: -value})
+}
+
+func (vm *VM) buildArray(startIndex, endIndex int) object.Object {
+	elements := make([]object.Object, endIndex-startIndex)
+	for i := startIndex; i < endIndex; i++ {
+		elements[i-startIndex] = vm.stack[i]
+	}
+	return &object.Array{Elements: elements}
+}
+
+func (vm *VM) buildHash(startIndex, endIndex int) (object.Object, error) {
+	hashedPairs := make(map[object.HashKey]object.HashPair)
+
+	for i := startIndex; i < endIndex; i += 2 {
+		key := vm.stack[i]
+		value := vm.stack[i+1]
+
+		hashKey, ok := key.(object.Hashable)
+		if !ok {
+			return nil, fmt.Errorf("unusable as hash key: %s", key.Type())
+		}
+
+		hashedPairs[hashKey.HashKey()] = object.HashPair{Key: key, Value: value}
+	}
+
+	return &object.Hash{Pairs: hashedPairs}, nil
+}
+
+func (vm *VM) executeIndexExpression(left, index object.Object) error {
+	switch {
+	case left.Type() == object.ARRAY_OBJ && index.Type() == object.INTEGER_OBJ:
+		arrayObject := left.(*object.Array)
+		i := index.(*object.Integer).Value
+		max := int64(len(arrayObject.Elements) - 1)
+		if i < 0 || i > max {
+			return fmt.Errorf("array index out of bounds, got index %d, while array size is %d", i, len(arrayObject.Elements))
+		}
+		return vm.push(arrayObject.Elements[i])
+	case left.Type() == object.HASH_OBJ:
+		return vm.executeHashIndex(left.(*object.Hash), index)
+	default:
+		return vm.executeNativeIndex(left, index)
+	}
+}
+
+func (vm *VM) executeHashIndex(hash *object.Hash, index object.Object) error {
+	key, ok := index.(object.Hashable)
+	if !ok {
+		return fmt.Errorf("unusable as hash key: %s", index.Type())
+	}
+
+	pair, ok := hash.Pairs[key.HashKey()]
+	if !ok {
+		return vm.push(Null)
+	}
+
+	return vm.push(pair.Value)
+}
+
+func (vm *VM) executeNativeIndex(left, index object.Object) error {
+	l := object.ToGo(left)
+	if l == nil {
+		return vm.push(Null)
+	}
+
+	rv := reflect.ValueOf(l)
+	if rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			return vm.push(Null)
+		}
+		rv = rv.Elem()
+	}
+
+	idx := object.ToGo(index)
+	switch rv.Kind() {
+	case reflect.Map:
+		mapKeyType := rv.Type().Key().Kind()
+		keyValue := reflect.ValueOf(idx)
+		if mapKeyType != reflect.Interface && keyValue.Kind() != mapKeyType {
+			return fmt.Errorf("cannot use %v (%s constant) as %s value in map index", idx, keyValue.Kind().String(), mapKeyType.String())
+		}
+		val := rv.MapIndex(keyValue)
+		if !val.IsValid() {
+			return vm.push(Null)
+		}
+		return vm.push(object.Wrap(val.Interface()))
+	case reflect.Array, reflect.Slice:
+		i, ok := idx.(int)
+		if !ok {
+			return fmt.Errorf("can't access Slice/Array with a non int Index (%v)", idx)
+		}
+		if i < 0 || rv.Len()-1 < i {
+			return fmt.Errorf("array index out of bounds, got index %d, while array size is %d", i, rv.Len())
+		}
+		return vm.push(object.Wrap(rv.Index(i).Interface()))
+	default:
+		return fmt.Errorf("could not index %T with %T", l, idx)
+	}
+}
+
+func (vm *VM) executeSetIndex(left, index, value object.Object) error {
+	switch left := left.(type) {
+	case *object.Array:
+		i, ok := toInt(index)
+		if !ok {
+			return fmt.Errorf("can't access Slice/Array with a non int Index (%v)", object.ToGo(index))
+		}
+		if i < 0 || int(i) >= len(left.Elements) {
+			return fmt.Errorf("array index out of bounds, got index %d, while array size is %d", i, len(left.Elements))
+		}
+		left.Elements[int(i)] = value
+		return nil
+	case *object.Hash:
+		hashKey, ok := index.(object.Hashable)
+		if !ok {
+			return fmt.Errorf("unusable as hash key: %s", index.Type())
+		}
+		left.Pairs[hashKey.HashKey()] = object.HashPair{Key: index, Value: value}
+		return nil
+	default:
+		return vm.executeNativeSetIndex(left, index, value)
+	}
+}
+
+func (vm *VM) executeNativeSetIndex(left, index, value object.Object) error {
+	l := object.ToGo(left)
+	rv := reflect.ValueOf(l)
+	if rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			return fmt.Errorf("could not index %T with %T", l, object.ToGo(index))
+		}
+		rv = rv.Elem()
+	}
+
+	idx := object.ToGo(index)
+	val := reflect.ValueOf(object.ToGo(value))
+
+	switch rv.Kind() {
+	case reflect.Map:
+		rv.SetMapIndex(reflect.ValueOf(idx), val)
+		return nil
+	case reflect.Array, reflect.Slice:
+		i, ok := idx.(int)
+		if !ok {
+			return fmt.Errorf("can't access Slice/Array with a non int Index (%v)", idx)
+		}
+		if i < 0 || rv.Len()-1 < i {
+			return fmt.Errorf("array index out of bounds, got index %d, while array size is %d", i, rv.Len())
+		}
+		elemType := rv.Type().Elem()
+		if elemType.Kind() != reflect.Interface && !val.Type().AssignableTo(elemType) {
+			return fmt.Errorf("cannot use '%v' (untyped %s constant) as %s value in assignment", object.ToGo(value), val.Type(), elemType)
+		}
+		rv.Index(i).Set(val)
+		return nil
+	default:
+		return fmt.Errorf("could not index %T with %T", l, idx)
+	}
+}
+
+func (vm *VM) executeCall(name string, numArgs int, block *object.Closure, cacheSlot *object.InlineCacheSlot) error {
+	if err := vm.spendFunctionCall(name); err != nil {
+		return err
+	}
+	return vm.executeCallAfterSpend(name, numArgs, block, cacheSlot)
+}
+
+func (vm *VM) executeCallAfterSpend(name string, numArgs int, block *object.Closure, cacheSlot *object.InlineCacheSlot) error {
+	callee := vm.stack[vm.sp-1-numArgs]
+	switch callee := callee.(type) {
+	case *object.Closure:
+		return vm.callClosure(callee, numArgs, block, false, true)
+	case *object.Builtin:
+		return vm.callBuiltin(callee, numArgs)
+	default:
+		return vm.callNative(name, callee, numArgs, block, cacheSlot)
+	}
+}
+
+func (vm *VM) executeWriteCall(name string, numArgs int, cacheSlot *object.InlineCacheSlot) error {
+	if err := vm.spendFunctionCall(name); err != nil {
+		return err
+	}
+
+	callee := vm.stack[vm.sp-1-numArgs]
+	switch callee := callee.(type) {
+	case *object.Closure:
+		return vm.callClosure(callee, numArgs, nil, true, true)
+	case *object.Builtin:
+		return vm.writeBuiltinCall(callee, numArgs, true)
+	default:
+		handled, err := vm.tryWriteRegisteredFastHelper(name, numArgs, true)
+		if handled || err != nil {
+			return err
+		}
+		handled, err = vm.tryFastWriteNativeCall(name, callee, numArgs, cacheSlot, true)
+		if handled || err != nil {
+			return err
+		}
+		if err := vm.executeCallAfterSpend(name, numArgs, nil, cacheSlot); err != nil {
+			return err
+		}
+		result := vm.pop()
+		vm.writeFrameOutput(vm.currentFrame(), result)
+		return nil
+	}
+}
+
+func (vm *VM) executeWriteNameCall(nameIndex int, numArgs int, cacheSlot *object.InlineCacheSlot) error {
+	name := vm.stringConstant(nameIndex)
+	raw, ok := vm.contextValueByNameIndex(nameIndex)
+	if !ok {
+		return fmt.Errorf("%q: unknown identifier", name)
+	}
+	if err := vm.spendFunctionCall(name); err != nil {
+		return err
+	}
+	if handled, err := vm.tryWriteLiteralPartialNameCall(name, raw, numArgs); handled || err != nil {
+		return err
+	}
+
+	if callee, ok := raw.(object.Object); ok {
+		switch callee := callee.(type) {
+		case *object.Closure:
+			return vm.callClosure(callee, numArgs, nil, true, false)
+		case *object.Builtin:
+			return vm.writeBuiltinCall(callee, numArgs, false)
+		default:
+			handled, err := vm.tryWriteRegisteredFastHelper(name, numArgs, false)
+			if handled || err != nil {
+				return err
+			}
+			return vm.writeNativeCall(name, callee, numArgs, cacheSlot, false)
+		}
+	}
+	if handled, err := vm.tryWriteRegisteredFastHelper(name, numArgs, false); handled || err != nil {
+		return err
+	}
+	return vm.writeNativeValueCall(name, raw, numArgs, cacheSlot, false)
+}
+
+func (vm *VM) callClosure(cl *object.Closure, numArgs int, block *object.Closure, writeReturn bool, calleeOnStack bool) error {
+	if numArgs != cl.Fn.NumParameters {
+		return fmt.Errorf("wrong number of arguments: want=%d, got=%d", cl.Fn.NumParameters, numArgs)
+	}
+
+	frame := newFrame(cl, vm.sp-numArgs, vm.pooled)
+	frame.block = block
+	frame.writeReturn = writeReturn
+	frame.calleeOnStack = calleeOnStack
+	vm.pushFrame(frame)
+	vm.sp = frame.basePointer + cl.Fn.NumLocals
+	vm.markStack()
+	return nil
+}
+
+func (vm *VM) callBuiltin(builtin *object.Builtin, numArgs int) error {
+	args := vm.stack[vm.sp-numArgs : vm.sp]
+
+	result := builtin.Fn(args...)
+	vm.sp = vm.sp - numArgs - 1
+	if result != nil {
+		return vm.push(result)
+	}
+	return vm.push(Null)
+}
+
+func (vm *VM) writeBuiltinCall(builtin *object.Builtin, numArgs int, calleeOnStack bool) error {
+	args := vm.stack[vm.sp-numArgs : vm.sp]
+	result := builtin.Fn(args...)
+	vm.sp = vm.sp - numArgs
+	if calleeOnStack {
+		vm.sp--
+	}
+	if result == nil {
+		result = Null
+	}
+	vm.writeFrameOutput(vm.currentFrame(), result)
+	return nil
+}
+
+func (vm *VM) tryWriteRegisteredFastHelper(name string, numArgs int, calleeOnStack bool) (bool, error) {
+	helper, ok := fastHelperForContext(vm.ctx, name)
+	if !ok {
+		return false, nil
+	}
+	frame := vm.currentFrame()
+	if frame == nil {
+		return false, nil
+	}
+	var args fastCallArgs
+	for _, obj := range vm.stack[vm.sp-numArgs : vm.sp] {
+		args.Append(obj)
+	}
+	handled, err := writeRegisteredFastHelperNamed(&frame.output, vm.ctx, name, helper, fastCallArgsOrNil(&args, numArgs))
+	if err != nil || !handled {
+		return handled, err
+	}
+	vm.sp -= numArgs
+	if calleeOnStack {
+		vm.sp--
+	}
+	frame.hasOutput = true
+	return true, nil
+}
+
+func (vm *VM) callNative(name string, callee object.Object, numArgs int, block *object.Closure, cacheSlot *object.InlineCacheSlot) error {
+	raw := object.ToGo(callee)
+	return vm.callNativeValue(name, raw, numArgs, block, cacheSlot)
+}
+
+func (vm *VM) callNativeValue(name string, raw interface{}, numArgs int, block *object.Closure, cacheSlot *object.InlineCacheSlot) error {
+	rv := reflect.ValueOf(raw)
+	if rv.Kind() == reflect.Ptr {
+		rv = rv.Elem()
+	}
+	if !rv.IsValid() {
+		return fmt.Errorf("%T is an invalid function", raw)
+	}
+	if rv.Kind() != reflect.Func {
+		return fmt.Errorf("%+v (%T) is an invalid function", raw, raw)
+	}
+
+	rt := rv.Type()
+	plan := cachedCallPlanForSlot(rt, cacheSlot)
+	var scratch [1]reflect.Value
+	args, err := vm.reflectArgs(name, plan, numArgs, block, scratch[:0])
+	if err != nil {
+		return err
+	}
+
+	res := rv.Call(args)
+	vm.sp = vm.sp - numArgs - 1
+
+	if len(res) == 0 {
+		return vm.push(Null)
+	}
+
+	if err := lastReturnError(res); err != nil {
+		return fmt.Errorf("could not call %s function: %w", name, err)
+	}
+
+	return vm.push(object.Wrap(res[0].Interface()))
+}
+
+func (vm *VM) writeNativeCall(name string, callee object.Object, numArgs int, cacheSlot *object.InlineCacheSlot, calleeOnStack bool) error {
+	raw := object.ToGo(callee)
+	return vm.writeNativeValueCall(name, raw, numArgs, cacheSlot, calleeOnStack)
+}
+
+func (vm *VM) writeNativeValueCall(name string, raw interface{}, numArgs int, cacheSlot *object.InlineCacheSlot, calleeOnStack bool) error {
+	if handled, err := vm.tryFastWriteNativeValueCall(name, raw, numArgs, cacheSlot, calleeOnStack); handled || err != nil {
+		return err
+	}
+
+	rv := reflect.ValueOf(raw)
+	if rv.Kind() == reflect.Ptr {
+		rv = rv.Elem()
+	}
+	if !rv.IsValid() {
+		return fmt.Errorf("%T is an invalid function", raw)
+	}
+	if rv.Kind() != reflect.Func {
+		return fmt.Errorf("%+v (%T) is an invalid function", raw, raw)
+	}
+
+	rt := rv.Type()
+	plan := cachedCallPlanForSlot(rt, cacheSlot)
+	var scratch [1]reflect.Value
+	args, err := vm.reflectArgs(name, plan, numArgs, nil, scratch[:0])
+	if err != nil {
+		return err
+	}
+
+	res := rv.Call(args)
+	vm.sp = vm.sp - numArgs
+	if calleeOnStack {
+		vm.sp--
+	}
+
+	if len(res) == 0 {
+		vm.writeFrameOutput(vm.currentFrame(), Null)
+		return nil
+	}
+
+	if err := lastReturnError(res); err != nil {
+		return fmt.Errorf("could not call %s function: %w", name, err)
+	}
+
+	frame := vm.currentFrame()
+	if frame != nil {
+		frame.hasOutput = true
+		vm.writeNativeReturnValue(frame, res[0], plan)
+	}
+	return nil
+}
+
+func (vm *VM) tryFastWriteNativeCall(name string, callee object.Object, numArgs int, cacheSlot *object.InlineCacheSlot, calleeOnStack bool) (bool, error) {
+	raw := object.ToGo(callee)
+	return vm.tryFastWriteNativeValueCall(name, raw, numArgs, cacheSlot, calleeOnStack)
+}
+
+func (vm *VM) tryFastWriteNativeValueCall(name string, raw interface{}, numArgs int, cacheSlot *object.InlineCacheSlot, calleeOnStack bool) (bool, error) {
+	rv := reflect.ValueOf(raw)
+	if !rv.IsValid() {
+		return false, fmt.Errorf("%T is an invalid function", raw)
+	}
+	if rv.Kind() == reflect.Ptr {
+		return false, nil
+	}
+	if rv.Kind() != reflect.Func {
+		return false, fmt.Errorf("%+v (%T) is an invalid function", raw, raw)
+	}
+
+	entry := cachedCallEntryForSlot(rv.Type(), raw, cacheSlot)
+	if entry == nil || entry.invoker == nil {
+		return false, nil
+	}
+
+	args := vm.stack[vm.sp-numArgs : vm.sp]
+	oldSP := vm.sp
+	vm.sp = vm.sp - numArgs
+	if calleeOnStack {
+		vm.sp--
+	}
+	if err := entry.invoker(vm, vm.currentFrame(), name, raw, args); err != nil {
+		if errors.Is(err, errFastWriteUnsupported) {
+			vm.sp = oldSP
+			return false, nil
+		}
+		return true, err
+	}
+	return true, nil
+}
+
+func (vm *VM) writeNativeReturnValue(frame *Frame, value reflect.Value, plan *callPlan) {
+	switch plan.returnKind {
+	case callReturnNone:
+		return
+	case callReturnString:
+		frame.output.WriteString(template.HTMLEscapeString(value.String()))
+	case callReturnHTML:
+		frame.output.WriteString(value.String())
+	case callReturnBool:
+		frame.output.WriteString(strconv.FormatBool(value.Bool()))
+	case callReturnInt:
+		frame.output.WriteString(strconv.FormatInt(value.Int(), 10))
+	case callReturnUint:
+		frame.output.WriteString(strconv.FormatUint(value.Uint(), 10))
+	case callReturnFloat:
+		frame.output.WriteString(strconv.FormatFloat(value.Float(), 'g', -1, int(value.Type().Bits())))
+	case callReturnObject:
+		if isNilReflectValue(value) {
+			return
+		}
+		if obj, ok := value.Interface().(object.Object); ok {
+			vm.writeObject(&frame.output, obj)
+			return
+		}
+		vm.writeGoValue(&frame.output, value.Interface())
+	default:
+		vm.writeGoValue(&frame.output, value.Interface())
+	}
+}

--- a/VM/vm/execution_fast_value_helpers_test.go
+++ b/VM/vm/execution_fast_value_helpers_test.go
@@ -1,0 +1,194 @@
+package vm
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/code"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_VM_Execute_Comparison_Or_Logical_Branches(t *testing.T) {
+	tests := []struct {
+		name     string
+		op       code.Opcode
+		left     object.Object
+		right    object.Object
+		expected bool
+	}{
+		{"equal", code.OpEqual, &object.Integer{Value: 1}, &object.Native{Value: uint32(1)}, true},
+		{"not equal", code.OpNotEqual, &object.String{Value: "a"}, &object.String{Value: "b"}, true},
+		{"greater", code.OpGreaterThan, &object.Integer{Value: 2}, &object.Integer{Value: 1}, true},
+		{"greater equal", code.OpGreaterEqual, &object.Native{Value: int32(2)}, &object.Integer{Value: 2}, true},
+		{"matches", code.OpMatches, &object.String{Value: "abc"}, &object.String{Value: "^a"}, true},
+		{"and", code.OpAnd, object.TrueObject, &object.String{Value: "x"}, true},
+		{"or", code.OpOr, object.FalseObject, &object.String{Value: "x"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			machine := newRuntimeHelperTestVM(plush.NewContext())
+			require.NoError(t, machine.push(tt.left))
+			require.NoError(t, machine.push(tt.right))
+			require.NoError(t, machine.executeComparisonOrLogical(tt.op))
+			result := machine.pop()
+			require.Equal(t, nativeBoolToBooleanObject(tt.expected), result)
+		})
+	}
+
+	machine := newRuntimeHelperTestVM(plush.NewContext())
+	require.NoError(t, machine.push(&object.String{Value: "abc"}))
+	require.NoError(t, machine.push(&object.String{Value: "("}))
+	require.ErrorContains(t, machine.executeComparisonOrLogical(code.OpMatches), "couldn't compile regex")
+
+	machine = newRuntimeHelperTestVM(plush.NewContext())
+	require.NoError(t, machine.push(&object.String{Value: "a"}))
+	require.NoError(t, machine.push(&object.String{Value: "b"}))
+	require.ErrorContains(t, machine.executeComparisonOrLogical(code.OpAdd), "unknown comparison operator")
+
+	machine = newRuntimeHelperTestVM(plush.NewContext())
+	require.NoError(t, machine.push(&object.Integer{Value: 1}))
+	require.NoError(t, machine.push(&object.String{Value: "one"}))
+	require.ErrorContains(t, machine.executeComparisonOrLogical(code.OpEqual), "unable to operate")
+
+	machine = newRuntimeHelperTestVM(plush.NewContext())
+	require.NoError(t, machine.push(&object.Integer{Value: 1}))
+	require.NoError(t, machine.push(&object.String{Value: "one"}))
+	require.ErrorContains(t, machine.executeComparisonOrLogical(code.OpNotEqual), "unable to operate")
+
+	machine = newRuntimeHelperTestVM(plush.NewContext())
+	require.NoError(t, machine.push(&object.Integer{Value: 1}))
+	require.NoError(t, machine.push(&object.String{Value: "one"}))
+	require.ErrorContains(t, machine.executeComparisonOrLogical(code.OpGreaterThan), "unable to operate")
+
+	_, err := compareOrdered(code.OpEqual, &object.String{Value: "a"}, &object.String{Value: "b"})
+	require.ErrorContains(t, err, "unknown ordered comparison")
+}
+
+func Test_VM_Execute_Arithmetic_And_Native_Slice_Edge_Branches(t *testing.T) {
+	machine := newRuntimeHelperTestVM(plush.NewContext())
+	require.NoError(t, machine.push(&object.Integer{Value: 1}))
+	require.NoError(t, machine.push(&object.Integer{Value: 2}))
+	require.ErrorContains(t, machine.executeBinaryOperation(code.OpEqual), "unknown binary operator")
+
+	handled, err := machine.executeNativeSliceAppend(object.NullObject, &object.String{Value: "x"})
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	var nilStrings *[]string
+	handled, err = machine.executeNativeSliceAppend(&object.Native{Value: nilStrings}, &object.String{Value: "x"})
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	handled, err = machine.executeNativeSliceAppend(&object.Native{Value: 7}, &object.String{Value: "x"})
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	machine = newRuntimeHelperTestVM(plush.NewContext())
+	handled, err = machine.executeNativeSliceAppend(&object.Native{Value: []string{"a"}}, object.NullObject)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, []string{"a", ""}, object.ToGo(machine.pop()))
+
+	machine = newRuntimeHelperTestVM(plush.NewContext())
+	handled, err = machine.executeNativeSliceAppend(&object.Native{Value: []interface{}{"a"}}, object.NullObject)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, []interface{}{"a", nil}, object.ToGo(machine.pop()))
+
+	machine = newRuntimeHelperTestVM(plush.NewContext())
+	handled, err = machine.executeNativeSliceAppend(&object.Native{Value: []string{}}, &object.Integer{Value: 1})
+	require.True(t, handled)
+	require.ErrorContains(t, err, "cannot append")
+
+	machine = newRuntimeHelperTestVM(plush.NewContext())
+	require.NoError(t, machine.executeAdd(object.TrueObject, object.TrueObject))
+	require.Same(t, object.TrueObject, machine.pop())
+
+	machine = newRuntimeHelperTestVM(plush.NewContext())
+	require.NoError(t, machine.executeAdd(&object.Native{Value: []string{"a"}}, &object.String{Value: "b"}))
+	require.Equal(t, []string{"a", "b"}, object.ToGo(machine.pop()))
+
+	machine = newRuntimeHelperTestVM(plush.NewContext())
+	require.ErrorContains(t, machine.executeNumericOperation(code.OpAdd, &object.String{Value: "a"}, &object.Integer{Value: 1}), "unsupported types")
+	require.ErrorContains(t, machine.executeNumericOperation(code.OpEqual, &object.Integer{Value: 1}, &object.Integer{Value: 1}), "unknown numeric operator")
+	require.ErrorContains(t, machine.executeNumericOperation(code.OpAdd, &object.Native{Value: uint64(math.MaxUint64)}, &object.Integer{Value: -1}), "unsupported mixed signed/unsigned")
+
+	require.NoError(t, machine.push(&object.Float{Value: 1.5}))
+	require.NoError(t, machine.executeMinusOperator())
+	require.Equal(t, &object.Float{Value: -1.5}, machine.pop())
+
+	require.NoError(t, machine.push(&object.Integer{Value: 3}))
+	require.NoError(t, machine.executeMinusOperator())
+	require.Equal(t, &object.Integer{Value: -3}, machine.pop())
+
+	require.NoError(t, machine.push(&object.String{Value: "bad"}))
+	require.ErrorContains(t, machine.executeMinusOperator(), "unsupported type for negation")
+}
+
+func Test_VM_Write_Fast_Value_Plan_Output_Branches(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"user": vmFastPropertyUser{Name: "<mido>"},
+	})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"user"}}, ctx)
+	var out strings.Builder
+
+	handled, ok, err := writeFastValuePlanOutput(&out, ctx, bindings, nil)
+	require.NoError(t, err)
+	require.False(t, handled)
+	require.False(t, ok)
+
+	handled, ok, err = writeFastValuePlanOutput(&out, ctx, bindings, &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "plain"})
+	require.NoError(t, err)
+	require.False(t, handled)
+	require.False(t, ok)
+
+	handled, ok, err = writeFastValuePlanOutput(&out, ctx, bindings, &compiler.FastValuePlan{
+		Kind:     compiler.FastValueInfix,
+		Operator: "==",
+		Left:     &compiler.FastValuePlan{Kind: compiler.FastValueInteger, IntValue: 1},
+		Right:    &compiler.FastValuePlan{Kind: compiler.FastValueFloat, FloatValue: 1},
+	})
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.True(t, ok)
+	require.Equal(t, "true", out.String())
+
+	out.Reset()
+	handled, ok, err = writeFastValuePlanOutput(&out, ctx, bindings, &compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: 0,
+		Path: []compiler.FastPathStep{
+			{Kind: compiler.FastPathStepProperty, Value: "Name", Receiver: "user", Full: "user.Name", Line: 1},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.True(t, ok)
+	require.Equal(t, "&lt;mido&gt;", out.String())
+
+	out.Reset()
+	handled, ok, err = writeFastValuePlanOutput(&out, ctx, bindings, &compiler.FastValuePlan{
+		Kind:          compiler.FastValuePath,
+		NameIndex:     99,
+		Value:         "missing",
+		NullOnMissing: true,
+	})
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.True(t, ok)
+	require.Empty(t, out.String())
+
+	handled, ok, err = writeFastValuePlanOutput(&out, ctx, bindings, &compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: 99,
+		Value:     "missing",
+	})
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.False(t, ok)
+}

--- a/VM/vm/fast_access_chain_helpers_test.go
+++ b/VM/vm/fast_access_chain_helpers_test.go
@@ -1,0 +1,475 @@
+package vm
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/stretchr/testify/require"
+)
+
+type vmAccessProfile struct {
+	Name string
+}
+
+type vmAccessUser struct {
+	Profile *vmAccessProfile
+	Friends []vmAccessProfile
+	Labels  map[string]string
+	Counts  map[string]int
+}
+
+type vmAccessWrapper struct {
+	Profile vmAccessProfile
+}
+
+func vmAccessProfileNamePlan(nameIndex int) *compiler.FastValuePlan {
+	return &compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: nameIndex,
+		Value:     "user",
+		Path: []compiler.FastPathStep{
+			{Kind: compiler.FastPathStepProperty, Value: "Profile", Receiver: "user", Full: "user.Profile", Line: 1},
+			{Kind: compiler.FastPathStepProperty, Value: "Name", Receiver: "user.Profile", Full: "user.Profile.Name", Line: 1},
+		},
+		Line: 1,
+	}
+}
+
+func Test_VM_Fast_Field_Chain_Value_And_Output_Branches(t *testing.T) {
+	ctx := plush.NewContext()
+	user := vmAccessUser{Profile: &vmAccessProfile{Name: "<mido>"}}
+	plan := vmAccessProfileNamePlan(-1)
+
+	value, handled, err := evalFastFieldChainValue(plan, user, ctx)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "<mido>", value)
+
+	_, handled, err = evalFastFieldChainValue(plan, user, plush.NewContext().WithBudget(plush.NewBudget(0)))
+	require.ErrorContains(t, err, "line 1")
+	require.True(t, handled)
+
+	var out strings.Builder
+	handled, err = writeFastFieldChainValue(&out, ctx, plan, user)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "&lt;mido&gt;", out.String())
+
+	out.Reset()
+	handled, err = writeFastFieldChainValue(&out, ctx, plan, vmAccessUser{})
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Empty(t, out.String())
+
+	_, handled, err = evalFastFieldChainValue(plan, nil, ctx)
+	require.NoError(t, err)
+	require.True(t, handled)
+
+	handled, err = writeFastFieldChainValue(&out, ctx, plan, nil)
+	require.NoError(t, err)
+	require.True(t, handled)
+
+	_, handled, err = evalFastFieldChainValue(plan, object.NullObject, ctx)
+	require.NoError(t, err)
+	require.True(t, handled)
+
+	value, handled, err = evalFastFieldChainValue(plan, &object.Native{Value: user}, ctx)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "<mido>", value)
+
+	handled, err = writeFastFieldChainValue(&out, ctx, plan, 7)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	chain, ok := fastFieldChainPlanFor(plan, reflect.TypeOf(user))
+	require.True(t, ok)
+	require.NoError(t, writeFastFieldChainPlanOutput(&out, ctx, nil, reflect.ValueOf(user)))
+	require.NoError(t, writeFastFieldChainPlanOutput(&out, ctx, chain, reflect.Value{}))
+	require.NoError(t, writeFastFieldChainPlanOutput(&out, ctx, &fastFieldChainPlan{}, reflect.ValueOf(user)))
+	require.ErrorContains(t, writeFastFieldChainPlanOutput(&out, plush.NewContext().WithBudget(plush.NewBudget(0)), chain, reflect.ValueOf(user)), "line 1")
+
+	hiddenStep := fastFieldChainStep{
+		name:      "hidden",
+		receiver:  "user",
+		full:      "user.hidden",
+		line:      4,
+		fieldType: stringType,
+		lookup:    cachedPropertyLookup(reflect.TypeOf(vmFastPropertyUser{}), "hidden"),
+	}
+	hiddenChain := &fastFieldChainPlan{steps: []fastFieldChainStep{hiddenStep}}
+	_, handled, err = evalFastFieldChainValue(&compiler.FastValuePlan{
+		Kind: compiler.FastValuePath,
+		Path: []compiler.FastPathStep{{Kind: compiler.FastPathStepProperty, Value: "hidden", Receiver: "user", Full: "user.hidden", Line: 4}},
+	}, vmFastPropertyUser{hidden: "secret"}, ctx)
+	require.ErrorContains(t, err, "line 4")
+	require.True(t, handled)
+	require.ErrorContains(t, writeFastFieldChainPlanOutput(&out, ctx, hiddenChain, reflect.ValueOf(vmFastPropertyUser{hidden: "secret"})), "line 4")
+	require.ErrorContains(t, writeFastFieldChainPlanOutput(&out, ctx, &fastFieldChainPlan{steps: []fastFieldChainStep{hiddenStep, hiddenStep}}, reflect.ValueOf(vmFastPropertyUser{hidden: "secret"})), "line 4")
+
+	wrapperPlan := &compiler.FastValuePlan{
+		Kind: compiler.FastValuePath,
+		Path: []compiler.FastPathStep{{Kind: compiler.FastPathStepProperty, Value: "Profile", Receiver: "wrapper", Full: "wrapper.Profile", Line: 5}},
+	}
+	wrapperChain, ok := fastFieldChainPlanFor(wrapperPlan, reflect.TypeOf(vmAccessWrapper{}))
+	require.True(t, ok)
+	out.Reset()
+	require.NoError(t, writeFastFieldChainPlanOutput(&out, ctx, wrapperChain, reflect.ValueOf(vmAccessWrapper{Profile: vmAccessProfile{Name: "nested"}})))
+	require.Empty(t, out.String())
+}
+
+func Test_VM_Fast_Access_Chain_Root_Field_And_Intermediate_Branches(t *testing.T) {
+	rv, nilValue, ok := fastAccessChainRootValue(object.NullObject)
+	require.False(t, rv.IsValid())
+	require.True(t, nilValue)
+	require.True(t, ok)
+
+	rv, nilValue, ok = fastAccessChainRootValue(&object.Native{Value: (*vmAccessUser)(nil)})
+	require.False(t, rv.IsValid())
+	require.True(t, nilValue)
+	require.True(t, ok)
+
+	rv, nilValue, ok = fastAccessChainRootValue(&object.String{Value: "name"})
+	require.False(t, rv.IsValid())
+	require.False(t, nilValue)
+	require.False(t, ok)
+
+	rv, nilValue, ok = fastAccessChainRootValue(vmAccessUser{})
+	require.True(t, rv.IsValid())
+	require.False(t, nilValue)
+	require.True(t, ok)
+
+	rv, nilValue, ok = fastAccessChainRootValue([]string{"a"})
+	require.True(t, rv.IsValid())
+	require.False(t, nilValue)
+	require.True(t, ok)
+
+	rv, nilValue, ok = fastAccessChainRootValue(map[string]string{"a": "b"})
+	require.True(t, rv.IsValid())
+	require.False(t, nilValue)
+	require.True(t, ok)
+
+	rv, nilValue, ok = fastAccessChainRootValue(7)
+	require.False(t, rv.IsValid())
+	require.False(t, nilValue)
+	require.False(t, ok)
+
+	step := &fastAccessChainStep{
+		kind:      fastAccessStepField,
+		name:      "Name",
+		receiver:  "profile",
+		full:      "profile.Name",
+		line:      4,
+		fieldType: stringType,
+		lookup:    cachedPropertyLookup(reflect.TypeOf(vmAccessProfile{}), "Name"),
+	}
+	field, ok, err := fastAccessFieldValue(reflect.ValueOf(vmAccessProfile{Name: "Mido"}), step)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "Mido", field.Interface())
+
+	field, ok, err = fastAccessFieldValue(reflect.Value{}, step)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.False(t, field.IsValid())
+
+	field, ok, err = fastAccessFieldValue(reflect.ValueOf("not-struct"), step)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.False(t, field.IsValid())
+
+	value, ok, err := fastAccessIntermediateValue(reflect.Value{}, step)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.False(t, value.IsValid())
+
+	hidden := reflect.ValueOf(vmFastPropertyUser{hidden: "secret"}).FieldByName("hidden")
+	value, ok, err = fastAccessIntermediateValue(hidden, &fastAccessChainStep{name: "hidden", receiver: "user", full: "user.hidden", line: 9})
+	require.ErrorContains(t, err, "line 9")
+	require.False(t, ok)
+	require.False(t, value.IsValid())
+}
+
+func Test_VM_Fast_Access_Chain_Plan_Value_And_Output_Edges(t *testing.T) {
+	ctx := plush.NewContext()
+	user := vmAccessUser{
+		Profile: &vmAccessProfile{Name: "<mido>"},
+		Friends: []vmAccessProfile{{Name: "<amy>"}},
+		Labels:  map[string]string{"status": "<ready>"},
+	}
+	fieldChain, ok := fastAccessChainPlanFor(vmAccessProfileNamePlan(-1), reflect.TypeOf(user))
+	require.True(t, ok)
+
+	value, handled, err := evalFastAccessChainPlanValue(fieldChain, reflect.ValueOf(user), ctx)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "<mido>", value)
+
+	value, handled, err = evalFastAccessChainPlanValue(&fastAccessChainPlan{}, reflect.ValueOf("root"), ctx)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "root", value)
+
+	value, handled, err = evalFastAccessChainPlanValue(fieldChain, reflect.ValueOf("bad-root"), ctx)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Nil(t, value)
+
+	_, handled, err = evalFastAccessChainPlanValue(fieldChain, reflect.ValueOf(user), plush.NewContext().WithBudget(plush.NewBudget(0)))
+	require.ErrorContains(t, err, "line 1")
+	require.True(t, handled)
+
+	hiddenChain := &fastAccessChainPlan{steps: []fastAccessChainStep{{
+		kind:      fastAccessStepField,
+		name:      "hidden",
+		receiver:  "user",
+		full:      "user.hidden",
+		line:      4,
+		fieldType: stringType,
+		lookup:    cachedPropertyLookup(reflect.TypeOf(vmFastPropertyUser{}), "hidden"),
+	}}}
+	_, handled, err = evalFastAccessChainPlanValue(hiddenChain, reflect.ValueOf(vmFastPropertyUser{hidden: "secret"}), ctx)
+	require.ErrorContains(t, err, "line 4")
+	require.True(t, handled)
+
+	friendsPlan := &compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: -1,
+		Path: []compiler.FastPathStep{
+			{Kind: compiler.FastPathStepProperty, Value: "Friends", Receiver: "user", Full: "user.Friends", Line: 2},
+			{Kind: compiler.FastPathStepIndexInteger, Index: 9, Line: 2},
+		},
+	}
+	indexChain, ok := fastAccessChainPlanFor(friendsPlan, reflect.TypeOf(user))
+	require.True(t, ok)
+	_, handled, err = evalFastAccessChainPlanValue(indexChain, reflect.ValueOf(user), ctx)
+	require.ErrorContains(t, err, "line 2")
+	require.True(t, handled)
+
+	missingMapPlan := &compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: -1,
+		Path: []compiler.FastPathStep{
+			{Kind: compiler.FastPathStepProperty, Value: "Labels", Receiver: "user", Full: "user.Labels", Line: 3},
+			{Kind: compiler.FastPathStepIndexString, Value: "missing", Line: 3},
+		},
+	}
+	mapChain, ok := fastAccessChainPlanFor(missingMapPlan, reflect.TypeOf(user))
+	require.True(t, ok)
+	value, handled, err = evalFastAccessChainPlanValue(mapChain, reflect.ValueOf(user), ctx)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Nil(t, value)
+
+	var out strings.Builder
+	handled, err = writeFastAccessChainValue(&out, ctx, vmAccessProfileNamePlan(-1), nil)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Empty(t, out.String())
+
+	handled, err = writeFastAccessChainValue(&out, ctx, vmAccessProfileNamePlan(-1), 7)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	handled, err = writeFastAccessChainValue(&out, ctx, &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "bad"}, user)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	out.Reset()
+	handled, err = writeFastAccessChainValue(&out, ctx, vmAccessProfileNamePlan(-1), user)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "&lt;mido&gt;", out.String())
+
+	out.Reset()
+	handled, err = writeFastAccessChainPlanOutput(&out, ctx, &fastAccessChainPlan{}, reflect.ValueOf(user))
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Empty(t, out.String())
+
+	handled, err = writeFastAccessChainPlanOutput(&out, plush.NewContext().WithBudget(plush.NewBudget(0)), fieldChain, reflect.ValueOf(user))
+	require.ErrorContains(t, err, "line 1")
+	require.True(t, handled)
+
+	handled, err = writeFastAccessChainPlanOutput(&out, ctx, fieldChain, reflect.ValueOf("bad-root"))
+	require.NoError(t, err)
+	require.True(t, handled)
+
+	handled, err = writeFastAccessChainPlanOutput(&out, ctx, hiddenChain, reflect.ValueOf(vmFastPropertyUser{hidden: "secret"}))
+	require.ErrorContains(t, err, "line 4")
+	require.True(t, handled)
+
+	handled, err = writeFastAccessChainPlanOutput(&out, ctx, indexChain, reflect.ValueOf(user))
+	require.ErrorContains(t, err, "line 2")
+	require.True(t, handled)
+
+	out.Reset()
+	handled, err = writeFastAccessChainPlanOutput(&out, ctx, mapChain, reflect.ValueOf(user))
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Empty(t, out.String())
+
+	structFieldPlan := &compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: -1,
+		Path: []compiler.FastPathStep{
+			{Kind: compiler.FastPathStepProperty, Value: "Profile", Receiver: "wrapper", Full: "wrapper.Profile", Line: 5},
+		},
+	}
+	structFieldChain, ok := fastAccessChainPlanFor(structFieldPlan, reflect.TypeOf(vmAccessWrapper{}))
+	require.True(t, ok)
+	handled, err = writeFastAccessChainPlanOutput(&out, ctx, structFieldChain, reflect.ValueOf(vmAccessWrapper{Profile: vmAccessProfile{Name: "nested"}}))
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Empty(t, out.String())
+}
+
+func Test_VM_Fast_Top_Level_Access_Chain_Output_Branches(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"user": vmAccessUser{
+			Profile: &vmAccessProfile{Name: "<mido>"},
+			Friends: []vmAccessProfile{{Name: "<amy>"}},
+			Labels:  map[string]string{"status": "<ready>"},
+			Counts:  map[string]int{"count": 3},
+		},
+	})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"user"}}, ctx)
+
+	fieldPlan := vmAccessProfileNamePlan(0)
+	var out strings.Builder
+	handled, ok, err := writeFastTopLevelAccessChainOutput(&out, ctx, bindings, fieldPlan, nil)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.True(t, ok)
+	require.Equal(t, "&lt;mido&gt;", out.String())
+
+	out.Reset()
+	slicePlan := &compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: 0,
+		Value:     "user",
+		Path: []compiler.FastPathStep{
+			{Kind: compiler.FastPathStepProperty, Value: "Friends", Receiver: "user", Full: "user.Friends", Line: 1},
+			{Kind: compiler.FastPathStepIndexInteger, Index: 0, Line: 1},
+			{Kind: compiler.FastPathStepProperty, Value: "Name", Receiver: "user.Friends[0]", Full: "user.Friends[0].Name", Line: 1},
+		},
+		Line: 1,
+	}
+	handled, ok, err = writeFastTopLevelAccessChainOutput(&out, ctx, bindings, slicePlan, nil)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.True(t, ok)
+	require.Equal(t, "&lt;amy&gt;", out.String())
+
+	out.Reset()
+	mapPlan := &compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: 0,
+		Value:     "user",
+		Path: []compiler.FastPathStep{
+			{Kind: compiler.FastPathStepProperty, Value: "Labels", Receiver: "user", Full: "user.Labels", Line: 1},
+			{Kind: compiler.FastPathStepIndexString, Value: "status", Line: 1},
+		},
+		Line: 1,
+	}
+	handled, ok, err = writeFastTopLevelAccessChainOutput(&out, ctx, bindings, mapPlan, nil)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.True(t, ok)
+	require.Equal(t, "&lt;ready&gt;", out.String())
+
+	out.Reset()
+	countPlan := &compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: 0,
+		Value:     "user",
+		Path: []compiler.FastPathStep{
+			{Kind: compiler.FastPathStepProperty, Value: "Counts", Receiver: "user", Full: "user.Counts", Line: 1},
+			{Kind: compiler.FastPathStepIndexString, Value: "count", Line: 1},
+		},
+		Line: 1,
+	}
+	handled, ok, err = writeFastTopLevelAccessChainOutput(&out, ctx, bindings, countPlan, nil)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.True(t, ok)
+	require.Equal(t, "3", out.String())
+
+	handled, ok, err = writeFastTopLevelAccessChainOutput(&out, ctx, bindings, &compiler.FastValuePlan{Kind: compiler.FastValueString}, nil)
+	require.NoError(t, err)
+	require.False(t, handled)
+	require.False(t, ok)
+
+	require.False(t, canUseFastTopLevelAccessChain(&compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: 0,
+		Path:      []compiler.FastPathStep{{Kind: compiler.FastPathStepKind(255)}},
+	}))
+
+	handled, err = writeFastTopLevelAccessChainRaw(&out, ctx, &compiler.FastValuePlan{Kind: compiler.FastValueString}, ctx.Value("user"), nil)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	handled, err = writeFastTopLevelAccessChainRaw(&out, ctx, fieldPlan, nil, nil)
+	require.NoError(t, err)
+	require.True(t, handled)
+
+	var unknownKindSlot object.InlineCacheSlot
+	unknownKindSlot.Store(&fastTopLevelAccessCacheEntry{
+		typ:  reflect.TypeOf(vmAccessUser{}),
+		kind: fastTopLevelAccessKind(255),
+	})
+	handled, err = writeFastTopLevelAccessChainRaw(&out, ctx, fieldPlan, ctx.Value("user"), &unknownKindSlot)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	handled, ok, err = writeFastTopLevelAccessChainOutput(&out, ctx, bindings, &compiler.FastValuePlan{Kind: compiler.FastValuePath, NameIndex: 99, NullOnMissing: true, Path: fieldPlan.Path}, nil)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.True(t, ok)
+
+	handled, ok, err = writeFastTopLevelAccessChainOutput(&out, ctx, bindings, &compiler.FastValuePlan{Kind: compiler.FastValuePath, NameIndex: 99, Value: "missing", Path: fieldPlan.Path}, nil)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.False(t, ok)
+}
+
+func Test_VM_Fast_Access_Index_Plan_Branches(t *testing.T) {
+	_, _, ok := buildFastIndexAccessStep(reflect.TypeOf([2]string{}), &compiler.FastPathStep{Kind: compiler.FastPathStepIndexString, Value: "bad"})
+	require.False(t, ok)
+
+	_, _, ok = buildFastIndexAccessStep(reflect.TypeOf([2]string{}), &compiler.FastPathStep{Kind: compiler.FastPathStepIndexInteger, Index: 3})
+	require.False(t, ok)
+
+	_, _, ok = buildFastIndexAccessStep(reflect.TypeOf([]string{}), &compiler.FastPathStep{Kind: compiler.FastPathStepIndexInteger, Index: -1})
+	require.False(t, ok)
+
+	step, next, ok := buildFastIndexAccessStep(reflect.TypeOf(map[int]string{}), &compiler.FastPathStep{Kind: compiler.FastPathStepIndexInteger, Index: 7})
+	require.True(t, ok)
+	require.Equal(t, stringType, next)
+	require.True(t, step.mapKey.IsValid())
+
+	_, _, ok = buildFastIndexAccessStep(reflect.TypeOf(map[int]string{}), &compiler.FastPathStep{Kind: compiler.FastPathStepIndexString, Value: "bad"})
+	require.False(t, ok)
+
+	_, _, ok = buildFastIndexAccessStep(reflect.TypeOf(struct{}{}), &compiler.FastPathStep{Kind: compiler.FastPathStepIndexInteger, Index: 0})
+	require.False(t, ok)
+}
+
+func Test_VM_Fast_Access_Index_Value_Edge_Branches(t *testing.T) {
+	_, ok, err := fastAccessIndexValue(reflect.Value{}, &fastAccessChainStep{index: 0})
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	_, ok, err = fastAccessIndexValue(reflect.ValueOf(map[bool]string{}), &fastAccessChainStep{index: 1})
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	_, ok, err = fastAccessIndexValue(reflect.ValueOf(12), &fastAccessChainStep{index: 0})
+	require.NoError(t, err)
+	require.False(t, ok)
+}

--- a/VM/vm/fast_bindings.go
+++ b/VM/vm/fast_bindings.go
@@ -1,0 +1,269 @@
+package vm
+
+import (
+	"fmt"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+)
+
+type fastRenderBindings struct {
+	ctx       hctx.Context
+	names     []string
+	lookup    contextIDLookup
+	ids       []int
+	inlineIDs [8]int
+	localOK   []bool
+	localVals []interface{}
+}
+
+type fastRenderBindingPlan struct {
+	names     []string
+	ids       []int
+	inlineIDs [8]int
+}
+
+func newFastRenderBindingsWithPlan(plan *compiler.FastRenderPlan, ctx hctx.Context, bindingPlan *fastRenderBindingPlan) fastRenderBindings {
+	bindings := fastRenderBindings{ctx: ctx}
+	if plan != nil {
+		bindings.names = plan.Bindings
+	}
+	lookup, ok := ctx.(contextIDLookup)
+	if !ok || len(bindings.names) == 0 {
+		return bindings
+	}
+	bindings.lookup = lookup
+	if bindingPlan != nil && bindingPlan.matches(bindings.names) {
+		if len(bindings.names) > len(bindings.inlineIDs) {
+			bindings.ids = bindingPlan.ids
+		} else {
+			bindings.inlineIDs = bindingPlan.inlineIDs
+		}
+		return bindings
+	}
+	fillFastRenderBindingIDs(bindings.names, lookup, &bindings.inlineIDs, &bindings.ids)
+	return bindings
+}
+
+func newFastRenderBindingPlan(plan *compiler.FastRenderPlan, ctx hctx.Context) *fastRenderBindingPlan {
+	if plan == nil || len(plan.Bindings) == 0 {
+		return nil
+	}
+	if !canCacheFastRenderBindingPlan(ctx) {
+		return nil
+	}
+	lookup := ctx.(contextIDLookup)
+	bindingPlan := &fastRenderBindingPlan{names: plan.Bindings}
+	fillFastRenderBindingIDs(plan.Bindings, lookup, &bindingPlan.inlineIDs, &bindingPlan.ids)
+	return bindingPlan
+}
+
+func fillFastRenderBindingIDs(names []string, lookup contextIDLookup, inlineIDs *[8]int, ids *[]int) {
+	if lookup == nil || len(names) == 0 {
+		return
+	}
+	if len(names) > len(*inlineIDs) {
+		if *ids == nil || len(*ids) != len(names) {
+			*ids = make([]int, len(names))
+		}
+		if binder, ok := lookup.(contextIDBinder); ok {
+			binder.InternIDs(names, *ids)
+			return
+		}
+		for i, name := range names {
+			(*ids)[i] = lookup.InternID(name)
+		}
+		return
+	}
+	if binder, ok := lookup.(contextIDBinder); ok {
+		tmp := inlineIDs[:len(names)]
+		binder.InternIDs(names, tmp)
+		return
+	}
+	for i, name := range names {
+		(*inlineIDs)[i] = lookup.InternID(name)
+	}
+}
+
+func (p *fastRenderBindingPlan) matches(names []string) bool {
+	if p == nil || len(p.names) != len(names) {
+		return false
+	}
+	for i := range names {
+		if p.names[i] != names[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (b fastRenderBindings) value(index int) (interface{}, bool) {
+	if index < 0 || index >= len(b.names) {
+		return nil, false
+	}
+	if index < len(b.localOK) && b.localOK[index] {
+		return b.localVals[index], true
+	}
+	if b.lookup != nil {
+		var id int
+		if b.ids != nil {
+			id = b.ids[index]
+		} else {
+			id = b.inlineIDs[index]
+		}
+		return b.lookup.LookupID(id)
+	}
+	return fastContextValue(b.ctx, b.names[index])
+}
+
+func (b *fastRenderBindings) setLocal(index int, value interface{}) {
+	if b == nil || index < 0 || index >= len(b.names) {
+		return
+	}
+	b.ensureLocalCapacity()
+	b.localOK[index] = true
+	b.localVals[index] = value
+}
+
+func (b *fastRenderBindings) setLocalAndContext(index int, value interface{}) {
+	if b == nil || index < 0 || index >= len(b.names) {
+		return
+	}
+	b.setLocal(index, value)
+	if b.ctx == nil {
+		return
+	}
+	if id, ok := b.bindingID(index); ok {
+		if setter, ok := b.ctx.(interface{ SetID(int, interface{}) }); ok {
+			setter.SetID(id, value)
+			return
+		}
+	}
+	b.ctx.Set(b.names[index], value)
+}
+
+func (b fastRenderBindings) bindingID(index int) (int, bool) {
+	if index < 0 || index >= len(b.names) {
+		return 0, false
+	}
+	if b.ids != nil {
+		if index >= len(b.ids) {
+			return 0, false
+		}
+		return b.ids[index], true
+	}
+	if index >= len(b.inlineIDs) {
+		return 0, false
+	}
+	return b.inlineIDs[index], true
+}
+
+func (b *fastRenderBindings) ensureLocalCapacity() {
+	if b == nil || len(b.localOK) >= len(b.names) {
+		return
+	}
+	ok := make([]bool, len(b.names))
+	vals := make([]interface{}, len(b.names))
+	copy(ok, b.localOK)
+	copy(vals, b.localVals)
+	b.localOK = ok
+	b.localVals = vals
+}
+
+func fastRenderScopedBindings(ctx hctx.Context, bindings fastRenderBindings) (hctx.Context, fastRenderBindings, func()) {
+	child, cleanup := partialHelperChildContext(ctx)
+	if child == nil {
+		return ctx, bindings, func() {}
+	}
+	scoped := bindings
+	scoped.ctx = child
+	if lookup, ok := child.(contextIDLookup); ok {
+		scoped.lookup = lookup
+	} else {
+		scoped.lookup = nil
+		scoped.ids = nil
+		scoped.inlineIDs = [8]int{}
+	}
+	if cleanup == nil {
+		cleanup = func() {}
+	}
+	return child, scoped, cleanup
+}
+
+type fastPartialLocalStorage struct {
+	ok   [8]bool
+	vals [8]interface{}
+}
+
+func fastContextValue(ctx hctx.Context, name string) (interface{}, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	if lookup, ok := ctx.(contextLookup); ok {
+		return lookup.Lookup(name)
+	}
+	if ctx.Has(name) {
+		return ctx.Value(name), true
+	}
+	return nil, false
+}
+
+func fastLineError(line int, err error) error {
+	if err == nil {
+		return nil
+	}
+	if line <= 0 {
+		line = 1
+	}
+	return fmt.Errorf("line %d: %w", line, err)
+}
+
+func fastBudget(ctx hctx.Context) *plush.Budget {
+	if provider, ok := ctx.(interface{ Budget() *plush.Budget }); ok {
+		return provider.Budget()
+	}
+	return nil
+}
+
+func spendFastTraversal(ctx hctx.Context, line int) error {
+	if err := fastBudget(ctx).SpendObjectTraversal(1); err != nil {
+		return fastLineError(line, err)
+	}
+	return nil
+}
+
+func spendFastLoop(ctx hctx.Context, line int) error {
+	if err := fastBudget(ctx).SpendLoop(); err != nil {
+		return fastLineError(line, err)
+	}
+	return nil
+}
+
+func spendFastCondition(ctx hctx.Context, line int) error {
+	if err := fastBudget(ctx).SpendCondition(); err != nil {
+		return fastLineError(line, err)
+	}
+	return nil
+}
+
+func spendFastAssignment(ctx hctx.Context, line int) error {
+	if err := fastBudget(ctx).SpendAssignment(); err != nil {
+		return fastLineError(line, err)
+	}
+	return nil
+}
+
+func spendFastFunctionCall(ctx hctx.Context, name string, line int) error {
+	if err := fastBudget(ctx).SpendFunctionCall(name); err != nil {
+		return fastLineError(line, err)
+	}
+	return nil
+}
+
+func spendFastSubRender(ctx hctx.Context, line int) error {
+	if err := fastBudget(ctx).SpendSubRender(); err != nil {
+		return fastLineError(line, err)
+	}
+	return nil
+}

--- a/VM/vm/fast_cache_partial_helpers_test.go
+++ b/VM/vm/fast_cache_partial_helpers_test.go
@@ -1,0 +1,512 @@
+package vm
+
+import (
+	"context"
+	"html/template"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/gobuffalo/plush/v5/helpers/meta"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_VM_Clone_Fast_Top_Level_Access_Cache_Branches(t *testing.T) {
+	require.Nil(t, cloneFastTopLevelAccessCache(nil, 2))
+	require.Nil(t, cloneFastTopLevelAccessCache(&fastTopLevelAccessCacheEntry{}, 0))
+
+	methodPlan := &fastLoopMethodCallPlan{}
+	fieldPlan := &fastFieldChainPlan{}
+	chainPlan := &fastAccessChainPlan{}
+	head := &fastTopLevelAccessCacheEntry{
+		typ:        reflect.TypeOf(""),
+		kind:       fastTopLevelAccessMethodCall,
+		method:     methodPlan,
+		fieldChain: fieldPlan,
+		chain:      chainPlan,
+		next: &fastTopLevelAccessCacheEntry{
+			typ:  reflect.TypeOf(1),
+			kind: fastTopLevelAccessFieldChain,
+			next: &fastTopLevelAccessCacheEntry{
+				typ:  reflect.TypeOf(uint32(1)),
+				kind: fastTopLevelAccessChain,
+			},
+		},
+	}
+
+	clone := cloneFastTopLevelAccessCache(head, 2)
+	require.NotNil(t, clone)
+	require.NotSame(t, head, clone)
+	require.Equal(t, head.typ, clone.typ)
+	require.Equal(t, fastTopLevelAccessMethodCall, clone.kind)
+	require.Same(t, methodPlan, clone.method)
+	require.Same(t, fieldPlan, clone.fieldChain)
+	require.Same(t, chainPlan, clone.chain)
+
+	require.NotNil(t, clone.next)
+	require.NotSame(t, head.next, clone.next)
+	require.Equal(t, reflect.TypeOf(1), clone.next.typ)
+	require.Nil(t, clone.next.next)
+}
+
+func Test_VM_Fast_Top_Level_Access_Cache_Entry_For_Branches(t *testing.T) {
+	value := &compiler.FastValuePlan{Kind: compiler.FastValueName, Value: "name"}
+
+	entry := fastTopLevelAccessCacheEntryFor(nil, value, reflect.TypeOf(""))
+	require.NotNil(t, entry)
+	require.Equal(t, reflect.TypeOf(""), entry.typ)
+	require.Equal(t, fastTopLevelAccessUnsupported, entry.kind)
+
+	var slot object.InlineCacheSlot
+	cachedString := fastTopLevelAccessCacheEntryFor(&slot, value, reflect.TypeOf(""))
+	require.NotNil(t, cachedString)
+	require.Equal(t, reflect.TypeOf(""), cachedString.typ)
+
+	cachedInt := fastTopLevelAccessCacheEntryFor(&slot, value, reflect.TypeOf(1))
+	require.NotNil(t, cachedInt)
+	require.Equal(t, reflect.TypeOf(1), cachedInt.typ)
+	require.NotNil(t, cachedInt.next)
+	require.Equal(t, reflect.TypeOf(""), cachedInt.next.typ)
+}
+
+func Test_VM_Partial_Bytecode_Link_Cache_Edges(t *testing.T) {
+	var nilCache *partialBytecodeLinkCache
+	bytecode, ok := nilCache.Get("row", 1)
+	require.False(t, ok)
+	require.Nil(t, bytecode)
+
+	link, ok := nilCache.GetLink("row", 1)
+	require.False(t, ok)
+	require.Nil(t, link)
+
+	require.Nil(t, nilCache.Set("row", 1, &compiler.Bytecode{}))
+	require.Zero(t, nilCache.Len())
+	require.Equal(t, -1, nilCache.partialFeederID(nil))
+
+	cache := newPartialBytecodeLinkCache()
+	require.Nil(t, cache.Set("", 1, &compiler.Bytecode{}))
+	require.Nil(t, cache.Set("row", 1, nil))
+	require.Zero(t, cache.Len())
+
+	stored := cache.Set("row", 1, &compiler.Bytecode{FastRenderPlan: &compiler.FastRenderPlan{Bindings: []string{"name"}}})
+	require.NotNil(t, stored)
+	require.Equal(t, 1, cache.Len())
+	bytecode, ok = cache.Get("row", 2)
+	require.False(t, ok)
+	require.Nil(t, bytecode)
+	bytecode, ok = cache.Get("row", 1)
+	require.True(t, ok)
+	require.Same(t, stored.bytecode, bytecode)
+
+	_, ok = cache.partialFeeder(nil)
+	require.False(t, ok)
+	metaIDs, ok := cache.partialMetaIDs(newVMFallbackContext(map[string]interface{}{}))
+	require.False(t, ok)
+	require.Equal(t, partialMetaIDs{}, metaIDs)
+
+	partialCtx := borrowPartialOverlayContext(plush.NewContext())
+	defer releasePartialOverlayContext(partialCtx)
+	feeder := func(name string) (string, error) { return name, nil }
+	partialCtx.Set(vmPartialFeederName, feeder)
+	gotFeeder, ok := cache.partialFeeder(partialCtx)
+	require.True(t, ok)
+	require.NotNil(t, gotFeeder)
+
+	id := cache.partialFeederID(partialCtx)
+	require.Equal(t, id, cache.partialFeederID(partialCtx))
+
+	firstPlan := stored.fastBindingPlan(partialCtx)
+	require.NotNil(t, firstPlan)
+	require.Same(t, firstPlan, stored.fastBindingPlan(partialCtx))
+	require.Nil(t, (*partialBytecodeLink)(nil).fastBindingPlan(partialCtx))
+}
+
+func Test_VM_Fast_Partial_Metadata_Helpers(t *testing.T) {
+	var nilCache *partialBytecodeLinkCache
+	_, ok := nilCache.partialMetaIDs(plush.NewContext())
+	require.False(t, ok)
+
+	cache := newPartialBytecodeLinkCache()
+	_, ok = cache.partialMetaIDs(newIDLookupTestContext(map[string]interface{}{}))
+	require.False(t, ok)
+
+	metaCtx := borrowPartialOverlayContext(plush.NewContext())
+	defer releasePartialOverlayContext(metaCtx)
+	idsFromCache, ok := cache.partialMetaIDs(metaCtx)
+	require.True(t, ok)
+	require.NotEqual(t, 0, idsFromCache.templateBaseFileID)
+	idsFromCacheAgain, ok := cache.partialMetaIDs(metaCtx)
+	require.True(t, ok)
+	require.Equal(t, idsFromCache, idsFromCacheAgain)
+
+	filename, err := fastPartialTemplateFilename(nil, "row.plush")
+	require.NoError(t, err)
+	require.Equal(t, "row.plush", filename)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		meta.TemplateBaseFileNameKey: "index",
+		meta.TemplateExtensionKey:    "plush",
+		meta.TemplateFileKey:         "templates/index.plush",
+	})
+	filename, err = fastPartialTemplateFilename(ctx, "row.plush")
+	require.NoError(t, err)
+	require.Equal(t, "templates/row.plush", filename)
+
+	ctx.Set(vmAlreadyInPartial, "parent.plush")
+	ctx.Set(meta.TemplateFileKey, "templates/index.plushparent.plush")
+	filename, err = fastPartialTemplateFilename(ctx, "row.plush")
+	require.NoError(t, err)
+	require.Equal(t, "templates/row.plush", filename)
+
+	ctx.Set(meta.TemplateFileKey, 99)
+	_, err = fastPartialTemplateFilename(ctx, "row.plush")
+	require.ErrorContains(t, err, "expected fileKey to be a string")
+
+	require.True(t, partialNeedsJSEscape(plush.NewContextWith(map[string]interface{}{"contentType": "application/javascript"}), "row.plush"))
+	require.False(t, partialNeedsJSEscape(plush.NewContextWith(map[string]interface{}{"contentType": "application/javascript"}), "row.js"))
+	require.False(t, partialNeedsJSEscape(plush.NewContextWith(map[string]interface{}{"contentType": "text/html"}), "row.plush"))
+	require.False(t, partialNeedsJSEscape(nil, "row.plush"))
+
+	partialCtx := borrowPartialOverlayContext(plush.NewContext())
+	defer releasePartialOverlayContext(partialCtx)
+	ids := partialMetaIDs{
+		templateFileID:     partialCtx.InternID(meta.TemplateFileKey),
+		templateBaseFileID: partialCtx.InternID(meta.TemplateBaseFileNameKey),
+		templateExtID:      partialCtx.InternID(meta.TemplateExtensionKey),
+		alreadyPartialID:   partialCtx.InternID(vmAlreadyInPartial),
+		contentTypeID:      partialCtx.InternID("contentType"),
+	}
+	partialCtx.SetID(ids.contentTypeID, "application/javascript")
+	require.True(t, partialNeedsJSEscapeFast(partialCtx, "row.plush", ids))
+	require.False(t, partialNeedsJSEscapeFast(partialCtx, "row.js", ids))
+	partialCtx.SetID(ids.contentTypeID, 12)
+	require.False(t, partialNeedsJSEscapeFast(partialCtx, "row.plush", ids))
+	require.False(t, partialNeedsJSEscapeFast(nil, "row.plush", ids))
+	require.NoError(t, setupFastPartialTemplateFile(nil, "row.plush", ids))
+
+	partialCtx.SetID(ids.templateBaseFileID, "index")
+	partialCtx.SetID(ids.templateExtID, "plush")
+	partialCtx.SetID(ids.templateFileID, "templates/index.plush")
+	require.NoError(t, setupFastPartialTemplateFile(partialCtx, "row.plush", ids))
+	value, ok := partialCtx.LookupID(ids.templateFileID)
+	require.True(t, ok)
+	require.Equal(t, "templates/row.plush", value)
+
+	partialCtx.SetID(ids.templateFileID, "templates/parent.plush")
+	partialCtx.SetID(ids.alreadyPartialID, "parent.plush")
+	require.NoError(t, setupFastPartialTemplateFile(partialCtx, "child.plush", ids))
+	value, ok = partialCtx.LookupID(ids.templateFileID)
+	require.True(t, ok)
+	require.Equal(t, "templates/child.plush", value)
+
+	fallbackCtx := borrowPartialOverlayContext(plush.NewContext())
+	defer releasePartialOverlayContext(fallbackCtx)
+	fallbackIDs := partialMetaIDs{templateFileID: fallbackCtx.InternID(meta.TemplateFileKey)}
+	require.NoError(t, setupFastPartialTemplateFile(fallbackCtx, "plain.plush", fallbackIDs))
+	value, ok = fallbackCtx.LookupID(fallbackIDs.templateFileID)
+	require.True(t, ok)
+	require.Equal(t, "plain.plush", value)
+
+	errorCtx := borrowPartialOverlayContext(plush.NewContext())
+	defer releasePartialOverlayContext(errorCtx)
+	errorIDs := partialMetaIDs{
+		templateFileID:     errorCtx.InternID(meta.TemplateFileKey),
+		templateBaseFileID: errorCtx.InternID(meta.TemplateBaseFileNameKey),
+		templateExtID:      errorCtx.InternID(meta.TemplateExtensionKey),
+	}
+	errorCtx.SetID(errorIDs.templateBaseFileID, "index")
+	errorCtx.SetID(errorIDs.templateExtID, "plush")
+	errorCtx.SetID(errorIDs.templateFileID, 99)
+	require.ErrorContains(t, setupFastPartialTemplateFile(errorCtx, "row.plush", errorIDs), "expected fileKey to be a string")
+}
+
+func Test_VM_Partial_Helper_Install_And_Function_Identity_Branches(t *testing.T) {
+	require.Nil(t, installVMPartialHelper(nil))
+	require.False(t, sameFunction(nil, plush.PartialHelper))
+	require.False(t, sameFunction("partial", plush.PartialHelper))
+	require.False(t, sameFunction(plush.PartialHelper, "partial"))
+
+	ctx := newLookupTestContext(map[string]interface{}{})
+	require.Nil(t, installVMPartialHelper(ctx))
+
+	plushCtx := plush.NewContext()
+	plushCtx.Set("partial", func(string, interface{}, plush.HelperContext) (template.HTML, error) {
+		return template.HTML("custom"), nil
+	})
+	require.Nil(t, installVMPartialHelper(plushCtx))
+
+	plushCtx.Set("partial", plush.PartialHelper)
+	restore := installVMPartialHelper(plushCtx)
+	require.NotNil(t, restore)
+	require.True(t, sameFunction(plushCtx.Value("partial"), vmPartialHelper))
+	restore()
+	require.True(t, sameFunction(plushCtx.Value("partial"), plush.PartialHelper))
+}
+
+func Test_VM_Partial_Overlay_Update_ID_Branches(t *testing.T) {
+	require.False(t, (*partialOverlayContext)(nil).UpdateID(1, "x"))
+	require.False(t, (*partialOverlayContext)(nil).UpdateID(1, nil))
+
+	parent := newIDLookupTestContext(map[string]interface{}{"parent": "old"})
+	parentID := parent.InternID("parent")
+	local := borrowPartialOverlayContext(parent)
+	defer releasePartialOverlayContext(local)
+
+	localID := local.InternID("local")
+	local.SetID(localID, "first")
+	require.True(t, local.UpdateID(localID, "second"))
+	value, ok := local.LookupID(localID)
+	require.True(t, ok)
+	require.Equal(t, "second", value)
+
+	require.True(t, local.UpdateID(parentID, "new"))
+	require.Equal(t, "new", parent.values["parent"])
+
+	missingID := local.InternID("missing")
+	require.False(t, local.UpdateID(missingID, "value"))
+	require.False(t, local.UpdateID(missingID, nil))
+}
+
+func Test_VM_Partial_Overlay_Lookup_And_Context_Branches(t *testing.T) {
+	var nilOverlay *partialOverlayContext
+	nilOverlay.reset(nil)
+	require.False(t, nilOverlay.stableBindingIDs())
+	deadline, ok := nilOverlay.Deadline()
+	require.False(t, ok)
+	require.True(t, deadline.IsZero())
+	require.Nil(t, nilOverlay.Done())
+	require.NoError(t, nilOverlay.Err())
+	require.Nil(t, nilOverlay.Value("missing"))
+	require.False(t, nilOverlay.Has("missing"))
+	value, ok := nilOverlay.Lookup("missing")
+	require.False(t, ok)
+	require.Nil(t, value)
+	require.Equal(t, -1, nilOverlay.InternID("missing"))
+	nilOverlay.InternIDs([]string{"a"}, []int{0})
+	value, ok = nilOverlay.LookupID(1)
+	require.False(t, ok)
+	require.Nil(t, value)
+	nilOverlay.SetID(1, "x")
+	require.False(t, nilOverlay.Update("x", "y"))
+	nilOverlay.Set("x", "y")
+	require.Nil(t, nilOverlay.Budget())
+
+	childParent := newLookupTestContext(map[string]interface{}{"fallback": "F"})
+	fallbackChild, fallbackRelease := partialHelperChildContext(childParent)
+	require.Nil(t, fallbackRelease)
+	require.NotSame(t, childParent, fallbackChild)
+	require.Equal(t, "F", fallbackChild.Value("fallback"))
+
+	orphan := borrowPartialOverlayContext(nil)
+	defer releasePartialOverlayContext(orphan)
+	require.Nil(t, orphan.Value("missing"))
+	value, ok = orphan.Lookup("missing")
+	require.False(t, ok)
+	require.Nil(t, value)
+	require.False(t, orphan.Update("missing", "M"))
+	require.False(t, orphan.UpdateID(12, "M"))
+	require.Nil(t, orphan.Budget())
+	fallbackIDs := make([]int, 2)
+	orphan.InternIDs([]string{"one", "two"}, fallbackIDs)
+	require.NotEqual(t, fallbackIDs[0], fallbackIDs[1])
+	name, ok := orphan.nameForID(fallbackIDs[0])
+	require.True(t, ok)
+	require.Equal(t, "one", name)
+	clear(orphan.idNames)
+	name, ok = orphan.nameForID(fallbackIDs[0])
+	require.True(t, ok)
+	require.Equal(t, "one", name)
+	orphan.setLocalWithID("", fallbackIDs[0], "first")
+	orphan.setLocalWithID("", fallbackIDs[0], "second")
+	value, ok = orphan.LookupID(fallbackIDs[0])
+	require.True(t, ok)
+	require.Equal(t, "second", value)
+
+	noBudgetParent := newLookupTestContext(map[string]interface{}{"parent": "P"})
+	noBudgetOverlay := borrowPartialOverlayContext(noBudgetParent)
+	defer releasePartialOverlayContext(noBudgetOverlay)
+	require.Nil(t, noBudgetOverlay.Budget())
+
+	parent := plush.NewContextWith(map[string]interface{}{"parent": "P"})
+	budget := plush.NewBudget(10)
+	parent.WithBudget(budget)
+	overlay := borrowPartialOverlayContext(parent)
+	defer releasePartialOverlayContext(overlay)
+	require.True(t, overlay.stableBindingIDs())
+
+	overlay.Set("local", "L")
+	require.Equal(t, "L", overlay.Value("local"))
+	require.Equal(t, "P", overlay.Value("parent"))
+	require.True(t, overlay.Has("local"))
+	require.True(t, overlay.Has("parent"))
+	require.False(t, overlay.Has("missing"))
+
+	value, ok = overlay.Lookup("local")
+	require.True(t, ok)
+	require.Equal(t, "L", value)
+	value, ok = overlay.Lookup("parent")
+	require.True(t, ok)
+	require.Equal(t, "P", value)
+	value, ok = overlay.Lookup("missing")
+	require.False(t, ok)
+	require.Nil(t, value)
+
+	child := overlay.New()
+	require.NotSame(t, overlay, child)
+	require.Equal(t, "L", child.Value("local"))
+	require.Same(t, budget, overlay.Budget())
+
+	ids := make([]int, 2)
+	overlay.InternIDs(nil, ids)
+	overlay.InternIDs([]string{"too", "short"}, ids[:1])
+	overlay.InternIDs([]string{"local", "parent"}, ids)
+	require.NotEqual(t, ids[0], ids[1])
+	value, ok = overlay.LookupID(ids[0])
+	require.True(t, ok)
+	require.Equal(t, "L", value)
+	value, ok = overlay.LookupID(ids[1])
+	require.True(t, ok)
+	require.Equal(t, "P", value)
+
+	overlay.SetID(ids[0], "L2")
+	value, ok = overlay.LookupID(ids[0])
+	require.True(t, ok)
+	require.Equal(t, "L2", value)
+	require.True(t, overlay.Update("local", "L3"))
+	value, ok = overlay.Lookup("local")
+	require.True(t, ok)
+	require.Equal(t, "L3", value)
+	require.True(t, overlay.Update("parent", "P2"))
+	require.Equal(t, "P2", parent.Value("parent"))
+	require.False(t, overlay.Update("missing", "M"))
+
+	extra := borrowPartialOverlayContext(nil)
+	defer releasePartialOverlayContext(extra)
+	for i := 0; i < 10; i++ {
+		extra.Set(string(rune('a'+i)), i)
+	}
+	value, ok = extra.Lookup("j")
+	require.True(t, ok)
+	require.Equal(t, 9, value)
+	extra.Set("j", "updated")
+	value, ok = extra.Lookup("j")
+	require.True(t, ok)
+	require.Equal(t, "updated", value)
+
+	extraID := extra.InternID("extra")
+	extra.SetID(extraID, "first")
+	require.True(t, extra.UpdateID(extraID, "second"))
+	value, ok = extra.LookupID(extraID)
+	require.True(t, ok)
+	require.Equal(t, "second", value)
+
+	deadlineAt := time.Now().Add(time.Hour)
+	deadlineCtx, cancel := context.WithDeadline(context.Background(), deadlineAt)
+	parentWithDeadline := plush.NewContextWithContext(deadlineCtx)
+	overlayWithDeadline := borrowPartialOverlayContext(parentWithDeadline)
+	defer releasePartialOverlayContext(overlayWithDeadline)
+
+	deadline, ok = overlayWithDeadline.Deadline()
+	require.True(t, ok)
+	require.Equal(t, deadlineAt, deadline)
+	require.NotNil(t, overlayWithDeadline.Done())
+	require.NoError(t, overlayWithDeadline.Err())
+	cancel()
+	require.ErrorIs(t, overlayWithDeadline.Err(), context.Canceled)
+
+	childOverlay := borrowPartialOverlayContext(overlay)
+	defer releasePartialOverlayContext(childOverlay)
+	require.True(t, childOverlay.stableBindingIDs())
+
+	binderParent := &vmBindingIDContext{idLookupTestContext: newIDLookupTestContext(map[string]interface{}{})}
+	binderOverlay := borrowPartialOverlayContext(binderParent)
+	defer releasePartialOverlayContext(binderOverlay)
+	binderIDs := make([]int, 2)
+	binderOverlay.InternIDs([]string{"boundA", "boundB"}, binderIDs)
+	require.Equal(t, 1, binderParent.internIDs)
+	require.NotEqual(t, binderIDs[0], binderIDs[1])
+	_, ok = binderOverlay.nameForID(binderIDs[0])
+	require.True(t, ok)
+
+	fallbackParent := newVMFallbackContext(map[string]interface{}{"fallback": "F"})
+	fallbackOverlay := borrowPartialOverlayContext(fallbackParent)
+	defer releasePartialOverlayContext(fallbackOverlay)
+	value, ok = fallbackOverlay.Lookup("fallback")
+	require.True(t, ok)
+	require.Equal(t, "F", value)
+	require.Equal(t, 1, fallbackParent.has)
+	require.Equal(t, 1, fallbackParent.value)
+
+	releasePartialOverlayContext(nil)
+}
+
+func Test_VM_Fast_Partial_Data_Local_Storage_And_Pair_Branches(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{"name": "Mido"})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"name"}}, ctx)
+
+	require.NoError(t, evalFastPartialDataLocalValues(&fastPartialDataBindingPlan{}, ctx, bindings))
+
+	value, err := evalFastPartialDataPairValue(nil, ctx, bindings)
+	require.NoError(t, err)
+	require.Nil(t, value)
+
+	stringPair := &fastPartialDataBindingPair{
+		key:   "label",
+		value: &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "static", Line: 1}},
+		line:  1,
+	}
+	value, err = evalFastPartialDataPairValue(stringPair, ctx, bindings)
+	require.NoError(t, err)
+	require.Equal(t, "static", value)
+
+	missingPair := &fastPartialDataBindingPair{
+		key:   "missing",
+		value: &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing", Line: 5}},
+		line:  5,
+	}
+	_, err = evalFastPartialDataPairValue(missingPair, ctx, bindings)
+	require.ErrorContains(t, err, "line 5")
+
+	require.Error(t, evalFastPartialDataLocalValues(&fastPartialDataBindingPlan{pairs: []fastPartialDataBindingPair{*missingPair}}, ctx, bindings))
+
+	var storage fastPartialLocalStorage
+	require.NotPanics(t, func() {
+		prepareFastPartialLocalStorage(nil, &storage)
+	})
+
+	emptyBindings := newFastRenderBindings(&compiler.FastRenderPlan{}, ctx)
+	prepareFastPartialLocalStorage(&emptyBindings, &storage)
+	require.Nil(t, emptyBindings.localOK)
+	require.Nil(t, emptyBindings.localVals)
+
+	localBindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"a", "b"}}, ctx)
+	prepareFastPartialLocalStorage(&localBindings, &storage)
+	require.Len(t, localBindings.localOK, 2)
+	require.Len(t, localBindings.localVals, 2)
+	localBindings.localOK[0] = true
+	localBindings.localVals[1] = "stored"
+	require.True(t, storage.ok[0])
+	require.Equal(t, "stored", storage.vals[1])
+
+	manyBindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"a", "b", "c", "d", "e", "f", "g", "h", "i"}}, ctx)
+	var manyStorage fastPartialLocalStorage
+	prepareFastPartialLocalStorage(&manyBindings, &manyStorage)
+	require.Len(t, manyBindings.localOK, 9)
+	require.Len(t, manyBindings.localVals, 9)
+	manyBindings.localOK[0] = true
+	manyBindings.localVals[0] = "heap"
+	require.False(t, manyStorage.ok[0])
+	require.Nil(t, manyStorage.vals[0])
+
+	partialBindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label", "other"}}, ctx)
+	plan := &fastPartialDataBindingPlan{pairs: []fastPartialDataBindingPair{*stringPair}}
+	require.NoError(t, attachFastPartialDataLocalsFromPlan(&partialBindings, plan, ctx, bindings, &storage))
+	require.True(t, partialBindings.localOK[0])
+	require.Equal(t, "static", partialBindings.localVals[0])
+
+	require.NoError(t, attachFastPartialDataLocalsFromPlan(nil, plan, ctx, bindings, &storage))
+	require.NoError(t, attachFastPartialDataLocalsFromPlan(&partialBindings, nil, ctx, bindings, &storage))
+}

--- a/VM/vm/fast_calls.go
+++ b/VM/vm/fast_calls.go
@@ -1,0 +1,378 @@
+package vm
+
+import (
+	"fmt"
+	"html/template"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+)
+
+func (a *fastCallArgs) Append(value interface{}) {
+	if a.n < len(a.inline) {
+		a.inline[a.n] = value
+	} else {
+		a.extra = append(a.extra, value)
+	}
+	a.n++
+}
+
+func (a *fastCallArgs) Reset() {
+	if a == nil {
+		return
+	}
+	for i := 0; i < a.n && i < len(a.inline); i++ {
+		a.inline[i] = nil
+	}
+	for i := range a.extra {
+		a.extra[i] = nil
+	}
+	a.n = 0
+	a.extra = a.extra[:0]
+	a.objects = nil
+}
+
+func (a *fastCallArgs) Len() int {
+	if a == nil {
+		return 0
+	}
+	return a.n
+}
+
+func (a *fastCallArgs) Raw(index int) interface{} {
+	if a == nil || index < 0 || index >= a.n {
+		return nil
+	}
+	if index < len(a.inline) {
+		return a.inline[index]
+	}
+	return a.extra[index-len(a.inline)]
+}
+
+func (a *fastCallArgs) Objects() []object.Object {
+	if a == nil || a.n == 0 {
+		return nil
+	}
+	if len(a.objects) == a.n {
+		return a.objects
+	}
+	objects := make([]object.Object, a.n)
+	for i := 0; i < a.n; i++ {
+		objects[i] = object.Wrap(a.Raw(i))
+	}
+	a.objects = objects
+	return objects
+}
+
+func writeFastCallSegment(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, call *compiler.FastCallPlan) error {
+	if call == nil {
+		return nil
+	}
+	raw, ok := bindings.value(call.NameIndex)
+	if !ok {
+		return fastLineError(call.Line, fmt.Errorf("%q: unknown identifier", call.Name))
+	}
+	if err := spendFastFunctionCall(ctx, call.Name, call.Line); err != nil {
+		return err
+	}
+	if helper, ok := fastHelperForContext(ctx, call.Name); ok {
+		var argStore fastCallArgs
+		args, err := evalFastCallArgsInto(call.Args, ctx, bindings, &argStore)
+		if err != nil {
+			return err
+		}
+		if handled, err := writeRegisteredFastHelperNamed(out, ctx, call.Name, helper, args); handled || err != nil {
+			if err != nil {
+				return fastLineError(call.Line, err)
+			}
+			return nil
+		}
+	}
+	if handled, err := writeFastDirectStringCallSegment(out, ctx, bindings, call, raw); handled || err != nil {
+		return err
+	}
+	var argStore fastCallArgs
+	args, err := evalFastCallArgsInto(call.Args, ctx, bindings, &argStore)
+	if err != nil {
+		return err
+	}
+	if err := writeFastCallValue(out, ctx, call.Name, raw, args, &call.Cache); err != nil {
+		return fastLineError(call.Line, err)
+	}
+	return nil
+}
+
+func writeFastBlockCallSegment(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, call *compiler.FastBlockCallPlan) error {
+	if call == nil {
+		return nil
+	}
+	raw, ok := bindings.value(call.NameIndex)
+	if !ok {
+		return fastLineError(call.Line, fmt.Errorf("%q: unknown identifier", call.Name))
+	}
+	if err := spendFastFunctionCall(ctx, call.Name, call.Line); err != nil {
+		return err
+	}
+	var argStore fastCallArgs
+	args, err := evalFastCallArgsInto(call.Args, ctx, bindings, &argStore)
+	if err != nil {
+		return err
+	}
+	helperCtx := plush.NewHelperContext(ctx, func(blockCtx hctx.Context) (string, error) {
+		return renderFastBlockCallBytecode(call, fastBlockContext(blockCtx, bindings))
+	})
+	if err := writeFastBlockCallValue(out, ctx, call.Name, raw, args, helperCtx, &call.Cache); err != nil {
+		return fastLineError(call.Line, err)
+	}
+	return nil
+}
+
+func writeFastLoopBlockCallPart(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, loop *compiler.FastLoopPlan, call *compiler.FastBlockCallPlan, loopKey, loopValue interface{}) error {
+	if call == nil {
+		return nil
+	}
+	raw, ok := bindings.value(call.NameIndex)
+	if !ok {
+		return fastLineError(call.Line, fmt.Errorf("%q: unknown identifier", call.Name))
+	}
+	if err := spendFastFunctionCall(ctx, call.Name, call.Line); err != nil {
+		return err
+	}
+	var argStore fastCallArgs
+	args, err := evalFastLoopCallArgsInto(call.Args, ctx, bindings, loopKey, loopValue, &argStore)
+	if err != nil {
+		return err
+	}
+	helperCtx := plush.NewHelperContext(ctx, func(blockCtx hctx.Context) (string, error) {
+		return renderFastBlockCallBytecode(call, fastLoopBlockContext(blockCtx, bindings, loop, loopKey, loopValue))
+	})
+	if err := writeFastBlockCallValue(out, ctx, call.Name, raw, args, helperCtx, &call.Cache); err != nil {
+		return fastLineError(call.Line, err)
+	}
+	return nil
+}
+
+func renderFastBlockCallBytecode(call *compiler.FastBlockCallPlan, ctx hctx.Context) (string, error) {
+	if call == nil || call.BlockBytecode == nil {
+		return "", nil
+	}
+	bytecode := call.BlockBytecode
+	if bytecode.Static {
+		return bytecode.StaticOutput, nil
+	}
+	if bytecode.FastRenderPlan != nil {
+		if rendered, ok, err := renderFastPlanWithBindingPlan(bytecode.FastRenderPlan, ctx, topLevelFastBindingPlan(bytecode.FastRenderPlan, ctx)); ok || err != nil {
+			return rendered, err
+		}
+	}
+	if restorePartial := installVMPartialHelperForBytecode(bytecode, ctx); restorePartial != nil {
+		defer restorePartial()
+	}
+	return renderBytecodeVMWithState(bytecode, ctx, "", false, "")
+}
+
+func fastBlockContext(ctx hctx.Context, bindings fastRenderBindings) hctx.Context {
+	if ctx == nil {
+		ctx = plush.NewContext()
+	}
+	scoped := ctx.New()
+	for i, ok := range bindings.localOK {
+		if !ok || i >= len(bindings.names) || i >= len(bindings.localVals) {
+			continue
+		}
+		scoped.Set(bindings.names[i], bindings.localVals[i])
+	}
+	return scoped
+}
+
+func fastLoopBlockContext(ctx hctx.Context, bindings fastRenderBindings, loop *compiler.FastLoopPlan, key, value interface{}) hctx.Context {
+	scoped := fastBlockContext(ctx, bindings)
+	if loop == nil || (!fastLoopBindingName(loop.KeyName) && !fastLoopBindingName(loop.ValueName)) {
+		return scoped
+	}
+	scoped = scoped.New()
+	if fastLoopBindingName(loop.KeyName) {
+		scoped.Set(loop.KeyName, key)
+	}
+	if fastLoopBindingName(loop.ValueName) {
+		scoped.Set(loop.ValueName, value)
+	}
+	return scoped
+}
+
+func writeFastBlockCallValue(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs, helperCtx plush.HelperContext, cacheSlot *object.InlineCacheSlot) error {
+	if obj, ok := raw.(object.Object); ok {
+		raw = object.ToGo(obj)
+	}
+	rv := reflect.ValueOf(raw)
+	if !rv.IsValid() {
+		return fmt.Errorf("%T is an invalid function", raw)
+	}
+	if rv.Kind() != reflect.Func {
+		return fmt.Errorf("%+v (%T) is an invalid function", raw, raw)
+	}
+	entry := cachedFastCallEntry(rv.Type(), raw, cacheSlot)
+	if entry == nil || entry.plan == nil {
+		return fmt.Errorf("%+v (%T) is an invalid function", raw, raw)
+	}
+	var scratch [4]reflect.Value
+	reflectArgs, err := fastReflectArgsIntoWithHelperContext(name, entry.plan, args, ctx, helperCtx, scratch[:0])
+	if err != nil {
+		return err
+	}
+	start := time.Now()
+	res := rv.Call(reflectArgs)
+	plush.AddRenderDiagnosticVMHelperTiming(ctx, name, time.Since(start))
+	return writeFastReflectCallResults(out, ctx, name, res)
+}
+
+func fastReflectArgsIntoWithHelperContext(name string, plan *callPlan, rawArgs *fastCallArgs, ctx hctx.Context, helperCtx plush.HelperContext, scratch []reflect.Value) ([]reflect.Value, error) {
+	numArgs := rawArgs.Len()
+	needed := plan.numIn
+	if plan.isVariadic && numArgs > needed {
+		needed = numArgs
+	}
+	args := scratch
+	if cap(args) < needed {
+		args = make([]reflect.Value, 0, needed)
+	} else {
+		args = args[:0]
+	}
+
+	if !plan.isVariadic && numArgs > plan.numIn {
+		return nil, fmt.Errorf("too many arguments (%d for %d)", numArgs, plan.numIn)
+	}
+	if plan.isVariadic && numArgs < plan.minArgs {
+		return nil, fmt.Errorf("too few arguments (%d for %d)", numArgs, plan.numIn)
+	}
+
+	fixed := numArgs
+	if plan.isVariadic {
+		fixed = plan.minArgs
+	}
+	for pos := 0; pos < fixed; pos++ {
+		arg, err := fastReflectArgForCall(name, pos, rawArgs.Raw(pos), plan.argTypes[pos])
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, arg)
+	}
+	if plan.isVariadic {
+		for pos := fixed; pos < numArgs; pos++ {
+			arg, err := fastReflectArgForCall(name, pos, rawArgs.Raw(pos), plan.variadicElem)
+			if err != nil {
+				return nil, err
+			}
+			args = append(args, arg)
+		}
+	} else if len(args) < plan.numIn {
+		for len(args) < plan.numIn {
+			arg, ok := fastOptionalArgWithHelperContext(plan.optionalArgs[len(args)], plan.argTypes[len(args)], ctx, helperCtx)
+			if !ok {
+				break
+			}
+			args = append(args, arg)
+		}
+	}
+	if len(args) < plan.minArgs {
+		return nil, errFastWriteUnsupported
+	}
+	return args, nil
+}
+
+func fastOptionalArgWithHelperContext(kind optionalArgKind, expected reflect.Type, ctx hctx.Context, helperCtx plush.HelperContext) (reflect.Value, bool) {
+	if kind == optionalArgHelperContext {
+		value := reflect.ValueOf(helperCtx)
+		if value.Type().AssignableTo(expected) {
+			return value, true
+		}
+		if value.Type().ConvertibleTo(expected) {
+			return value.Convert(expected), true
+		}
+		if expected.Kind() == reflect.Interface && value.Type().Implements(expected) {
+			return value, true
+		}
+		return reflect.Value{}, false
+	}
+	return fastOptionalArg(kind, expected, ctx)
+}
+
+func writeFastDirectStringCallSegment(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, call *compiler.FastCallPlan, raw interface{}) (bool, error) {
+	if out == nil || call == nil || len(call.Args) != 1 {
+		return false, nil
+	}
+	if obj, ok := raw.(object.Object); ok {
+		raw = object.ToGo(obj)
+	}
+	arg, ok, err := evalFastCallStringArg(&call.Args[0], ctx, bindings)
+	if err != nil {
+		return true, err
+	}
+	if !ok {
+		return false, nil
+	}
+	switch fn := raw.(type) {
+	case func(string) string:
+		writeFastEscapedString(out, fn(arg))
+		return true, nil
+	case func(string) (string, error):
+		value, err := fn(arg)
+		if err != nil {
+			return true, fastLineError(call.Line, fmt.Errorf("could not call %s function: %w", call.Name, err))
+		}
+		writeFastEscapedString(out, value)
+		return true, nil
+	case func(string) template.HTML:
+		out.WriteString(string(fn(arg)))
+		return true, nil
+	case func(string) (template.HTML, error):
+		value, err := fn(arg)
+		if err != nil {
+			return true, fastLineError(call.Line, fmt.Errorf("could not call %s function: %w", call.Name, err))
+		}
+		out.WriteString(string(value))
+		return true, nil
+	case func(string) object.Object:
+		writeFastObject(out, ctx, fn(arg))
+		return true, nil
+	}
+	return false, nil
+}
+
+func evalFastCallStringArg(plan *compiler.FastValuePlan, ctx hctx.Context, bindings fastRenderBindings) (string, bool, error) {
+	value, ok, err := evalFastValue(plan, ctx, bindings, nil)
+	if err != nil {
+		return "", false, err
+	}
+	if !ok {
+		return "", false, fastLineError(plan.Line, fmt.Errorf("%q: unknown identifier", plan.Value))
+	}
+	arg, ok := fastWriteRawStringArg(value)
+	return arg, ok, nil
+}
+
+func evalFastCallArgsInto(plans []compiler.FastValuePlan, ctx hctx.Context, bindings fastRenderBindings, args *fastCallArgs) (*fastCallArgs, error) {
+	if len(plans) == 0 {
+		return nil, nil
+	}
+	if args == nil {
+		args = &fastCallArgs{}
+	}
+	args.Reset()
+	for i := range plans {
+		value, ok, err := evalFastValue(&plans[i], ctx, bindings, nil)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, fastLineError(plans[i].Line, fmt.Errorf("%q: unknown identifier", plans[i].Value))
+		}
+		args.Append(value)
+	}
+	return args, nil
+}

--- a/VM/vm/fast_calls_helpers_test.go
+++ b/VM/vm/fast_calls_helpers_test.go
@@ -1,0 +1,317 @@
+package vm
+
+import (
+	"errors"
+	"html/template"
+	"strings"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_VM_Write_Fast_Direct_String_Call_Segment_Variants(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{"name": "<Mido>"})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"name"}}, ctx)
+	call := &compiler.FastCallPlan{
+		Name: "helper",
+		Args: []compiler.FastValuePlan{{Kind: compiler.FastValueName, NameIndex: 0, Value: "name", Line: 3}},
+		Line: 3,
+	}
+
+	tests := []struct {
+		name     string
+		raw      interface{}
+		expected string
+	}{
+		{"string", func(value string) string { return value + "!" }, "&lt;Mido&gt;!"},
+		{"string_error", func(value string) (string, error) { return value + "?", nil }, "&lt;Mido&gt;?"},
+		{"html", func(value string) template.HTML { return template.HTML("<b>" + value + "</b>") }, "<b><Mido></b>"},
+		{"html_error", func(value string) (template.HTML, error) { return template.HTML("<i>" + value + "</i>"), nil }, "<i><Mido></i>"},
+		{"object", func(value string) object.Object { return &object.String{Value: value} }, "&lt;Mido&gt;"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out strings.Builder
+			handled, err := writeFastDirectStringCallSegment(&out, ctx, bindings, call, tt.raw)
+			require.NoError(t, err)
+			require.True(t, handled)
+			require.Equal(t, tt.expected, out.String())
+		})
+	}
+
+	handled, err := writeFastDirectStringCallSegment(&strings.Builder{}, ctx, bindings, call, func(string) (string, error) {
+		return "", errors.New("boom")
+	})
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 3: could not call helper function")
+
+	handled, err = writeFastDirectStringCallSegment(&strings.Builder{}, ctx, bindings, call, func(int) string { return "" })
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	handled, err = writeFastDirectStringCallSegment(nil, ctx, bindings, call, func(string) string { return "" })
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	var out strings.Builder
+	handled, err = writeFastDirectStringCallSegment(&out, ctx, bindings, call, &object.Native{Value: func(value string) string { return value + " native" }})
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "&lt;Mido&gt; native", out.String())
+
+	handled, err = writeFastDirectStringCallSegment(&strings.Builder{}, ctx, bindings, call, func(string) (template.HTML, error) {
+		return "", errors.New("html boom")
+	})
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 3: could not call helper function")
+
+	missingArgCall := &compiler.FastCallPlan{
+		Name: "helper",
+		Args: []compiler.FastValuePlan{{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing", Line: 11}},
+		Line: 11,
+	}
+	handled, err = writeFastDirectStringCallSegment(&strings.Builder{}, ctx, bindings, missingArgCall, func(string) string { return "" })
+	require.True(t, handled)
+	require.ErrorContains(t, err, `line 11: "missing": unknown identifier`)
+
+	countArgCall := &compiler.FastCallPlan{
+		Name: "helper",
+		Args: []compiler.FastValuePlan{{Kind: compiler.FastValueInteger, IntValue: 3, Line: 12}},
+		Line: 12,
+	}
+	handled, err = writeFastDirectStringCallSegment(&strings.Builder{}, ctx, bindings, countArgCall, func(string) string { return "" })
+	require.NoError(t, err)
+	require.False(t, handled)
+}
+
+func Test_VM_Fast_Writer_Write_Go_Value_Edges(t *testing.T) {
+	require.False(t, FastWriter{}.WriteGoValue("ignored"))
+
+	var out strings.Builder
+	writer := FastWriter{out: &out, ctx: plush.NewContext()}
+	require.True(t, writer.WriteGoValue("<value>"))
+	require.Equal(t, "&lt;value&gt;", out.String())
+}
+
+func Test_VM_Write_Fast_Call_Segment_Branches(t *testing.T) {
+	var out strings.Builder
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"registered": "raw",
+		"direct":     func(value string) string { return value + "!" },
+		"fallback":   func(value string) template.HTML { return template.HTML("<" + value + ">") },
+		"bad":        "raw",
+		"name":       "<Mido>",
+	})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{
+		Bindings: []string{"registered", "direct", "fallback", "bad", "name"},
+	}, ctx)
+
+	require.NoError(t, writeFastCallSegment(&out, ctx, bindings, nil))
+	require.Empty(t, out.String())
+
+	SetFastHelper(ctx, "registered", func(w FastWriter, args FastArgs) error {
+		value, ok := args.String(0)
+		require.True(t, ok)
+		w.WriteEscapedString(value + "?")
+		return nil
+	})
+	require.NoError(t, writeFastCallSegment(&out, ctx, bindings, &compiler.FastCallPlan{
+		Name:      "registered",
+		NameIndex: 0,
+		Args:      []compiler.FastValuePlan{{Kind: compiler.FastValueName, NameIndex: 4, Value: "name", Line: 2}},
+		Line:      2,
+	}))
+	require.Equal(t, "&lt;Mido&gt;?", out.String())
+
+	SetFastHelper(ctx, "bad", func(FastWriter, FastArgs) error {
+		return errors.New("bad helper")
+	})
+	err := writeFastCallSegment(&out, ctx, bindings, &compiler.FastCallPlan{
+		Name:      "bad",
+		NameIndex: 3,
+		Args:      []compiler.FastValuePlan{{Kind: compiler.FastValueName, NameIndex: 4, Value: "name", Line: 3}},
+		Line:      3,
+	})
+	require.ErrorContains(t, err, "line 3: bad helper")
+
+	SetFastHelper(ctx, "direct", func(FastWriter, FastArgs) error {
+		return ErrFastUnsupported
+	})
+	out.Reset()
+	require.NoError(t, writeFastCallSegment(&out, ctx, bindings, &compiler.FastCallPlan{
+		Name:      "direct",
+		NameIndex: 1,
+		Args:      []compiler.FastValuePlan{{Kind: compiler.FastValueName, NameIndex: 4, Value: "name", Line: 4}},
+		Line:      4,
+	}))
+	require.Equal(t, "&lt;Mido&gt;!", out.String())
+
+	out.Reset()
+	require.NoError(t, writeFastCallSegment(&out, ctx, bindings, &compiler.FastCallPlan{
+		Name:      "fallback",
+		NameIndex: 2,
+		Args:      []compiler.FastValuePlan{{Kind: compiler.FastValueString, Value: "b", Line: 5}},
+		Line:      5,
+	}))
+	require.Equal(t, "<b>", out.String())
+
+	err = writeFastCallSegment(&out, ctx, bindings, &compiler.FastCallPlan{Name: "missing", NameIndex: 99, Line: 6})
+	require.ErrorContains(t, err, `line 6: "missing": unknown identifier`)
+
+	budgetCtx := plush.NewContextWith(map[string]interface{}{
+		"direct": func(value string) string { return value },
+		"name":   "Mido",
+	}).WithBudget(plush.NewBudget(0))
+	budgetBindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"direct", "name"}}, budgetCtx)
+	err = writeFastCallSegment(&out, budgetCtx, budgetBindings, &compiler.FastCallPlan{
+		Name:      "direct",
+		NameIndex: 0,
+		Args:      []compiler.FastValuePlan{{Kind: compiler.FastValueName, NameIndex: 1, Value: "name", Line: 7}},
+		Line:      7,
+	})
+	require.ErrorContains(t, err, "line 7")
+
+	SetFastHelper(ctx, "registered", func(FastWriter, FastArgs) error {
+		return nil
+	})
+	err = writeFastCallSegment(&out, ctx, bindings, &compiler.FastCallPlan{
+		Name:      "registered",
+		NameIndex: 0,
+		Args:      []compiler.FastValuePlan{{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing", Line: 8}},
+		Line:      8,
+	})
+	require.ErrorContains(t, err, `line 8: "missing": unknown identifier`)
+
+	err = writeFastCallSegment(&out, ctx, bindings, &compiler.FastCallPlan{
+		Name:      "bad",
+		NameIndex: 3,
+		Args: []compiler.FastValuePlan{
+			{Kind: compiler.FastValueString, Value: "ok", Line: 9},
+			{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing", Line: 9},
+		},
+		Line: 9,
+	})
+	require.ErrorContains(t, err, `line 9: "missing": unknown identifier`)
+
+	err = writeFastCallSegment(&out, ctx, bindings, &compiler.FastCallPlan{
+		Name:      "fallback",
+		NameIndex: 2,
+		Args:      []compiler.FastValuePlan{{Kind: compiler.FastValueBool, BoolValue: true, Line: 10}},
+		Line:      10,
+	})
+	require.ErrorContains(t, err, "line 10")
+}
+
+func Test_VM_Eval_Fast_Call_Args_Into_Branches(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{"name": "Mido", "count": 3})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"name", "count"}}, ctx)
+
+	args, err := evalFastCallArgsInto([]compiler.FastValuePlan{
+		{Kind: compiler.FastValueName, NameIndex: 0, Value: "name", Line: 1},
+		{Kind: compiler.FastValueName, NameIndex: 1, Value: "count", Line: 1},
+	}, ctx, bindings, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, args.Len())
+	require.Equal(t, "Mido", args.Raw(0))
+	require.Equal(t, 3, args.Raw(1))
+
+	args, err = evalFastCallArgsInto(nil, ctx, bindings, &fastCallArgs{})
+	require.NoError(t, err)
+	require.Nil(t, args)
+
+	_, err = evalFastCallArgsInto([]compiler.FastValuePlan{{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing", Line: 5}}, ctx, bindings, nil)
+	require.ErrorContains(t, err, `line 5: "missing": unknown identifier`)
+
+	_, err = evalFastCallArgsInto([]compiler.FastValuePlan{{
+		Kind: compiler.FastValueCall,
+		Call: &compiler.FastCallPlan{Name: "name", NameIndex: 0, Line: 6},
+		Line: 6,
+	}}, plush.NewContextWith(map[string]interface{}{"name": func() string { return "blocked" }}).WithBudget(plush.NewBudget(0)), bindings, nil)
+	require.ErrorContains(t, err, "line 6")
+}
+
+func Test_VM_Fast_Call_Args_Reset_And_String_Arg_Branches(t *testing.T) {
+	var nilArgs *fastCallArgs
+	nilArgs.Reset()
+	require.Equal(t, 0, nilArgs.Len())
+	require.Nil(t, nilArgs.Raw(0))
+	require.Nil(t, nilArgs.Objects())
+
+	args := &fastCallArgs{}
+	for i := 0; i < len(args.inline)+2; i++ {
+		args.Append(i)
+	}
+	require.Equal(t, len(args.inline)+2, args.Len())
+	require.Equal(t, 2, len(args.extra))
+	objects := args.Objects()
+	require.NotNil(t, objects)
+	require.Equal(t, objects, args.Objects())
+	args.Reset()
+	require.Zero(t, args.Len())
+	require.Empty(t, args.extra)
+	require.Nil(t, args.objects)
+
+	ctx := plush.NewContextWith(map[string]interface{}{"name": "Mido", "count": 3})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"name", "count"}}, ctx)
+	value, ok, err := evalFastCallStringArg(&compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 0, Value: "name", Line: 8}, ctx, bindings)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "Mido", value)
+
+	value, ok, err = evalFastCallStringArg(&compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 1, Value: "count", Line: 9}, ctx, bindings)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Empty(t, value)
+
+	_, _, err = evalFastCallStringArg(&compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing", Line: 10}, ctx, bindings)
+	require.ErrorContains(t, err, `line 10: "missing": unknown identifier`)
+
+	_, _, err = evalFastCallStringArg(&compiler.FastValuePlan{
+		Kind: compiler.FastValueCall,
+		Call: &compiler.FastCallPlan{Name: "name", NameIndex: 0, Line: 11},
+		Line: 11,
+	}, plush.NewContextWith(map[string]interface{}{"name": func() string { return "blocked" }}).WithBudget(plush.NewBudget(0)), bindings)
+	require.ErrorContains(t, err, "line 11")
+}
+
+func Test_VM_Try_Write_Registered_Fast_Helper(t *testing.T) {
+	ctx := plush.NewContext()
+	SetFastHelper(ctx, "fast", func(w FastWriter, args FastArgs) error {
+		value, ok := args.String(0)
+		require.True(t, ok)
+		w.WriteEscapedString(value + "!")
+		return nil
+	})
+
+	machine := newRuntimeHelperTestVM(ctx)
+	machine.stack[0] = &object.Native{Value: func(string) string { return "" }}
+	machine.stack[1] = &object.String{Value: "<name>"}
+	machine.sp = 2
+	handled, err := machine.tryWriteRegisteredFastHelper("fast", 1, true)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, 0, machine.sp)
+	require.Equal(t, "&lt;name&gt;!", machine.currentFrame().output.String())
+
+	handled, err = machine.tryWriteRegisteredFastHelper("missing", 0, false)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	SetFastHelper(ctx, "fallback", func(FastWriter, FastArgs) error {
+		return ErrFastUnsupported
+	})
+	machine.currentFrame().output.Reset()
+	machine.sp = 0
+	handled, err = machine.tryWriteRegisteredFastHelper("fallback", 0, false)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	machine.frames[0] = nil
+	handled, err = machine.tryWriteRegisteredFastHelper("fast", 0, false)
+	require.NoError(t, err)
+	require.False(t, handled)
+}

--- a/VM/vm/fast_condition_property_helpers_test.go
+++ b/VM/vm/fast_condition_property_helpers_test.go
@@ -1,0 +1,423 @@
+package vm
+
+import (
+	"html/template"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/code"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/stretchr/testify/require"
+)
+
+type vmFastPropertyChild struct {
+	Name string
+}
+
+func (c vmFastPropertyChild) Echo() string {
+	return c.Name + "!"
+}
+
+type vmFastPropertyUser struct {
+	Name   string
+	Count  int32
+	Markup template.HTML
+	Child  *vmFastPropertyChild
+	hidden string
+}
+
+func (u vmFastPropertyUser) Echo() string {
+	return u.Name + "!"
+}
+
+func (u *vmFastPropertyUser) PointerEcho() string {
+	return u.Name + "?"
+}
+
+func Test_VM_Fast_Condition_Operand_Branches(t *testing.T) {
+	var iface interface{} = true
+	var nilIface interface{} = (*vmFastPropertyUser)(nil)
+
+	boolValue, ok := (fastConditionOperandValue{raw: true}).boolValue()
+	require.True(t, ok)
+	require.True(t, boolValue)
+
+	boolValue, ok = (fastConditionOperandValue{raw: object.FalseObject}).boolValue()
+	require.True(t, ok)
+	require.False(t, boolValue)
+
+	_, ok = (fastConditionOperandValue{raw: "true"}).boolValue()
+	require.False(t, ok)
+
+	boolValue, ok = (fastConditionOperandValue{hasReflect: true, reflect: reflect.ValueOf(iface)}).boolValue()
+	require.True(t, ok)
+	require.True(t, boolValue)
+
+	boolValue, ok = (fastConditionOperandValue{hasReflect: true, reflect: reflect.ValueOf(&iface).Elem()}).boolValue()
+	require.True(t, ok)
+	require.True(t, boolValue)
+
+	var nilConcreteIface interface{}
+	_, ok = (fastConditionOperandValue{hasReflect: true, reflect: reflect.ValueOf(&nilConcreteIface).Elem()}).boolValue()
+	require.False(t, ok)
+
+	_, ok = (fastConditionOperandValue{hasReflect: true, reflect: reflect.ValueOf(nilIface)}).boolValue()
+	require.False(t, ok)
+
+	stringValue, ok := (fastConditionOperandValue{raw: "<name>"}).stringValue()
+	require.True(t, ok)
+	require.Equal(t, "<name>", stringValue)
+
+	stringValue, ok = (fastConditionOperandValue{raw: &object.String{Value: "object"}}).stringValue()
+	require.True(t, ok)
+	require.Equal(t, "object", stringValue)
+
+	var stringIface interface{} = "iface"
+	stringValue, ok = (fastConditionOperandValue{hasReflect: true, reflect: reflect.ValueOf(stringIface)}).stringValue()
+	require.True(t, ok)
+	require.Equal(t, "iface", stringValue)
+
+	stringValue, ok = (fastConditionOperandValue{hasReflect: true, reflect: reflect.ValueOf(&stringIface).Elem()}).stringValue()
+	require.True(t, ok)
+	require.Equal(t, "iface", stringValue)
+
+	_, ok = (fastConditionOperandValue{hasReflect: true, reflect: reflect.ValueOf(&nilConcreteIface).Elem()}).stringValue()
+	require.False(t, ok)
+
+	_, ok = (fastConditionOperandValue{hasReflect: true, reflect: reflect.ValueOf(3)}).stringValue()
+	require.False(t, ok)
+
+	numericValue, ok := (fastConditionOperandValue{raw: int32(7)}).numericValue()
+	require.True(t, ok)
+	require.Equal(t, int64(7), numericValue.i)
+
+	numericValue, ok = (fastConditionOperandValue{raw: &object.Float{Value: 1.5}}).numericValue()
+	require.True(t, ok)
+	require.Equal(t, 1.5, numericValue.f)
+
+	numericValue, ok = (fastConditionOperandValue{hasReflect: true, reflect: reflect.ValueOf(uint32(8))}).numericValue()
+	require.True(t, ok)
+	require.Equal(t, uint64(8), numericValue.u)
+
+	require.Equal(t, "go", (fastConditionOperandValue{raw: &object.String{Value: "go"}}).goValue())
+	require.Equal(t, "iface", (fastConditionOperandValue{hasReflect: true, reflect: reflect.ValueOf(stringIface)}).goValue())
+	require.Nil(t, (fastConditionOperandValue{hasReflect: true, reflect: reflect.Value{}}).goValue())
+
+	require.True(t, (fastConditionOperandValue{raw: nil}).isNil())
+	require.True(t, (fastConditionOperandValue{raw: object.NullObject}).isNil())
+	require.True(t, (fastConditionOperandValue{hasReflect: true, reflect: reflect.ValueOf(nilIface)}).isNil())
+	require.False(t, (fastConditionOperandValue{raw: "value"}).isNil())
+
+	require.True(t, isTruthyFastConditionOperand(fastConditionOperandValue{raw: &object.String{Value: "x"}}))
+	require.False(t, isTruthyFastConditionOperand(fastConditionOperandValue{hasReflect: true, reflect: reflect.ValueOf("")}))
+
+	require.Equal(t, "string", fastConditionTypeName(fastConditionOperandValue{raw: "x"}))
+	require.Equal(t, "int32", fastConditionTypeName(fastConditionOperandValue{hasReflect: true, reflect: reflect.ValueOf(int32(1))}))
+}
+
+func Test_VM_Fast_Condition_Comparisons(t *testing.T) {
+	_, ok := numericValueFromGo(nil)
+	require.False(t, ok)
+	_, ok = numericValueFromGo("nope")
+	require.False(t, ok)
+	value, ok := numericValueFromGo(uintptr(9))
+	require.True(t, ok)
+	require.Equal(t, numericUnsigned, value.kind)
+	require.Equal(t, uint64(9), value.u)
+	value, ok = numericValueFromGo(float32(1.25))
+	require.True(t, ok)
+	require.Equal(t, numericFloat, value.kind)
+	require.InDelta(t, 1.25, value.f, 0.0001)
+
+	equal, err := compareFastConditionEquality(
+		"==",
+		fastConditionOperandValue{raw: uint32(0)},
+		fastConditionOperandValue{raw: &object.Integer{Value: 0}},
+	)
+	require.NoError(t, err)
+	require.True(t, equal)
+
+	equal, err = compareFastConditionEquality(
+		"==",
+		fastConditionOperandValue{raw: true},
+		fastConditionOperandValue{raw: "truthy"},
+	)
+	require.NoError(t, err)
+	require.True(t, equal)
+
+	equal, err = compareFastConditionEquality(
+		"==",
+		fastConditionOperandValue{raw: &object.String{Value: "same"}},
+		fastConditionOperandValue{hasReflect: true, reflect: reflect.ValueOf("same")},
+	)
+	require.NoError(t, err)
+	require.True(t, equal)
+
+	_, err = compareFastConditionEquality(
+		"!=",
+		fastConditionOperandValue{raw: uint32(0)},
+		fastConditionOperandValue{raw: "0"},
+	)
+	require.ErrorContains(t, err, "unable to operate (!=)")
+
+	equal, err = compareFastConditionEquality(
+		"==",
+		fastConditionOperandValue{raw: []int{1, 2}},
+		fastConditionOperandValue{raw: []int{1, 2}},
+	)
+	require.NoError(t, err)
+	require.True(t, equal)
+
+	ordered, err := compareFastConditionOrdered(
+		code.OpGreaterEqual,
+		fastConditionOperandValue{raw: int32(5)},
+		fastConditionOperandValue{raw: uint64(5)},
+	)
+	require.NoError(t, err)
+	require.True(t, ordered)
+
+	ordered, err = compareFastConditionOrdered(
+		code.OpGreaterThan,
+		fastConditionOperandValue{raw: "z"},
+		fastConditionOperandValue{raw: "a"},
+	)
+	require.NoError(t, err)
+	require.True(t, ordered)
+
+	ordered, err = compareFastConditionOrdered(
+		code.OpGreaterEqual,
+		fastConditionOperandValue{raw: "same"},
+		fastConditionOperandValue{raw: "same"},
+	)
+	require.NoError(t, err)
+	require.True(t, ordered)
+
+	ordered, err = compareFloatOrdered(code.OpGreaterThan, 2, 1)
+	require.NoError(t, err)
+	require.True(t, ordered)
+
+	ordered, err = compareFloatOrdered(code.OpGreaterEqual, 2, 2)
+	require.NoError(t, err)
+	require.True(t, ordered)
+
+	_, err = compareFastConditionOrdered(
+		code.OpGreaterThan,
+		fastConditionOperandValue{raw: float64(1.5)},
+		fastConditionOperandValue{raw: "x"},
+	)
+	require.ErrorContains(t, err, "unable to operate (>)")
+
+	_, err = compareFastConditionOrdered(
+		code.OpAdd,
+		fastConditionOperandValue{raw: "a"},
+		fastConditionOperandValue{raw: "b"},
+	)
+	require.ErrorContains(t, err, "unknown ordered comparison")
+
+	_, err = compareFloatOrdered(code.OpAdd, 1, 2)
+	require.ErrorContains(t, err, "unknown ordered comparison")
+}
+
+func Test_VM_Fast_Struct_Loop_Element_Type_Branches(t *testing.T) {
+	elemType, ok := fastStructLoopElementType(reflect.TypeOf([]vmFastPropertyUser{}))
+	require.True(t, ok)
+	require.Equal(t, reflect.TypeOf(vmFastPropertyUser{}), elemType)
+
+	elemType, ok = fastStructLoopElementType(reflect.TypeOf([]*vmFastPropertyUser{}))
+	require.True(t, ok)
+	require.Equal(t, reflect.TypeOf(vmFastPropertyUser{}), elemType)
+
+	_, ok = fastStructLoopElementType(reflect.TypeOf([]string{}))
+	require.False(t, ok)
+
+	_, ok = fastStructLoopElementType(reflect.TypeOf(map[string]vmFastPropertyUser{}))
+	require.False(t, ok)
+}
+
+func Test_VM_Fast_Property_Value_And_Output_Branches(t *testing.T) {
+	ctx := plush.NewContext()
+	user := vmFastPropertyUser{
+		Name:   "<mido>",
+		Count:  7,
+		Markup: template.HTML("<b>safe</b>"),
+		Child:  &vmFastPropertyChild{Name: "kid"},
+		hidden: "private",
+	}
+	access := object.PropertyAccess{Receiver: "user", Full: "user.Name"}
+	var nameSlot object.InlineCacheSlot
+	var countSlot object.InlineCacheSlot
+	var echoSlot object.InlineCacheSlot
+	var pointerEchoSlot object.InlineCacheSlot
+	var markupSlot object.InlineCacheSlot
+	var missingSlot object.InlineCacheSlot
+
+	value, err := fastPropertyValue(user, "Name", access, &nameSlot)
+	require.NoError(t, err)
+	require.Equal(t, "<mido>", value)
+
+	value, err = fastPropertyValue(&user, "Count", object.PropertyAccess{Receiver: "user", Full: "user.Count"}, &countSlot)
+	require.NoError(t, err)
+	require.Equal(t, int32(7), value)
+
+	value, err = fastPropertyValue(user, "Echo", object.PropertyAccess{Receiver: "user", Full: "user.Echo()", Method: true}, &echoSlot)
+	require.NoError(t, err)
+	require.IsType(t, func() string { return "" }, value)
+
+	value, err = fastPropertyValue(user, "PointerEcho", object.PropertyAccess{Receiver: "user", Full: "user.PointerEcho()", Method: true}, &pointerEchoSlot)
+	require.NoError(t, err)
+	require.IsType(t, func() string { return "" }, value)
+
+	value, err = fastPropertyValue((*vmFastPropertyUser)(nil), "Name", access, &nameSlot)
+	require.NoError(t, err)
+	require.Nil(t, value)
+
+	value, err = fastPropertyValue(object.NullObject, "Name", access, &nameSlot)
+	require.NoError(t, err)
+	require.Nil(t, value)
+
+	hashKey := (&object.String{Value: "Name"}).HashKey()
+	hash := &object.Hash{Pairs: map[object.HashKey]object.HashPair{
+		hashKey: {Key: &object.String{Value: "Name"}, Value: &object.String{Value: "<hash>"}},
+	}}
+	value, err = fastPropertyValue(hash, "Name", access, &nameSlot)
+	require.NoError(t, err)
+	require.Equal(t, &object.String{Value: "<hash>"}, value)
+
+	value, err = fastPropertyValue(hash, "Missing", access, &missingSlot)
+	require.NoError(t, err)
+	require.Nil(t, value)
+
+	_, err = fastPropertyValue(user, "Name", object.PropertyAccess{Receiver: "user", Full: "user.Name()", Method: true}, &nameSlot)
+	require.ErrorContains(t, err, "does not have a method")
+
+	_, err = fastPropertyValue(user, "Missing", object.PropertyAccess{Receiver: "user", Full: "user.Missing"}, &missingSlot)
+	require.ErrorContains(t, err, "does not have a field or method")
+
+	var out strings.Builder
+	require.NoError(t, writeFastPropertyOutput(&out, ctx, hash, "Name", access, &nameSlot))
+	require.Equal(t, "&lt;hash&gt;", out.String())
+
+	out.Reset()
+	require.NoError(t, writeFastPropertyOutput(&out, ctx, user, "Name", access, &nameSlot))
+	require.Equal(t, "&lt;mido&gt;", out.String())
+
+	out.Reset()
+	require.NoError(t, writeFastPropertyOutput(&out, ctx, user, "Markup", object.PropertyAccess{Receiver: "user", Full: "user.Markup"}, &markupSlot))
+	require.Equal(t, "<b>safe</b>", out.String())
+
+	out.Reset()
+	require.NoError(t, writeFastPropertyOutput(&out, ctx, (*vmFastPropertyUser)(nil), "Name", access, &nameSlot))
+	require.Empty(t, out.String())
+
+	out.Reset()
+	require.NoError(t, writeFastPropertyOutput(&out, ctx, hash, "Missing", access, &missingSlot))
+	require.Empty(t, out.String())
+
+	entry := inlinePropertyEntry(nil, reflect.TypeOf(user), "Name")
+	value, err = fastPropertyValueFromReflect(reflect.ValueOf(user), user, "Name", access, entry)
+	require.NoError(t, err)
+	require.Equal(t, "<mido>", value)
+
+	_, err = fastPropertyValueFromReflect(reflect.ValueOf(user), user, "Missing", access, nil)
+	require.ErrorContains(t, err, "does not have a field or method")
+
+	_, err = fastFieldValue(reflect.ValueOf(user).FieldByName("hidden"), object.PropertyAccess{Receiver: "user", Full: "user.hidden"}, "hidden")
+	require.ErrorContains(t, err, "unexported field")
+}
+
+func Test_VM_Fast_Output_Cache_Entry_Branches(t *testing.T) {
+	ctx := plush.NewContext()
+	tests := []struct {
+		name     string
+		value    interface{}
+		expected string
+	}{
+		{"string", "<x>", "&lt;x&gt;"},
+		{"html", template.HTML("<b>"), "<b>"},
+		{"bool", true, "true"},
+		{"int", int(-1), "-1"},
+		{"int8", int8(-2), "-2"},
+		{"int16", int16(-3), "-3"},
+		{"int32", int32(-4), "-4"},
+		{"int64", int64(-5), "-5"},
+		{"uint", uint(1), "1"},
+		{"uint8", uint8(2), "2"},
+		{"uint16", uint16(3), "3"},
+		{"uint32", uint32(4), "4"},
+		{"uint64", uint64(5), "5"},
+		{"uintptr", uintptr(6), "6"},
+		{"float32", float32(1.5), "1.5"},
+		{"float64", float64(2.5), "2.5"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry := newFastOutputCacheEntry(tt.value)
+			require.NotNil(t, entry)
+			require.True(t, entry.matches(tt.value))
+			require.False(t, entry.matches(nil))
+
+			var out strings.Builder
+			require.True(t, writeFastBindingOutput(&out, ctx, tt.value, &object.InlineCacheSlot{}))
+			require.Equal(t, tt.expected, out.String())
+		})
+	}
+
+	require.Nil(t, newFastOutputCacheEntry(struct{}{}))
+	require.True(t, canWriteFastBindingOutput(nil))
+	require.True(t, canWriteFastBindingOutput(struct{}{}))
+
+	var out strings.Builder
+	require.True(t, writeFastBindingOutput(&out, ctx, nil, &object.InlineCacheSlot{}))
+	require.Empty(t, out.String())
+}
+
+func Test_VM_Execution_Comparison_Helper_Branches(t *testing.T) {
+	equal, err := compareEquality("==", object.NullObject, Null)
+	require.NoError(t, err)
+	require.True(t, equal)
+
+	equal, err = compareEquality("==", &object.Array{Elements: []object.Object{&object.String{Value: "x"}}}, &object.Array{Elements: []object.Object{&object.String{Value: "x"}}})
+	require.NoError(t, err)
+	require.True(t, equal)
+
+	equal, err = compareEquality("==", &object.Native{Value: uint32(0)}, &object.Integer{Value: 0})
+	require.NoError(t, err)
+	require.True(t, equal)
+
+	equal, err = compareEquality("==", object.TrueObject, &object.String{Value: "x"})
+	require.NoError(t, err)
+	require.True(t, equal)
+
+	equal, err = compareEquality("==", &object.String{Value: "7"}, &object.Integer{Value: 7})
+	require.NoError(t, err)
+	require.True(t, equal)
+
+	_, err = compareEquality("!=", &object.Integer{Value: 1}, &object.String{Value: "1"})
+	require.ErrorContains(t, err, "unable to operate (!=)")
+
+	ordered, err := compareOrdered(code.OpGreaterEqual, &object.Native{Value: int32(2)}, &object.Integer{Value: 2})
+	require.NoError(t, err)
+	require.True(t, ordered)
+
+	ordered, err = compareOrdered(code.OpGreaterThan, &object.String{Value: "b"}, &object.String{Value: "a"})
+	require.NoError(t, err)
+	require.True(t, ordered)
+
+	_, err = compareOrdered(code.OpGreaterThan, &object.Integer{Value: 1}, &object.String{Value: "x"})
+	require.ErrorContains(t, err, "unable to operate")
+
+	_, err = compareOrdered(code.OpAdd, &object.String{Value: "a"}, &object.String{Value: "b"})
+	require.ErrorContains(t, err, "unknown ordered comparison")
+
+	require.Equal(t, "bool", plushTypeName(object.TrueObject))
+	require.Equal(t, "int", plushTypeName(&object.Integer{Value: 1}))
+	require.Equal(t, "float64", plushTypeName(&object.Float{Value: 1}))
+	require.Equal(t, "string", plushTypeName(&object.String{Value: "x"}))
+	require.Equal(t, "<nil>", plushTypeName(object.NullObject))
+	require.Equal(t, "<nil>", plushTypeName(&object.Native{}))
+	require.Equal(t, "uint32", plushTypeName(&object.Native{Value: uint32(1)}))
+	require.Equal(t, "[]interface {}", plushTypeName(&object.Array{}))
+}

--- a/VM/vm/fast_helpers.go
+++ b/VM/vm/fast_helpers.go
@@ -1,0 +1,388 @@
+package vm
+
+import (
+	"errors"
+	"html/template"
+	"math"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+)
+
+var ErrFastUnsupported = errors.New("fast write unsupported")
+
+var errFastWriteUnsupported = ErrFastUnsupported
+
+type writeFastInvoker func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error
+type writeFastBuilderInvoker func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error
+type valueFastInvoker func(name string, raw interface{}, args *fastCallArgs) (interface{}, error)
+type contextualValueFastInvoker func(name string, raw interface{}, args *fastCallArgs, ctx hctx.Context) (interface{}, error)
+type fastStructLoopDirectCallWriter func(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, plan *fastStructLoopCallPlan, loopKey interface{}, item reflect.Value) (bool, error)
+type FastHelperFunc func(FastWriter, FastArgs) error
+
+type fastHelperRegistry struct {
+	mu      sync.RWMutex
+	helpers map[string]FastHelperFunc
+}
+
+type FastWriter struct {
+	out *strings.Builder
+	ctx hctx.Context
+}
+
+type FastArgs struct {
+	args *fastCallArgs
+}
+
+func SetFastHelper(ctx hctx.Context, name string, helper FastHelperFunc) {
+	if ctx == nil || name == "" {
+		return
+	}
+	registry := fastHelperRegistryForContext(ctx, true)
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	if helper == nil {
+		delete(registry.helpers, name)
+		return
+	}
+	registry.helpers[name] = helper
+}
+
+func ClearFastHelper(ctx hctx.Context, name string) {
+	SetFastHelper(ctx, name, nil)
+}
+
+func fastHelperRegistryForContext(ctx hctx.Context, create bool) *fastHelperRegistry {
+	if ctx == nil {
+		return nil
+	}
+	if registry, ok := ctx.Value(vmFastHelpersKey).(*fastHelperRegistry); ok && registry != nil {
+		return registry
+	}
+	if !create {
+		return nil
+	}
+	registry := &fastHelperRegistry{helpers: map[string]FastHelperFunc{}}
+	ctx.Set(vmFastHelpersKey, registry)
+	return registry
+}
+
+func fastHelperForContext(ctx hctx.Context, name string) (FastHelperFunc, bool) {
+	if name == "" {
+		return nil, false
+	}
+	registry := fastHelperRegistryForContext(ctx, false)
+	if registry == nil {
+		return nil, false
+	}
+	registry.mu.RLock()
+	defer registry.mu.RUnlock()
+	helper, ok := registry.helpers[name]
+	return helper, ok && helper != nil
+}
+
+func writeRegisteredFastHelper(out *strings.Builder, ctx hctx.Context, helper FastHelperFunc, args *fastCallArgs) (bool, error) {
+	if out == nil || helper == nil {
+		return false, nil
+	}
+	err := helper(FastWriter{out: out, ctx: ctx}, FastArgs{args: args})
+	if errors.Is(err, ErrFastUnsupported) {
+		return false, nil
+	}
+	return true, err
+}
+
+func writeRegisteredFastHelperNamed(out *strings.Builder, ctx hctx.Context, name string, helper FastHelperFunc, args *fastCallArgs) (bool, error) {
+	start := time.Now()
+	handled, err := writeRegisteredFastHelper(out, ctx, helper, args)
+	if handled {
+		plush.AddRenderDiagnosticVMHelperTiming(ctx, name, time.Since(start))
+	}
+	return handled, err
+}
+
+func (w FastWriter) Context() hctx.Context {
+	return w.ctx
+}
+
+func (w FastWriter) WriteEscapedString(value string) {
+	if w.out != nil {
+		writeFastEscapedString(w.out, value)
+	}
+}
+
+func (w FastWriter) WriteHTML(value template.HTML) {
+	if w.out != nil {
+		w.out.WriteString(string(value))
+	}
+}
+
+func (w FastWriter) WriteHTMLString(value string) {
+	if w.out != nil {
+		w.out.WriteString(value)
+	}
+}
+
+func (w FastWriter) WriteGoValue(value interface{}) bool {
+	if w.out == nil {
+		return false
+	}
+	return writeFastGoValue(w.out, w.ctx, value)
+}
+
+func (a FastArgs) Len() int {
+	if a.args == nil {
+		return 0
+	}
+	return a.args.Len()
+}
+
+func (a FastArgs) Raw(index int) (interface{}, bool) {
+	if a.args == nil || index < 0 || index >= a.args.Len() {
+		return nil, false
+	}
+	return fastArgGoValue(a.args.Raw(index)), true
+}
+
+func (a FastArgs) String(index int) (string, bool) {
+	if a.args == nil || index < 0 || index >= a.args.Len() {
+		return "", false
+	}
+	return fastWriteRawStringArg(a.args.Raw(index))
+}
+
+func (a FastArgs) Bool(index int) (bool, bool) {
+	value, ok := a.Raw(index)
+	if !ok {
+		return false, false
+	}
+	v, ok := value.(bool)
+	return v, ok
+}
+
+func (a FastArgs) Int64(index int) (int64, bool) {
+	value, ok := a.Raw(index)
+	if !ok {
+		return 0, false
+	}
+	return fastArgInt64(value)
+}
+
+func (a FastArgs) Uint64(index int) (uint64, bool) {
+	value, ok := a.Raw(index)
+	if !ok {
+		return 0, false
+	}
+	return fastArgUint64(value)
+}
+
+func (a FastArgs) Float64(index int) (float64, bool) {
+	value, ok := a.Raw(index)
+	if !ok {
+		return 0, false
+	}
+	return fastArgFloat64(value)
+}
+
+func (a FastArgs) Object(index int) (object.Object, bool) {
+	if a.args == nil || index < 0 || index >= a.args.Len() {
+		return nil, false
+	}
+	obj, ok := a.args.Raw(index).(object.Object)
+	return obj, ok
+}
+
+func fastArgGoValue(value interface{}) interface{} {
+	if obj, ok := value.(object.Object); ok {
+		if object.IsNull(obj) {
+			return nil
+		}
+		return object.ToGo(obj)
+	}
+	return value
+}
+
+func fastArgInt64(value interface{}) (int64, bool) {
+	value = fastArgGoValue(value)
+	switch value := value.(type) {
+	case int:
+		return int64(value), true
+	case int8:
+		return int64(value), true
+	case int16:
+		return int64(value), true
+	case int32:
+		return int64(value), true
+	case int64:
+		return value, true
+	case uint:
+		if uint64(value) > math.MaxInt64 {
+			return 0, false
+		}
+		return int64(value), true
+	case uint8:
+		return int64(value), true
+	case uint16:
+		return int64(value), true
+	case uint32:
+		return int64(value), true
+	case uint64:
+		if value > math.MaxInt64 {
+			return 0, false
+		}
+		return int64(value), true
+	case uintptr:
+		if uint64(value) > math.MaxInt64 {
+			return 0, false
+		}
+		return int64(value), true
+	case float32:
+		return int64(value), true
+	case float64:
+		return int64(value), true
+	default:
+		rv := reflect.ValueOf(value)
+		if !rv.IsValid() {
+			return 0, false
+		}
+		switch rv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return rv.Int(), true
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+			v := rv.Uint()
+			if v > math.MaxInt64 {
+				return 0, false
+			}
+			return int64(v), true
+		case reflect.Float32, reflect.Float64:
+			return int64(rv.Float()), true
+		}
+		return 0, false
+	}
+}
+
+func fastArgUint64(value interface{}) (uint64, bool) {
+	value = fastArgGoValue(value)
+	switch value := value.(type) {
+	case int:
+		if value < 0 {
+			return 0, false
+		}
+		return uint64(value), true
+	case int8:
+		if value < 0 {
+			return 0, false
+		}
+		return uint64(value), true
+	case int16:
+		if value < 0 {
+			return 0, false
+		}
+		return uint64(value), true
+	case int32:
+		if value < 0 {
+			return 0, false
+		}
+		return uint64(value), true
+	case int64:
+		if value < 0 {
+			return 0, false
+		}
+		return uint64(value), true
+	case uint:
+		return uint64(value), true
+	case uint8:
+		return uint64(value), true
+	case uint16:
+		return uint64(value), true
+	case uint32:
+		return uint64(value), true
+	case uint64:
+		return value, true
+	case uintptr:
+		return uint64(value), true
+	case float32:
+		if value < 0 {
+			return 0, false
+		}
+		return uint64(value), true
+	case float64:
+		if value < 0 {
+			return 0, false
+		}
+		return uint64(value), true
+	default:
+		rv := reflect.ValueOf(value)
+		if !rv.IsValid() {
+			return 0, false
+		}
+		switch rv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			v := rv.Int()
+			if v < 0 {
+				return 0, false
+			}
+			return uint64(v), true
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+			return rv.Uint(), true
+		case reflect.Float32, reflect.Float64:
+			v := rv.Float()
+			if v < 0 {
+				return 0, false
+			}
+			return uint64(v), true
+		}
+		return 0, false
+	}
+}
+
+func fastArgFloat64(value interface{}) (float64, bool) {
+	value = fastArgGoValue(value)
+	switch value := value.(type) {
+	case int:
+		return float64(value), true
+	case int8:
+		return float64(value), true
+	case int16:
+		return float64(value), true
+	case int32:
+		return float64(value), true
+	case int64:
+		return float64(value), true
+	case uint:
+		return float64(value), true
+	case uint8:
+		return float64(value), true
+	case uint16:
+		return float64(value), true
+	case uint32:
+		return float64(value), true
+	case uint64:
+		return float64(value), true
+	case uintptr:
+		return float64(value), true
+	case float32:
+		return float64(value), true
+	case float64:
+		return value, true
+	default:
+		rv := reflect.ValueOf(value)
+		if !rv.IsValid() {
+			return 0, false
+		}
+		switch rv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return float64(rv.Int()), true
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+			return float64(rv.Uint()), true
+		case reflect.Float32, reflect.Float64:
+			return rv.Float(), true
+		}
+		return 0, false
+	}
+}

--- a/VM/vm/fast_invoker_arg_helpers_test.go
+++ b/VM/vm/fast_invoker_arg_helpers_test.go
@@ -1,0 +1,97 @@
+package vm
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/stretchr/testify/require"
+)
+
+type vmRawString string
+type vmRawBool bool
+
+func (s vmRawString) String() string {
+	return "stringer:" + string(s)
+}
+
+func Test_VM_Fast_Invoker_String_And_Bool_Arg_Helpers(t *testing.T) {
+	value, ok := fastWriteStringArg(&object.String{Value: "object"})
+	require.True(t, ok)
+	require.Equal(t, "object", value)
+
+	value, ok = fastWriteStringArg(&object.Native{Value: "native"})
+	require.True(t, ok)
+	require.Equal(t, "native", value)
+
+	_, ok = fastWriteStringArg(&object.Integer{Value: 1})
+	require.False(t, ok)
+
+	value, ok = fastWriteRawStringArg("raw")
+	require.True(t, ok)
+	require.Equal(t, "raw", value)
+
+	value, ok = fastWriteRawStringArg(&object.String{Value: "wrapped"})
+	require.True(t, ok)
+	require.Equal(t, "wrapped", value)
+
+	value, ok = fastWriteRawStringArg(&object.Native{Value: "native"})
+	require.True(t, ok)
+	require.Equal(t, "native", value)
+
+	value, ok = fastWriteRawStringArg(vmRawString("value"))
+	require.True(t, ok)
+	require.Equal(t, "stringer:value", value)
+
+	type plainString string
+	value, ok = fastWriteRawStringArg(plainString("plain"))
+	require.True(t, ok)
+	require.Equal(t, "plain", value)
+
+	_, ok = fastWriteRawStringArg(7)
+	require.False(t, ok)
+
+	boolValue, ok := fastWriteRawBoolArg(true)
+	require.True(t, ok)
+	require.True(t, boolValue)
+
+	boolValue, ok = fastWriteRawBoolArg(vmRawBool(true))
+	require.True(t, ok)
+	require.True(t, boolValue)
+
+	_, ok = fastWriteRawBoolArg("true")
+	require.False(t, ok)
+}
+
+func Test_VM_Fast_Invoker_Numeric_Arg_Helpers(t *testing.T) {
+	value, ok := fastWriteRawIntArg(int32(7))
+	require.True(t, ok)
+	require.Equal(t, 7, value)
+
+	_, ok = fastWriteRawIntArg(uint64(math.MaxUint64))
+	require.False(t, ok)
+
+	int64Value, ok := fastWriteRawInt64Arg(uint32(9))
+	require.True(t, ok)
+	require.Equal(t, int64(9), int64Value)
+
+	uintValue, ok := fastWriteRawUintArg(uint32(10))
+	require.True(t, ok)
+	require.Equal(t, uint(10), uintValue)
+
+	_, ok = fastWriteRawUintArg(-1)
+	require.False(t, ok)
+
+	uint64Value, ok := fastWriteRawUint64Arg(uint32(11))
+	require.True(t, ok)
+	require.Equal(t, uint64(11), uint64Value)
+
+	floatValue, ok := fastWriteRawFloat64Arg(fmt.Stringer(nil))
+	require.False(t, ok)
+	require.Zero(t, floatValue)
+
+	floatValue, ok = fastWriteRawFloat64Arg(float32(1.5))
+	require.True(t, ok)
+	require.InDelta(t, 1.5, floatValue, 0.001)
+}

--- a/VM/vm/fast_invokers.go
+++ b/VM/vm/fast_invokers.go
@@ -1,0 +1,1655 @@
+package vm
+
+import (
+	"fmt"
+	"html/template"
+	"math"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+)
+
+func writeFastBuilderInvokerForRaw(raw interface{}) writeFastBuilderInvoker {
+	switch raw.(type) {
+	case func():
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 0 {
+				return errFastWriteUnsupported
+			}
+			raw.(func())()
+			return nil
+		}
+	case func() string:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 0 {
+				return errFastWriteUnsupported
+			}
+			out.WriteString(template.HTMLEscapeString(raw.(func() string)()))
+			return nil
+		}
+	case func(string) string:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 1 {
+				return errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			out.WriteString(template.HTMLEscapeString(raw.(func(string) string)(arg)))
+			return nil
+		}
+	case func(string, string) string:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 2 {
+				return errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawStringArg(args.Raw(1))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			out.WriteString(template.HTMLEscapeString(raw.(func(string, string) string)(first, second)))
+			return nil
+		}
+	case func(int) string:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 1 {
+				return errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawIntArg(args.Raw(0))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastEscapedString(out, raw.(func(int) string)(arg))
+			return nil
+		}
+	case func(int64) string:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 1 {
+				return errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawInt64Arg(args.Raw(0))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastEscapedString(out, raw.(func(int64) string)(arg))
+			return nil
+		}
+	case func(uint) string:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 1 {
+				return errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawUintArg(args.Raw(0))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastEscapedString(out, raw.(func(uint) string)(arg))
+			return nil
+		}
+	case func(uint32) string:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 1 {
+				return errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawUint32Arg(args.Raw(0))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastEscapedString(out, raw.(func(uint32) string)(arg))
+			return nil
+		}
+	case func(uint64) string:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 1 {
+				return errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawUint64Arg(args.Raw(0))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastEscapedString(out, raw.(func(uint64) string)(arg))
+			return nil
+		}
+	case func(bool) string:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 1 {
+				return errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawBoolArg(args.Raw(0))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastEscapedString(out, raw.(func(bool) string)(arg))
+			return nil
+		}
+	case func(float64) string:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 1 {
+				return errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawFloat64Arg(args.Raw(0))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastEscapedString(out, raw.(func(float64) string)(arg))
+			return nil
+		}
+	case func(int, string) string:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 2 {
+				return errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawIntArg(args.Raw(0))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawStringArg(args.Raw(1))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastEscapedString(out, raw.(func(int, string) string)(first, second))
+			return nil
+		}
+	case func(string, int) string:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 2 {
+				return errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawIntArg(args.Raw(1))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastEscapedString(out, raw.(func(string, int) string)(first, second))
+			return nil
+		}
+	case func(uint32, string) string:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 2 {
+				return errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawUint32Arg(args.Raw(0))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawStringArg(args.Raw(1))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastEscapedString(out, raw.(func(uint32, string) string)(first, second))
+			return nil
+		}
+	case func(string, uint32) string:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 2 {
+				return errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawUint32Arg(args.Raw(1))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastEscapedString(out, raw.(func(string, uint32) string)(first, second))
+			return nil
+		}
+	case func(bool, string) string:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 2 {
+				return errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawBoolArg(args.Raw(0))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawStringArg(args.Raw(1))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastEscapedString(out, raw.(func(bool, string) string)(first, second))
+			return nil
+		}
+	case func(string, bool) string:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 2 {
+				return errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawBoolArg(args.Raw(1))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastEscapedString(out, raw.(func(string, bool) string)(first, second))
+			return nil
+		}
+	case func(float64, string) string:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 2 {
+				return errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawFloat64Arg(args.Raw(0))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawStringArg(args.Raw(1))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastEscapedString(out, raw.(func(float64, string) string)(first, second))
+			return nil
+		}
+	case func(string, float64) string:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 2 {
+				return errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawFloat64Arg(args.Raw(1))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastEscapedString(out, raw.(func(string, float64) string)(first, second))
+			return nil
+		}
+	case func() (string, error):
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 0 {
+				return errFastWriteUnsupported
+			}
+			value, err := raw.(func() (string, error))()
+			if err != nil {
+				return fmt.Errorf("could not call %s function: %w", name, err)
+			}
+			out.WriteString(template.HTMLEscapeString(value))
+			return nil
+		}
+	case func(string) (string, error):
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 1 {
+				return errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			value, err := raw.(func(string) (string, error))(arg)
+			if err != nil {
+				return fmt.Errorf("could not call %s function: %w", name, err)
+			}
+			out.WriteString(template.HTMLEscapeString(value))
+			return nil
+		}
+	case func() template.HTML:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 0 {
+				return errFastWriteUnsupported
+			}
+			out.WriteString(string(raw.(func() template.HTML)()))
+			return nil
+		}
+	case func(string) template.HTML:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 1 {
+				return errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			out.WriteString(string(raw.(func(string) template.HTML)(arg)))
+			return nil
+		}
+	case func() (template.HTML, error):
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 0 {
+				return errFastWriteUnsupported
+			}
+			value, err := raw.(func() (template.HTML, error))()
+			if err != nil {
+				return fmt.Errorf("could not call %s function: %w", name, err)
+			}
+			out.WriteString(string(value))
+			return nil
+		}
+	case func(string) (template.HTML, error):
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 1 {
+				return errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			value, err := raw.(func(string) (template.HTML, error))(arg)
+			if err != nil {
+				return fmt.Errorf("could not call %s function: %w", name, err)
+			}
+			out.WriteString(string(value))
+			return nil
+		}
+	case func() bool:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 0 {
+				return errFastWriteUnsupported
+			}
+			out.WriteString(strconv.FormatBool(raw.(func() bool)()))
+			return nil
+		}
+	case func() int:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 0 {
+				return errFastWriteUnsupported
+			}
+			out.WriteString(strconv.FormatInt(int64(raw.(func() int)()), 10))
+			return nil
+		}
+	case func() int64:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 0 {
+				return errFastWriteUnsupported
+			}
+			out.WriteString(strconv.FormatInt(raw.(func() int64)(), 10))
+			return nil
+		}
+	case func() uint:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 0 {
+				return errFastWriteUnsupported
+			}
+			out.WriteString(strconv.FormatUint(uint64(raw.(func() uint)()), 10))
+			return nil
+		}
+	case func() uint64:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 0 {
+				return errFastWriteUnsupported
+			}
+			out.WriteString(strconv.FormatUint(raw.(func() uint64)(), 10))
+			return nil
+		}
+	case func() float64:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 0 {
+				return errFastWriteUnsupported
+			}
+			out.WriteString(strconv.FormatFloat(raw.(func() float64)(), 'g', -1, 64))
+			return nil
+		}
+	case func() object.Object:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 0 {
+				return errFastWriteUnsupported
+			}
+			writeFastObject(out, ctx, raw.(func() object.Object)())
+			return nil
+		}
+	case func(string) object.Object:
+		return func(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs) error {
+			if args.Len() != 1 {
+				return errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastObject(out, ctx, raw.(func(string) object.Object)(arg))
+			return nil
+		}
+	}
+	return nil
+}
+
+func valueFastInvokerForRaw(raw interface{}) valueFastInvoker {
+	switch raw.(type) {
+	case func():
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 0 {
+				return nil, errFastWriteUnsupported
+			}
+			raw.(func())()
+			return nil, nil
+		}
+	case func() string:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 0 {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func() string)(), nil
+		}
+	case func(string) string:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 1 {
+				return nil, errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(string) string)(arg), nil
+		}
+	case func(int) string:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 1 {
+				return nil, errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawIntArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(int) string)(arg), nil
+		}
+	case func(int64) string:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 1 {
+				return nil, errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawInt64Arg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(int64) string)(arg), nil
+		}
+	case func(uint) string:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 1 {
+				return nil, errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawUintArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(uint) string)(arg), nil
+		}
+	case func(uint32) string:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 1 {
+				return nil, errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawUint32Arg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(uint32) string)(arg), nil
+		}
+	case func(uint64) string:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 1 {
+				return nil, errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawUint64Arg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(uint64) string)(arg), nil
+		}
+	case func(bool) string:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 1 {
+				return nil, errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawBoolArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(bool) string)(arg), nil
+		}
+	case func(float64) string:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 1 {
+				return nil, errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawFloat64Arg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(float64) string)(arg), nil
+		}
+	case func(string, string) string:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 2 {
+				return nil, errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawStringArg(args.Raw(1))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(string, string) string)(first, second), nil
+		}
+	case func(int, string) string:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 2 {
+				return nil, errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawIntArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawStringArg(args.Raw(1))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(int, string) string)(first, second), nil
+		}
+	case func(string, int) string:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 2 {
+				return nil, errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawIntArg(args.Raw(1))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(string, int) string)(first, second), nil
+		}
+	case func(int64, string) string:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 2 {
+				return nil, errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawInt64Arg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawStringArg(args.Raw(1))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(int64, string) string)(first, second), nil
+		}
+	case func(string, int64) string:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 2 {
+				return nil, errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawInt64Arg(args.Raw(1))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(string, int64) string)(first, second), nil
+		}
+	case func(uint, string) string:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 2 {
+				return nil, errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawUintArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawStringArg(args.Raw(1))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(uint, string) string)(first, second), nil
+		}
+	case func(string, uint) string:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 2 {
+				return nil, errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawUintArg(args.Raw(1))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(string, uint) string)(first, second), nil
+		}
+	case func(uint32, string) string:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 2 {
+				return nil, errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawUint32Arg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawStringArg(args.Raw(1))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(uint32, string) string)(first, second), nil
+		}
+	case func(string, uint32) string:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 2 {
+				return nil, errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawUint32Arg(args.Raw(1))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(string, uint32) string)(first, second), nil
+		}
+	case func(uint64, string) string:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 2 {
+				return nil, errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawUint64Arg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawStringArg(args.Raw(1))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(uint64, string) string)(first, second), nil
+		}
+	case func(string, uint64) string:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 2 {
+				return nil, errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawUint64Arg(args.Raw(1))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(string, uint64) string)(first, second), nil
+		}
+	case func(bool, string) string:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 2 {
+				return nil, errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawBoolArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawStringArg(args.Raw(1))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(bool, string) string)(first, second), nil
+		}
+	case func(string, bool) string:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 2 {
+				return nil, errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawBoolArg(args.Raw(1))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(string, bool) string)(first, second), nil
+		}
+	case func(float64, string) string:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 2 {
+				return nil, errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawFloat64Arg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawStringArg(args.Raw(1))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(float64, string) string)(first, second), nil
+		}
+	case func(string, float64) string:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 2 {
+				return nil, errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawFloat64Arg(args.Raw(1))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(string, float64) string)(first, second), nil
+		}
+	case func() template.HTML:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 0 {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func() template.HTML)(), nil
+		}
+	case func() bool:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 0 {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func() bool)(), nil
+		}
+	case func() int:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 0 {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func() int)(), nil
+		}
+	case func() int64:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 0 {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func() int64)(), nil
+		}
+	case func() uint:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 0 {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func() uint)(), nil
+		}
+	case func() uint64:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 0 {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func() uint64)(), nil
+		}
+	case func() float64:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 0 {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func() float64)(), nil
+		}
+	case func() object.Object:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 0 {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func() object.Object)(), nil
+		}
+	case func() (string, error):
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 0 {
+				return nil, errFastWriteUnsupported
+			}
+			value, err := raw.(func() (string, error))()
+			if err != nil {
+				return nil, fmt.Errorf("could not call %s function: %w", name, err)
+			}
+			return value, nil
+		}
+	case func() (template.HTML, error):
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 0 {
+				return nil, errFastWriteUnsupported
+			}
+			value, err := raw.(func() (template.HTML, error))()
+			if err != nil {
+				return nil, fmt.Errorf("could not call %s function: %w", name, err)
+			}
+			return value, nil
+		}
+	case func(string) (string, error):
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 1 {
+				return nil, errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			value, err := raw.(func(string) (string, error))(arg)
+			if err != nil {
+				return nil, fmt.Errorf("could not call %s function: %w", name, err)
+			}
+			return value, nil
+		}
+	case func(string, string) (string, error):
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 2 {
+				return nil, errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawStringArg(args.Raw(1))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			value, err := raw.(func(string, string) (string, error))(first, second)
+			if err != nil {
+				return nil, fmt.Errorf("could not call %s function: %w", name, err)
+			}
+			return value, nil
+		}
+	case func(string) template.HTML:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 1 {
+				return nil, errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(string) template.HTML)(arg), nil
+		}
+	case func(string, string) template.HTML:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 2 {
+				return nil, errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawStringArg(args.Raw(1))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(string, string) template.HTML)(first, second), nil
+		}
+	case func(string) (template.HTML, error):
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 1 {
+				return nil, errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			value, err := raw.(func(string) (template.HTML, error))(arg)
+			if err != nil {
+				return nil, fmt.Errorf("could not call %s function: %w", name, err)
+			}
+			return value, nil
+		}
+	case func(string, string) (template.HTML, error):
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 2 {
+				return nil, errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawStringArg(args.Raw(1))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			value, err := raw.(func(string, string) (template.HTML, error))(first, second)
+			if err != nil {
+				return nil, fmt.Errorf("could not call %s function: %w", name, err)
+			}
+			return value, nil
+		}
+	case func(string) object.Object:
+		return func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			if args.Len() != 1 {
+				return nil, errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(string) object.Object)(arg), nil
+		}
+	}
+	return nil
+}
+
+func contextualValueFastInvokerForRaw(raw interface{}) contextualValueFastInvoker {
+	switch raw.(type) {
+	case func(string, plush.HelperContext) string:
+		return func(name string, raw interface{}, args *fastCallArgs, ctx hctx.Context) (interface{}, error) {
+			if args.Len() != 1 {
+				return nil, errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(string, plush.HelperContext) string)(arg, plush.NewHelperContext(ctx, nil)), nil
+		}
+	case func(string, hctx.HelperContext) string:
+		return func(name string, raw interface{}, args *fastCallArgs, ctx hctx.Context) (interface{}, error) {
+			if args.Len() != 1 {
+				return nil, errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(string, hctx.HelperContext) string)(arg, plush.NewHelperContext(ctx, nil)), nil
+		}
+	case func(string, plush.HelperContext) (string, error):
+		return func(name string, raw interface{}, args *fastCallArgs, ctx hctx.Context) (interface{}, error) {
+			if args.Len() != 1 {
+				return nil, errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			value, err := raw.(func(string, plush.HelperContext) (string, error))(arg, plush.NewHelperContext(ctx, nil))
+			if err != nil {
+				return nil, fmt.Errorf("could not call %s function: %w", name, err)
+			}
+			return value, nil
+		}
+	case func(string, hctx.HelperContext) (string, error):
+		return func(name string, raw interface{}, args *fastCallArgs, ctx hctx.Context) (interface{}, error) {
+			if args.Len() != 1 {
+				return nil, errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			value, err := raw.(func(string, hctx.HelperContext) (string, error))(arg, plush.NewHelperContext(ctx, nil))
+			if err != nil {
+				return nil, fmt.Errorf("could not call %s function: %w", name, err)
+			}
+			return value, nil
+		}
+	case func(string, plush.HelperContext) template.HTML:
+		return func(name string, raw interface{}, args *fastCallArgs, ctx hctx.Context) (interface{}, error) {
+			if args.Len() != 1 {
+				return nil, errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(string, plush.HelperContext) template.HTML)(arg, plush.NewHelperContext(ctx, nil)), nil
+		}
+	case func(string, hctx.HelperContext) template.HTML:
+		return func(name string, raw interface{}, args *fastCallArgs, ctx hctx.Context) (interface{}, error) {
+			if args.Len() != 1 {
+				return nil, errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			return raw.(func(string, hctx.HelperContext) template.HTML)(arg, plush.NewHelperContext(ctx, nil)), nil
+		}
+	case func(string, plush.HelperContext) (template.HTML, error):
+		return func(name string, raw interface{}, args *fastCallArgs, ctx hctx.Context) (interface{}, error) {
+			if args.Len() != 1 {
+				return nil, errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			value, err := raw.(func(string, plush.HelperContext) (template.HTML, error))(arg, plush.NewHelperContext(ctx, nil))
+			if err != nil {
+				return nil, fmt.Errorf("could not call %s function: %w", name, err)
+			}
+			return value, nil
+		}
+	case func(string, hctx.HelperContext) (template.HTML, error):
+		return func(name string, raw interface{}, args *fastCallArgs, ctx hctx.Context) (interface{}, error) {
+			if args.Len() != 1 {
+				return nil, errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawStringArg(args.Raw(0))
+			if !ok {
+				return nil, errFastWriteUnsupported
+			}
+			value, err := raw.(func(string, hctx.HelperContext) (template.HTML, error))(arg, plush.NewHelperContext(ctx, nil))
+			if err != nil {
+				return nil, fmt.Errorf("could not call %s function: %w", name, err)
+			}
+			return value, nil
+		}
+	}
+
+	rt := reflect.TypeOf(raw)
+	if rt == nil || rt.Kind() != reflect.Func || rt.IsVariadic() || rt.NumIn() < 2 {
+		return nil
+	}
+	helperIndex := rt.NumIn() - 1
+	if optionalArgKindFor(rt.In(helperIndex)) != optionalArgHelperContext {
+		return nil
+	}
+	requiredArgs := helperIndex
+	return func(name string, raw interface{}, args *fastCallArgs, ctx hctx.Context) (interface{}, error) {
+		if args.Len() != requiredArgs {
+			return nil, errFastWriteUnsupported
+		}
+		var scratch [4]reflect.Value
+		reflectArgs := scratch[:0]
+		if cap(reflectArgs) < rt.NumIn() {
+			reflectArgs = make([]reflect.Value, 0, rt.NumIn())
+		}
+		for pos := 0; pos < requiredArgs; pos++ {
+			arg, err := fastReflectArgForCall(name, pos, args.Raw(pos), rt.In(pos))
+			if err != nil {
+				return nil, errFastWriteUnsupported
+			}
+			reflectArgs = append(reflectArgs, arg)
+		}
+		helperCtx, ok := fastOptionalArg(optionalArgHelperContext, rt.In(helperIndex), ctx)
+		if !ok {
+			return nil, errFastWriteUnsupported
+		}
+		reflectArgs = append(reflectArgs, helperCtx)
+		res := reflect.ValueOf(raw).Call(reflectArgs)
+		if len(res) == 0 {
+			return nil, nil
+		}
+		if err := lastReturnError(res); err != nil {
+			return nil, fmt.Errorf("could not call %s function: %w", name, err)
+		}
+		if isNilReflectValue(res[0]) {
+			return nil, nil
+		}
+		return res[0].Interface(), nil
+	}
+}
+
+func writeFastInvokerForRaw(raw interface{}) writeFastInvoker {
+	switch raw.(type) {
+	case func():
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 0 {
+				return errFastWriteUnsupported
+			}
+			raw.(func())()
+			markFastOutput(frame)
+			return nil
+		}
+	case func() string:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 0 {
+				return errFastWriteUnsupported
+			}
+			writeFastString(frame, raw.(func() string)())
+			return nil
+		}
+	case func(string) string:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 1 {
+				return errFastWriteUnsupported
+			}
+			arg, ok := fastWriteStringArg(args[0])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastString(frame, raw.(func(string) string)(arg))
+			return nil
+		}
+	case func(string, string) string:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 2 {
+				return errFastWriteUnsupported
+			}
+			first, ok := fastWriteStringArg(args[0])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			second, ok := fastWriteStringArg(args[1])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastString(frame, raw.(func(string, string) string)(first, second))
+			return nil
+		}
+	case func(int) string:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 1 {
+				return errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawIntArg(args[0])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastString(frame, raw.(func(int) string)(arg))
+			return nil
+		}
+	case func(int64) string:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 1 {
+				return errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawInt64Arg(args[0])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastString(frame, raw.(func(int64) string)(arg))
+			return nil
+		}
+	case func(uint) string:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 1 {
+				return errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawUintArg(args[0])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastString(frame, raw.(func(uint) string)(arg))
+			return nil
+		}
+	case func(uint32) string:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 1 {
+				return errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawUint32Arg(args[0])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastString(frame, raw.(func(uint32) string)(arg))
+			return nil
+		}
+	case func(uint64) string:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 1 {
+				return errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawUint64Arg(args[0])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastString(frame, raw.(func(uint64) string)(arg))
+			return nil
+		}
+	case func(bool) string:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 1 {
+				return errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawBoolArg(args[0])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastString(frame, raw.(func(bool) string)(arg))
+			return nil
+		}
+	case func(float64) string:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 1 {
+				return errFastWriteUnsupported
+			}
+			arg, ok := fastWriteRawFloat64Arg(args[0])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastString(frame, raw.(func(float64) string)(arg))
+			return nil
+		}
+	case func(int, string) string:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 2 {
+				return errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawIntArg(args[0])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawStringArg(args[1])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastString(frame, raw.(func(int, string) string)(first, second))
+			return nil
+		}
+	case func(string, int) string:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 2 {
+				return errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawStringArg(args[0])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawIntArg(args[1])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastString(frame, raw.(func(string, int) string)(first, second))
+			return nil
+		}
+	case func(uint32, string) string:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 2 {
+				return errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawUint32Arg(args[0])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawStringArg(args[1])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastString(frame, raw.(func(uint32, string) string)(first, second))
+			return nil
+		}
+	case func(string, uint32) string:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 2 {
+				return errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawStringArg(args[0])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawUint32Arg(args[1])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastString(frame, raw.(func(string, uint32) string)(first, second))
+			return nil
+		}
+	case func(bool, string) string:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 2 {
+				return errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawBoolArg(args[0])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawStringArg(args[1])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastString(frame, raw.(func(bool, string) string)(first, second))
+			return nil
+		}
+	case func(string, bool) string:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 2 {
+				return errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawStringArg(args[0])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawBoolArg(args[1])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastString(frame, raw.(func(string, bool) string)(first, second))
+			return nil
+		}
+	case func(float64, string) string:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 2 {
+				return errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawFloat64Arg(args[0])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawStringArg(args[1])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastString(frame, raw.(func(float64, string) string)(first, second))
+			return nil
+		}
+	case func(string, float64) string:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 2 {
+				return errFastWriteUnsupported
+			}
+			first, ok := fastWriteRawStringArg(args[0])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			second, ok := fastWriteRawFloat64Arg(args[1])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastString(frame, raw.(func(string, float64) string)(first, second))
+			return nil
+		}
+	case func() (string, error):
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 0 {
+				return errFastWriteUnsupported
+			}
+			value, err := raw.(func() (string, error))()
+			if err != nil {
+				return fmt.Errorf("could not call %s function: %w", name, err)
+			}
+			writeFastString(frame, value)
+			return nil
+		}
+	case func(string) (string, error):
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 1 {
+				return errFastWriteUnsupported
+			}
+			arg, ok := fastWriteStringArg(args[0])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			value, err := raw.(func(string) (string, error))(arg)
+			if err != nil {
+				return fmt.Errorf("could not call %s function: %w", name, err)
+			}
+			writeFastString(frame, value)
+			return nil
+		}
+	case func() template.HTML:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 0 {
+				return errFastWriteUnsupported
+			}
+			writeFastHTML(frame, raw.(func() template.HTML)())
+			return nil
+		}
+	case func(string) template.HTML:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 1 {
+				return errFastWriteUnsupported
+			}
+			arg, ok := fastWriteStringArg(args[0])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			writeFastHTML(frame, raw.(func(string) template.HTML)(arg))
+			return nil
+		}
+	case func() (template.HTML, error):
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 0 {
+				return errFastWriteUnsupported
+			}
+			value, err := raw.(func() (template.HTML, error))()
+			if err != nil {
+				return fmt.Errorf("could not call %s function: %w", name, err)
+			}
+			writeFastHTML(frame, value)
+			return nil
+		}
+	case func(string) (template.HTML, error):
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 1 {
+				return errFastWriteUnsupported
+			}
+			arg, ok := fastWriteStringArg(args[0])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			value, err := raw.(func(string) (template.HTML, error))(arg)
+			if err != nil {
+				return fmt.Errorf("could not call %s function: %w", name, err)
+			}
+			writeFastHTML(frame, value)
+			return nil
+		}
+	case func() bool:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 0 {
+				return errFastWriteUnsupported
+			}
+			writeFastBool(frame, raw.(func() bool)())
+			return nil
+		}
+	case func() int:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 0 {
+				return errFastWriteUnsupported
+			}
+			writeFastInt(frame, int64(raw.(func() int)()))
+			return nil
+		}
+	case func() int64:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 0 {
+				return errFastWriteUnsupported
+			}
+			writeFastInt(frame, raw.(func() int64)())
+			return nil
+		}
+	case func() uint:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 0 {
+				return errFastWriteUnsupported
+			}
+			writeFastUint(frame, uint64(raw.(func() uint)()))
+			return nil
+		}
+	case func() uint64:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 0 {
+				return errFastWriteUnsupported
+			}
+			writeFastUint(frame, raw.(func() uint64)())
+			return nil
+		}
+	case func() float64:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 0 {
+				return errFastWriteUnsupported
+			}
+			writeFastFloat(frame, raw.(func() float64)(), 64)
+			return nil
+		}
+	case func() object.Object:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 0 {
+				return errFastWriteUnsupported
+			}
+			vm.writeFrameOutput(frame, raw.(func() object.Object)())
+			return nil
+		}
+	case func(string) object.Object:
+		return func(vm *VM, frame *Frame, name string, raw interface{}, args []object.Object) error {
+			if len(args) != 1 {
+				return errFastWriteUnsupported
+			}
+			arg, ok := fastWriteStringArg(args[0])
+			if !ok {
+				return errFastWriteUnsupported
+			}
+			vm.writeFrameOutput(frame, raw.(func(string) object.Object)(arg))
+			return nil
+		}
+	}
+	return nil
+}
+
+func markFastOutput(frame *Frame) {
+	if frame != nil {
+		frame.hasOutput = true
+	}
+}
+
+func writeFastString(frame *Frame, value string) {
+	if frame == nil {
+		return
+	}
+	frame.hasOutput = true
+	writeFastEscapedString(&frame.output, value)
+}
+
+func writeFastHTML(frame *Frame, value template.HTML) {
+	if frame == nil {
+		return
+	}
+	frame.hasOutput = true
+	frame.output.WriteString(string(value))
+}
+
+func writeFastBool(frame *Frame, value bool) {
+	if frame == nil {
+		return
+	}
+	frame.hasOutput = true
+	frame.output.WriteString(strconv.FormatBool(value))
+}
+
+func writeFastInt(frame *Frame, value int64) {
+	if frame == nil {
+		return
+	}
+	frame.hasOutput = true
+	var buf [20]byte
+	frame.output.Write(strconv.AppendInt(buf[:0], value, 10))
+}
+
+func writeFastUint(frame *Frame, value uint64) {
+	if frame == nil {
+		return
+	}
+	frame.hasOutput = true
+	var buf [20]byte
+	frame.output.Write(strconv.AppendUint(buf[:0], value, 10))
+}
+
+func writeFastFloat(frame *Frame, value float64, bits int) {
+	if frame == nil {
+		return
+	}
+	frame.hasOutput = true
+	var buf [32]byte
+	frame.output.Write(strconv.AppendFloat(buf[:0], value, 'g', -1, bits))
+}
+
+func fastWriteStringArg(obj object.Object) (string, bool) {
+	switch obj := obj.(type) {
+	case *object.String:
+		return obj.Value, true
+	case *object.Native:
+		value, ok := obj.Value.(string)
+		return value, ok
+	}
+	return "", false
+}
+
+func fastWriteRawStringArg(value interface{}) (string, bool) {
+	value = fastArgGoValue(value)
+	switch value := value.(type) {
+	case string:
+		return value, true
+	case object.Object:
+		raw, ok := object.ToGo(value).(string)
+		return raw, ok
+	default:
+		raw, ok := value.(fmt.Stringer)
+		if ok {
+			return raw.String(), true
+		}
+		rv := reflect.ValueOf(value)
+		if rv.IsValid() && rv.Kind() == reflect.String {
+			return rv.String(), true
+		}
+		return "", false
+	}
+}
+
+func fastWriteRawBoolArg(value interface{}) (bool, bool) {
+	value = fastArgGoValue(value)
+	if raw, ok := value.(bool); ok {
+		return raw, true
+	}
+	rv := reflect.ValueOf(value)
+	if rv.IsValid() && rv.Kind() == reflect.Bool {
+		return rv.Bool(), true
+	}
+	return false, false
+}
+
+func fastWriteRawIntArg(value interface{}) (int, bool) {
+	raw, ok := fastArgInt64(value)
+	if !ok || !fastInt64FitsInt(raw) {
+		return 0, false
+	}
+	return int(raw), true
+}
+
+func fastWriteRawInt64Arg(value interface{}) (int64, bool) {
+	return fastArgInt64(value)
+}
+
+func fastWriteRawUintArg(value interface{}) (uint, bool) {
+	raw, ok := fastArgUint64(value)
+	if !ok || !fastUint64FitsUint(raw) {
+		return 0, false
+	}
+	return uint(raw), true
+}
+
+func fastWriteRawUint32Arg(value interface{}) (uint32, bool) {
+	raw, ok := fastArgUint64(value)
+	if !ok || raw > uint64(^uint32(0)) {
+		return 0, false
+	}
+	return uint32(raw), true
+}
+
+func fastWriteRawUint64Arg(value interface{}) (uint64, bool) {
+	return fastArgUint64(value)
+}
+
+func fastWriteRawFloat64Arg(value interface{}) (float64, bool) {
+	return fastArgFloat64(value)
+}
+
+func fastInt64FitsInt(value int64) bool {
+	return fastInt64FitsIntSize(value, strconv.IntSize)
+}
+
+func fastInt64FitsIntSize(value int64, intSize int) bool {
+	if intSize == 32 {
+		return value >= math.MinInt32 && value <= math.MaxInt32
+	}
+	return true
+}
+
+func fastUint64FitsUint(value uint64) bool {
+	return fastUint64FitsUintSize(value, strconv.IntSize)
+}
+
+func fastUint64FitsUintSize(value uint64, intSize int) bool {
+	if intSize == 32 {
+		return value <= math.MaxUint32
+	}
+	return true
+}

--- a/VM/vm/fast_invokers_test.go
+++ b/VM/vm/fast_invokers_test.go
@@ -1,0 +1,673 @@
+package vm
+
+import (
+	"errors"
+	"html/template"
+	"strings"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/stretchr/testify/require"
+)
+
+type vmRawStringAlias string
+type vmRawBoolAlias bool
+
+func fastArgs(values ...interface{}) *fastCallArgs {
+	args := &fastCallArgs{}
+	for _, value := range values {
+		args.Append(value)
+	}
+	return args
+}
+
+func requireFastBuilderUnsupported(t *testing.T, raw interface{}, args *fastCallArgs) {
+	t.Helper()
+	invoker := writeFastBuilderInvokerForRaw(raw)
+	require.NotNil(t, invoker)
+	require.ErrorIs(t, invoker(&strings.Builder{}, plush.NewContext(), "helper", raw, args), errFastWriteUnsupported)
+}
+
+func requireFastValueUnsupported(t *testing.T, raw interface{}, args *fastCallArgs) {
+	t.Helper()
+	invoker := valueFastInvokerForRaw(raw)
+	require.NotNil(t, invoker)
+	_, err := invoker("helper", raw, args)
+	require.ErrorIs(t, err, errFastWriteUnsupported)
+}
+
+func requireFastWriteUnsupported(t *testing.T, machine *VM, frame *Frame, raw interface{}, args []object.Object) {
+	t.Helper()
+	invoker := writeFastInvokerForRaw(raw)
+	require.NotNil(t, invoker)
+	require.ErrorIs(t, invoker(machine, frame, "helper", raw, args), errFastWriteUnsupported)
+}
+
+func Test_VM_Fast_Write_Raw_Arg_Helpers(t *testing.T) {
+	value, ok := fastWriteRawStringArg("raw")
+	require.True(t, ok)
+	require.Equal(t, "raw", value)
+
+	value, ok = fastWriteRawStringArg(&object.String{Value: "object"})
+	require.True(t, ok)
+	require.Equal(t, "object", value)
+
+	value, ok = fastWriteRawStringArg(&object.Native{Value: "native"})
+	require.True(t, ok)
+	require.Equal(t, "native", value)
+
+	value, ok = fastWriteRawStringArg(vmFastOutputStringer("value"))
+	require.True(t, ok)
+	require.Equal(t, "stringer:value", value)
+
+	value, ok = fastWriteRawStringArg(vmRawStringAlias("alias"))
+	require.True(t, ok)
+	require.Equal(t, "alias", value)
+
+	_, ok = fastWriteRawStringArg(&object.Builtin{})
+	require.False(t, ok)
+	_, ok = fastWriteRawStringArg(12)
+	require.False(t, ok)
+
+	boolValue, ok := fastWriteRawBoolArg(true)
+	require.True(t, ok)
+	require.True(t, boolValue)
+	boolValue, ok = fastWriteRawBoolArg(vmRawBoolAlias(true))
+	require.True(t, ok)
+	require.True(t, boolValue)
+	_, ok = fastWriteRawBoolArg("true")
+	require.False(t, ok)
+
+	intValue, ok := fastWriteRawIntArg(int64(3))
+	require.True(t, ok)
+	require.Equal(t, 3, intValue)
+	_, ok = fastWriteRawIntArg(uint64(^uint(0)))
+	require.False(t, ok)
+
+	uintValue, ok := fastWriteRawUintArg(uint64(4))
+	require.True(t, ok)
+	require.Equal(t, uint(4), uintValue)
+
+	uint32Value, ok := fastWriteRawUint32Arg(uint64(5))
+	require.True(t, ok)
+	require.Equal(t, uint32(5), uint32Value)
+	_, ok = fastWriteRawUint32Arg(uint64(^uint32(0)) + 1)
+	require.False(t, ok)
+
+	uint64Value, ok := fastWriteRawUint64Arg(uint32(6))
+	require.True(t, ok)
+	require.Equal(t, uint64(6), uint64Value)
+
+	floatValue, ok := fastWriteRawFloat64Arg(float32(1.5))
+	require.True(t, ok)
+	require.InDelta(t, 1.5, floatValue, 0.0001)
+
+	require.True(t, fastInt64FitsIntSize(0, 32))
+	require.True(t, fastInt64FitsIntSize(int64(^uint(0)>>1), 64))
+	require.False(t, fastInt64FitsIntSize(int64(1)<<40, 32))
+	require.True(t, fastUint64FitsUintSize(0, 32))
+	require.True(t, fastUint64FitsUintSize(uint64(^uint(0)), 64))
+	require.False(t, fastUint64FitsUintSize(uint64(1)<<40, 32))
+}
+
+func Test_VM_Fast_Builder_Invokers_Unsupported_Return_Signatures(t *testing.T) {
+	requireFastBuilderUnsupported(t, func() string { return "" }, fastArgs("extra"))
+	requireFastBuilderUnsupported(t, func() (string, error) { return "", nil }, fastArgs("extra"))
+	requireFastBuilderUnsupported(t, func(value string) (string, error) { return value, nil }, fastArgs())
+	requireFastBuilderUnsupported(t, func(value string) (string, error) { return value, nil }, fastArgs(1))
+	requireFastBuilderUnsupported(t, func() template.HTML { return "" }, fastArgs("extra"))
+	requireFastBuilderUnsupported(t, func(value string) template.HTML { return template.HTML(value) }, fastArgs())
+	requireFastBuilderUnsupported(t, func(value string) template.HTML { return template.HTML(value) }, fastArgs(1))
+	requireFastBuilderUnsupported(t, func() (template.HTML, error) { return "", nil }, fastArgs("extra"))
+	requireFastBuilderUnsupported(t, func(value string) (template.HTML, error) { return template.HTML(value), nil }, fastArgs())
+	requireFastBuilderUnsupported(t, func(value string) (template.HTML, error) { return template.HTML(value), nil }, fastArgs(1))
+	requireFastBuilderUnsupported(t, func() bool { return true }, fastArgs("extra"))
+	requireFastBuilderUnsupported(t, func() int { return 1 }, fastArgs("extra"))
+	requireFastBuilderUnsupported(t, func() int64 { return 1 }, fastArgs("extra"))
+	requireFastBuilderUnsupported(t, func() uint { return 1 }, fastArgs("extra"))
+	requireFastBuilderUnsupported(t, func() uint64 { return 1 }, fastArgs("extra"))
+	requireFastBuilderUnsupported(t, func() float64 { return 1 }, fastArgs("extra"))
+	requireFastBuilderUnsupported(t, func() object.Object { return Null }, fastArgs("extra"))
+	requireFastBuilderUnsupported(t, func(value string) object.Object { return &object.String{Value: value} }, fastArgs())
+	requireFastBuilderUnsupported(t, func(value string) object.Object { return &object.String{Value: value} }, fastArgs(1))
+
+	stringErr := func(value string) (string, error) { return "", errors.New("boom") }
+	invoker := writeFastBuilderInvokerForRaw(stringErr)
+	require.NotNil(t, invoker)
+	require.ErrorContains(t, invoker(&strings.Builder{}, plush.NewContext(), "bad", stringErr, fastArgs("x")), "could not call bad function")
+
+	htmlArgErr := func(value string) (template.HTML, error) { return "", errors.New("boom") }
+	invoker = writeFastBuilderInvokerForRaw(htmlArgErr)
+	require.NotNil(t, invoker)
+	require.ErrorContains(t, invoker(&strings.Builder{}, plush.NewContext(), "bad", htmlArgErr, fastArgs("x")), "could not call bad function")
+
+	htmlNoArgErr := func() (template.HTML, error) { return "", errors.New("boom") }
+	invoker = writeFastBuilderInvokerForRaw(htmlNoArgErr)
+	require.NotNil(t, invoker)
+	require.ErrorContains(t, invoker(&strings.Builder{}, plush.NewContext(), "bad", htmlNoArgErr, fastArgs()), "could not call bad function")
+}
+
+func Test_VM_Fast_Builder_Invokers_For_Common_Signatures(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      interface{}
+		args     *fastCallArgs
+		expected string
+	}{
+		{"no_args_string", func() string { return "<ok>" }, fastArgs(), "&lt;ok&gt;"},
+		{"string", func(value string) string { return value + "!" }, fastArgs("<name>"), "&lt;name&gt;!"},
+		{"string_string", func(first, second string) string { return first + ":" + second }, fastArgs("a", "b"), "a:b"},
+		{"int", func(value int) string { return strings.Repeat("x", value) }, fastArgs(3), "xxx"},
+		{"int64", func(value int64) string { return strings.Repeat("y", int(value)) }, fastArgs(int64(2)), "yy"},
+		{"uint", func(value uint) string { return strings.Repeat("u", int(value)) }, fastArgs(uint(2)), "uu"},
+		{"uint32", func(value uint32) string { return strings.Repeat("v", int(value)) }, fastArgs(uint32(2)), "vv"},
+		{"uint64", func(value uint64) string { return strings.Repeat("w", int(value)) }, fastArgs(uint64(2)), "ww"},
+		{"bool", func(value bool) string { return map[bool]string{true: "yes", false: "no"}[value] }, fastArgs(true), "yes"},
+		{"float64", func(value float64) string { return strings.Repeat("f", int(value)) }, fastArgs(float64(2.9)), "ff"},
+		{"int_string", func(count int, value string) string { return strings.Repeat(value, count) }, fastArgs(2, "a"), "aa"},
+		{"string_int", func(value string, count int) string { return strings.Repeat(value, count) }, fastArgs("b", 2), "bb"},
+		{"uint32_string", func(count uint32, value string) string { return strings.Repeat(value, int(count)) }, fastArgs(uint32(2), "c"), "cc"},
+		{"string_uint32", func(value string, count uint32) string { return strings.Repeat(value, int(count)) }, fastArgs("d", uint32(2)), "dd"},
+		{"bool_string", func(ok bool, value string) string {
+			if ok {
+				return value
+			}
+			return ""
+		}, fastArgs(true, "e"), "e"},
+		{"string_bool", func(value string, ok bool) string {
+			if ok {
+				return value
+			}
+			return ""
+		}, fastArgs("g", true), "g"},
+		{"float64_string", func(count float64, value string) string { return strings.Repeat(value, int(count)) }, fastArgs(float64(2), "h"), "hh"},
+		{"string_float64", func(value string, count float64) string { return strings.Repeat(value, int(count)) }, fastArgs("i", float64(2)), "ii"},
+		{"string_error", func() (string, error) { return "<safe?>", nil }, fastArgs(), "&lt;safe?&gt;"},
+		{"string_arg_error", func(value string) (string, error) { return value + "?", nil }, fastArgs("<arg>"), "&lt;arg&gt;?"},
+		{"html", func() template.HTML { return template.HTML("<b>") }, fastArgs(), "<b>"},
+		{"html_arg", func(value string) template.HTML { return template.HTML("<" + value + ">") }, fastArgs("i"), "<i>"},
+		{"html_error", func() (template.HTML, error) { return template.HTML("<em>"), nil }, fastArgs(), "<em>"},
+		{"html_arg_error", func(value string) (template.HTML, error) { return template.HTML("<" + value + ">"), nil }, fastArgs("strong"), "<strong>"},
+		{"bool_return", func() bool { return true }, fastArgs(), "true"},
+		{"int_return", func() int { return 12 }, fastArgs(), "12"},
+		{"int64_return", func() int64 { return 13 }, fastArgs(), "13"},
+		{"uint_return", func() uint { return 14 }, fastArgs(), "14"},
+		{"uint64_return", func() uint64 { return 15 }, fastArgs(), "15"},
+		{"float_return", func() float64 { return 1.25 }, fastArgs(), "1.25"},
+		{"object_return", func() object.Object { return &object.String{Value: "<obj>"} }, fastArgs(), "&lt;obj&gt;"},
+		{"object_arg_return", func(value string) object.Object { return &object.String{Value: value} }, fastArgs("<argobj>"), "&lt;argobj&gt;"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			invoker := writeFastBuilderInvokerForRaw(tt.raw)
+			require.NotNil(t, invoker)
+			var out strings.Builder
+			require.NoError(t, invoker(&out, plush.NewContext(), "helper", tt.raw, tt.args))
+			require.Equal(t, tt.expected, out.String())
+		})
+	}
+
+	raw := func() (string, error) { return "", errors.New("boom") }
+	invoker := writeFastBuilderInvokerForRaw(raw)
+	require.NotNil(t, invoker)
+	require.ErrorContains(t, invoker(&strings.Builder{}, plush.NewContext(), "bad", raw, fastArgs()), "could not call bad function")
+
+	called := false
+	voidRaw := func() { called = true }
+	voidInvoker := writeFastBuilderInvokerForRaw(voidRaw)
+	require.NotNil(t, voidInvoker)
+	require.NoError(t, voidInvoker(&strings.Builder{}, plush.NewContext(), "void", voidRaw, fastArgs()))
+	require.True(t, called)
+	require.ErrorIs(t, voidInvoker(&strings.Builder{}, plush.NewContext(), "void", voidRaw, fastArgs("extra")), errFastWriteUnsupported)
+
+	require.Nil(t, writeFastBuilderInvokerForRaw("not a helper"))
+	require.ErrorIs(t, writeFastBuilderInvokerForRaw(func(value string) string { return value })(&strings.Builder{}, plush.NewContext(), "helper", func(value string) string { return value }, fastArgs()), errFastWriteUnsupported)
+	require.ErrorIs(t, writeFastBuilderInvokerForRaw(func(value string) string { return value })(&strings.Builder{}, plush.NewContext(), "helper", func(value string) string { return value }, fastArgs(12)), errFastWriteUnsupported)
+	require.ErrorIs(t, writeFastBuilderInvokerForRaw(func(first, second string) string { return first + second })(&strings.Builder{}, plush.NewContext(), "helper", func(first, second string) string { return first + second }, fastArgs("a")), errFastWriteUnsupported)
+	require.ErrorIs(t, writeFastBuilderInvokerForRaw(func(first, second string) string { return first + second })(&strings.Builder{}, plush.NewContext(), "helper", func(first, second string) string { return first + second }, fastArgs(1, "b")), errFastWriteUnsupported)
+	require.ErrorIs(t, writeFastBuilderInvokerForRaw(func(first, second string) string { return first + second })(&strings.Builder{}, plush.NewContext(), "helper", func(first, second string) string { return first + second }, fastArgs("a", 2)), errFastWriteUnsupported)
+	require.ErrorIs(t, writeFastBuilderInvokerForRaw(func(value int) string { return "" })(&strings.Builder{}, plush.NewContext(), "helper", func(value int) string { return "" }, fastArgs()), errFastWriteUnsupported)
+	require.ErrorIs(t, writeFastBuilderInvokerForRaw(func(value int) string { return "" })(&strings.Builder{}, plush.NewContext(), "helper", func(value int) string { return "" }, fastArgs("bad")), errFastWriteUnsupported)
+	require.ErrorIs(t, writeFastBuilderInvokerForRaw(func(value int64) string { return "" })(&strings.Builder{}, plush.NewContext(), "helper", func(value int64) string { return "" }, fastArgs()), errFastWriteUnsupported)
+	require.ErrorIs(t, writeFastBuilderInvokerForRaw(func(value int64) string { return "" })(&strings.Builder{}, plush.NewContext(), "helper", func(value int64) string { return "" }, fastArgs("bad")), errFastWriteUnsupported)
+	require.ErrorIs(t, writeFastBuilderInvokerForRaw(func(value uint) string { return "" })(&strings.Builder{}, plush.NewContext(), "helper", func(value uint) string { return "" }, fastArgs()), errFastWriteUnsupported)
+	requireFastBuilderUnsupported(t, func(value uint) string { return "" }, fastArgs("bad"))
+	requireFastBuilderUnsupported(t, func(value uint32) string { return "" }, fastArgs())
+	requireFastBuilderUnsupported(t, func(value uint32) string { return "" }, fastArgs("bad"))
+	requireFastBuilderUnsupported(t, func(value uint64) string { return "" }, fastArgs())
+	requireFastBuilderUnsupported(t, func(value uint64) string { return "" }, fastArgs("bad"))
+	requireFastBuilderUnsupported(t, func(value bool) string { return "" }, fastArgs())
+	requireFastBuilderUnsupported(t, func(value bool) string { return "" }, fastArgs("bad"))
+	requireFastBuilderUnsupported(t, func(value float64) string { return "" }, fastArgs())
+	requireFastBuilderUnsupported(t, func(value float64) string { return "" }, fastArgs("bad"))
+	requireFastBuilderUnsupported(t, func(count int, value string) string { return "" }, fastArgs(1))
+	requireFastBuilderUnsupported(t, func(count int, value string) string { return "" }, fastArgs("bad", "x"))
+	requireFastBuilderUnsupported(t, func(count int, value string) string { return "" }, fastArgs(1, 2))
+	requireFastBuilderUnsupported(t, func(value string, count int) string { return "" }, fastArgs("x"))
+	requireFastBuilderUnsupported(t, func(value string, count int) string { return "" }, fastArgs(1, 2))
+	requireFastBuilderUnsupported(t, func(value string, count int) string { return "" }, fastArgs("x", "bad"))
+	requireFastBuilderUnsupported(t, func(count uint32, value string) string { return "" }, fastArgs(uint32(1)))
+	requireFastBuilderUnsupported(t, func(count uint32, value string) string { return "" }, fastArgs("bad", "x"))
+	requireFastBuilderUnsupported(t, func(count uint32, value string) string { return "" }, fastArgs(uint32(1), 2))
+	requireFastBuilderUnsupported(t, func(value string, count uint32) string { return "" }, fastArgs("x"))
+	requireFastBuilderUnsupported(t, func(value string, count uint32) string { return "" }, fastArgs(1, uint32(2)))
+	requireFastBuilderUnsupported(t, func(value string, count uint32) string { return "" }, fastArgs("x", "bad"))
+	requireFastBuilderUnsupported(t, func(ok bool, value string) string { return "" }, fastArgs(true))
+	requireFastBuilderUnsupported(t, func(ok bool, value string) string { return "" }, fastArgs("bad", "x"))
+	requireFastBuilderUnsupported(t, func(ok bool, value string) string { return "" }, fastArgs(true, 2))
+	requireFastBuilderUnsupported(t, func(value string, ok bool) string { return "" }, fastArgs("x"))
+	requireFastBuilderUnsupported(t, func(value string, ok bool) string { return "" }, fastArgs(1, true))
+	requireFastBuilderUnsupported(t, func(value string, ok bool) string { return "" }, fastArgs("x", "bad"))
+	requireFastBuilderUnsupported(t, func(count float64, value string) string { return "" }, fastArgs(float64(1)))
+	requireFastBuilderUnsupported(t, func(count float64, value string) string { return "" }, fastArgs("bad", "x"))
+	requireFastBuilderUnsupported(t, func(count float64, value string) string { return "" }, fastArgs(float64(1), 2))
+	requireFastBuilderUnsupported(t, func(value string, count float64) string { return "" }, fastArgs("x"))
+	requireFastBuilderUnsupported(t, func(value string, count float64) string { return "" }, fastArgs(1, float64(2)))
+	requireFastBuilderUnsupported(t, func(value string, count float64) string { return "" }, fastArgs("x", "bad"))
+}
+
+func Test_VM_Value_Fast_Invokers_For_Common_Signatures(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      interface{}
+		args     *fastCallArgs
+		expected interface{}
+	}{
+		{"no_args_string", func() string { return "ok" }, fastArgs(), "ok"},
+		{"string", func(value string) string { return value + "!" }, fastArgs("name"), "name!"},
+		{"int", func(value int) string { return strings.Repeat("x", value) }, fastArgs(2), "xx"},
+		{"int64", func(value int64) string { return strings.Repeat("i", int(value)) }, fastArgs(int64(2)), "ii"},
+		{"uint", func(value uint) string { return strings.Repeat("u", int(value)) }, fastArgs(uint(2)), "uu"},
+		{"uint32", func(value uint32) string { return strings.Repeat("v", int(value)) }, fastArgs(uint32(2)), "vv"},
+		{"uint64", func(value uint64) string { return strings.Repeat("w", int(value)) }, fastArgs(uint64(2)), "ww"},
+		{"bool", func(value bool) string {
+			if value {
+				return "yes"
+			}
+			return "no"
+		}, fastArgs(true), "yes"},
+		{"float64", func(value float64) string { return strings.Repeat("f", int(value)) }, fastArgs(float64(2.1)), "ff"},
+		{"string_string", func(first, second string) string { return first + second }, fastArgs("a", "b"), "ab"},
+		{"int_string", func(count int, value string) string { return strings.Repeat(value, count) }, fastArgs(2, "a"), "aa"},
+		{"string_int", func(value string, count int) string { return strings.Repeat(value, count) }, fastArgs("b", 2), "bb"},
+		{"int64_string", func(count int64, value string) string { return strings.Repeat(value, int(count)) }, fastArgs(int64(2), "c"), "cc"},
+		{"string_int64", func(value string, count int64) string { return strings.Repeat(value, int(count)) }, fastArgs("d", int64(2)), "dd"},
+		{"uint_string", func(count uint, value string) string { return strings.Repeat(value, int(count)) }, fastArgs(uint(2), "e"), "ee"},
+		{"string_uint", func(value string, count uint) string { return strings.Repeat(value, int(count)) }, fastArgs("f", uint(2)), "ff"},
+		{"uint32_string", func(count uint32, value string) string { return strings.Repeat(value, int(count)) }, fastArgs(uint32(2), "g"), "gg"},
+		{"string_uint32", func(value string, count uint32) string { return strings.Repeat(value, int(count)) }, fastArgs("h", uint32(2)), "hh"},
+		{"uint64_string", func(count uint64, value string) string { return strings.Repeat(value, int(count)) }, fastArgs(uint64(2), "i"), "ii"},
+		{"string_uint64", func(value string, count uint64) string { return strings.Repeat(value, int(count)) }, fastArgs("j", uint64(2)), "jj"},
+		{"bool_string", func(ok bool, value string) string {
+			if ok {
+				return value
+			}
+			return ""
+		}, fastArgs(true, "k"), "k"},
+		{"string_bool", func(value string, ok bool) string {
+			if ok {
+				return value
+			}
+			return ""
+		}, fastArgs("l", true), "l"},
+		{"float_string", func(count float64, value string) string { return strings.Repeat(value, int(count)) }, fastArgs(float64(2), "m"), "mm"},
+		{"string_float", func(value string, count float64) string { return strings.Repeat(value, int(count)) }, fastArgs("n", float64(2)), "nn"},
+		{"html", func() template.HTML { return template.HTML("<b>") }, fastArgs(), template.HTML("<b>")},
+		{"bool_return", func() bool { return true }, fastArgs(), true},
+		{"int_return", func() int { return 7 }, fastArgs(), 7},
+		{"int64_return", func() int64 { return 8 }, fastArgs(), int64(8)},
+		{"uint_return", func() uint { return 9 }, fastArgs(), uint(9)},
+		{"uint64_return", func() uint64 { return 10 }, fastArgs(), uint64(10)},
+		{"float_return", func() float64 { return 2.5 }, fastArgs(), 2.5},
+		{"object_return", func() object.Object { return &object.String{Value: "obj"} }, fastArgs(), &object.String{Value: "obj"}},
+		{"string_error", func() (string, error) { return "ok", nil }, fastArgs(), "ok"},
+		{"html_error", func() (template.HTML, error) { return template.HTML("<ok>"), nil }, fastArgs(), template.HTML("<ok>")},
+		{"string_arg_error", func(value string) (string, error) { return value + "!", nil }, fastArgs("arg"), "arg!"},
+		{"string_string_error", func(first, second string) (string, error) { return first + second, nil }, fastArgs("a", "b"), "ab"},
+		{"html_arg", func(value string) template.HTML { return template.HTML("<" + value + ">") }, fastArgs("i"), template.HTML("<i>")},
+		{"html_string_string", func(first, second string) template.HTML { return template.HTML("<" + first + second + ">") }, fastArgs("e", "m"), template.HTML("<em>")},
+		{"html_arg_error", func(value string) (template.HTML, error) { return template.HTML("<" + value + ">"), nil }, fastArgs("strong"), template.HTML("<strong>")},
+		{"html_string_string_error", func(first, second string) (template.HTML, error) {
+			return template.HTML("<" + first + second + ">"), nil
+		}, fastArgs("s", "pan"), template.HTML("<span>")},
+		{"object_arg", func(value string) object.Object { return &object.String{Value: value} }, fastArgs("obj"), &object.String{Value: "obj"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			invoker := valueFastInvokerForRaw(tt.raw)
+			require.NotNil(t, invoker)
+			value, err := invoker("helper", tt.raw, tt.args)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, value)
+		})
+	}
+
+	raw := func() (template.HTML, error) { return "", errors.New("boom") }
+	invoker := valueFastInvokerForRaw(raw)
+	require.NotNil(t, invoker)
+	_, err := invoker("bad", raw, fastArgs())
+	require.ErrorContains(t, err, "could not call bad function")
+
+	called := false
+	voidRaw := func() { called = true }
+	voidInvoker := valueFastInvokerForRaw(voidRaw)
+	require.NotNil(t, voidInvoker)
+	value, err := voidInvoker("void", voidRaw, fastArgs())
+	require.NoError(t, err)
+	require.Nil(t, value)
+	require.True(t, called)
+	_, err = voidInvoker("void", voidRaw, fastArgs("extra"))
+	require.ErrorIs(t, err, errFastWriteUnsupported)
+
+	require.Nil(t, valueFastInvokerForRaw(struct{}{}))
+	_, err = valueFastInvokerForRaw(func() string { return "" })("helper", func() string { return "" }, fastArgs("extra"))
+	require.ErrorIs(t, err, errFastWriteUnsupported)
+	_, err = valueFastInvokerForRaw(func(value string) string { return value })("helper", func(value string) string { return value }, fastArgs())
+	require.ErrorIs(t, err, errFastWriteUnsupported)
+	_, err = valueFastInvokerForRaw(func(value string) string { return value })("helper", func(value string) string { return value }, fastArgs(12))
+	require.ErrorIs(t, err, errFastWriteUnsupported)
+	_, err = valueFastInvokerForRaw(func(value int) string { return "" })("helper", func(value int) string { return "" }, fastArgs())
+	require.ErrorIs(t, err, errFastWriteUnsupported)
+	_, err = valueFastInvokerForRaw(func(value int) string { return "" })("helper", func(value int) string { return "" }, fastArgs("bad"))
+	require.ErrorIs(t, err, errFastWriteUnsupported)
+	_, err = valueFastInvokerForRaw(func(value int64) string { return "" })("helper", func(value int64) string { return "" }, fastArgs())
+	require.ErrorIs(t, err, errFastWriteUnsupported)
+	_, err = valueFastInvokerForRaw(func(value int64) string { return "" })("helper", func(value int64) string { return "" }, fastArgs("bad"))
+	require.ErrorIs(t, err, errFastWriteUnsupported)
+	_, err = valueFastInvokerForRaw(func(value uint) string { return "" })("helper", func(value uint) string { return "" }, fastArgs())
+	require.ErrorIs(t, err, errFastWriteUnsupported)
+	_, err = valueFastInvokerForRaw(func(value uint) string { return "" })("helper", func(value uint) string { return "" }, fastArgs("bad"))
+	require.ErrorIs(t, err, errFastWriteUnsupported)
+	_, err = valueFastInvokerForRaw(func(value uint32) string { return "" })("helper", func(value uint32) string { return "" }, fastArgs())
+	require.ErrorIs(t, err, errFastWriteUnsupported)
+	_, err = valueFastInvokerForRaw(func(value uint32) string { return "" })("helper", func(value uint32) string { return "" }, fastArgs("bad"))
+	require.ErrorIs(t, err, errFastWriteUnsupported)
+	_, err = valueFastInvokerForRaw(func(value uint64) string { return "" })("helper", func(value uint64) string { return "" }, fastArgs())
+	require.ErrorIs(t, err, errFastWriteUnsupported)
+	_, err = valueFastInvokerForRaw(func(value uint64) string { return "" })("helper", func(value uint64) string { return "" }, fastArgs("bad"))
+	require.ErrorIs(t, err, errFastWriteUnsupported)
+	_, err = valueFastInvokerForRaw(func(value bool) string { return "" })("helper", func(value bool) string { return "" }, fastArgs())
+	require.ErrorIs(t, err, errFastWriteUnsupported)
+	_, err = valueFastInvokerForRaw(func(value bool) string { return "" })("helper", func(value bool) string { return "" }, fastArgs("bad"))
+	require.ErrorIs(t, err, errFastWriteUnsupported)
+	_, err = valueFastInvokerForRaw(func(value float64) string { return "" })("helper", func(value float64) string { return "" }, fastArgs())
+	require.ErrorIs(t, err, errFastWriteUnsupported)
+	_, err = valueFastInvokerForRaw(func(value float64) string { return "" })("helper", func(value float64) string { return "" }, fastArgs("bad"))
+	require.ErrorIs(t, err, errFastWriteUnsupported)
+	_, err = valueFastInvokerForRaw(func(first, second string) string { return first + second })("helper", func(first, second string) string { return first + second }, fastArgs("a"))
+	require.ErrorIs(t, err, errFastWriteUnsupported)
+	_, err = valueFastInvokerForRaw(func(first, second string) string { return first + second })("helper", func(first, second string) string { return first + second }, fastArgs(1, "b"))
+	require.ErrorIs(t, err, errFastWriteUnsupported)
+	_, err = valueFastInvokerForRaw(func(first, second string) string { return first + second })("helper", func(first, second string) string { return first + second }, fastArgs("a", 2))
+	require.ErrorIs(t, err, errFastWriteUnsupported)
+	requireFastValueUnsupported(t, func(count int, value string) string { return "" }, fastArgs(1))
+	requireFastValueUnsupported(t, func(count int, value string) string { return "" }, fastArgs("bad", "x"))
+	requireFastValueUnsupported(t, func(count int, value string) string { return "" }, fastArgs(1, 2))
+	requireFastValueUnsupported(t, func(value string, count int) string { return "" }, fastArgs("x"))
+	requireFastValueUnsupported(t, func(value string, count int) string { return "" }, fastArgs(1, 2))
+	requireFastValueUnsupported(t, func(value string, count int) string { return "" }, fastArgs("x", "bad"))
+	requireFastValueUnsupported(t, func(count int64, value string) string { return "" }, fastArgs(int64(1)))
+	requireFastValueUnsupported(t, func(count int64, value string) string { return "" }, fastArgs("bad", "x"))
+	requireFastValueUnsupported(t, func(count int64, value string) string { return "" }, fastArgs(int64(1), 2))
+	requireFastValueUnsupported(t, func(value string, count int64) string { return "" }, fastArgs("x"))
+	requireFastValueUnsupported(t, func(value string, count int64) string { return "" }, fastArgs(1, int64(2)))
+	requireFastValueUnsupported(t, func(value string, count int64) string { return "" }, fastArgs("x", "bad"))
+	requireFastValueUnsupported(t, func(count uint, value string) string { return "" }, fastArgs(uint(1)))
+	requireFastValueUnsupported(t, func(count uint, value string) string { return "" }, fastArgs("bad", "x"))
+	requireFastValueUnsupported(t, func(count uint, value string) string { return "" }, fastArgs(uint(1), 2))
+	requireFastValueUnsupported(t, func(value string, count uint) string { return "" }, fastArgs("x"))
+	requireFastValueUnsupported(t, func(value string, count uint) string { return "" }, fastArgs(1, uint(2)))
+	requireFastValueUnsupported(t, func(value string, count uint) string { return "" }, fastArgs("x", "bad"))
+	requireFastValueUnsupported(t, func(count uint32, value string) string { return "" }, fastArgs(uint32(1)))
+	requireFastValueUnsupported(t, func(count uint32, value string) string { return "" }, fastArgs("bad", "x"))
+	requireFastValueUnsupported(t, func(count uint32, value string) string { return "" }, fastArgs(uint32(1), 2))
+	requireFastValueUnsupported(t, func(value string, count uint32) string { return "" }, fastArgs("x"))
+	requireFastValueUnsupported(t, func(value string, count uint32) string { return "" }, fastArgs(1, uint32(2)))
+	requireFastValueUnsupported(t, func(value string, count uint32) string { return "" }, fastArgs("x", "bad"))
+	requireFastValueUnsupported(t, func(count uint64, value string) string { return "" }, fastArgs(uint64(1)))
+	requireFastValueUnsupported(t, func(count uint64, value string) string { return "" }, fastArgs("bad", "x"))
+	requireFastValueUnsupported(t, func(count uint64, value string) string { return "" }, fastArgs(uint64(1), 2))
+	requireFastValueUnsupported(t, func(value string, count uint64) string { return "" }, fastArgs("x"))
+	requireFastValueUnsupported(t, func(value string, count uint64) string { return "" }, fastArgs(1, uint64(2)))
+	requireFastValueUnsupported(t, func(value string, count uint64) string { return "" }, fastArgs("x", "bad"))
+	requireFastValueUnsupported(t, func(ok bool, value string) string { return "" }, fastArgs(true))
+	requireFastValueUnsupported(t, func(ok bool, value string) string { return "" }, fastArgs("bad", "x"))
+	requireFastValueUnsupported(t, func(ok bool, value string) string { return "" }, fastArgs(true, 2))
+	requireFastValueUnsupported(t, func(value string, ok bool) string { return "" }, fastArgs("x"))
+	requireFastValueUnsupported(t, func(value string, ok bool) string { return "" }, fastArgs(1, true))
+	requireFastValueUnsupported(t, func(value string, ok bool) string { return "" }, fastArgs("x", "bad"))
+	requireFastValueUnsupported(t, func(count float64, value string) string { return "" }, fastArgs(float64(1)))
+	requireFastValueUnsupported(t, func(count float64, value string) string { return "" }, fastArgs("bad", "x"))
+	requireFastValueUnsupported(t, func(count float64, value string) string { return "" }, fastArgs(float64(1), 2))
+	requireFastValueUnsupported(t, func(value string, count float64) string { return "" }, fastArgs("x"))
+	requireFastValueUnsupported(t, func(value string, count float64) string { return "" }, fastArgs(1, float64(2)))
+	requireFastValueUnsupported(t, func(value string, count float64) string { return "" }, fastArgs("x", "bad"))
+}
+
+func Test_VM_Value_Fast_Invokers_Unsupported_Return_Signatures(t *testing.T) {
+	requireFastValueUnsupported(t, func() template.HTML { return "" }, fastArgs("extra"))
+	requireFastValueUnsupported(t, func() bool { return true }, fastArgs("extra"))
+	requireFastValueUnsupported(t, func() int { return 1 }, fastArgs("extra"))
+	requireFastValueUnsupported(t, func() int64 { return 1 }, fastArgs("extra"))
+	requireFastValueUnsupported(t, func() uint { return 1 }, fastArgs("extra"))
+	requireFastValueUnsupported(t, func() uint64 { return 1 }, fastArgs("extra"))
+	requireFastValueUnsupported(t, func() float64 { return 1 }, fastArgs("extra"))
+	requireFastValueUnsupported(t, func() object.Object { return Null }, fastArgs("extra"))
+	requireFastValueUnsupported(t, func() (string, error) { return "", nil }, fastArgs("extra"))
+	requireFastValueUnsupported(t, func() (template.HTML, error) { return "", nil }, fastArgs("extra"))
+	requireFastValueUnsupported(t, func(value string) (string, error) { return value, nil }, fastArgs())
+	requireFastValueUnsupported(t, func(value string) (string, error) { return value, nil }, fastArgs(1))
+	requireFastValueUnsupported(t, func(first, second string) (string, error) { return first + second, nil }, fastArgs("a"))
+	requireFastValueUnsupported(t, func(first, second string) (string, error) { return first + second, nil }, fastArgs(1, "b"))
+	requireFastValueUnsupported(t, func(first, second string) (string, error) { return first + second, nil }, fastArgs("a", 2))
+	requireFastValueUnsupported(t, func(value string) template.HTML { return template.HTML(value) }, fastArgs())
+	requireFastValueUnsupported(t, func(value string) template.HTML { return template.HTML(value) }, fastArgs(1))
+	requireFastValueUnsupported(t, func(first, second string) template.HTML { return template.HTML(first + second) }, fastArgs("a"))
+	requireFastValueUnsupported(t, func(first, second string) template.HTML { return template.HTML(first + second) }, fastArgs(1, "b"))
+	requireFastValueUnsupported(t, func(first, second string) template.HTML { return template.HTML(first + second) }, fastArgs("a", 2))
+	requireFastValueUnsupported(t, func(value string) (template.HTML, error) { return template.HTML(value), nil }, fastArgs())
+	requireFastValueUnsupported(t, func(value string) (template.HTML, error) { return template.HTML(value), nil }, fastArgs(1))
+	requireFastValueUnsupported(t, func(first, second string) (template.HTML, error) { return template.HTML(first + second), nil }, fastArgs("a"))
+	requireFastValueUnsupported(t, func(first, second string) (template.HTML, error) { return template.HTML(first + second), nil }, fastArgs(1, "b"))
+	requireFastValueUnsupported(t, func(first, second string) (template.HTML, error) { return template.HTML(first + second), nil }, fastArgs("a", 2))
+	requireFastValueUnsupported(t, func(value string) object.Object { return &object.String{Value: value} }, fastArgs())
+	requireFastValueUnsupported(t, func(value string) object.Object { return &object.String{Value: value} }, fastArgs(1))
+
+	stringErr := func() (string, error) { return "", errors.New("boom") }
+	invoker := valueFastInvokerForRaw(stringErr)
+	require.NotNil(t, invoker)
+	_, err := invoker("bad", stringErr, fastArgs())
+	require.ErrorContains(t, err, "could not call bad function")
+
+	stringArgErr := func(value string) (string, error) { return "", errors.New("boom") }
+	invoker = valueFastInvokerForRaw(stringArgErr)
+	require.NotNil(t, invoker)
+	_, err = invoker("bad", stringArgErr, fastArgs("x"))
+	require.ErrorContains(t, err, "could not call bad function")
+
+	stringStringErr := func(first, second string) (string, error) { return "", errors.New("boom") }
+	invoker = valueFastInvokerForRaw(stringStringErr)
+	require.NotNil(t, invoker)
+	_, err = invoker("bad", stringStringErr, fastArgs("a", "b"))
+	require.ErrorContains(t, err, "could not call bad function")
+
+	htmlArgErr := func(value string) (template.HTML, error) { return "", errors.New("boom") }
+	invoker = valueFastInvokerForRaw(htmlArgErr)
+	require.NotNil(t, invoker)
+	_, err = invoker("bad", htmlArgErr, fastArgs("x"))
+	require.ErrorContains(t, err, "could not call bad function")
+
+	htmlStringStringErr := func(first, second string) (template.HTML, error) { return "", errors.New("boom") }
+	invoker = valueFastInvokerForRaw(htmlStringStringErr)
+	require.NotNil(t, invoker)
+	_, err = invoker("bad", htmlStringStringErr, fastArgs("a", "b"))
+	require.ErrorContains(t, err, "could not call bad function")
+}
+
+func Test_VM_Write_Fast_Invokers_For_Frame_Output(t *testing.T) {
+	machine := newRuntimeHelperTestVM(plush.NewContext())
+	frame := machine.currentFrame()
+
+	tests := []struct {
+		name     string
+		raw      interface{}
+		args     []object.Object
+		expected string
+	}{
+		{"no_args_void", func() {}, nil, ""},
+		{"no_args_string", func() string { return "<ok>" }, nil, "&lt;ok&gt;"},
+		{"string", func(value string) string { return value + "!" }, []object.Object{&object.String{Value: "<name>"}}, "&lt;name&gt;!"},
+		{"string_string", func(first, second string) string { return first + second }, []object.Object{&object.String{Value: "a"}, &object.String{Value: "b"}}, "ab"},
+		{"int", func(value int) string { return strings.Repeat("x", value) }, []object.Object{&object.Integer{Value: 2}}, "xx"},
+		{"int64", func(value int64) string { return strings.Repeat("i", int(value)) }, []object.Object{&object.Integer{Value: 2}}, "ii"},
+		{"uint", func(value uint) string { return strings.Repeat("u", int(value)) }, []object.Object{&object.Integer{Value: 2}}, "uu"},
+		{"uint32", func(value uint32) string { return strings.Repeat("u", int(value)) }, []object.Object{&object.Integer{Value: 2}}, "uu"},
+		{"uint64", func(value uint64) string { return strings.Repeat("w", int(value)) }, []object.Object{&object.Integer{Value: 2}}, "ww"},
+		{"bool", func(value bool) string {
+			if value {
+				return "yes"
+			}
+			return "no"
+		}, []object.Object{True}, "yes"},
+		{"float64", func(value float64) string { return strings.Repeat("f", int(value)) }, []object.Object{&object.Float{Value: 2}}, "ff"},
+		{"int_string", func(count int, value string) string { return strings.Repeat(value, count) }, []object.Object{&object.Integer{Value: 2}, &object.String{Value: "a"}}, "aa"},
+		{"string_int", func(value string, count int) string { return strings.Repeat(value, count) }, []object.Object{&object.String{Value: "b"}, &object.Integer{Value: 2}}, "bb"},
+		{"uint32_string", func(count uint32, value string) string { return strings.Repeat(value, int(count)) }, []object.Object{&object.Integer{Value: 2}, &object.String{Value: "c"}}, "cc"},
+		{"string_uint32", func(value string, count uint32) string { return strings.Repeat(value, int(count)) }, []object.Object{&object.String{Value: "d"}, &object.Integer{Value: 2}}, "dd"},
+		{"bool_string", func(ok bool, value string) string {
+			if ok {
+				return value
+			}
+			return "no"
+		}, []object.Object{True, &object.String{Value: "e"}}, "e"},
+		{"string_bool", func(value string, ok bool) string {
+			if ok {
+				return value
+			}
+			return "no"
+		}, []object.Object{&object.String{Value: "f"}, True}, "f"},
+		{"float_string", func(count float64, value string) string { return strings.Repeat(value, int(count)) }, []object.Object{&object.Float{Value: 2}, &object.String{Value: "g"}}, "gg"},
+		{"string_float", func(value string, count float64) string { return strings.Repeat(value, int(count)) }, []object.Object{&object.String{Value: "h"}, &object.Float{Value: 2}}, "hh"},
+		{"html", func() template.HTML { return template.HTML("<b>") }, nil, "<b>"},
+		{"html_arg", func(value string) template.HTML { return template.HTML("<" + value + ">") }, []object.Object{&object.String{Value: "i"}}, "<i>"},
+		{"bool_return", func() bool { return true }, nil, "true"},
+		{"int_return", func() int { return 12 }, nil, "12"},
+		{"int64_return", func() int64 { return 13 }, nil, "13"},
+		{"uint_return", func() uint { return 13 }, nil, "13"},
+		{"uint64_return", func() uint64 { return 14 }, nil, "14"},
+		{"float_return", func() float64 { return 1.5 }, nil, "1.5"},
+		{"object_return", func() object.Object { return &object.String{Value: "<obj>"} }, nil, "&lt;obj&gt;"},
+		{"object_arg_return", func(value string) object.Object { return &object.String{Value: value} }, []object.Object{&object.String{Value: "<argobj>"}}, "&lt;argobj&gt;"},
+		{"string_error", func() (string, error) { return "<ok>", nil }, nil, "&lt;ok&gt;"},
+		{"string_arg_error", func(value string) (string, error) { return value + "!", nil }, []object.Object{&object.String{Value: "<errarg>"}}, "&lt;errarg&gt;!"},
+		{"html_error", func() (template.HTML, error) { return template.HTML("<em>"), nil }, nil, "<em>"},
+		{"html_arg_error", func(value string) (template.HTML, error) { return template.HTML("<" + value + ">"), nil }, []object.Object{&object.String{Value: "strong"}}, "<strong>"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			frame.output.Reset()
+			frame.hasOutput = false
+			invoker := writeFastInvokerForRaw(tt.raw)
+			require.NotNil(t, invoker)
+			require.NoError(t, invoker(machine, frame, "helper", tt.raw, tt.args))
+			require.True(t, frame.hasOutput)
+			require.Equal(t, tt.expected, frame.output.String())
+		})
+	}
+
+	raw := func() (string, error) { return "", errors.New("boom") }
+	invoker := writeFastInvokerForRaw(raw)
+	require.NotNil(t, invoker)
+	require.ErrorContains(t, invoker(machine, frame, "bad", raw, nil), "could not call bad function")
+
+	stringArgRaw := func(string) (string, error) { return "", errors.New("boom") }
+	stringArgInvoker := writeFastInvokerForRaw(stringArgRaw)
+	require.NotNil(t, stringArgInvoker)
+	require.ErrorContains(t, stringArgInvoker(machine, frame, "bad", stringArgRaw, []object.Object{&object.String{Value: "x"}}), "could not call bad function")
+
+	htmlRaw := func() (template.HTML, error) { return "", errors.New("boom") }
+	htmlInvoker := writeFastInvokerForRaw(htmlRaw)
+	require.NotNil(t, htmlInvoker)
+	require.ErrorContains(t, htmlInvoker(machine, frame, "bad", htmlRaw, nil), "could not call bad function")
+
+	htmlArgRaw := func(string) (template.HTML, error) { return "", errors.New("boom") }
+	htmlArgInvoker := writeFastInvokerForRaw(htmlArgRaw)
+	require.NotNil(t, htmlArgInvoker)
+	require.ErrorContains(t, htmlArgInvoker(machine, frame, "bad", htmlArgRaw, []object.Object{&object.String{Value: "x"}}), "could not call bad function")
+
+	require.Nil(t, writeFastInvokerForRaw(struct{}{}))
+	require.ErrorIs(t, writeFastInvokerForRaw(func(value string) string { return value })(machine, frame, "helper", func(value string) string { return value }, nil), errFastWriteUnsupported)
+	requireFastWriteUnsupported(t, machine, frame, func(value string) string { return value }, []object.Object{&object.Integer{Value: 1}})
+	require.ErrorIs(t, writeFastInvokerForRaw(func(value string) template.HTML { return template.HTML(value) })(machine, frame, "helper", func(value string) template.HTML { return template.HTML(value) }, nil), errFastWriteUnsupported)
+	requireFastWriteUnsupported(t, machine, frame, func(value int) string { return "" }, nil)
+	requireFastWriteUnsupported(t, machine, frame, func(value int) string { return "" }, []object.Object{&object.String{Value: "bad"}})
+	requireFastWriteUnsupported(t, machine, frame, func(value int64) string { return "" }, nil)
+	requireFastWriteUnsupported(t, machine, frame, func(value int64) string { return "" }, []object.Object{&object.String{Value: "bad"}})
+	requireFastWriteUnsupported(t, machine, frame, func(value uint) string { return "" }, nil)
+	requireFastWriteUnsupported(t, machine, frame, func(value uint) string { return "" }, []object.Object{&object.String{Value: "bad"}})
+	requireFastWriteUnsupported(t, machine, frame, func(value uint32) string { return "" }, nil)
+	requireFastWriteUnsupported(t, machine, frame, func(value uint32) string { return "" }, []object.Object{&object.String{Value: "bad"}})
+	requireFastWriteUnsupported(t, machine, frame, func(value uint64) string { return "" }, nil)
+	requireFastWriteUnsupported(t, machine, frame, func(value uint64) string { return "" }, []object.Object{&object.String{Value: "bad"}})
+	requireFastWriteUnsupported(t, machine, frame, func(value bool) string { return "" }, nil)
+	requireFastWriteUnsupported(t, machine, frame, func(value bool) string { return "" }, []object.Object{&object.String{Value: "bad"}})
+	requireFastWriteUnsupported(t, machine, frame, func(value float64) string { return "" }, nil)
+	requireFastWriteUnsupported(t, machine, frame, func(value float64) string { return "" }, []object.Object{&object.String{Value: "bad"}})
+	requireFastWriteUnsupported(t, machine, frame, func(count int, value string) string { return "" }, []object.Object{&object.Integer{Value: 1}})
+	requireFastWriteUnsupported(t, machine, frame, func(count int, value string) string { return "" }, []object.Object{&object.String{Value: "bad"}, &object.String{Value: "x"}})
+	requireFastWriteUnsupported(t, machine, frame, func(count int, value string) string { return "" }, []object.Object{&object.Integer{Value: 1}, &object.Integer{Value: 2}})
+	requireFastWriteUnsupported(t, machine, frame, func(value string, count int) string { return "" }, []object.Object{&object.String{Value: "x"}})
+	requireFastWriteUnsupported(t, machine, frame, func(value string, count int) string { return "" }, []object.Object{&object.Integer{Value: 1}, &object.Integer{Value: 2}})
+	requireFastWriteUnsupported(t, machine, frame, func(value string, count int) string { return "" }, []object.Object{&object.String{Value: "x"}, &object.String{Value: "bad"}})
+	requireFastWriteUnsupported(t, machine, frame, func(count uint32, value string) string { return "" }, []object.Object{&object.Integer{Value: 1}})
+	requireFastWriteUnsupported(t, machine, frame, func(count uint32, value string) string { return "" }, []object.Object{&object.String{Value: "bad"}, &object.String{Value: "x"}})
+	requireFastWriteUnsupported(t, machine, frame, func(count uint32, value string) string { return "" }, []object.Object{&object.Integer{Value: 1}, &object.Integer{Value: 2}})
+	requireFastWriteUnsupported(t, machine, frame, func(value string, count uint32) string { return "" }, []object.Object{&object.String{Value: "x"}})
+	requireFastWriteUnsupported(t, machine, frame, func(value string, count uint32) string { return "" }, []object.Object{&object.Integer{Value: 1}, &object.Integer{Value: 2}})
+	requireFastWriteUnsupported(t, machine, frame, func(value string, count uint32) string { return "" }, []object.Object{&object.String{Value: "x"}, &object.String{Value: "bad"}})
+	requireFastWriteUnsupported(t, machine, frame, func(ok bool, value string) string { return "" }, []object.Object{True})
+	requireFastWriteUnsupported(t, machine, frame, func(ok bool, value string) string { return "" }, []object.Object{&object.String{Value: "bad"}, &object.String{Value: "x"}})
+	requireFastWriteUnsupported(t, machine, frame, func(ok bool, value string) string { return "" }, []object.Object{True, &object.Integer{Value: 2}})
+	requireFastWriteUnsupported(t, machine, frame, func(value string, ok bool) string { return "" }, []object.Object{&object.String{Value: "x"}})
+	requireFastWriteUnsupported(t, machine, frame, func(value string, ok bool) string { return "" }, []object.Object{&object.Integer{Value: 1}, True})
+	requireFastWriteUnsupported(t, machine, frame, func(value string, ok bool) string { return "" }, []object.Object{&object.String{Value: "x"}, &object.String{Value: "bad"}})
+	requireFastWriteUnsupported(t, machine, frame, func(count float64, value string) string { return "" }, []object.Object{&object.Float{Value: 1}})
+	requireFastWriteUnsupported(t, machine, frame, func(count float64, value string) string { return "" }, []object.Object{&object.String{Value: "bad"}, &object.String{Value: "x"}})
+	requireFastWriteUnsupported(t, machine, frame, func(count float64, value string) string { return "" }, []object.Object{&object.Float{Value: 1}, &object.Integer{Value: 2}})
+	requireFastWriteUnsupported(t, machine, frame, func(value string, count float64) string { return "" }, []object.Object{&object.String{Value: "x"}})
+	requireFastWriteUnsupported(t, machine, frame, func(value string, count float64) string { return "" }, []object.Object{&object.Integer{Value: 1}, &object.Float{Value: 2}})
+	requireFastWriteUnsupported(t, machine, frame, func(value string, count float64) string { return "" }, []object.Object{&object.String{Value: "x"}, &object.String{Value: "bad"}})
+	requireFastWriteUnsupported(t, machine, frame, func(value string) (string, error) { return value, nil }, nil)
+	requireFastWriteUnsupported(t, machine, frame, func(value string) (string, error) { return value, nil }, []object.Object{&object.Integer{Value: 1}})
+	requireFastWriteUnsupported(t, machine, frame, func(value string) template.HTML { return template.HTML(value) }, []object.Object{&object.Integer{Value: 1}})
+	requireFastWriteUnsupported(t, machine, frame, func(value string) (template.HTML, error) { return template.HTML(value), nil }, nil)
+	requireFastWriteUnsupported(t, machine, frame, func(value string) (template.HTML, error) { return template.HTML(value), nil }, []object.Object{&object.Integer{Value: 1}})
+}
+
+func Test_VM_Write_Fast_Invokers_Unsupported_Return_Signatures(t *testing.T) {
+	machine := newRuntimeHelperTestVM(plush.NewContext())
+	frame := machine.currentFrame()
+	extra := []object.Object{&object.String{Value: "extra"}}
+
+	requireFastWriteUnsupported(t, machine, frame, func() {}, extra)
+	requireFastWriteUnsupported(t, machine, frame, func() string { return "" }, extra)
+	requireFastWriteUnsupported(t, machine, frame, func(first, second string) string { return first + second }, []object.Object{&object.String{Value: "a"}})
+	requireFastWriteUnsupported(t, machine, frame, func(first, second string) string { return first + second }, []object.Object{&object.Integer{Value: 1}, &object.String{Value: "b"}})
+	requireFastWriteUnsupported(t, machine, frame, func(first, second string) string { return first + second }, []object.Object{&object.String{Value: "a"}, &object.Integer{Value: 2}})
+	requireFastWriteUnsupported(t, machine, frame, func() (string, error) { return "", nil }, extra)
+	requireFastWriteUnsupported(t, machine, frame, func() template.HTML { return "" }, extra)
+	requireFastWriteUnsupported(t, machine, frame, func() (template.HTML, error) { return "", nil }, extra)
+	requireFastWriteUnsupported(t, machine, frame, func() bool { return true }, extra)
+	requireFastWriteUnsupported(t, machine, frame, func() int { return 1 }, extra)
+	requireFastWriteUnsupported(t, machine, frame, func() int64 { return 1 }, extra)
+	requireFastWriteUnsupported(t, machine, frame, func() uint { return 1 }, extra)
+	requireFastWriteUnsupported(t, machine, frame, func() uint64 { return 1 }, extra)
+	requireFastWriteUnsupported(t, machine, frame, func() float64 { return 1 }, extra)
+	requireFastWriteUnsupported(t, machine, frame, func() object.Object { return Null }, extra)
+	requireFastWriteUnsupported(t, machine, frame, func(value string) object.Object { return &object.String{Value: value} }, nil)
+	requireFastWriteUnsupported(t, machine, frame, func(value string) object.Object { return &object.String{Value: value} }, []object.Object{&object.Integer{Value: 1}})
+}

--- a/VM/vm/fast_loop_branch_edges_test.go
+++ b/VM/vm/fast_loop_branch_edges_test.go
@@ -1,0 +1,245 @@
+package vm
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_VM_Render_Fast_Conditional_Branches(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{"flag": false})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"flag"}}, ctx)
+	var out strings.Builder
+
+	handled, err := renderFastConditional(&out, ctx, bindings, nil)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	handled, err = renderFastConditional(&out, ctx, bindings, &compiler.FastConditionalPlan{
+		Branches: []compiler.FastConditionalBranch{{
+			Condition: compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing", NullOnMissing: true, Line: 1},
+			Segments:  []compiler.FastRenderSegment{{Kind: compiler.FastRenderSegmentStatic, Value: "then"}},
+			Line:      1,
+		}},
+		ElseSegments: []compiler.FastRenderSegment{{Kind: compiler.FastRenderSegmentStatic, Value: "else"}},
+	})
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "else", out.String())
+
+	out.Reset()
+	handled, err = renderFastConditional(&out, ctx, bindings, &compiler.FastConditionalPlan{
+		Branches: []compiler.FastConditionalBranch{{
+			Condition: compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true, Line: 1},
+			Segments:  []compiler.FastRenderSegment{{Kind: compiler.FastRenderSegmentStatic, Value: "then"}},
+			Line:      1,
+		}},
+	})
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "then", out.String())
+}
+
+func Test_VM_Render_Fast_Conditional_Error_And_Empty_Branches(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{"user": struct{}{}})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"user"}}, ctx)
+	conditional := &compiler.FastConditionalPlan{
+		Branches: []compiler.FastConditionalBranch{{
+			Condition: compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true, Line: 9},
+			Segments:  []compiler.FastRenderSegment{{Kind: compiler.FastRenderSegmentStatic, Value: "blocked"}},
+			Line:      9,
+		}},
+	}
+
+	handled, err := renderFastConditional(&strings.Builder{}, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, conditional)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 9")
+
+	conditional.Branches[0].Condition = compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: 0,
+		Value:     "user",
+		Path:      []compiler.FastPathStep{{Kind: compiler.FastPathStepProperty, Value: "Missing", Receiver: "user", Full: "user.Missing", Line: 10}},
+		Line:      10,
+	}
+	handled, err = renderFastConditional(&strings.Builder{}, ctx, bindings, conditional)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 10")
+
+	conditional.Branches[0].Condition = compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing", Line: 11}
+	conditional.Branches[0].Segments = nil
+	handled, err = renderFastConditional(&strings.Builder{}, ctx, bindings, conditional)
+	require.NoError(t, err)
+	require.True(t, handled)
+}
+
+func Test_VM_Render_Fast_Loop_Error_Branches(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"items": []interface{}{"a"},
+		"objs":  &object.Array{Elements: []object.Object{&object.String{Value: "<obj>"}}},
+	})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"items", "objs"}}, ctx)
+	var out strings.Builder
+
+	require.NoError(t, renderFastPartialSegmentWithDataPlan(nil, ctx, bindings, &compiler.FastPartialPlan{Name: "row", Line: 1}, nil))
+
+	handled, err := renderFastLoop(&out, ctx, bindings, &compiler.FastLoopPlan{
+		IterableName:      "objs",
+		IterableNameIndex: 1,
+		Line:              1,
+		Parts:             []compiler.FastLoopPart{{Kind: compiler.FastLoopPartValue}},
+	})
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "&lt;obj&gt;", out.String())
+
+	err = renderFastLoopParts(&out, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, &compiler.FastLoopPlan{Line: 12}, []compiler.FastLoopPart{{
+		Kind:     compiler.FastLoopPartValueProperty,
+		Value:    "Name",
+		Receiver: "item",
+		Full:     "item.Name",
+		Line:     12,
+	}}, 0, struct{}{})
+	require.ErrorContains(t, err, "line 12")
+
+	err = renderFastLoopParts(&out, ctx, bindings, &compiler.FastLoopPlan{Line: 13}, []compiler.FastLoopPart{{
+		Kind: compiler.FastLoopPartValuePath,
+		ValuePlan: compiler.FastValuePlan{
+			Kind:      compiler.FastValuePath,
+			NameIndex: -1,
+			Path:      []compiler.FastPathStep{{Kind: compiler.FastPathStepProperty, Value: "Missing", Receiver: "item", Full: "item.Missing", Line: 13}},
+			Line:      13,
+		},
+	}}, 0, "value")
+	require.ErrorContains(t, err, "line 13")
+
+	err = renderFastLoopParts(&out, ctx, bindings, &compiler.FastLoopPlan{Line: 14}, []compiler.FastLoopPart{{
+		Kind: compiler.FastLoopPartConditional,
+		Conditional: &compiler.FastLoopConditionalPlan{Branches: []compiler.FastLoopConditionalBranch{{
+			Condition: compiler.FastValuePlan{
+				Kind:      compiler.FastValuePath,
+				NameIndex: -1,
+				Path:      []compiler.FastPathStep{{Kind: compiler.FastPathStepProperty, Value: "Missing", Receiver: "item", Full: "item.Missing", Line: 14}},
+				Line:      14,
+			},
+			Line: 14,
+		}}},
+	}}, 0, "value")
+	require.ErrorContains(t, err, "line 14")
+}
+
+func Test_VM_Render_Fast_Loop_Conditional_Error_And_Empty_Branches(t *testing.T) {
+	ctx := plush.NewContext()
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{}, ctx)
+	loop := &compiler.FastLoopPlan{Line: 1}
+	conditional := &compiler.FastLoopConditionalPlan{
+		Branches: []compiler.FastLoopConditionalBranch{{
+			Condition: compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true, Line: 15},
+			Parts:     []compiler.FastLoopPart{{Kind: compiler.FastLoopPartStatic, Value: "blocked"}},
+			Line:      15,
+		}},
+	}
+
+	err := renderFastLoopConditional(&strings.Builder{}, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, loop, conditional, 0, "value")
+	require.ErrorContains(t, err, "line 15")
+
+	conditional.Branches[0].Condition = compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: -1,
+		Path:      []compiler.FastPathStep{{Kind: compiler.FastPathStepProperty, Value: "Missing", Receiver: "item", Full: "item.Missing", Line: 16}},
+		Line:      16,
+	}
+	err = renderFastLoopConditional(&strings.Builder{}, ctx, bindings, loop, conditional, 0, "value")
+	require.ErrorContains(t, err, "line 16")
+
+	conditional.Branches[0].Condition = compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing", Line: 17}
+	conditional.Branches[0].Parts = nil
+	err = renderFastLoopConditional(&strings.Builder{}, ctx, bindings, loop, conditional, 0, "value")
+	require.NoError(t, err)
+}
+
+func Test_VM_Eval_Fast_Loop_Call_Args_Empty_And_Missing(t *testing.T) {
+	ctx := plush.NewContext()
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{}, ctx)
+
+	args, err := evalFastLoopCallArgsInto(nil, ctx, bindings, 0, "value", nil)
+	require.NoError(t, err)
+	require.Nil(t, args)
+
+	args, err = evalFastLoopCallArgsInto([]compiler.FastValuePlan{{Kind: compiler.FastValuePath, NameIndex: -1}}, ctx, bindings, 0, "value", nil)
+	require.NoError(t, err)
+	require.NotNil(t, args)
+	require.Equal(t, "value", args.Raw(0))
+
+	args, err = evalFastLoopCallArgsInto([]compiler.FastValuePlan{{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing", Line: 18}}, ctx, bindings, 0, "value", nil)
+	require.Nil(t, args)
+	require.ErrorContains(t, err, "line 18")
+
+	args, err = evalFastLoopCallArgsInto([]compiler.FastValuePlan{{
+		Kind:      compiler.FastValuePath,
+		NameIndex: -1,
+		Path:      []compiler.FastPathStep{{Kind: compiler.FastPathStepProperty, Value: "Missing", Receiver: "item", Full: "item.Missing", Line: 19}},
+		Line:      19,
+	}}, ctx, bindings, 0, struct{}{}, nil)
+	require.Nil(t, args)
+	require.ErrorContains(t, err, "line 19")
+}
+
+func Test_VM_Write_Fast_Loop_Call_Part_Error_And_Fast_Helper_Branches(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"label": func(value string) string { return "slow:" + value },
+	})
+	SetFastHelper(ctx, "label", func(w FastWriter, args FastArgs) error {
+		value, ok := args.String(0)
+		require.True(t, ok)
+		w.WriteEscapedString("fast:" + value)
+		return nil
+	})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label"}}, ctx)
+	call := &compiler.FastCallPlan{
+		Name:      "label",
+		NameIndex: 0,
+		Args:      []compiler.FastValuePlan{{Kind: compiler.FastValuePath, NameIndex: -1, Line: 1}},
+		Line:      1,
+	}
+	var out strings.Builder
+	require.NoError(t, writeFastLoopCallPart(&out, ctx, bindings, nil, 0, "item"))
+	require.Empty(t, out.String())
+
+	require.NoError(t, writeFastLoopCallPart(&out, ctx, bindings, call, 0, "<item>"))
+	require.Equal(t, "fast:&lt;item&gt;", out.String())
+
+	missingCall := &compiler.FastCallPlan{Name: "missing", NameIndex: 99, Line: 7}
+	err := writeFastLoopCallPart(&strings.Builder{}, ctx, bindings, missingCall, 0, "item")
+	require.ErrorContains(t, err, `line 7`)
+
+	err = writeFastLoopCallPart(&strings.Builder{}, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, call, 0, "item")
+	require.ErrorContains(t, err, `line 1`)
+
+	badArg := &compiler.FastCallPlan{
+		Name:      "label",
+		NameIndex: 0,
+		Args:      []compiler.FastValuePlan{{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing", Line: 8}},
+		Line:      8,
+	}
+	err = writeFastLoopCallPart(&strings.Builder{}, ctx, bindings, badArg, 0, "item")
+	require.ErrorContains(t, err, `line 8`)
+
+	slowCtx := plush.NewContextWith(map[string]interface{}{
+		"label": func(value string) string { return value },
+	})
+	slowBindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label"}}, slowCtx)
+	err = writeFastLoopCallPart(&strings.Builder{}, slowCtx, slowBindings, badArg, 0, "item")
+	require.ErrorContains(t, err, `line 8`)
+
+	SetFastHelper(ctx, "label", func(FastWriter, FastArgs) error {
+		return errors.New("boom")
+	})
+	err = writeFastLoopCallPart(&strings.Builder{}, ctx, bindings, call, 0, "item")
+	require.ErrorContains(t, err, `line 1`)
+}

--- a/VM/vm/fast_loop_helpers_test.go
+++ b/VM/vm/fast_loop_helpers_test.go
@@ -1,0 +1,289 @@
+package vm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_VM_Render_Fast_Loop_Branches(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"items":   []interface{}{"<a>", "b"},
+		"objects": []object.Object{&object.String{Value: "<obj>"}},
+		"map":     map[string]string{"one": "<1>"},
+		"users":   &[]vmFastPropertyUser{{Name: "<mido>"}},
+		"scalar":  3,
+		"strings": []string{"<s>"},
+		"nilPtr":  (*[]string)(nil),
+		"array":   [1]string{"<array>"},
+		"badList": []interface{}{struct{}{}},
+		"badObjs": []object.Object{&object.Native{Value: struct{}{}}},
+		"badMap":  map[string]struct{}{"bad": {}},
+		"badInts": []int{1},
+	})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"items", "objects", "map", "users", "missing", "scalar", "strings", "nilPtr", "array", "badList", "badObjs", "badMap", "badInts"}}, ctx)
+
+	loop := &compiler.FastLoopPlan{
+		IterableName:      "items",
+		IterableNameIndex: 0,
+		Line:              1,
+		Parts: []compiler.FastLoopPart{
+			{Kind: compiler.FastLoopPartKey},
+			{Kind: compiler.FastLoopPartStatic, Value: ":"},
+			{Kind: compiler.FastLoopPartValue},
+			{Kind: compiler.FastLoopPartStatic, Value: ";"},
+		},
+	}
+	var out strings.Builder
+	handled, err := renderFastLoop(&out, ctx, bindings, loop)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "0:&lt;a&gt;;1:b;", out.String())
+
+	out.Reset()
+	loop.IterableName = "objects"
+	loop.IterableNameIndex = 1
+	handled, err = renderFastLoop(&out, ctx, bindings, loop)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "0:&lt;obj&gt;;", out.String())
+
+	out.Reset()
+	loop.IterableName = "map"
+	loop.IterableNameIndex = 2
+	handled, err = renderFastLoop(&out, ctx, bindings, loop)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "one:&lt;1&gt;;", out.String())
+
+	out.Reset()
+	loop.IterableName = "strings"
+	loop.IterableNameIndex = 6
+	handled, err = renderFastLoop(&out, ctx, bindings, loop)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "0:&lt;s&gt;;", out.String())
+
+	out.Reset()
+	loop.IterableName = "users"
+	loop.IterableNameIndex = 3
+	loop.Parts = []compiler.FastLoopPart{{Kind: compiler.FastLoopPartValueProperty, Value: "Name", Receiver: "user", Full: "user.Name", Line: 1}}
+	handled, err = renderFastLoop(&out, ctx, bindings, loop)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "&lt;mido&gt;", out.String())
+
+	out.Reset()
+	loop.IterableName = "nilPtr"
+	loop.IterableNameIndex = 7
+	handled, err = renderFastLoop(&out, ctx, bindings, loop)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Empty(t, out.String())
+
+	out.Reset()
+	loop.IterableName = "array"
+	loop.IterableNameIndex = 8
+	loop.Parts = []compiler.FastLoopPart{
+		{Kind: compiler.FastLoopPartKey},
+		{Kind: compiler.FastLoopPartStatic, Value: ":"},
+		{Kind: compiler.FastLoopPartValue},
+	}
+	handled, err = renderFastLoop(&out, ctx, bindings, loop)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "0:&lt;array&gt;", out.String())
+
+	loop.Parts = []compiler.FastLoopPart{{Kind: compiler.FastLoopPartValueProperty, Value: "Missing", Receiver: "item", Full: "item.Missing", Line: 4}}
+	loop.IterableName = "badList"
+	loop.IterableNameIndex = 9
+	_, err = renderFastLoop(&out, ctx, bindings, loop)
+	require.ErrorContains(t, err, "line 4")
+
+	loop.IterableName = "badObjs"
+	loop.IterableNameIndex = 10
+	_, err = renderFastLoop(&out, ctx, bindings, loop)
+	require.ErrorContains(t, err, "line 4")
+
+	loop.IterableName = "badInts"
+	loop.IterableNameIndex = 12
+	_, err = renderFastLoop(&out, ctx, bindings, loop)
+	require.ErrorContains(t, err, "line 4")
+
+	loop.IterableName = "badMap"
+	loop.IterableNameIndex = 11
+	_, err = renderFastLoop(&out, ctx, bindings, loop)
+	require.ErrorContains(t, err, "line 4")
+
+	loop.IterableName = "strings"
+	loop.IterableNameIndex = 6
+	_, err = renderFastLoop(&out, ctx, bindings, loop)
+	require.ErrorContains(t, err, "line 4")
+
+	out.Reset()
+	loop.Parts = []compiler.FastLoopPart{{Kind: compiler.FastLoopPartValuePath, ValuePlan: compiler.FastValuePlan{Kind: 255}}}
+	loop.IterableName = "items"
+	loop.IterableNameIndex = 0
+	handled, err = renderFastLoop(&out, ctx, bindings, loop)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Empty(t, out.String())
+
+	out.Reset()
+	loop.Parts = []compiler.FastLoopPart{{Kind: compiler.FastLoopPartKey}}
+
+	out.Reset()
+	loop.IterableName = "missing"
+	loop.IterableNameIndex = 4
+	_, err = renderFastLoop(&out, ctx, bindings, loop)
+	require.ErrorContains(t, err, `"missing": unknown identifier`)
+
+	handled, err = renderFastLoop(&out, ctx, bindings, nil)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	ctx.Set("items", nil)
+	bindings = newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"items", "scalar"}}, ctx)
+	handled, err = renderFastLoop(&out, ctx, bindings, &compiler.FastLoopPlan{IterableName: "items", IterableNameIndex: 0, Line: 1})
+	require.NoError(t, err)
+	require.True(t, handled)
+
+	nilBindings := fastRenderBindings{names: []string{"items"}, localOK: []bool{true}, localVals: []interface{}{nil}}
+	handled, err = renderFastLoop(&out, ctx, nilBindings, &compiler.FastLoopPlan{IterableName: "items", IterableNameIndex: 0, Line: 1})
+	require.NoError(t, err)
+	require.True(t, handled)
+
+	handled, err = renderFastLoop(&out, ctx, bindings, &compiler.FastLoopPlan{IterableName: "scalar", IterableNameIndex: 1, Line: 1})
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	err = renderFastLoopIteration(&out, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, &compiler.FastLoopPlan{
+		Line: 9,
+		Parts: []compiler.FastLoopPart{
+			{Kind: compiler.FastLoopPartStatic, Value: "never"},
+		},
+	}, 0, "value")
+	require.ErrorContains(t, err, "line 9")
+}
+
+func Test_VM_Render_Fast_Loop_Parts_Branches(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"label": func(value string, key int) string {
+			return value + ":" + object.Wrap(key).Inspect()
+		},
+	})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label"}}, ctx)
+	user := vmFastPropertyUser{Name: "<mido>"}
+	loop := &compiler.FastLoopPlan{Line: 1}
+	parts := []compiler.FastLoopPart{
+		{Kind: compiler.FastLoopPartValuePath, ValuePlan: compiler.FastValuePlan{
+			Kind:      compiler.FastValuePath,
+			NameIndex: -1,
+			Path:      []compiler.FastPathStep{{Kind: compiler.FastPathStepProperty, Value: "Name", Receiver: "user", Full: "user.Name", Line: 1}},
+			Line:      1,
+		}},
+		{Kind: compiler.FastLoopPartStatic, Value: "|"},
+		{Kind: compiler.FastLoopPartCall, Call: &compiler.FastCallPlan{
+			Name:      "label",
+			NameIndex: 0,
+			Args: []compiler.FastValuePlan{
+				{
+					Kind:      compiler.FastValuePath,
+					NameIndex: -1,
+					Path:      []compiler.FastPathStep{{Kind: compiler.FastPathStepProperty, Value: "Name", Receiver: "user", Full: "user.Name", Line: 1}},
+					Line:      1,
+				},
+				{Kind: compiler.FastValueLoopKey, Value: "i", Line: 1},
+			},
+			Line: 1,
+		}},
+		{Kind: compiler.FastLoopPartStatic, Value: "|"},
+		{Kind: compiler.FastLoopPartConditional, Conditional: &compiler.FastLoopConditionalPlan{
+			Branches: []compiler.FastLoopConditionalBranch{
+				{
+					Condition: compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: false, Line: 1},
+					Parts:     []compiler.FastLoopPart{{Kind: compiler.FastLoopPartStatic, Value: "no"}},
+					Line:      1,
+				},
+			},
+			ElseParts: []compiler.FastLoopPart{{Kind: compiler.FastLoopPartStatic, Value: "else"}},
+		}},
+	}
+
+	var out strings.Builder
+	require.NoError(t, renderFastLoopParts(&out, ctx, bindings, loop, parts, 3, user))
+	require.Equal(t, "&lt;mido&gt;|&lt;mido&gt;:3|else", out.String())
+
+	out.Reset()
+	require.NoError(t, renderFastLoopParts(&out, ctx, bindings, loop, []compiler.FastLoopPart{{Kind: 255}}, 0, user))
+	require.Empty(t, out.String())
+
+	require.NoError(t, renderFastLoopParts(&out, ctx, bindings, loop, []compiler.FastLoopPart{{
+		Kind: compiler.FastLoopPartValuePath,
+		ValuePlan: compiler.FastValuePlan{
+			Kind:          compiler.FastValueName,
+			NameIndex:     99,
+			Value:         "missing",
+			NullOnMissing: true,
+			Line:          3,
+		},
+	}}, 0, user))
+	require.Empty(t, out.String())
+
+	err := renderFastLoopParts(&out, ctx, bindings, loop, []compiler.FastLoopPart{{
+		Kind:     compiler.FastLoopPartValueProperty,
+		Value:    "Missing",
+		Receiver: "user",
+		Full:     "user.Missing",
+		Line:     6,
+	}}, 0, user)
+	require.ErrorContains(t, err, "line 6")
+
+	err = renderFastLoopParts(&out, ctx, bindings, loop, []compiler.FastLoopPart{{
+		Kind: compiler.FastLoopPartCall,
+		Call: &compiler.FastCallPlan{Name: "missing", NameIndex: 99, Line: 8},
+	}}, 0, user)
+	require.ErrorContains(t, err, "line 8")
+
+	_, err = renderFastLoop(&out, ctx, bindings, &compiler.FastLoopPlan{IterableName: "label", IterableNameIndex: 99, Line: 7})
+	require.ErrorContains(t, err, `line 7`)
+}
+
+func Test_VM_Fast_Struct_Loop_Static_Call_Arg_Branches(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{"name": "Mido"})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"name"}}, ctx)
+
+	tests := []struct {
+		name     string
+		plan     *fastStructLoopCallArgPlan
+		expected interface{}
+		ok       bool
+	}{
+		{"nil", nil, nil, true},
+		{"binding", &fastStructLoopCallArgPlan{kind: fastStructLoopCallArgBinding, nameIndex: 0}, "Mido", true},
+		{"nil literal", &fastStructLoopCallArgPlan{kind: fastStructLoopCallArgNil}, nil, true},
+		{"string", &fastStructLoopCallArgPlan{kind: fastStructLoopCallArgString, stringVal: "x"}, "x", true},
+		{"int", &fastStructLoopCallArgPlan{kind: fastStructLoopCallArgInt, intVal: 2}, 2, true},
+		{"float", &fastStructLoopCallArgPlan{kind: fastStructLoopCallArgFloat, floatVal: 1.5}, 1.5, true},
+		{"bool", &fastStructLoopCallArgPlan{kind: fastStructLoopCallArgBool, boolVal: true}, true, true},
+		{"unknown", &fastStructLoopCallArgPlan{kind: fastStructLoopCallArgKey}, nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, ok := evalFastStructLoopStaticCallArgValue(tt.plan, bindings)
+			require.Equal(t, tt.ok, ok)
+			require.Equal(t, tt.expected, value)
+		})
+	}
+
+	value, err := evalFastStructLoopStaticCallArgReflect(&fastStructLoopCallArgPlan{kind: fastStructLoopCallArgString, stringVal: "x"}, bindings, stringType, "helper", 0)
+	require.NoError(t, err)
+	require.Equal(t, "x", value.Interface())
+
+	_, err = evalFastStructLoopStaticCallArgReflect(&fastStructLoopCallArgPlan{kind: fastStructLoopCallArgBinding, nameIndex: 99, line: 4, value: compiler.FastValuePlan{Value: "missing"}}, bindings, stringType, "helper", 0)
+	require.ErrorContains(t, err, `line 4`)
+}

--- a/VM/vm/fast_loops.go
+++ b/VM/vm/fast_loops.go
@@ -1,0 +1,578 @@
+package vm
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+)
+
+var (
+	errFastLoopBreak    = errors.New("fast loop break")
+	errFastLoopContinue = errors.New("fast loop continue")
+)
+
+func renderFastConditional(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, conditional *compiler.FastConditionalPlan) (bool, error) {
+	if conditional == nil {
+		return false, nil
+	}
+	if conditional.Silent {
+		return renderFastConditionalSilently(ctx, bindings, conditional)
+	}
+	for i := range conditional.Branches {
+		branch := &conditional.Branches[i]
+		if err := spendFastCondition(ctx, branch.Line); err != nil {
+			return true, err
+		}
+		value, ok, err := evalFastValue(&branch.Condition, ctx, bindings, nil)
+		if err != nil {
+			return true, err
+		}
+		if !ok {
+			value = nil
+		}
+		if isTruthyFastValue(value) {
+			branchCtx, branchBindings, cleanup := fastRenderSegmentScopeForLet(ctx, bindings, branch.Segments)
+			defer cleanup()
+			ctx = branchCtx
+			bindings = branchBindings
+			return renderFastSegments(out, ctx, bindings, branch.Segments)
+		}
+	}
+	if len(conditional.ElseSegments) > 0 {
+		branchCtx, branchBindings, cleanup := fastRenderSegmentScopeForLet(ctx, bindings, conditional.ElseSegments)
+		defer cleanup()
+		ctx = branchCtx
+		bindings = branchBindings
+		return renderFastSegments(out, ctx, bindings, conditional.ElseSegments)
+	}
+	return true, nil
+}
+
+func renderFastConditionalSilently(ctx hctx.Context, bindings fastRenderBindings, conditional *compiler.FastConditionalPlan) (bool, error) {
+	if conditional == nil {
+		return false, nil
+	}
+	for i := range conditional.Branches {
+		branch := &conditional.Branches[i]
+		if err := spendFastCondition(ctx, branch.Line); err != nil {
+			return true, err
+		}
+		value, ok, err := evalFastValue(&branch.Condition, ctx, bindings, nil)
+		if err != nil {
+			return true, err
+		}
+		if !ok {
+			value = nil
+		}
+		if isTruthyFastValue(value) {
+			var discard strings.Builder
+			return renderFastSegments(&discard, ctx, bindings, branch.Segments)
+		}
+	}
+	if len(conditional.ElseSegments) > 0 {
+		var discard strings.Builder
+		return renderFastSegments(&discard, ctx, bindings, conditional.ElseSegments)
+	}
+	return true, nil
+}
+
+func renderFastPartialSegment(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, partial *compiler.FastPartialPlan) error {
+	return renderFastPartialSegmentWithDataPlan(out, ctx, bindings, partial, nil)
+}
+
+func renderFastPartialSegmentWithDataPlan(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, partial *compiler.FastPartialPlan, dataPlan *fastPartialDataBindingPlan) error {
+	if partial == nil {
+		return nil
+	}
+	if err := spendFastFunctionCall(ctx, "partial", partial.Line); err != nil {
+		return err
+	}
+	if len(partial.Data) > 0 {
+		if ok, err := renderFastDataPartialInto(out, partial, ctx, bindings, dataPlan); ok || err != nil {
+			if err != nil {
+				return err
+			}
+			return nil
+		}
+	}
+	if ok, err := renderFastNoDataPartialInto(out, partial.Name, ctx, partial.Line); ok || err != nil {
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	return nil
+}
+
+func renderFastLoop(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, loop *compiler.FastLoopPlan) (bool, error) {
+	if loop == nil {
+		return false, nil
+	}
+	if fastLoopPartsHaveLet(loop.Parts) {
+		scopedCtx, scopedBindings, cleanup := fastRenderScopedBindings(ctx, bindings)
+		defer cleanup()
+		ctx = scopedCtx
+		bindings = scopedBindings
+		bindings = fastRenderBindingsWithLocalCopy(bindings)
+		bindings.ensureLocalCapacity()
+	}
+
+	iter, ok, err := fastLoopIterableValue(loop, ctx, bindings)
+	if err != nil {
+		return true, err
+	}
+	if !ok {
+		return true, fastLineError(loop.Line, fmt.Errorf("%q: unknown identifier", loop.IterableName))
+	}
+	if obj, ok := iter.(object.Object); ok {
+		iter = object.ToGo(obj)
+	}
+	if iter == nil {
+		return true, nil
+	}
+
+	switch iter := iter.(type) {
+	case []string:
+		if handled, err := renderFastStringKeyValueLoop(out, ctx, loop, iter); handled || err != nil {
+			return true, err
+		}
+		for i, value := range iter {
+			stop, err := renderFastLoopIterationOrControl(out, ctx, bindings, loop, i, value)
+			if err != nil {
+				return true, err
+			}
+			if stop {
+				break
+			}
+		}
+		return true, nil
+	case []interface{}:
+		for i, value := range iter {
+			stop, err := renderFastLoopIterationOrControl(out, ctx, bindings, loop, i, value)
+			if err != nil {
+				return true, err
+			}
+			if stop {
+				break
+			}
+		}
+		return true, nil
+	case []object.Object:
+		for i, value := range iter {
+			stop, err := renderFastLoopIterationOrControl(out, ctx, bindings, loop, i, value)
+			if err != nil {
+				return true, err
+			}
+			if stop {
+				break
+			}
+		}
+		return true, nil
+	}
+
+	rv := reflect.ValueOf(iter)
+	if rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			return true, nil
+		}
+		rv = rv.Elem()
+	}
+	switch rv.Kind() {
+	case reflect.Array, reflect.Slice:
+		if handled, err := renderFastStructFieldLoop(out, ctx, bindings, loop, rv); handled || err != nil {
+			return true, err
+		}
+		for i := 0; i < rv.Len(); i++ {
+			stop, err := renderFastLoopIterationOrControl(out, ctx, bindings, loop, i, rv.Index(i).Interface())
+			if err != nil {
+				return true, err
+			}
+			if stop {
+				break
+			}
+		}
+		return true, nil
+	case reflect.Map:
+		for _, key := range rv.MapKeys() {
+			stop, err := renderFastLoopIterationOrControl(out, ctx, bindings, loop, key.Interface(), rv.MapIndex(key).Interface())
+			if err != nil {
+				return true, err
+			}
+			if stop {
+				break
+			}
+		}
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+func fastLoopIterableValue(loop *compiler.FastLoopPlan, ctx hctx.Context, bindings fastRenderBindings) (interface{}, bool, error) {
+	if loop == nil {
+		return nil, false, nil
+	}
+	if loop.Iterable.Kind != compiler.FastValueInvalid {
+		return evalFastValue(&loop.Iterable, ctx, bindings, nil)
+	}
+	value, ok := bindings.value(loop.IterableNameIndex)
+	return value, ok, nil
+}
+
+func renderFastLoopIterationOrControl(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, loop *compiler.FastLoopPlan, key, value interface{}) (bool, error) {
+	err := renderFastLoopIteration(out, ctx, bindings, loop, key, value)
+	switch err {
+	case nil:
+		return false, nil
+	case errFastLoopBreak:
+		return true, nil
+	case errFastLoopContinue:
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
+func renderFastLoopIteration(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, loop *compiler.FastLoopPlan, key, value interface{}) error {
+	if err := spendFastLoop(ctx, loop.Line); err != nil {
+		return err
+	}
+
+	return renderFastLoopParts(out, ctx, bindings, loop, loop.Parts, key, value)
+}
+
+func renderFastLoopParts(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, loop *compiler.FastLoopPlan, parts []compiler.FastLoopPart, key, value interface{}) error {
+	for i := range parts {
+		part := &parts[i]
+		switch part.Kind {
+		case compiler.FastLoopPartStatic:
+			out.WriteString(part.Value)
+		case compiler.FastLoopPartKey:
+			writeFastGoValue(out, ctx, key)
+		case compiler.FastLoopPartValue:
+			writeFastGoValue(out, ctx, value)
+		case compiler.FastLoopPartValueProperty:
+			if err := spendFastTraversal(ctx, part.Line); err != nil {
+				return err
+			}
+			if err := writeFastPropertyOutput(out, ctx, value, part.Value, object.PropertyAccess{
+				Receiver: part.Receiver,
+				Full:     part.Full,
+			}, &part.PropertyCache); err != nil {
+				return fastLineError(part.Line, err)
+			}
+		case compiler.FastLoopPartValuePath:
+			property, ok, err := evalFastLoopValue(&part.ValuePlan, ctx, bindings, key, value)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
+			}
+			writeFastGoValue(out, ctx, property)
+		case compiler.FastLoopPartCall:
+			if err := writeFastLoopCallPart(out, ctx, bindings, part.Call, key, value); err != nil {
+				return err
+			}
+		case compiler.FastLoopPartBlockCall:
+			if err := writeFastLoopBlockCallPart(out, ctx, bindings, loop, part.BlockCall, key, value); err != nil {
+				return err
+			}
+		case compiler.FastLoopPartPartial:
+			if err := renderFastLoopPartialPart(out, ctx, bindings, loop, part.Partial, key, value); err != nil {
+				return err
+			}
+		case compiler.FastLoopPartLet:
+			local, ok, err := evalFastLoopValue(&part.ValuePlan, ctx, bindings, key, value)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return fastLineError(part.Line, fmt.Errorf("%q: unknown identifier", fastValueMissingName(&part.ValuePlan)))
+			}
+			if err := spendFastAssignment(ctx, part.Line); err != nil {
+				return err
+			}
+			bindings.setLocalAndContext(part.NameIndex, local)
+		case compiler.FastLoopPartConditional:
+			if err := renderFastLoopConditional(out, ctx, bindings, loop, part.Conditional, key, value); err != nil {
+				return err
+			}
+		case compiler.FastLoopPartLoop:
+			nestedBindings := fastLoopBindingsWithCurrentLocals(bindings, loop, key, value)
+			ok, err := renderFastLoop(out, ctx, nestedBindings, part.Loop)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return fastLineError(part.Line, fmt.Errorf("unsupported nested fast loop"))
+			}
+		case compiler.FastLoopPartBreak:
+			return errFastLoopBreak
+		case compiler.FastLoopPartContinue:
+			return errFastLoopContinue
+		default:
+			return nil
+		}
+	}
+	return nil
+}
+
+func renderFastLoopPartialPart(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, loop *compiler.FastLoopPlan, partial *compiler.FastPartialPlan, key, value interface{}) error {
+	if partial == nil {
+		return nil
+	}
+	scopedCtx, scopedBindings, cleanup := fastRenderScopedBindings(ctx, fastLoopBindingsWithCurrentLocals(bindings, loop, key, value))
+	defer cleanup()
+	if loop != nil && scopedCtx != nil {
+		if fastLoopBindingName(loop.KeyName) {
+			scopedCtx.Set(loop.KeyName, key)
+		}
+		if fastLoopBindingName(loop.ValueName) {
+			scopedCtx.Set(loop.ValueName, value)
+		}
+	}
+	return renderFastPartialSegment(out, scopedCtx, scopedBindings, partial)
+}
+
+func renderFastLoopConditional(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, loop *compiler.FastLoopPlan, conditional *compiler.FastLoopConditionalPlan, key, value interface{}) error {
+	if conditional == nil {
+		return nil
+	}
+	if conditional.Silent {
+		return renderFastLoopConditionalSilently(ctx, bindings, loop, conditional, key, value)
+	}
+	for i := range conditional.Branches {
+		branch := &conditional.Branches[i]
+		if err := spendFastCondition(ctx, branch.Line); err != nil {
+			return err
+		}
+		result, ok, err := evalFastLoopValue(&branch.Condition, ctx, bindings, key, value)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			result = nil
+		}
+		if isTruthyFastValue(result) {
+			branchCtx, branchBindings, cleanup := fastRenderLoopPartScopeForLet(ctx, bindings, branch.Parts)
+			defer cleanup()
+			ctx = branchCtx
+			bindings = branchBindings
+			return renderFastLoopParts(out, ctx, bindings, loop, branch.Parts, key, value)
+		}
+	}
+	if len(conditional.ElseParts) > 0 {
+		branchCtx, branchBindings, cleanup := fastRenderLoopPartScopeForLet(ctx, bindings, conditional.ElseParts)
+		defer cleanup()
+		ctx = branchCtx
+		bindings = branchBindings
+		return renderFastLoopParts(out, ctx, bindings, loop, conditional.ElseParts, key, value)
+	}
+	return nil
+}
+
+func renderFastLoopConditionalSilently(ctx hctx.Context, bindings fastRenderBindings, loop *compiler.FastLoopPlan, conditional *compiler.FastLoopConditionalPlan, key, value interface{}) error {
+	if conditional == nil {
+		return nil
+	}
+	for i := range conditional.Branches {
+		branch := &conditional.Branches[i]
+		if err := spendFastCondition(ctx, branch.Line); err != nil {
+			return err
+		}
+		result, ok, err := evalFastLoopValue(&branch.Condition, ctx, bindings, key, value)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			result = nil
+		}
+		if isTruthyFastValue(result) {
+			var discard strings.Builder
+			return renderFastLoopParts(&discard, ctx, bindings, loop, branch.Parts, key, value)
+		}
+	}
+	if len(conditional.ElseParts) > 0 {
+		var discard strings.Builder
+		return renderFastLoopParts(&discard, ctx, bindings, loop, conditional.ElseParts, key, value)
+	}
+	return nil
+}
+
+func fastLoopBindingsWithCurrentLocals(bindings fastRenderBindings, loop *compiler.FastLoopPlan, key, value interface{}) fastRenderBindings {
+	if loop == nil || len(bindings.names) == 0 {
+		return bindings
+	}
+	scoped := bindings
+	if fastLoopBindingName(loop.KeyName) || fastLoopBindingName(loop.ValueName) {
+		scoped = fastRenderBindingsWithLocalCopy(scoped)
+	}
+	if fastLoopBindingName(loop.KeyName) {
+		scoped.setLocalByName(loop.KeyName, key)
+	}
+	if fastLoopBindingName(loop.ValueName) {
+		scoped.setLocalByName(loop.ValueName, value)
+	}
+	return scoped
+}
+
+func fastRenderBindingsWithLocalCopy(bindings fastRenderBindings) fastRenderBindings {
+	if len(bindings.localOK) == 0 {
+		return bindings
+	}
+	localOK := make([]bool, len(bindings.localOK))
+	localVals := make([]interface{}, len(bindings.localVals))
+	copy(localOK, bindings.localOK)
+	copy(localVals, bindings.localVals)
+	bindings.localOK = localOK
+	bindings.localVals = localVals
+	return bindings
+}
+
+func fastLoopPartsHaveLet(parts []compiler.FastLoopPart) bool {
+	for i := range parts {
+		part := &parts[i]
+		switch part.Kind {
+		case compiler.FastLoopPartLet:
+			return true
+		case compiler.FastLoopPartConditional:
+			if part.Conditional == nil {
+				continue
+			}
+			for branchIndex := range part.Conditional.Branches {
+				if fastLoopPartsHaveLet(part.Conditional.Branches[branchIndex].Parts) {
+					return true
+				}
+			}
+			if fastLoopPartsHaveLet(part.Conditional.ElseParts) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func fastRenderSegmentsHaveLet(segments []compiler.FastRenderSegment) bool {
+	for i := range segments {
+		segment := &segments[i]
+		switch segment.Kind {
+		case compiler.FastRenderSegmentLet:
+			return true
+		case compiler.FastRenderSegmentConditional:
+			if segment.Conditional == nil {
+				continue
+			}
+			for branchIndex := range segment.Conditional.Branches {
+				if fastRenderSegmentsHaveLet(segment.Conditional.Branches[branchIndex].Segments) {
+					return true
+				}
+			}
+			if fastRenderSegmentsHaveLet(segment.Conditional.ElseSegments) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func fastRenderSegmentScopeForLet(ctx hctx.Context, bindings fastRenderBindings, segments []compiler.FastRenderSegment) (hctx.Context, fastRenderBindings, func()) {
+	if !fastRenderSegmentsHaveLet(segments) {
+		return ctx, bindings, func() {}
+	}
+	childCtx, scopedBindings, cleanup := fastRenderScopedBindings(ctx, bindings)
+	scopedBindings = fastRenderBindingsWithLocalCopy(scopedBindings)
+	scopedBindings.ensureLocalCapacity()
+	return childCtx, scopedBindings, cleanup
+}
+
+func fastRenderLoopPartScopeForLet(ctx hctx.Context, bindings fastRenderBindings, parts []compiler.FastLoopPart) (hctx.Context, fastRenderBindings, func()) {
+	if !fastLoopPartsHaveLet(parts) {
+		return ctx, bindings, func() {}
+	}
+	childCtx, scopedBindings, cleanup := fastRenderScopedBindings(ctx, bindings)
+	scopedBindings = fastRenderBindingsWithLocalCopy(scopedBindings)
+	scopedBindings.ensureLocalCapacity()
+	return childCtx, scopedBindings, cleanup
+}
+
+func (b *fastRenderBindings) setLocalByName(name string, value interface{}) bool {
+	if b == nil || !fastLoopBindingName(name) {
+		return false
+	}
+	for i := range b.names {
+		if b.names[i] == name {
+			b.setLocal(i, value)
+			return true
+		}
+	}
+	return false
+}
+
+func fastLoopBindingName(name string) bool {
+	return name != "" && name != "_"
+}
+
+func writeFastLoopCallPart(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, call *compiler.FastCallPlan, loopKey, loopValue interface{}) error {
+	if call == nil {
+		return nil
+	}
+	raw, ok := bindings.value(call.NameIndex)
+	if !ok {
+		return fastLineError(call.Line, fmt.Errorf("%q: unknown identifier", call.Name))
+	}
+	if err := spendFastFunctionCall(ctx, call.Name, call.Line); err != nil {
+		return err
+	}
+	var argStore fastCallArgs
+	var args *fastCallArgs
+	var err error
+	if helper, ok := fastHelperForContext(ctx, call.Name); ok {
+		args, err = evalFastLoopCallArgsInto(call.Args, ctx, bindings, loopKey, loopValue, &argStore)
+		if err != nil {
+			return err
+		}
+		if handled, err := writeRegisteredFastHelperNamed(out, ctx, call.Name, helper, args); handled || err != nil {
+			if err != nil {
+				return fastLineError(call.Line, err)
+			}
+			return nil
+		}
+	}
+	if args == nil {
+		args, err = evalFastLoopCallArgsInto(call.Args, ctx, bindings, loopKey, loopValue, &argStore)
+		if err != nil {
+			return err
+		}
+	}
+	if err := writeFastCallValue(out, ctx, call.Name, raw, args, &call.Cache); err != nil {
+		return fastLineError(call.Line, err)
+	}
+	return nil
+}
+
+func evalFastLoopCallArgsInto(plans []compiler.FastValuePlan, ctx hctx.Context, bindings fastRenderBindings, loopKey, loopValue interface{}, args *fastCallArgs) (*fastCallArgs, error) {
+	if len(plans) == 0 {
+		return nil, nil
+	}
+	if args == nil {
+		args = &fastCallArgs{}
+	}
+	args.Reset()
+	for i := range plans {
+		value, ok, err := evalFastLoopValue(&plans[i], ctx, bindings, loopKey, loopValue)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, fastLineError(plans[i].Line, fmt.Errorf("%q: unknown identifier", plans[i].Value))
+		}
+		args.Append(value)
+	}
+	return args, nil
+}

--- a/VM/vm/fast_output.go
+++ b/VM/vm/fast_output.go
@@ -1,0 +1,546 @@
+package vm
+
+import (
+	"fmt"
+	"html/template"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+)
+
+func writeBuilderFastInt(out *strings.Builder, value int64) {
+	var buf [20]byte
+	out.Write(strconv.AppendInt(buf[:0], value, 10))
+}
+
+func writeBuilderFastUint(out *strings.Builder, value uint64) {
+	var buf [20]byte
+	out.Write(strconv.AppendUint(buf[:0], value, 10))
+}
+
+func writeBuilderFastFloat(out *strings.Builder, value float64, bitSize int) {
+	var buf [32]byte
+	out.Write(strconv.AppendFloat(buf[:0], value, 'g', -1, bitSize))
+}
+
+func writeFastPropertyOutput(out *strings.Builder, ctx hctx.Context, base interface{}, name string, access object.PropertyAccess, cacheSlot *object.InlineCacheSlot) error {
+	if hash, ok := base.(*object.Hash); ok {
+		key := (&object.String{Value: name}).HashKey()
+		if pair, ok := hash.Pairs[key]; ok {
+			writeFastGoValue(out, ctx, pair.Value)
+		}
+		return nil
+	}
+
+	rv, _, ok, err := fastPropertyReflectValue(base)
+	if err != nil || !ok {
+		return err
+	}
+	return writeFastPropertyReflectOutput(out, ctx, rv, name, access, cacheSlot)
+}
+
+func writeFastPropertyReflectOutput(out *strings.Builder, ctx hctx.Context, rv reflect.Value, name string, access object.PropertyAccess, cacheSlot *object.InlineCacheSlot) error {
+	if !rv.IsValid() {
+		return nil
+	}
+	if rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			return nil
+		}
+		rv = rv.Elem()
+	}
+	entry := inlinePropertyEntry(cacheSlot, rv.Type(), name)
+	if entry != nil && entry.writer != nil {
+		written, err := entry.writer(out, ctx, rv, access, name)
+		if err != nil || written {
+			return err
+		}
+	}
+
+	raw := interface{}(nil)
+	if rv.CanInterface() {
+		raw = rv.Interface()
+	}
+	value, err := fastPropertyValueFromReflect(rv, raw, name, access, entry)
+	if err != nil {
+		return err
+	}
+	writeFastGoValue(out, ctx, value)
+	return nil
+}
+
+func fastPropertyValue(base interface{}, name string, access object.PropertyAccess, cacheSlot *object.InlineCacheSlot) (interface{}, error) {
+	if hash, ok := base.(*object.Hash); ok {
+		key := (&object.String{Value: name}).HashKey()
+		if pair, ok := hash.Pairs[key]; ok {
+			return pair.Value, nil
+		}
+		return nil, nil
+	}
+
+	rv, raw, ok, err := fastPropertyReflectValue(base)
+	if err != nil || !ok {
+		return nil, err
+	}
+	return fastPropertyValueFromReflect(rv, raw, name, access, inlinePropertyEntry(cacheSlot, rv.Type(), name))
+}
+
+func fastPropertyReflectValue(base interface{}) (reflect.Value, interface{}, bool, error) {
+	if obj, ok := base.(object.Object); ok {
+		if object.IsNull(obj) {
+			return reflect.Value{}, nil, false, nil
+		}
+		base = object.ToGo(obj)
+	}
+	if base == nil {
+		return reflect.Value{}, nil, false, nil
+	}
+
+	rv := reflect.ValueOf(base)
+	if rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			return reflect.Value{}, nil, false, nil
+		}
+		rv = rv.Elem()
+	}
+	return rv, base, true, nil
+}
+
+func fastPropertyValueFromReflect(rv reflect.Value, raw interface{}, name string, access object.PropertyAccess, entry *propertyInlineCacheEntry) (interface{}, error) {
+	if entry == nil {
+		return nil, propertyMissingError(access, raw, name)
+	}
+	if entry.reader != nil {
+		return entry.reader(rv, access, name)
+	}
+	lookup := entry.lookup
+	switch lookup.kind {
+	case propertyLookupValueMethod:
+		method := rv.Method(lookup.index)
+		if method.IsValid() {
+			return method.Interface(), nil
+		}
+	case propertyLookupPointerMethod:
+		var method reflect.Value
+		if rv.CanAddr() {
+			method = rv.Addr().Method(lookup.index)
+		} else {
+			ptr := reflect.New(rv.Type())
+			ptr.Elem().Set(rv)
+			method = ptr.Method(lookup.index)
+		}
+		if method.IsValid() {
+			return method.Interface(), nil
+		}
+	case propertyLookupField:
+		if access.Method {
+			return nil, propertyMissingError(access, raw, name)
+		}
+		field := rv.FieldByIndex(lookup.fieldIndex)
+		return fastFieldValue(field, access, name)
+	}
+
+	if access.Method || rv.Kind() != reflect.Struct {
+		return nil, propertyMissingError(access, raw, name)
+	}
+	return nil, propertyMissingError(access, raw, name)
+}
+
+func fastFieldValue(field reflect.Value, access object.PropertyAccess, name string) (interface{}, error) {
+	if field.Kind() == reflect.Ptr {
+		if field.IsNil() {
+			return nil, nil
+		}
+		field = field.Elem()
+	}
+	if !field.CanInterface() {
+		if access.Receiver != "" && access.Full != "" {
+			return nil, fmt.Errorf("'%s'cannot return value obtained from unexported field or method '%s' (%s)", access.Receiver, name, access.Full)
+		}
+		return nil, fmt.Errorf("cannot return value obtained from unexported field or method '%s'", name)
+	}
+	return field.Interface(), nil
+}
+
+type fastOutputKind uint8
+
+const (
+	fastOutputString fastOutputKind = iota + 1
+	fastOutputHTML
+	fastOutputBool
+	fastOutputInt
+	fastOutputInt8
+	fastOutputInt16
+	fastOutputInt32
+	fastOutputInt64
+	fastOutputUint
+	fastOutputUint8
+	fastOutputUint16
+	fastOutputUint32
+	fastOutputUint64
+	fastOutputUintptr
+	fastOutputFloat
+	fastOutputFloat64
+)
+
+type fastOutputCacheEntry struct {
+	kind fastOutputKind
+}
+
+func writeFastBindingOutput(out *strings.Builder, ctx hctx.Context, value interface{}, cacheSlot *object.InlineCacheSlot) bool {
+	if entry, ok := cacheSlot.Load().(*fastOutputCacheEntry); ok && entry != nil && entry.matches(value) {
+		entry.write(out, value)
+		return true
+	}
+	if entry := newFastOutputCacheEntry(value); entry != nil {
+		cacheSlot.Store(entry)
+		entry.write(out, value)
+		return true
+	}
+	return writeFastGoValue(out, ctx, value)
+}
+
+func canWriteFastBindingOutput(value interface{}) bool {
+	if value == nil {
+		return true
+	}
+	if newFastOutputCacheEntry(value) != nil {
+		return true
+	}
+	return canWriteFastGoValue(value)
+}
+
+func (e *fastOutputCacheEntry) matches(value interface{}) bool {
+	if e == nil || value == nil {
+		return false
+	}
+	switch e.kind {
+	case fastOutputString:
+		_, ok := value.(string)
+		return ok
+	case fastOutputHTML:
+		_, ok := value.(template.HTML)
+		return ok
+	case fastOutputBool:
+		_, ok := value.(bool)
+		return ok
+	case fastOutputInt:
+		_, ok := value.(int)
+		return ok
+	case fastOutputInt8:
+		_, ok := value.(int8)
+		return ok
+	case fastOutputInt16:
+		_, ok := value.(int16)
+		return ok
+	case fastOutputInt32:
+		_, ok := value.(int32)
+		return ok
+	case fastOutputInt64:
+		_, ok := value.(int64)
+		return ok
+	case fastOutputUint:
+		_, ok := value.(uint)
+		return ok
+	case fastOutputUint8:
+		_, ok := value.(uint8)
+		return ok
+	case fastOutputUint16:
+		_, ok := value.(uint16)
+		return ok
+	case fastOutputUint32:
+		_, ok := value.(uint32)
+		return ok
+	case fastOutputUint64:
+		_, ok := value.(uint64)
+		return ok
+	case fastOutputUintptr:
+		_, ok := value.(uintptr)
+		return ok
+	case fastOutputFloat:
+		_, ok := value.(float32)
+		return ok
+	case fastOutputFloat64:
+		_, ok := value.(float64)
+		return ok
+	default:
+		return false
+	}
+}
+
+func (e *fastOutputCacheEntry) write(out *strings.Builder, value interface{}) {
+	switch e.kind {
+	case fastOutputString:
+		writeFastEscapedString(out, value.(string))
+	case fastOutputHTML:
+		out.WriteString(string(value.(template.HTML)))
+	case fastOutputBool:
+		out.WriteString(strconv.FormatBool(value.(bool)))
+	case fastOutputInt:
+		writeBuilderFastInt(out, int64(value.(int)))
+	case fastOutputInt8:
+		writeBuilderFastInt(out, int64(value.(int8)))
+	case fastOutputInt16:
+		writeBuilderFastInt(out, int64(value.(int16)))
+	case fastOutputInt32:
+		writeBuilderFastInt(out, int64(value.(int32)))
+	case fastOutputInt64:
+		writeBuilderFastInt(out, value.(int64))
+	case fastOutputUint:
+		writeBuilderFastUint(out, uint64(value.(uint)))
+	case fastOutputUint8:
+		writeBuilderFastUint(out, uint64(value.(uint8)))
+	case fastOutputUint16:
+		writeBuilderFastUint(out, uint64(value.(uint16)))
+	case fastOutputUint32:
+		writeBuilderFastUint(out, uint64(value.(uint32)))
+	case fastOutputUint64:
+		writeBuilderFastUint(out, value.(uint64))
+	case fastOutputUintptr:
+		writeBuilderFastUint(out, uint64(value.(uintptr)))
+	case fastOutputFloat:
+		writeBuilderFastFloat(out, float64(value.(float32)), 32)
+	case fastOutputFloat64:
+		writeBuilderFastFloat(out, value.(float64), 64)
+	}
+}
+
+func newFastOutputCacheEntry(value interface{}) *fastOutputCacheEntry {
+	if value == nil {
+		return nil
+	}
+	switch value.(type) {
+	case string:
+		return &fastOutputCacheEntry{kind: fastOutputString}
+	case template.HTML:
+		return &fastOutputCacheEntry{kind: fastOutputHTML}
+	case bool:
+		return &fastOutputCacheEntry{kind: fastOutputBool}
+	case int:
+		return &fastOutputCacheEntry{kind: fastOutputInt}
+	case int8:
+		return &fastOutputCacheEntry{kind: fastOutputInt8}
+	case int16:
+		return &fastOutputCacheEntry{kind: fastOutputInt16}
+	case int32:
+		return &fastOutputCacheEntry{kind: fastOutputInt32}
+	case int64:
+		return &fastOutputCacheEntry{kind: fastOutputInt64}
+	case uint:
+		return &fastOutputCacheEntry{kind: fastOutputUint}
+	case uint8:
+		return &fastOutputCacheEntry{kind: fastOutputUint8}
+	case uint16:
+		return &fastOutputCacheEntry{kind: fastOutputUint16}
+	case uint32:
+		return &fastOutputCacheEntry{kind: fastOutputUint32}
+	case uint64:
+		return &fastOutputCacheEntry{kind: fastOutputUint64}
+	case uintptr:
+		return &fastOutputCacheEntry{kind: fastOutputUintptr}
+	case float32:
+		return &fastOutputCacheEntry{kind: fastOutputFloat}
+	case float64:
+		return &fastOutputCacheEntry{kind: fastOutputFloat64}
+	default:
+		return nil
+	}
+}
+
+func writeFastGoValue(out *strings.Builder, ctx hctx.Context, value interface{}) bool {
+	switch value := value.(type) {
+	case nil:
+		return true
+	case object.Object:
+		return writeFastObject(out, ctx, value)
+	case time.Time:
+		writeFastTime(out, ctx, value)
+		return true
+	case *time.Time:
+		if value != nil {
+			writeFastTime(out, ctx, *value)
+		}
+		return true
+	case interface{ Interface() interface{} }:
+		return writeFastGoValue(out, ctx, value.Interface())
+	case template.HTML:
+		out.WriteString(string(value))
+		return true
+	case interface{ HTML() template.HTML }:
+		out.WriteString(string(value.HTML()))
+		return true
+	case string:
+		writeFastEscapedString(out, value)
+		return true
+	case bool:
+		out.WriteString(strconv.FormatBool(value))
+		return true
+	case int:
+		writeBuilderFastInt(out, int64(value))
+		return true
+	case int8:
+		writeBuilderFastInt(out, int64(value))
+		return true
+	case int16:
+		writeBuilderFastInt(out, int64(value))
+		return true
+	case int32:
+		writeBuilderFastInt(out, int64(value))
+		return true
+	case int64:
+		writeBuilderFastInt(out, value)
+		return true
+	case uint:
+		writeBuilderFastUint(out, uint64(value))
+		return true
+	case uint8:
+		writeBuilderFastUint(out, uint64(value))
+		return true
+	case uint16:
+		writeBuilderFastUint(out, uint64(value))
+		return true
+	case uint32:
+		writeBuilderFastUint(out, uint64(value))
+		return true
+	case uint64:
+		writeBuilderFastUint(out, value)
+		return true
+	case uintptr:
+		writeBuilderFastUint(out, uint64(value))
+		return true
+	case float32:
+		writeBuilderFastFloat(out, float64(value), 32)
+		return true
+	case float64:
+		writeBuilderFastFloat(out, value, 64)
+		return true
+	case fmt.Stringer:
+		out.WriteString(value.String())
+		return true
+	case []string:
+		for _, el := range value {
+			writeFastEscapedString(out, el)
+		}
+		return true
+	case []interface{}:
+		for _, el := range value {
+			if !writeFastGoValue(out, ctx, el) {
+				return false
+			}
+		}
+		return true
+	default:
+		rv := reflect.ValueOf(value)
+		if rv.IsValid() && (rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array) {
+			for i := 0; i < rv.Len(); i++ {
+				writeFastGoValue(out, ctx, rv.Index(i).Interface())
+			}
+		}
+		return true
+	}
+}
+
+func canWriteFastGoValue(value interface{}) bool {
+	switch value := value.(type) {
+	case nil:
+		return true
+	case object.Object:
+		return canWriteFastObject(value)
+	case time.Time, *time.Time, template.HTML, string, bool,
+		int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64, uintptr,
+		float32, float64, fmt.Stringer:
+		return true
+	case interface{ Interface() interface{} }:
+		return canWriteFastGoValue(value.Interface())
+	case interface{ HTML() template.HTML }:
+		return true
+	case []string:
+		return true
+	case []interface{}:
+		for _, el := range value {
+			if !canWriteFastGoValue(el) {
+				return false
+			}
+		}
+		return true
+	default:
+		return true
+	}
+}
+
+func writeFastObject(out *strings.Builder, ctx hctx.Context, obj object.Object) bool {
+	if obj == nil || object.IsNull(obj) {
+		return true
+	}
+
+	switch obj := obj.(type) {
+	case *object.Array:
+		for _, el := range obj.Elements {
+			if !writeFastObject(out, ctx, el) {
+				return false
+			}
+		}
+		return true
+	case *object.Integer:
+		writeBuilderFastInt(out, obj.Value)
+		return true
+	case *object.Float:
+		writeBuilderFastFloat(out, obj.Value, 64)
+		return true
+	case *object.Boolean:
+		out.WriteString(strconv.FormatBool(obj.Value))
+		return true
+	case *object.String:
+		writeFastEscapedString(out, obj.Value)
+		return true
+	case *object.Native:
+		return writeFastGoValue(out, ctx, obj.Value)
+	default:
+		return false
+	}
+}
+
+func canWriteFastObject(obj object.Object) bool {
+	if obj == nil || object.IsNull(obj) {
+		return true
+	}
+	switch obj := obj.(type) {
+	case *object.Array:
+		for _, el := range obj.Elements {
+			if !canWriteFastObject(el) {
+				return false
+			}
+		}
+		return true
+	case *object.Integer, *object.Float, *object.Boolean, *object.String:
+		return true
+	case *object.Native:
+		return canWriteFastGoValue(obj.Value)
+	default:
+		return false
+	}
+}
+
+func writeFastTime(out *strings.Builder, ctx hctx.Context, value time.Time) {
+	if ctx != nil {
+		if dtf, ok := ctx.Value("TIME_FORMAT").(string); ok {
+			out.WriteString(value.Format(dtf))
+			return
+		}
+	}
+	out.WriteString(value.Format(plush.DefaultTimeFormat))
+}
+
+func writeFastEscapedString(out *strings.Builder, value string) {
+	if !strings.ContainsAny(value, `&<>'"`) {
+		out.WriteString(value)
+		return
+	}
+	out.WriteString(template.HTMLEscapeString(value))
+}

--- a/VM/vm/fast_render.go
+++ b/VM/vm/fast_render.go
@@ -1,0 +1,1510 @@
+package vm
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+)
+
+// tryRenderFastBytecode is the VM fast-render entry point. A false handled
+// result means the caller should run the normal bytecode VM path.
+func tryRenderFastBytecode(bytecode *compiler.Bytecode, ctx hctx.Context) (string, bool, error) {
+	if bytecode == nil || bytecode.FastRenderPlan == nil {
+		return "", false, nil
+	}
+	return renderFastPlanWithBindingPlan(bytecode.FastRenderPlan, ctx, topLevelFastBindingPlan(bytecode.FastRenderPlan, ctx))
+}
+
+// renderFastPlanWithBindingPlan tries the prepared fast plan variants in order:
+// static-name, simple, mixed. Each variant must preserve Plush rendering
+// semantics or decline so the normal VM can handle the template.
+func renderFastPlanWithBindingPlan(plan *compiler.FastRenderPlan, ctx hctx.Context, bindingPlan *fastRenderBindingPlan) (string, bool, error) {
+	if plan == nil {
+		return "", false, nil
+	}
+
+	mixed := prepareFastMixedPlan(plan)
+	bindings := newFastRenderBindingsWithPlan(plan, ctx, bindingPlan)
+	var out strings.Builder
+	if grow := fastOutputGrowSize(mixed, bindings); grow > 0 {
+		out.Grow(grow)
+	}
+
+	if mixed.staticName != nil {
+		ok, err := renderFastStaticNamePlan(&out, ctx, bindings, mixed.staticName)
+		if !ok || err != nil {
+			return "", ok, err
+		}
+		return out.String(), true, nil
+	}
+
+	if mixed.simple != nil {
+		ok, err := renderFastSimplePlan(&out, ctx, bindings, mixed.simple)
+		if err != nil {
+			return "", true, err
+		}
+		if ok {
+			return out.String(), true, nil
+		}
+		out.Reset()
+		if grow := fastOutputGrowSize(mixed, bindings); grow > 0 {
+			out.Grow(grow)
+		}
+	}
+
+	ok, err := renderFastMixedPlan(&out, ctx, bindings, mixed)
+	if !ok || err != nil {
+		return "", ok, err
+	}
+
+	return out.String(), true, nil
+}
+
+func renderFastPlanInlineSafe(out *strings.Builder, plan *compiler.FastRenderPlan, ctx hctx.Context, bindingPlan *fastRenderBindingPlan) (bool, error) {
+	if out == nil || plan == nil {
+		return false, nil
+	}
+	bindings := newFastRenderBindingsWithPlan(plan, ctx, bindingPlan)
+	return renderFastPlanInlineWithBindings(out, plan, ctx, bindings)
+}
+
+func renderFastPlanInlineWithBindings(out *strings.Builder, plan *compiler.FastRenderPlan, ctx hctx.Context, bindings fastRenderBindings) (bool, error) {
+	if out == nil || plan == nil {
+		return false, nil
+	}
+	mixed := prepareFastMixedPlan(plan)
+	if mixed == nil || len(mixed.ops) == 0 {
+		return false, nil
+	}
+	if mixed.staticName != nil {
+		return renderFastStaticNamePlanInlineSafe(out, ctx, bindings, mixed.staticName)
+	}
+	if mixed.simple != nil {
+		return renderFastSimplePlanInlineSafe(out, ctx, bindings, mixed.simple)
+	}
+	var scratch strings.Builder
+	if grow := fastOutputGrowSize(mixed, bindings); grow > 0 {
+		scratch.Grow(grow)
+	}
+	ok, err := renderFastMixedPlan(&scratch, ctx, bindings, mixed)
+	if !ok || err != nil {
+		return ok, err
+	}
+	out.WriteString(scratch.String())
+	return true, nil
+}
+
+func topLevelFastBindingPlan(plan *compiler.FastRenderPlan, ctx hctx.Context) *fastRenderBindingPlan {
+	if plan == nil || len(plan.Bindings) == 0 || !canCacheFastRenderBindingPlan(ctx) {
+		return nil
+	}
+	if cached := plan.BindingPrepared.Load(); cached != nil {
+		bindingPlan, _ := cached.(*fastRenderBindingPlan)
+		if bindingPlan != nil && bindingPlan.matches(plan.Bindings) {
+			return bindingPlan
+		}
+	}
+	bindingPlan := newFastRenderBindingPlan(plan, ctx)
+	plan.BindingPrepared.Store(bindingPlan)
+	return bindingPlan
+}
+
+func canCacheFastRenderBindingPlan(ctx hctx.Context) bool {
+	switch c := ctx.(type) {
+	case nil:
+		return false
+	case *plush.Context:
+		return true
+	case *partialOverlayContext:
+		return c.stableBindingIDs()
+	default:
+		return false
+	}
+}
+
+func fastOutputGrowSize(plan *fastMixedPlan, bindings fastRenderBindings) int {
+	if plan == nil {
+		return 0
+	}
+	size := plan.staticSize + plan.nameCount*16
+	for i := range plan.ops {
+		op := &plan.ops[i]
+		if op.loop == nil {
+			continue
+		}
+		iter, ok, err := fastLoopIterableValue(op.loop, bindings.ctx, bindings)
+		if err != nil || !ok {
+			continue
+		}
+		length, ok := fastIterableLen(iter)
+		if !ok || length <= 0 {
+			continue
+		}
+		perItem := fastLoopGrowSize(op.loop)
+		maxInt := int(^uint(0) >> 1)
+		if perItem <= 0 || length > (maxInt-size)/perItem {
+			continue
+		}
+		size += length * perItem
+	}
+	return size
+}
+
+func fastLoopGrowSize(loop *compiler.FastLoopPlan) int {
+	if loop == nil {
+		return 0
+	}
+	size := loop.StaticSize
+	for i := range loop.Parts {
+		switch loop.Parts[i].Kind {
+		case compiler.FastLoopPartKey:
+			size += 4
+		case compiler.FastLoopPartValue, compiler.FastLoopPartValueProperty, compiler.FastLoopPartValuePath, compiler.FastLoopPartCall, compiler.FastLoopPartPartial:
+			size += 16
+		case compiler.FastLoopPartConditional:
+			size += fastLoopConditionalGrowSize(loop.Parts[i].Conditional)
+		case compiler.FastLoopPartLoop:
+			size += fastLoopGrowSize(loop.Parts[i].Loop)
+		}
+	}
+	return size
+}
+
+func fastLoopConditionalGrowSize(conditional *compiler.FastLoopConditionalPlan) int {
+	if conditional == nil {
+		return 0
+	}
+	size := 0
+	for i := range conditional.Branches {
+		if branchSize := fastLoopPartsGrowSize(conditional.Branches[i].Parts); branchSize > size {
+			size = branchSize
+		}
+	}
+	if elseSize := fastLoopPartsGrowSize(conditional.ElseParts); elseSize > size {
+		size = elseSize
+	}
+	return size
+}
+
+func fastLoopPartsGrowSize(parts []compiler.FastLoopPart) int {
+	size := 0
+	for i := range parts {
+		switch parts[i].Kind {
+		case compiler.FastLoopPartStatic:
+			continue
+		case compiler.FastLoopPartKey:
+			size += 4
+		case compiler.FastLoopPartValue, compiler.FastLoopPartValueProperty, compiler.FastLoopPartValuePath, compiler.FastLoopPartCall, compiler.FastLoopPartPartial:
+			size += 16
+		case compiler.FastLoopPartConditional:
+			size += fastLoopConditionalGrowSize(parts[i].Conditional)
+		}
+	}
+	return size
+}
+
+func fastIterableLen(iter interface{}) (int, bool) {
+	if obj, ok := iter.(object.Object); ok {
+		switch obj := obj.(type) {
+		case *object.Array:
+			return len(obj.Elements), true
+		case *object.Hash:
+			return len(obj.Pairs), true
+		default:
+			iter = object.ToGo(obj)
+		}
+	}
+	if iter == nil {
+		return 0, true
+	}
+	switch iter := iter.(type) {
+	case []string:
+		return len(iter), true
+	case []interface{}:
+		return len(iter), true
+	case []object.Object:
+		return len(iter), true
+	}
+	rv := reflect.ValueOf(iter)
+	rv = unwrapFastFieldChainValue(rv)
+	if !rv.IsValid() {
+		return 0, true
+	}
+	switch rv.Kind() {
+	case reflect.Array, reflect.Slice, reflect.Map:
+		return rv.Len(), true
+	default:
+		return 0, false
+	}
+}
+
+func prepareFastMixedPlan(plan *compiler.FastRenderPlan) *fastMixedPlan {
+	if plan == nil {
+		return nil
+	}
+	if cached := plan.Prepared.Load(); cached != nil {
+		return cached.(*fastMixedPlan)
+	}
+	prepared := buildFastMixedPlan(plan)
+	plan.Prepared.Store(prepared)
+	return prepared
+}
+
+func buildFastMixedPlan(plan *compiler.FastRenderPlan) *fastMixedPlan {
+	mixed := &fastMixedPlan{
+		staticSize: plan.StaticSize,
+		nameCount:  plan.NameCount,
+	}
+	prefix := ""
+	for i := range plan.Segments {
+		segment := &plan.Segments[i]
+		if segment.Kind == compiler.FastRenderSegmentStatic {
+			prefix += segment.Value
+			continue
+		}
+		op := fastMixedOp{
+			prefix:        prefix,
+			value:         segment.Value,
+			nameIndex:     segment.NameIndex,
+			nullOnMissing: segment.NullOnMissing,
+			property:      segment.Property,
+			receiver:      segment.Receiver,
+			full:          segment.Full,
+			line:          segment.Line,
+			loop:          segment.Loop,
+			valuePlan:     segment.ValuePlan,
+			call:          segment.Call,
+			blockCall:     segment.BlockCall,
+			conditional:   segment.Conditional,
+			partial:       segment.Partial,
+			propertyCache: segment.PropertyCache,
+			outputCache:   segment.OutputCache,
+		}
+		prefix = ""
+		switch segment.Kind {
+		case compiler.FastRenderSegmentName:
+			op.kind = fastMixedOpName
+		case compiler.FastRenderSegmentProperty:
+			op.kind = fastMixedOpProperty
+		case compiler.FastRenderSegmentValue:
+			if canUseFastTopLevelAccessChain(&segment.ValuePlan) {
+				op.kind = fastMixedOpAccessChain
+			} else {
+				op.kind = fastMixedOpValue
+			}
+		case compiler.FastRenderSegmentCall:
+			op.kind = fastMixedOpCall
+		case compiler.FastRenderSegmentBlockCall:
+			op.kind = fastMixedOpBlockCall
+		case compiler.FastRenderSegmentConditional:
+			op.kind = fastMixedOpConditional
+			op.simpleCond = buildFastSimpleConditionalPlan(segment.Conditional)
+		case compiler.FastRenderSegmentPartial:
+			op.kind = fastMixedOpPartial
+			op.partialData = buildFastPartialDataBindingPlan(segment.Partial)
+		case compiler.FastRenderSegmentLoop:
+			op.kind = fastMixedOpLoop
+		case compiler.FastRenderSegmentLet:
+			op.kind = fastMixedOpLet
+		case compiler.FastRenderSegmentAssign:
+			op.kind = fastMixedOpAssign
+		default:
+			op.kind = fastMixedOpStatic
+		}
+		mixed.ops = append(mixed.ops, op)
+	}
+	if prefix != "" {
+		mixed.ops = append(mixed.ops, fastMixedOp{kind: fastMixedOpStatic, prefix: prefix})
+	}
+	mixed.staticName = buildFastStaticNamePlan(mixed)
+	if mixed.staticName == nil {
+		mixed.simple = buildFastSimplePlan(mixed)
+	}
+	return mixed
+}
+
+func buildFastStaticNamePlan(mixed *fastMixedPlan) *fastStaticNamePlan {
+	if mixed == nil || len(mixed.ops) == 0 {
+		return nil
+	}
+	plan := &fastStaticNamePlan{ops: make([]fastStaticNameOp, 0, len(mixed.ops))}
+	for i := range mixed.ops {
+		op := &mixed.ops[i]
+		switch op.kind {
+		case fastMixedOpStatic:
+			if op.prefix != "" {
+				plan.ops = append(plan.ops, fastStaticNameOp{
+					prefix:      op.prefix,
+					nameIndex:   -1,
+					lookupIndex: -1,
+				})
+			}
+		case fastMixedOpName:
+			lookupIndex := plan.bindNameIndex(op.nameIndex)
+			plan.ops = append(plan.ops, fastStaticNameOp{
+				prefix:        op.prefix,
+				value:         op.value,
+				nameIndex:     op.nameIndex,
+				lookupIndex:   lookupIndex,
+				nullOnMissing: op.nullOnMissing,
+				line:          op.line,
+				outputCache:   &op.outputCache,
+			})
+		default:
+			return nil
+		}
+	}
+	if len(plan.ops) == 0 {
+		return nil
+	}
+	return plan
+}
+
+func (p *fastStaticNamePlan) bindNameIndex(nameIndex int) int {
+	if p == nil || nameIndex < 0 {
+		return -1
+	}
+	for i, existing := range p.nameIndexes {
+		if existing == nameIndex {
+			return i
+		}
+	}
+	p.nameIndexes = append(p.nameIndexes, nameIndex)
+	return len(p.nameIndexes) - 1
+}
+
+func buildFastSimplePlan(mixed *fastMixedPlan) *fastSimplePlan {
+	if mixed == nil || len(mixed.ops) == 0 {
+		return nil
+	}
+	plan := &fastSimplePlan{ops: make([]fastSimpleOp, 0, len(mixed.ops))}
+	for i := range mixed.ops {
+		op := &mixed.ops[i]
+		simpleOp := fastSimpleOp{op: op, lookupIndex: -1}
+		switch op.kind {
+		case fastMixedOpStatic:
+			if op.prefix == "" {
+				continue
+			}
+		case fastMixedOpName, fastMixedOpProperty:
+			simpleOp.lookupIndex = plan.bindNameIndex(op.nameIndex)
+		case fastMixedOpAccessChain:
+			if op.valuePlan.NameIndex < 0 {
+				return nil
+			}
+			simpleOp.lookupIndex = plan.bindNameIndex(op.valuePlan.NameIndex)
+		case fastMixedOpValue:
+			if op.valuePlan.Kind != compiler.FastValueInfix {
+				return nil
+			}
+			simpleOp.value = buildFastSimpleValuePlan(plan, &op.valuePlan)
+			if simpleOp.value == nil {
+				return nil
+			}
+		default:
+			return nil
+		}
+		plan.ops = append(plan.ops, simpleOp)
+	}
+	if len(plan.ops) == 0 {
+		return nil
+	}
+	return plan
+}
+
+func buildFastSimpleConditionalPlan(conditional *compiler.FastConditionalPlan) *fastSimpleConditionalPlan {
+	if conditional == nil || conditional.Silent || len(conditional.Branches) == 0 {
+		return nil
+	}
+	plan := &fastSimpleConditionalPlan{
+		branches: make([]fastSimpleConditionalBranch, 0, len(conditional.Branches)),
+	}
+	for i := range conditional.Branches {
+		branch := &conditional.Branches[i]
+		condition := buildFastSimpleValuePlan(plan, &branch.Condition)
+		if condition == nil {
+			return nil
+		}
+		segments := buildFastSimplePlanFromSegments(branch.Segments)
+		if len(branch.Segments) > 0 && segments == nil {
+			return nil
+		}
+		plan.branches = append(plan.branches, fastSimpleConditionalBranch{
+			condition: condition,
+			segments:  segments,
+			line:      branch.Line,
+		})
+	}
+	if len(conditional.ElseSegments) > 0 {
+		plan.elseSegments = buildFastSimplePlanFromSegments(conditional.ElseSegments)
+		if plan.elseSegments == nil {
+			return nil
+		}
+	}
+	return plan
+}
+
+func buildFastPartialDataBindingPlan(partial *compiler.FastPartialPlan) *fastPartialDataBindingPlan {
+	if partial == nil || len(partial.Data) == 0 {
+		return nil
+	}
+	plan := &fastPartialDataBindingPlan{
+		pairs: make([]fastPartialDataBindingPair, 0, len(partial.Data)),
+		keys:  make([]string, 0, len(partial.Data)),
+	}
+	for i := range partial.Data {
+		pair := &partial.Data[i]
+		value := buildFastSimpleValuePlan(plan, &pair.Value)
+		if value == nil {
+			return nil
+		}
+		plan.pairs = append(plan.pairs, fastPartialDataBindingPair{
+			key:   pair.Key,
+			value: value,
+			line:  pair.Line,
+		})
+		plan.keys = append(plan.keys, pair.Key)
+	}
+	return plan
+}
+
+func buildFastSimplePlanFromSegments(segments []compiler.FastRenderSegment) *fastSimplePlan {
+	if len(segments) == 0 {
+		return nil
+	}
+	mixed := &fastMixedPlan{ops: fastMixedOpsFromSegments(segments)}
+	return buildFastSimplePlan(mixed)
+}
+
+func fastMixedOpsFromSegments(segments []compiler.FastRenderSegment) []fastMixedOp {
+	ops := make([]fastMixedOp, 0, len(segments))
+	prefix := ""
+	for i := range segments {
+		segment := &segments[i]
+		if segment.Kind == compiler.FastRenderSegmentStatic {
+			prefix += segment.Value
+			continue
+		}
+		op := fastMixedOp{
+			prefix:        prefix,
+			value:         segment.Value,
+			nameIndex:     segment.NameIndex,
+			nullOnMissing: segment.NullOnMissing,
+			property:      segment.Property,
+			receiver:      segment.Receiver,
+			full:          segment.Full,
+			line:          segment.Line,
+			loop:          segment.Loop,
+			valuePlan:     segment.ValuePlan,
+			call:          segment.Call,
+			blockCall:     segment.BlockCall,
+			conditional:   segment.Conditional,
+			partial:       segment.Partial,
+			propertyCache: segment.PropertyCache,
+			outputCache:   segment.OutputCache,
+		}
+		prefix = ""
+		switch segment.Kind {
+		case compiler.FastRenderSegmentName:
+			op.kind = fastMixedOpName
+		case compiler.FastRenderSegmentProperty:
+			op.kind = fastMixedOpProperty
+		case compiler.FastRenderSegmentValue:
+			if canUseFastTopLevelAccessChain(&segment.ValuePlan) {
+				op.kind = fastMixedOpAccessChain
+			} else {
+				op.kind = fastMixedOpValue
+			}
+		case compiler.FastRenderSegmentCall:
+			op.kind = fastMixedOpCall
+		case compiler.FastRenderSegmentBlockCall:
+			op.kind = fastMixedOpBlockCall
+		case compiler.FastRenderSegmentConditional:
+			op.kind = fastMixedOpConditional
+			op.simpleCond = buildFastSimpleConditionalPlan(segment.Conditional)
+		case compiler.FastRenderSegmentPartial:
+			op.kind = fastMixedOpPartial
+			op.partialData = buildFastPartialDataBindingPlan(segment.Partial)
+		case compiler.FastRenderSegmentLoop:
+			op.kind = fastMixedOpLoop
+		case compiler.FastRenderSegmentLet:
+			op.kind = fastMixedOpLet
+		case compiler.FastRenderSegmentAssign:
+			op.kind = fastMixedOpAssign
+		default:
+			op.kind = fastMixedOpStatic
+		}
+		ops = append(ops, op)
+	}
+	if prefix != "" {
+		ops = append(ops, fastMixedOp{kind: fastMixedOpStatic, prefix: prefix})
+	}
+	return ops
+}
+
+func buildFastSimpleValuePlan(plan fastSimpleNameBinder, value *compiler.FastValuePlan) *fastSimpleValuePlan {
+	if plan == nil || value == nil {
+		return nil
+	}
+	prepared := &fastSimpleValuePlan{
+		value:       value,
+		lookupIndex: -1,
+	}
+	switch value.Kind {
+	case compiler.FastValueName:
+		if value.Value != "nil" {
+			prepared.lookupIndex = plan.bindNameIndex(value.NameIndex)
+		}
+	case compiler.FastValuePath:
+		prepared.lookupIndex = plan.bindNameIndex(value.NameIndex)
+	case compiler.FastValueInfix:
+		if value.Left == nil || value.Right == nil {
+			return nil
+		}
+		prepared.left = buildFastSimpleValuePlan(plan, value.Left)
+		prepared.right = buildFastSimpleValuePlan(plan, value.Right)
+		if prepared.left == nil || prepared.right == nil {
+			return nil
+		}
+	case compiler.FastValuePrefix:
+		if value.Right == nil {
+			return nil
+		}
+		prepared.right = buildFastSimpleValuePlan(plan, value.Right)
+		if prepared.right == nil {
+			return nil
+		}
+	case compiler.FastValueConcat:
+		if value.Left == nil || value.Right == nil {
+			return nil
+		}
+		prepared.left = buildFastSimpleValuePlan(plan, value.Left)
+		prepared.right = buildFastSimpleValuePlan(plan, value.Right)
+		if prepared.left == nil || prepared.right == nil {
+			return nil
+		}
+	case compiler.FastValueCall:
+		if value.Call == nil {
+			return nil
+		}
+		prepared.lookupIndex = plan.bindNameIndex(value.Call.NameIndex)
+		if len(value.Call.Args) > 0 {
+			prepared.args = make([]*fastSimpleValuePlan, 0, len(value.Call.Args))
+			for i := range value.Call.Args {
+				arg := buildFastSimpleValuePlan(plan, &value.Call.Args[i])
+				if arg == nil {
+					return nil
+				}
+				prepared.args = append(prepared.args, arg)
+			}
+		}
+	case compiler.FastValueArray:
+		if len(value.Elements) > 0 {
+			prepared.args = make([]*fastSimpleValuePlan, 0, len(value.Elements))
+			for i := range value.Elements {
+				element := buildFastSimpleValuePlan(plan, &value.Elements[i])
+				if element == nil {
+					return nil
+				}
+				prepared.args = append(prepared.args, element)
+			}
+		}
+	case compiler.FastValueHash:
+		if len(value.Pairs) > 0 {
+			prepared.args = make([]*fastSimpleValuePlan, 0, len(value.Pairs))
+			for i := range value.Pairs {
+				pairValue := buildFastSimpleValuePlan(plan, &value.Pairs[i].Value)
+				if pairValue == nil {
+					return nil
+				}
+				prepared.args = append(prepared.args, pairValue)
+			}
+		}
+	case compiler.FastValueString, compiler.FastValueInteger, compiler.FastValueFloat, compiler.FastValueBool:
+		// Literal operands do not need binding slots.
+	default:
+		return nil
+	}
+	return prepared
+}
+
+func (p *fastSimplePlan) bindNameIndex(nameIndex int) int {
+	if p == nil || nameIndex < 0 {
+		return -1
+	}
+	for i, existing := range p.nameIndexes {
+		if existing == nameIndex {
+			return i
+		}
+	}
+	p.nameIndexes = append(p.nameIndexes, nameIndex)
+	return len(p.nameIndexes) - 1
+}
+
+func (p *fastSimpleConditionalPlan) bindNameIndex(nameIndex int) int {
+	if p == nil || nameIndex < 0 {
+		return -1
+	}
+	for i, existing := range p.nameIndexes {
+		if existing == nameIndex {
+			return i
+		}
+	}
+	p.nameIndexes = append(p.nameIndexes, nameIndex)
+	return len(p.nameIndexes) - 1
+}
+
+func (p *fastPartialDataBindingPlan) bindNameIndex(nameIndex int) int {
+	if p == nil || nameIndex < 0 {
+		return -1
+	}
+	for i, existing := range p.nameIndexes {
+		if existing == nameIndex {
+			return i
+		}
+	}
+	p.nameIndexes = append(p.nameIndexes, nameIndex)
+	return len(p.nameIndexes) - 1
+}
+
+func renderFastStaticNamePlan(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, plan *fastStaticNamePlan) (bool, error) {
+	if plan == nil {
+		return false, nil
+	}
+	var cachedValues [8]interface{}
+	var cachedOK [8]bool
+	cacheValues := len(plan.nameIndexes) > 0 && len(plan.nameIndexes) <= len(cachedValues)
+	if cacheValues {
+		for i, nameIndex := range plan.nameIndexes {
+			cachedValues[i], cachedOK[i] = bindings.value(nameIndex)
+		}
+	}
+	for i := range plan.ops {
+		op := &plan.ops[i]
+		if op.prefix != "" {
+			out.WriteString(op.prefix)
+		}
+		if op.nameIndex < 0 {
+			continue
+		}
+		var value interface{}
+		var ok bool
+		if cacheValues && op.lookupIndex >= 0 {
+			value, ok = cachedValues[op.lookupIndex], cachedOK[op.lookupIndex]
+		} else {
+			value, ok = bindings.value(op.nameIndex)
+		}
+		if !ok {
+			if op.nullOnMissing {
+				continue
+			}
+			return true, fastLineError(op.line, fmt.Errorf("%q: unknown identifier", op.value))
+		}
+		if !writeFastBindingOutput(out, ctx, value, op.outputCache) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func renderFastStaticNamePlanInlineSafe(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, plan *fastStaticNamePlan) (bool, error) {
+	if out == nil || plan == nil {
+		return false, nil
+	}
+	var inlineValues [8]interface{}
+	var inlineOK [8]bool
+	values := inlineValues[:]
+	oks := inlineOK[:]
+	if len(plan.nameIndexes) > len(inlineValues) {
+		values = make([]interface{}, len(plan.nameIndexes))
+		oks = make([]bool, len(plan.nameIndexes))
+	} else {
+		values = values[:len(plan.nameIndexes)]
+		oks = oks[:len(plan.nameIndexes)]
+	}
+	for i, nameIndex := range plan.nameIndexes {
+		values[i], oks[i] = bindings.value(nameIndex)
+	}
+	for i := range plan.ops {
+		op := &plan.ops[i]
+		if op.nameIndex < 0 {
+			continue
+		}
+		value, ok := fastStaticNameCachedValue(op, bindings, values, oks)
+		if !ok {
+			if op.nullOnMissing {
+				continue
+			}
+			return true, fastLineError(op.line, fmt.Errorf("%q: unknown identifier", op.value))
+		}
+		if !canWriteFastBindingOutput(value) {
+			return false, nil
+		}
+	}
+	for i := range plan.ops {
+		op := &plan.ops[i]
+		if op.prefix != "" {
+			out.WriteString(op.prefix)
+		}
+		if op.nameIndex < 0 {
+			continue
+		}
+		value, ok := fastStaticNameCachedValue(op, bindings, values, oks)
+		if !ok {
+			continue
+		}
+		writeFastBindingOutput(out, ctx, value, op.outputCache)
+	}
+	return true, nil
+}
+
+func fastStaticNameCachedValue(op *fastStaticNameOp, bindings fastRenderBindings, values []interface{}, oks []bool) (interface{}, bool) {
+	if op != nil && op.lookupIndex >= 0 && op.lookupIndex < len(values) && op.lookupIndex < len(oks) {
+		return values[op.lookupIndex], oks[op.lookupIndex]
+	}
+	if op == nil {
+		return nil, false
+	}
+	return bindings.value(op.nameIndex)
+}
+
+func renderFastSimplePlan(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, plan *fastSimplePlan) (bool, error) {
+	if out == nil || plan == nil {
+		return false, nil
+	}
+	var inlineValues [8]interface{}
+	var inlineOK [8]bool
+	values := inlineValues[:]
+	oks := inlineOK[:]
+	if len(plan.nameIndexes) > len(inlineValues) {
+		values = make([]interface{}, len(plan.nameIndexes))
+		oks = make([]bool, len(plan.nameIndexes))
+	} else {
+		values = values[:len(plan.nameIndexes)]
+		oks = oks[:len(plan.nameIndexes)]
+	}
+	for i, nameIndex := range plan.nameIndexes {
+		values[i], oks[i] = bindings.value(nameIndex)
+	}
+	for i := range plan.ops {
+		simpleOp := &plan.ops[i]
+		op := simpleOp.op
+		if op == nil {
+			return false, nil
+		}
+		if op.prefix != "" {
+			out.WriteString(op.prefix)
+		}
+		switch op.kind {
+		case fastMixedOpStatic:
+			continue
+		case fastMixedOpName:
+			value, ok := fastSimpleCachedOpValue(simpleOp, bindings, values, oks)
+			if !ok {
+				if op.nullOnMissing {
+					continue
+				}
+				return true, fastLineError(op.line, fmt.Errorf("%q: unknown identifier", op.value))
+			}
+			if !writeFastBindingOutput(out, ctx, value, &op.outputCache) {
+				return false, nil
+			}
+		case fastMixedOpProperty:
+			value, ok := fastSimpleCachedOpValue(simpleOp, bindings, values, oks)
+			if !ok {
+				return true, fastLineError(op.line, fmt.Errorf("%q: unknown identifier", op.value))
+			}
+			if err := spendFastTraversal(ctx, op.line); err != nil {
+				return true, err
+			}
+			if err := writeFastPropertyOutput(out, ctx, value, op.property, object.PropertyAccess{
+				Receiver: op.receiver,
+				Full:     op.full,
+			}, &op.propertyCache); err != nil {
+				return true, fastLineError(op.line, err)
+			}
+		case fastMixedOpAccessChain:
+			value, ok := fastSimpleCachedOpValue(simpleOp, bindings, values, oks)
+			if !ok {
+				if op.valuePlan.NullOnMissing {
+					continue
+				}
+				return true, fastLineError(op.line, fmt.Errorf("%q: unknown identifier", op.valuePlan.Value))
+			}
+			handled, err := writeFastTopLevelAccessChainRaw(out, ctx, &op.valuePlan, value, &op.accessCache)
+			if err != nil {
+				return true, err
+			}
+			if !handled {
+				return false, nil
+			}
+		case fastMixedOpValue:
+			if !fastMixedValueCanUseSimple(op.valuePlan.Kind) || simpleOp.value == nil {
+				return false, nil
+			}
+			result, ok, err := evalFastSimpleValue(simpleOp.value, ctx, bindings, values, oks, nil)
+			if err != nil {
+				return true, err
+			}
+			if !ok {
+				return true, fastLineError(op.line, fmt.Errorf("%q: unknown identifier", op.valuePlan.Value))
+			}
+			if truth, ok := result.(bool); ok {
+				out.WriteString(strconv.FormatBool(truth))
+				continue
+			}
+			writeFastGoValue(out, ctx, result)
+		default:
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func fastMixedValueCanUseSimple(kind compiler.FastValueKind) bool {
+	switch kind {
+	case compiler.FastValueInfix, compiler.FastValuePrefix, compiler.FastValueConcat:
+		return true
+	default:
+		return false
+	}
+}
+
+func renderFastSimplePlanInlineSafe(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, plan *fastSimplePlan) (bool, error) {
+	if out == nil || plan == nil {
+		return false, nil
+	}
+	var scratch strings.Builder
+	if grow := fastSimplePlanGrowSize(plan); grow > 0 {
+		scratch.Grow(grow)
+	}
+	ok, err := renderFastSimplePlan(&scratch, ctx, bindings, plan)
+	if !ok || err != nil {
+		return ok, err
+	}
+	out.WriteString(scratch.String())
+	return true, nil
+}
+
+func fastSimplePlanGrowSize(plan *fastSimplePlan) int {
+	if plan == nil {
+		return 0
+	}
+	size := 0
+	for i := range plan.ops {
+		op := plan.ops[i].op
+		if op == nil {
+			continue
+		}
+		size += len(op.prefix)
+		if op.kind != fastMixedOpStatic {
+			size += 16
+		}
+	}
+	return size
+}
+
+func renderFastSimpleConditionalPlan(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, plan *fastSimpleConditionalPlan) (bool, error) {
+	if out == nil || plan == nil {
+		return false, nil
+	}
+	var inlineValues [8]interface{}
+	var inlineOK [8]bool
+	values := inlineValues[:]
+	oks := inlineOK[:]
+	if len(plan.nameIndexes) > len(inlineValues) {
+		values = make([]interface{}, len(plan.nameIndexes))
+		oks = make([]bool, len(plan.nameIndexes))
+	} else {
+		values = values[:len(plan.nameIndexes)]
+		oks = oks[:len(plan.nameIndexes)]
+	}
+	for i, nameIndex := range plan.nameIndexes {
+		values[i], oks[i] = bindings.value(nameIndex)
+	}
+	for i := range plan.branches {
+		branch := &plan.branches[i]
+		if err := spendFastCondition(ctx, branch.line); err != nil {
+			return true, err
+		}
+		value, ok, err := evalFastSimpleValue(branch.condition, ctx, bindings, values, oks, nil)
+		if err != nil {
+			return true, err
+		}
+		if !ok {
+			value = nil
+		}
+		if isTruthyFastValue(value) {
+			if branch.segments == nil {
+				return true, nil
+			}
+			return renderFastSimplePlan(out, ctx, bindings, branch.segments)
+		}
+	}
+	if plan.elseSegments != nil {
+		return renderFastSimplePlan(out, ctx, bindings, plan.elseSegments)
+	}
+	return true, nil
+}
+
+func fastSimpleCachedOpValue(op *fastSimpleOp, bindings fastRenderBindings, values []interface{}, oks []bool) (interface{}, bool) {
+	if op == nil || op.op == nil {
+		return nil, false
+	}
+	return fastSimpleCachedLookupValue(op.lookupIndex, bindings, values, oks, op.op.nameIndex)
+}
+
+func fastSimpleCachedLookupValue(lookupIndex int, bindings fastRenderBindings, values []interface{}, oks []bool, nameIndex int) (interface{}, bool) {
+	if lookupIndex >= 0 && lookupIndex < len(values) && lookupIndex < len(oks) {
+		return values[lookupIndex], oks[lookupIndex]
+	}
+	return bindings.value(nameIndex)
+}
+
+func evalFastSimpleValue(plan *fastSimpleValuePlan, ctx hctx.Context, bindings fastRenderBindings, values []interface{}, oks []bool, base interface{}) (interface{}, bool, error) {
+	if plan == nil || plan.value == nil {
+		return nil, true, nil
+	}
+	value := plan.value
+	switch value.Kind {
+	case compiler.FastValueName:
+		if value.Value == "nil" {
+			return nil, true, nil
+		}
+		raw, ok := fastSimpleCachedLookupValue(plan.lookupIndex, bindings, values, oks, value.NameIndex)
+		if !ok {
+			if value.NullOnMissing {
+				return nil, true, nil
+			}
+			return nil, false, nil
+		}
+		return raw, true, nil
+	case compiler.FastValueString:
+		return value.Value, true, nil
+	case compiler.FastValueInteger:
+		return int(value.IntValue), true, nil
+	case compiler.FastValueFloat:
+		return value.FloatValue, true, nil
+	case compiler.FastValueBool:
+		return value.BoolValue, true, nil
+	case compiler.FastValueInfix:
+		return evalFastSimpleInfixValue(plan, ctx, bindings, values, oks, base)
+	case compiler.FastValuePrefix:
+		return evalFastSimplePrefixValue(plan, ctx, bindings, values, oks, base)
+	case compiler.FastValueConcat:
+		return evalFastSimpleConcatValue(plan, ctx, bindings, values, oks, base)
+	case compiler.FastValueCall:
+		return evalFastSimpleCallValue(plan, ctx, bindings, values, oks)
+	case compiler.FastValueArray:
+		return evalFastSimpleArrayValue(plan, ctx, bindings, values, oks, base)
+	case compiler.FastValueHash:
+		return evalFastSimpleHashValue(plan, ctx, bindings, values, oks, base)
+	case compiler.FastValuePath:
+		raw := base
+		if value.NameIndex >= 0 {
+			var ok bool
+			raw, ok = fastSimpleCachedLookupValue(plan.lookupIndex, bindings, values, oks, value.NameIndex)
+			if !ok {
+				if value.NullOnMissing {
+					return nil, true, nil
+				}
+				return nil, false, nil
+			}
+		}
+		if result, handled, err := evalFastFieldChainValue(value, raw, ctx); handled || err != nil {
+			return result, true, err
+		}
+		if result, handled, err := evalFastAccessChainValue(value, raw, ctx); handled || err != nil {
+			return result, true, err
+		}
+		for i := range value.Path {
+			step := &value.Path[i]
+			var err error
+			raw, err = evalFastPathStep(raw, step, ctx)
+			if err != nil {
+				return nil, true, err
+			}
+		}
+		return raw, true, nil
+	default:
+		return evalFastValue(value, ctx, bindings, base)
+	}
+}
+
+func evalFastSimpleCallValue(plan *fastSimpleValuePlan, ctx hctx.Context, bindings fastRenderBindings, values []interface{}, oks []bool) (interface{}, bool, error) {
+	if plan == nil || plan.value == nil || plan.value.Call == nil {
+		return nil, false, nil
+	}
+	return evalFastCallValuePlan(plan.value.Call, plan.args, ctx, bindings, values, oks, plan)
+}
+
+func evalFastSimpleArrayValue(plan *fastSimpleValuePlan, ctx hctx.Context, bindings fastRenderBindings, values []interface{}, oks []bool, base interface{}) ([]interface{}, bool, error) {
+	if plan == nil || plan.value == nil || plan.value.Kind != compiler.FastValueArray || len(plan.args) != len(plan.value.Elements) {
+		return nil, false, nil
+	}
+	out := make([]interface{}, 0, len(plan.args))
+	for i := range plan.args {
+		value, ok, err := evalFastSimpleValue(plan.args[i], ctx, bindings, values, oks, base)
+		if err != nil || !ok {
+			return nil, ok, err
+		}
+		out = append(out, value)
+	}
+	return out, true, nil
+}
+
+func evalFastSimpleHashValue(plan *fastSimpleValuePlan, ctx hctx.Context, bindings fastRenderBindings, values []interface{}, oks []bool, base interface{}) (map[string]interface{}, bool, error) {
+	if plan == nil || plan.value == nil || plan.value.Kind != compiler.FastValueHash || len(plan.args) != len(plan.value.Pairs) {
+		return nil, false, nil
+	}
+	out := make(map[string]interface{}, len(plan.args))
+	for i := range plan.args {
+		value, ok, err := evalFastSimpleValue(plan.args[i], ctx, bindings, values, oks, base)
+		if err != nil || !ok {
+			return nil, ok, err
+		}
+		out[plan.value.Pairs[i].Key] = value
+	}
+	return out, true, nil
+}
+
+func evalFastCallValuePlan(call *compiler.FastCallPlan, simpleArgs []*fastSimpleValuePlan, ctx hctx.Context, bindings fastRenderBindings, values []interface{}, oks []bool, simpleCall *fastSimpleValuePlan) (interface{}, bool, error) {
+	if call == nil {
+		return nil, true, nil
+	}
+	raw, ok := bindings.value(call.NameIndex)
+	if simpleCall != nil {
+		raw, ok = fastSimpleCachedLookupValue(simpleCall.lookupIndex, bindings, values, oks, call.NameIndex)
+	}
+	if !ok {
+		return nil, false, nil
+	}
+	if err := spendFastFunctionCall(ctx, call.Name, call.Line); err != nil {
+		return nil, true, err
+	}
+
+	var argStore fastCallArgs
+	args := fastCallArgsOrNil(&argStore, len(call.Args))
+	if len(call.Args) > 0 {
+		argStore.Reset()
+		for i := range call.Args {
+			var value interface{}
+			var argOK bool
+			var err error
+			if i < len(simpleArgs) && simpleArgs[i] != nil {
+				value, argOK, err = evalFastSimpleValue(simpleArgs[i], ctx, bindings, values, oks, nil)
+			} else {
+				value, argOK, err = evalFastValue(&call.Args[i], ctx, bindings, nil)
+			}
+			if err != nil {
+				return nil, true, err
+			}
+			if !argOK {
+				return nil, false, nil
+			}
+			argStore.Append(value)
+		}
+	}
+	result, err := fastCallValue(call.Name, raw, args, ctx, &call.Cache)
+	if err != nil {
+		return nil, true, fastLineError(call.Line, err)
+	}
+	return result, true, nil
+}
+
+func fastSimpleValueMissingName(plan *fastSimpleValuePlan) string {
+	if plan == nil {
+		return ""
+	}
+	return fastValueMissingName(plan.value)
+}
+
+func fastValueMissingName(value *compiler.FastValuePlan) string {
+	if value == nil {
+		return ""
+	}
+	if value.Kind == compiler.FastValueCall && value.Call != nil {
+		return value.Call.Name
+	}
+	if value.Value != "" {
+		return value.Value
+	}
+	if value.Left != nil {
+		if name := fastValueMissingName(value.Left); name != "" {
+			return name
+		}
+	}
+	if value.Right != nil {
+		return fastValueMissingName(value.Right)
+	}
+	return ""
+}
+
+func evalFastSimpleInfixValue(plan *fastSimpleValuePlan, ctx hctx.Context, bindings fastRenderBindings, values []interface{}, oks []bool, base interface{}) (interface{}, bool, error) {
+	if plan == nil || plan.value == nil || plan.value.Kind != compiler.FastValueInfix || plan.left == nil || plan.right == nil {
+		return nil, false, nil
+	}
+	value := plan.value
+	if value.Operator == "&&" || value.Operator == "||" {
+		return evalFastSimpleLogicalInfixValue(plan, ctx, bindings, values, oks, base)
+	}
+	left, ok, err := evalFastSimpleValue(plan.left, ctx, bindings, values, oks, base)
+	if err != nil {
+		return nil, true, err
+	}
+	if !ok {
+		left = nil
+	}
+	right, ok, err := evalFastSimpleValue(plan.right, ctx, bindings, values, oks, base)
+	if err != nil {
+		return nil, true, err
+	}
+	if !ok {
+		right = nil
+	}
+	result, err := evalFastInfixOperator(value.Operator, left, right)
+	if err != nil {
+		return nil, true, fastLineError(value.Line, err)
+	}
+	return result, true, nil
+}
+
+func evalFastSimplePrefixValue(plan *fastSimpleValuePlan, ctx hctx.Context, bindings fastRenderBindings, values []interface{}, oks []bool, base interface{}) (interface{}, bool, error) {
+	if plan == nil || plan.value == nil || plan.value.Kind != compiler.FastValuePrefix || plan.right == nil {
+		return nil, false, nil
+	}
+	if plan.value.Operator != "!" {
+		return nil, true, fastLineError(plan.value.Line, fmt.Errorf("unknown fast prefix operator: %s", plan.value.Operator))
+	}
+	right, ok, err := evalFastSimpleValue(plan.right, ctx, bindings, values, oks, base)
+	if err != nil {
+		return nil, true, err
+	}
+	return !(ok && isTruthyFastValue(right)), true, nil
+}
+
+func evalFastSimpleConcatValue(plan *fastSimpleValuePlan, ctx hctx.Context, bindings fastRenderBindings, values []interface{}, oks []bool, base interface{}) (interface{}, bool, error) {
+	if plan == nil || plan.value == nil || plan.value.Kind != compiler.FastValueConcat || plan.left == nil || plan.right == nil {
+		return nil, false, nil
+	}
+	left, ok, err := evalFastSimpleValue(plan.left, ctx, bindings, values, oks, base)
+	if err != nil {
+		return nil, true, err
+	}
+	if !ok {
+		return nil, false, nil
+	}
+	right, ok, err := evalFastSimpleValue(plan.right, ctx, bindings, values, oks, base)
+	if err != nil {
+		return nil, true, err
+	}
+	if !ok {
+		return nil, false, nil
+	}
+	result, err := evalFastAddOperator(left, right)
+	if err != nil {
+		return nil, true, fastLineError(plan.value.Line, err)
+	}
+	return result, true, nil
+}
+
+func evalFastSimpleLogicalInfixValue(plan *fastSimpleValuePlan, ctx hctx.Context, bindings fastRenderBindings, values []interface{}, oks []bool, base interface{}) (interface{}, bool, error) {
+	if plan == nil || plan.value == nil || plan.left == nil || plan.right == nil {
+		return nil, false, nil
+	}
+	value := plan.value
+	left, ok, err := evalFastSimpleValue(plan.left, ctx, bindings, values, oks, base)
+	if err != nil {
+		return nil, true, err
+	}
+	leftTruthy := ok && isTruthyFastValue(left)
+	switch value.Operator {
+	case "&&":
+		if !leftTruthy {
+			return false, true, nil
+		}
+	case "||":
+		if leftTruthy {
+			return true, true, nil
+		}
+	default:
+		return nil, false, nil
+	}
+
+	right, ok, err := evalFastSimpleValue(plan.right, ctx, bindings, values, oks, base)
+	if err != nil {
+		return nil, true, err
+	}
+	return ok && isTruthyFastValue(right), true, nil
+}
+
+func renderFastMixedPlan(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, plan *fastMixedPlan) (bool, error) {
+	if plan == nil {
+		return false, nil
+	}
+	for i := range plan.ops {
+		op := &plan.ops[i]
+		if op.prefix != "" {
+			out.WriteString(op.prefix)
+		}
+		switch op.kind {
+		case fastMixedOpStatic:
+			continue
+		case fastMixedOpName:
+			value, ok := bindings.value(op.nameIndex)
+			if !ok {
+				if op.nullOnMissing {
+					continue
+				}
+				return true, fastLineError(op.line, fmt.Errorf("%q: unknown identifier", op.value))
+			}
+			if !writeFastBindingOutput(out, ctx, value, &op.outputCache) {
+				return false, nil
+			}
+		case fastMixedOpProperty:
+			value, ok := bindings.value(op.nameIndex)
+			if !ok {
+				return true, fastLineError(op.line, fmt.Errorf("%q: unknown identifier", op.value))
+			}
+			if err := spendFastTraversal(ctx, op.line); err != nil {
+				return true, err
+			}
+			if err := writeFastPropertyOutput(out, ctx, value, op.property, object.PropertyAccess{
+				Receiver: op.receiver,
+				Full:     op.full,
+			}, &op.propertyCache); err != nil {
+				return true, fastLineError(op.line, err)
+			}
+		case fastMixedOpValue:
+			if handled, ok, err := writeFastValuePlanOutput(out, ctx, bindings, &op.valuePlan); handled || err != nil {
+				if err != nil {
+					return true, err
+				}
+				if !ok {
+					return true, fastLineError(op.line, fmt.Errorf("%q: unknown identifier", op.valuePlan.Value))
+				}
+				continue
+			}
+			value, ok, err := evalFastValue(&op.valuePlan, ctx, bindings, nil)
+			if err != nil {
+				return true, err
+			}
+			if !ok {
+				return true, fastLineError(op.line, fmt.Errorf("%q: unknown identifier", op.valuePlan.Value))
+			}
+			writeFastGoValue(out, ctx, value)
+		case fastMixedOpAccessChain:
+			if handled, ok, err := writeFastTopLevelAccessChainOutput(out, ctx, bindings, &op.valuePlan, &op.accessCache); handled || err != nil {
+				if err != nil {
+					return true, err
+				}
+				if !ok {
+					return true, fastLineError(op.line, fmt.Errorf("%q: unknown identifier", op.valuePlan.Value))
+				}
+				continue
+			}
+			if handled, ok, err := writeFastValuePlanOutput(out, ctx, bindings, &op.valuePlan); handled || err != nil {
+				if err != nil {
+					return true, err
+				}
+				if !ok {
+					return true, fastLineError(op.line, fmt.Errorf("%q: unknown identifier", op.valuePlan.Value))
+				}
+				continue
+			}
+			value, ok, err := evalFastValue(&op.valuePlan, ctx, bindings, nil)
+			if err != nil {
+				return true, err
+			}
+			if !ok {
+				return true, fastLineError(op.line, fmt.Errorf("%q: unknown identifier", op.valuePlan.Value))
+			}
+			writeFastGoValue(out, ctx, value)
+		case fastMixedOpCall:
+			if err := writeFastCallSegment(out, ctx, bindings, op.call); err != nil {
+				return true, err
+			}
+		case fastMixedOpBlockCall:
+			if err := writeFastBlockCallSegment(out, ctx, bindings, op.blockCall); err != nil {
+				if errors.Is(err, errFastWriteUnsupported) {
+					return false, nil
+				}
+				return true, err
+			}
+		case fastMixedOpConditional:
+			if op.simpleCond != nil {
+				ok, err := renderFastSimpleConditionalPlan(out, ctx, bindings, op.simpleCond)
+				if !ok || err != nil {
+					if errors.Is(err, errFastWriteUnsupported) {
+						return false, nil
+					}
+					return ok, err
+				}
+				continue
+			}
+			ok, err := renderFastConditional(out, ctx, bindings, op.conditional)
+			if !ok || err != nil {
+				if errors.Is(err, errFastWriteUnsupported) {
+					return false, nil
+				}
+				return ok, err
+			}
+		case fastMixedOpPartial:
+			if err := renderFastPartialSegmentWithDataPlan(out, ctx, bindings, op.partial, op.partialData); err != nil {
+				return true, err
+			}
+		case fastMixedOpLoop:
+			ok, err := renderFastLoop(out, ctx, bindings, op.loop)
+			if !ok || err != nil {
+				if errors.Is(err, errFastWriteUnsupported) {
+					return false, nil
+				}
+				return ok, err
+			}
+		case fastMixedOpLet:
+			value, ok, err := evalFastValue(&op.valuePlan, ctx, bindings, nil)
+			if err != nil {
+				return true, err
+			}
+			if !ok {
+				return true, fastLineError(op.line, fmt.Errorf("%q: unknown identifier", fastValueMissingName(&op.valuePlan)))
+			}
+			if err := spendFastAssignment(ctx, op.line); err != nil {
+				return true, err
+			}
+			bindings.setLocalAndContext(op.nameIndex, value)
+		case fastMixedOpAssign:
+			if err := assignFastValue(ctx, &bindings, op.value, op.nameIndex, &op.valuePlan, op.line); err != nil {
+				return true, err
+			}
+		default:
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func renderFastSegments(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, segments []compiler.FastRenderSegment) (bool, error) {
+	for i := range segments {
+		segment := &segments[i]
+		switch segment.Kind {
+		case compiler.FastRenderSegmentStatic:
+			out.WriteString(segment.Value)
+		case compiler.FastRenderSegmentName:
+			value, ok := bindings.value(segment.NameIndex)
+			if !ok {
+				if segment.NullOnMissing {
+					continue
+				}
+				return true, fastLineError(segment.Line, fmt.Errorf("%q: unknown identifier", segment.Value))
+			}
+			if !writeFastBindingOutput(out, ctx, value, &segment.OutputCache) {
+				return false, nil
+			}
+		case compiler.FastRenderSegmentProperty:
+			value, ok := bindings.value(segment.NameIndex)
+			if !ok {
+				return true, fastLineError(segment.Line, fmt.Errorf("%q: unknown identifier", segment.Value))
+			}
+			if err := spendFastTraversal(ctx, segment.Line); err != nil {
+				return true, err
+			}
+			if err := writeFastPropertyOutput(out, ctx, value, segment.Property, object.PropertyAccess{
+				Receiver: segment.Receiver,
+				Full:     segment.Full,
+			}, &segment.PropertyCache); err != nil {
+				return true, fastLineError(segment.Line, err)
+			}
+		case compiler.FastRenderSegmentValue:
+			if handled, ok, err := writeFastValuePlanOutput(out, ctx, bindings, &segment.ValuePlan); handled || err != nil {
+				if err != nil {
+					return true, err
+				}
+				if !ok {
+					return true, fastLineError(segment.Line, fmt.Errorf("%q: unknown identifier", segment.ValuePlan.Value))
+				}
+				continue
+			}
+			value, ok, err := evalFastValue(&segment.ValuePlan, ctx, bindings, nil)
+			if err != nil {
+				return true, err
+			}
+			if !ok {
+				return true, fastLineError(segment.Line, fmt.Errorf("%q: unknown identifier", segment.ValuePlan.Value))
+			}
+			writeFastGoValue(out, ctx, value)
+		case compiler.FastRenderSegmentCall:
+			if err := writeFastCallSegment(out, ctx, bindings, segment.Call); err != nil {
+				return true, err
+			}
+		case compiler.FastRenderSegmentConditional:
+			ok, err := renderFastConditional(out, ctx, bindings, segment.Conditional)
+			if !ok || err != nil {
+				if errors.Is(err, errFastWriteUnsupported) {
+					return false, nil
+				}
+				return ok, err
+			}
+		case compiler.FastRenderSegmentPartial:
+			if err := renderFastPartialSegment(out, ctx, bindings, segment.Partial); err != nil {
+				return true, err
+			}
+		case compiler.FastRenderSegmentLoop:
+			ok, err := renderFastLoop(out, ctx, bindings, segment.Loop)
+			if !ok || err != nil {
+				if errors.Is(err, errFastWriteUnsupported) {
+					return false, nil
+				}
+				return ok, err
+			}
+		case compiler.FastRenderSegmentLet:
+			value, ok, err := evalFastValue(&segment.ValuePlan, ctx, bindings, nil)
+			if err != nil {
+				return true, err
+			}
+			if !ok {
+				return true, fastLineError(segment.Line, fmt.Errorf("%q: unknown identifier", fastValueMissingName(&segment.ValuePlan)))
+			}
+			if err := spendFastAssignment(ctx, segment.Line); err != nil {
+				return true, err
+			}
+			bindings.setLocalAndContext(segment.NameIndex, value)
+		case compiler.FastRenderSegmentAssign:
+			if err := assignFastValue(ctx, &bindings, segment.Value, segment.NameIndex, &segment.ValuePlan, segment.Line); err != nil {
+				return true, err
+			}
+		default:
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func assignFastValue(ctx hctx.Context, bindings *fastRenderBindings, name string, nameIndex int, valuePlan *compiler.FastValuePlan, line int) error {
+	if bindings == nil {
+		return fastLineError(line, fmt.Errorf("%q: unknown identifier", name))
+	}
+	if _, ok := bindings.value(nameIndex); !ok {
+		return fastLineError(line, fmt.Errorf("%q: unknown identifier", name))
+	}
+	value, ok, err := evalFastValue(valuePlan, ctx, *bindings, nil)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fastLineError(line, fmt.Errorf("%q: unknown identifier", fastValueMissingName(valuePlan)))
+	}
+	if err := spendFastAssignment(ctx, line); err != nil {
+		return err
+	}
+	bindings.setLocalAndContext(nameIndex, value)
+	return nil
+}

--- a/VM/vm/fast_render_edge_helpers_test.go
+++ b/VM/vm/fast_render_edge_helpers_test.go
@@ -1,0 +1,926 @@
+package vm
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/code"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_VM_Fast_Static_Name_Cached_Value_Branches(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{"name": "Mido"})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"name"}}, ctx)
+
+	value, ok := fastStaticNameCachedValue(&fastStaticNameOp{lookupIndex: 0, nameIndex: 99}, bindings, []interface{}{"cached"}, []bool{true})
+	require.True(t, ok)
+	require.Equal(t, "cached", value)
+
+	value, ok = fastStaticNameCachedValue(&fastStaticNameOp{lookupIndex: 2, nameIndex: 0}, bindings, []interface{}{"cached"}, []bool{true})
+	require.True(t, ok)
+	require.Equal(t, "Mido", value)
+
+	value, ok = fastStaticNameCachedValue(&fastStaticNameOp{lookupIndex: -1, nameIndex: 0}, bindings, nil, nil)
+	require.True(t, ok)
+	require.Equal(t, "Mido", value)
+
+	value, ok = fastStaticNameCachedValue(nil, bindings, nil, nil)
+	require.False(t, ok)
+	require.Nil(t, value)
+}
+
+func Test_VM_Fast_Render_Mixed_And_Conditional_Remaining_Branches(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"items": []string{"x"},
+		"name":  "Mido",
+		"fail": func() (string, error) {
+			return "", errors.New("boom")
+		},
+	})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"items", "name", "fail"}}, ctx)
+	maxInt := int(^uint(0) >> 1)
+
+	grow := fastOutputGrowSize(&fastMixedPlan{
+		staticSize: maxInt - 1,
+		ops: []fastMixedOp{{
+			loop: &compiler.FastLoopPlan{IterableNameIndex: 0, StaticSize: 10},
+		}},
+	}, bindings)
+	require.Equal(t, maxInt-1, grow)
+
+	require.Nil(t, buildFastSimpleConditionalPlan(&compiler.FastConditionalPlan{
+		Branches: []compiler.FastConditionalBranch{{
+			Condition: compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: false},
+		}},
+		ElseSegments: []compiler.FastRenderSegment{{
+			Kind: compiler.FastRenderSegmentCall,
+			Call: &compiler.FastCallPlan{Name: "name", NameIndex: 1},
+		}},
+	}))
+
+	var out strings.Builder
+	wideNames := []int{0, 1, 2, 3, 4, 5, 6, 7, 8}
+	ok, err := renderFastSimpleConditionalPlan(&out, ctx, bindings, &fastSimpleConditionalPlan{
+		nameIndexes: wideNames,
+		branches: []fastSimpleConditionalBranch{{
+			condition: &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: false}},
+			line:      31,
+		}},
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Empty(t, out.String())
+
+	_, err = renderFastSimpleConditionalPlan(&out, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, &fastSimpleConditionalPlan{
+		branches: []fastSimpleConditionalBranch{{
+			condition: &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true}},
+			line:      32,
+		}},
+	})
+	require.ErrorContains(t, err, "line 32")
+
+	_, err = renderFastSimpleConditionalPlan(&out, ctx, bindings, &fastSimpleConditionalPlan{
+		branches: []fastSimpleConditionalBranch{{
+			condition: &fastSimpleValuePlan{
+				value: &compiler.FastValuePlan{Kind: compiler.FastValueInfix, Operator: "??", Line: 33},
+				left:  &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueInteger, IntValue: 1}},
+				right: &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueInteger, IntValue: 2}},
+			},
+			line: 33,
+		}},
+	})
+	require.ErrorContains(t, err, "unknown fast infix operator")
+
+	_, _, err = evalFastSimpleValue(&fastSimpleValuePlan{
+		value: &compiler.FastValuePlan{
+			Kind:      compiler.FastValuePath,
+			NameIndex: 2,
+			Value:     "fail",
+			Path:      []compiler.FastPathStep{{Kind: compiler.FastPathStepCall, Value: "fail", Line: 34}},
+		},
+		lookupIndex: -1,
+	}, ctx, bindings, nil, nil, nil)
+	require.ErrorContains(t, err, "boom")
+
+	value, valueOK, err := evalFastSimpleValue(&fastSimpleValuePlan{
+		value: &compiler.FastValuePlan{Kind: compiler.FastValueKind(255)},
+	}, ctx, bindings, nil, nil, nil)
+	require.NoError(t, err)
+	require.False(t, valueOK)
+	require.Nil(t, value)
+
+	out.Reset()
+	ok, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{{
+		kind: fastMixedOpValue,
+		valuePlan: compiler.FastValuePlan{
+			Kind:     compiler.FastValueInfix,
+			Operator: "==",
+			Left:     &compiler.FastValuePlan{Kind: compiler.FastValueInteger, IntValue: 1},
+			Right:    &compiler.FastValuePlan{Kind: compiler.FastValueFloat, FloatValue: 1},
+			Line:     35,
+		},
+		line: 35,
+	}}})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "true", out.String())
+
+	out.Reset()
+	ok, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{{
+		kind: fastMixedOpAccessChain,
+		valuePlan: compiler.FastValuePlan{
+			Kind:     compiler.FastValueInfix,
+			Operator: "==",
+			Left:     &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "a"},
+			Right:    &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "a"},
+			Line:     36,
+		},
+		line: 36,
+	}}})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "true", out.String())
+
+	_, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{{
+		kind:      fastMixedOpAccessChain,
+		valuePlan: compiler.FastValuePlan{Kind: compiler.FastValuePath, NameIndex: 99, Value: "missing"},
+		line:      37,
+	}}})
+	require.ErrorContains(t, err, "line 37")
+
+	_, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{{
+		kind:      fastMixedOpAccessChain,
+		valuePlan: compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing"},
+		line:      38,
+	}}})
+	require.ErrorContains(t, err, "line 38")
+
+	_, err = renderFastMixedPlan(&out, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, &fastMixedPlan{ops: []fastMixedOp{{
+		kind: fastMixedOpConditional,
+		simpleCond: &fastSimpleConditionalPlan{
+			branches: []fastSimpleConditionalBranch{{
+				condition: &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true}},
+				line:      39,
+			}},
+		},
+	}}})
+	require.ErrorContains(t, err, "line 39")
+}
+
+func Test_VM_Fast_Value_Missing_Name_Branches(t *testing.T) {
+	require.Empty(t, fastSimpleValueMissingName(nil))
+	require.Empty(t, fastValueMissingName(nil))
+
+	require.Equal(t, "helper", fastValueMissingName(&compiler.FastValuePlan{
+		Kind: compiler.FastValueCall,
+		Call: &compiler.FastCallPlan{Name: "helper"},
+	}))
+	require.Equal(t, "direct", fastValueMissingName(&compiler.FastValuePlan{Value: "direct"}))
+	require.Equal(t, "left", fastValueMissingName(&compiler.FastValuePlan{
+		Left:  &compiler.FastValuePlan{Value: "left"},
+		Right: &compiler.FastValuePlan{Value: "right"},
+	}))
+	require.Equal(t, "right", fastValueMissingName(&compiler.FastValuePlan{
+		Right: &compiler.FastValuePlan{Value: "right"},
+	}))
+	require.Empty(t, fastValueMissingName(&compiler.FastValuePlan{}))
+}
+
+func Test_VM_Fast_Render_Inline_And_Simple_Value_Edges(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name": "Mido",
+		"bad":  7,
+		"echo": func(value string) string { return value + "!" },
+		"zero": func() string { return "zero!" },
+	})
+	plan := &compiler.FastRenderPlan{Bindings: []string{"name", "bad", "echo", "zero"}}
+	bindings := newFastRenderBindings(plan, ctx)
+	var out strings.Builder
+
+	rendered, handled, err := renderFastPlanWithBindingPlan(nil, ctx, nil)
+	require.NoError(t, err)
+	require.False(t, handled)
+	require.Empty(t, rendered)
+
+	ok, err := renderFastPlanInlineSafe(nil, plan, ctx, nil)
+	require.NoError(t, err)
+	require.False(t, ok)
+	ok, err = renderFastPlanInlineSafe(&out, nil, ctx, nil)
+	require.NoError(t, err)
+	require.False(t, ok)
+	ok, err = renderFastPlanInlineWithBindings(nil, plan, ctx, bindings)
+	require.NoError(t, err)
+	require.False(t, ok)
+	ok, err = renderFastPlanInlineWithBindings(&out, nil, ctx, bindings)
+	require.NoError(t, err)
+	require.False(t, ok)
+	ok, err = renderFastPlanInlineWithBindings(&out, &compiler.FastRenderPlan{}, ctx, bindings)
+	require.NoError(t, err)
+	require.False(t, ok)
+	nilPreparedPlan := &compiler.FastRenderPlan{}
+	nilPreparedPlan.Prepared.Store((*fastMixedPlan)(nil))
+	ok, err = renderFastPlanInlineWithBindings(&out, nilPreparedPlan, ctx, bindings)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	require.Nil(t, topLevelFastBindingPlan(nil, ctx))
+	require.Nil(t, topLevelFastBindingPlan(&compiler.FastRenderPlan{}, ctx))
+	require.Nil(t, topLevelFastBindingPlan(plan, newLookupTestContext(map[string]interface{}{"name": "Mido"})))
+	require.False(t, canCacheFastRenderBindingPlan(nil))
+	require.False(t, canCacheFastRenderBindingPlan(newLookupTestContext(map[string]interface{}{"name": "Mido"})))
+	prepared := topLevelFastBindingPlan(plan, ctx)
+	require.NotNil(t, prepared)
+	require.Same(t, prepared, topLevelFastBindingPlan(plan, ctx))
+	mismatched := &fastRenderBindingPlan{names: []string{"other"}}
+	otherPlan := &compiler.FastRenderPlan{Bindings: []string{"name"}}
+	otherPlan.BindingPrepared.Store(mismatched)
+	require.NotSame(t, mismatched, topLevelFastBindingPlan(otherPlan, ctx))
+
+	require.Zero(t, fastOutputGrowSize(nil, bindings))
+	require.Zero(t, fastLoopGrowSize(nil))
+	length, lengthOK := fastIterableLen(nil)
+	require.True(t, lengthOK)
+	require.Zero(t, length)
+	length, lengthOK = fastIterableLen(3)
+	require.False(t, lengthOK)
+	require.Zero(t, length)
+	var nilArrayPointer *[2]string
+	length, lengthOK = fastIterableLen(nilArrayPointer)
+	require.True(t, lengthOK)
+	require.Zero(t, length)
+	require.Equal(t, 0, fastOutputGrowSize(&fastMixedPlan{ops: []fastMixedOp{{loop: &compiler.FastLoopPlan{IterableName: "missing", IterableNameIndex: 99}}}}, bindings))
+	require.Equal(t, 0, fastOutputGrowSize(&fastMixedPlan{ops: []fastMixedOp{{loop: &compiler.FastLoopPlan{IterableName: "name", IterableNameIndex: 0}}}}, bindings))
+
+	require.Nil(t, buildFastStaticNamePlan(nil))
+	require.Nil(t, buildFastStaticNamePlan(&fastMixedPlan{}))
+	require.Nil(t, buildFastStaticNamePlan(&fastMixedPlan{ops: []fastMixedOp{{kind: fastMixedOpStatic}}}))
+	require.Equal(t, fastMixedOpStatic, buildFastMixedPlan(&compiler.FastRenderPlan{Segments: []compiler.FastRenderSegment{{Kind: compiler.FastRenderSegmentKind(255)}}}).ops[0].kind)
+	require.Equal(t, -1, (&fastStaticNamePlan{}).bindNameIndex(-1))
+	require.Equal(t, -1, (*fastSimplePlan)(nil).bindNameIndex(0))
+	require.Equal(t, -1, (&fastSimplePlan{}).bindNameIndex(-1))
+	require.Nil(t, buildFastPartialDataBindingPlan(&compiler.FastPartialPlan{Data: []compiler.FastPartialDataPair{{Key: "bad", Value: compiler.FastValuePlan{Kind: compiler.FastValueCall}}}}))
+
+	value, valueOK, err := evalFastSimpleValue(nil, ctx, bindings, nil, nil, nil)
+	require.NoError(t, err)
+	require.True(t, valueOK)
+	require.Nil(t, value)
+
+	tests := []struct {
+		name     string
+		plan     *fastSimpleValuePlan
+		expected interface{}
+		ok       bool
+	}{
+		{"name nil", &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueName, Value: "nil"}}, nil, true},
+		{"name cached", &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "name"}, lookupIndex: 0}, "cached", true},
+		{"name missing null", &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing", NullOnMissing: true}, lookupIndex: -1}, nil, true},
+		{"name missing hard", &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing"}, lookupIndex: -1}, nil, false},
+		{"string", &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "x"}}, "x", true},
+		{"integer", &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueInteger, IntValue: 3}}, 3, true},
+		{"float", &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueFloat, FloatValue: 1.25}}, 1.25, true},
+		{"bool", &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true}}, true, true},
+		{"path missing null", &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValuePath, NameIndex: 99, Value: "missing", NullOnMissing: true}, lookupIndex: -1}, nil, true},
+		{"path missing hard", &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValuePath, NameIndex: 99, Value: "missing"}, lookupIndex: -1}, nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, valueOK, err := evalFastSimpleValue(tt.plan, ctx, bindings, []interface{}{"cached"}, []bool{true}, nil)
+			require.NoError(t, err)
+			require.Equal(t, tt.ok, valueOK)
+			require.Equal(t, tt.expected, value)
+		})
+	}
+
+	pathCallValue, pathCallOK, err := evalFastSimpleValue(&fastSimpleValuePlan{
+		value: &compiler.FastValuePlan{
+			Kind:      compiler.FastValuePath,
+			NameIndex: 3,
+			Value:     "zero",
+			Path: []compiler.FastPathStep{
+				{Kind: compiler.FastPathStepCall, Value: "zero", Line: 1},
+			},
+		},
+		lookupIndex: -1,
+	}, ctx, bindings, nil, nil, nil)
+	require.NoError(t, err)
+	require.True(t, pathCallOK)
+	require.Equal(t, "zero!", pathCallValue)
+
+	callValue, callOK, err := evalFastSimpleCallValue(nil, ctx, bindings, nil, nil)
+	require.NoError(t, err)
+	require.False(t, callOK)
+	require.Nil(t, callValue)
+
+	callValue, callOK, err = evalFastCallValuePlan(nil, nil, ctx, bindings, nil, nil, nil)
+	require.NoError(t, err)
+	require.True(t, callOK)
+	require.Nil(t, callValue)
+
+	callValue, callOK, err = evalFastCallValuePlan(&compiler.FastCallPlan{Name: "missing", NameIndex: 99}, nil, ctx, bindings, nil, nil, nil)
+	require.NoError(t, err)
+	require.False(t, callOK)
+	require.Nil(t, callValue)
+
+	_, callOK, err = evalFastCallValuePlan(&compiler.FastCallPlan{Name: "echo", NameIndex: 2, Args: []compiler.FastValuePlan{{Kind: compiler.FastValueString, Value: "go"}}, Line: 6}, []*fastSimpleValuePlan{{value: &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "go"}}}, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, nil, nil, nil)
+	require.ErrorContains(t, err, "line 6")
+	require.True(t, callOK)
+
+	callValue, callOK, err = evalFastCallValuePlan(&compiler.FastCallPlan{Name: "echo", NameIndex: 2, Args: []compiler.FastValuePlan{{Kind: compiler.FastValueString, Value: "go"}}, Line: 7}, []*fastSimpleValuePlan{{value: &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "go"}}}, ctx, bindings, nil, nil, nil)
+	require.NoError(t, err)
+	require.True(t, callOK)
+	require.Equal(t, "go!", callValue)
+
+	callValue, callOK, err = evalFastCallValuePlan(&compiler.FastCallPlan{Name: "echo", NameIndex: 2, Args: []compiler.FastValuePlan{{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing", Line: 8}}, Line: 8}, nil, ctx, bindings, nil, nil, nil)
+	require.NoError(t, err)
+	require.False(t, callOK)
+	require.Nil(t, callValue)
+
+	_, callOK, err = evalFastCallValuePlan(&compiler.FastCallPlan{Name: "bad", NameIndex: 1, Line: 9}, nil, ctx, bindings, nil, nil, nil)
+	require.ErrorContains(t, err, "line 9")
+	require.True(t, callOK)
+
+	infixValue, infixOK, err := evalFastSimpleInfixValue(&fastSimpleValuePlan{
+		value: &compiler.FastValuePlan{Kind: compiler.FastValueInfix, Operator: "==", Line: 10},
+		left:  &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "missingLeft"}},
+		right: &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 100, Value: "missingRight"}},
+	}, ctx, bindings, nil, nil, nil)
+	require.NoError(t, err)
+	require.True(t, infixOK)
+	require.Equal(t, true, infixValue)
+
+	infixValue, infixOK, err = evalFastSimpleInfixValue(&fastSimpleValuePlan{
+		value: &compiler.FastValuePlan{Kind: compiler.FastValueInfix, Operator: "&&", Line: 11},
+		left:  &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: false}},
+		right: &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing"}},
+	}, ctx, bindings, nil, nil, nil)
+	require.NoError(t, err)
+	require.True(t, infixOK)
+	require.Equal(t, false, infixValue)
+
+	infixValue, infixOK, err = evalFastSimpleInfixValue(nil, ctx, bindings, nil, nil, nil)
+	require.NoError(t, err)
+	require.False(t, infixOK)
+	require.Nil(t, infixValue)
+
+	errorCall := &fastSimpleValuePlan{
+		value: &compiler.FastValuePlan{
+			Kind: compiler.FastValueCall,
+			Call: &compiler.FastCallPlan{
+				Name:      "echo",
+				NameIndex: 2,
+				Args:      []compiler.FastValuePlan{{Kind: compiler.FastValueString, Value: "go"}},
+				Line:      13,
+			},
+		},
+		args:        []*fastSimpleValuePlan{{value: &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "go"}}},
+		lookupIndex: -1,
+	}
+	_, infixOK, err = evalFastSimpleInfixValue(&fastSimpleValuePlan{
+		value: &compiler.FastValuePlan{Kind: compiler.FastValueInfix, Operator: "==", Line: 13},
+		left:  errorCall,
+		right: &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "go"}},
+	}, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, nil, nil, nil)
+	require.ErrorContains(t, err, "line 13")
+	require.True(t, infixOK)
+
+	_, infixOK, err = evalFastSimpleInfixValue(&fastSimpleValuePlan{
+		value: &compiler.FastValuePlan{Kind: compiler.FastValueInfix, Operator: "==", Line: 14},
+		left:  &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "go"}},
+		right: errorCall,
+	}, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, nil, nil, nil)
+	require.ErrorContains(t, err, "line 13")
+	require.True(t, infixOK)
+
+	infixValue, infixOK, err = evalFastSimpleLogicalInfixValue(&fastSimpleValuePlan{
+		value: &compiler.FastValuePlan{Kind: compiler.FastValueInfix, Operator: "??", Line: 12},
+		left:  &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true}},
+		right: &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true}},
+	}, ctx, bindings, nil, nil, nil)
+	require.NoError(t, err)
+	require.False(t, infixOK)
+	require.Nil(t, infixValue)
+
+	infixValue, infixOK, err = evalFastSimpleLogicalInfixValue(nil, ctx, bindings, nil, nil, nil)
+	require.NoError(t, err)
+	require.False(t, infixOK)
+	require.Nil(t, infixValue)
+
+	_, infixOK, err = evalFastSimpleLogicalInfixValue(&fastSimpleValuePlan{
+		value: &compiler.FastValuePlan{Kind: compiler.FastValueInfix, Operator: "&&", Line: 15},
+		left:  errorCall,
+		right: &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true}},
+	}, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, nil, nil, nil)
+	require.ErrorContains(t, err, "line 13")
+	require.True(t, infixOK)
+
+	_, infixOK, err = evalFastSimpleLogicalInfixValue(&fastSimpleValuePlan{
+		value: &compiler.FastValuePlan{Kind: compiler.FastValueInfix, Operator: "&&", Line: 16},
+		left:  &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true}},
+		right: errorCall,
+	}, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, nil, nil, nil)
+	require.ErrorContains(t, err, "line 13")
+	require.True(t, infixOK)
+
+	var nilConditionalPlan *fastSimpleConditionalPlan
+	require.Equal(t, -1, nilConditionalPlan.bindNameIndex(0))
+	conditionalPlan := &fastSimpleConditionalPlan{}
+	require.Equal(t, -1, conditionalPlan.bindNameIndex(-1))
+	require.Equal(t, 0, conditionalPlan.bindNameIndex(3))
+	require.Equal(t, 0, conditionalPlan.bindNameIndex(3))
+	require.Equal(t, []int{3}, conditionalPlan.nameIndexes)
+
+	var nilPartialDataPlan *fastPartialDataBindingPlan
+	require.Equal(t, -1, nilPartialDataPlan.bindNameIndex(0))
+	partialDataPlan := &fastPartialDataBindingPlan{}
+	require.Equal(t, -1, partialDataPlan.bindNameIndex(-1))
+	require.Equal(t, 0, partialDataPlan.bindNameIndex(4))
+	require.Equal(t, 0, partialDataPlan.bindNameIndex(4))
+	require.Equal(t, []int{4}, partialDataPlan.nameIndexes)
+}
+
+func Test_VM_Fast_Simple_Plan_Builder_Edge_Branches(t *testing.T) {
+	require.Nil(t, buildFastSimplePlan(nil))
+	require.Nil(t, buildFastSimplePlan(&fastMixedPlan{}))
+	require.Nil(t, buildFastSimplePlan(&fastMixedPlan{ops: []fastMixedOp{{kind: fastMixedOpStatic}}}))
+	require.Nil(t, buildFastSimplePlan(&fastMixedPlan{ops: []fastMixedOp{{
+		kind:      fastMixedOpAccessChain,
+		valuePlan: compiler.FastValuePlan{Kind: compiler.FastValuePath, NameIndex: -1},
+	}}}))
+	require.Nil(t, buildFastSimplePlan(&fastMixedPlan{ops: []fastMixedOp{{
+		kind:      fastMixedOpValue,
+		valuePlan: compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "x"},
+	}}}))
+	require.Nil(t, buildFastSimplePlan(&fastMixedPlan{ops: []fastMixedOp{{
+		kind: fastMixedOpValue,
+		valuePlan: compiler.FastValuePlan{
+			Kind:     compiler.FastValueInfix,
+			Operator: "==",
+			Left:     &compiler.FastValuePlan{Kind: compiler.FastValueLoopKey},
+			Right:    &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "x"},
+		},
+	}}}))
+
+	require.Nil(t, buildFastSimpleConditionalPlan(nil))
+	require.Nil(t, buildFastSimpleConditionalPlan(&compiler.FastConditionalPlan{}))
+	require.Nil(t, buildFastSimpleConditionalPlan(&compiler.FastConditionalPlan{
+		Branches: []compiler.FastConditionalBranch{{
+			Condition: compiler.FastValuePlan{Kind: compiler.FastValueLoopKey},
+		}},
+	}))
+}
+
+func Test_VM_Fast_Simple_Plan_Edge_Branches(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name":        "Mido",
+		"unsupported": &object.Builtin{},
+		"user":        vmSegmentUser{Name: "Bender"},
+		"scalar":      3,
+	})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"name", "unsupported", "user", "scalar"}}, ctx)
+	var out strings.Builder
+
+	ok, err := renderFastSimplePlan(nil, ctx, bindings, &fastSimplePlan{})
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	ok, err = renderFastSimplePlan(&out, ctx, bindings, nil)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	ok, err = renderFastSimplePlan(&out, ctx, bindings, &fastSimplePlan{ops: []fastSimpleOp{{}}})
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	value, cachedOK := fastSimpleCachedOpValue(nil, bindings, nil, nil)
+	require.False(t, cachedOK)
+	require.Nil(t, value)
+
+	value, cachedOK = fastSimpleCachedOpValue(&fastSimpleOp{op: &fastMixedOp{nameIndex: 0}, lookupIndex: -1}, bindings, nil, nil)
+	require.True(t, cachedOK)
+	require.Equal(t, "Mido", value)
+
+	require.Zero(t, fastSimplePlanGrowSize(nil))
+	require.Equal(t, 0, fastSimplePlanGrowSize(&fastSimplePlan{ops: []fastSimpleOp{{}}}))
+	require.Equal(t, 19, fastSimplePlanGrowSize(&fastSimplePlan{ops: []fastSimpleOp{{op: &fastMixedOp{prefix: "pre", kind: fastMixedOpName}}}}))
+
+	out.Reset()
+	ok, err = renderFastSimplePlan(&out, ctx, bindings, &fastSimplePlan{
+		nameIndexes: []int{99, 0},
+		ops: []fastSimpleOp{
+			{op: &fastMixedOp{kind: fastMixedOpName, prefix: "pre", nameIndex: 99, value: "missing", nullOnMissing: true, line: 1}, lookupIndex: 0},
+			{op: &fastMixedOp{kind: fastMixedOpName, nameIndex: 0, value: "name", line: 1}, lookupIndex: 1},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "preMido", out.String())
+
+	ok, err = renderFastSimplePlan(&out, ctx, bindings, &fastSimplePlan{
+		nameIndexes: []int{1},
+		ops: []fastSimpleOp{
+			{op: &fastMixedOp{kind: fastMixedOpName, nameIndex: 1, value: "unsupported", line: 2}, lookupIndex: 0},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	_, err = renderFastSimplePlan(&out, ctx, bindings, &fastSimplePlan{
+		nameIndexes: []int{99},
+		ops: []fastSimpleOp{
+			{op: &fastMixedOp{kind: fastMixedOpName, nameIndex: 99, value: "missing", line: 3}, lookupIndex: 0},
+		},
+	})
+	require.ErrorContains(t, err, "line 3")
+
+	_, err = renderFastSimplePlan(&out, ctx, bindings, &fastSimplePlan{
+		nameIndexes: []int{99},
+		ops: []fastSimpleOp{
+			{op: &fastMixedOp{kind: fastMixedOpProperty, nameIndex: 99, value: "missing", property: "Name", line: 4}, lookupIndex: 0},
+		},
+	})
+	require.ErrorContains(t, err, "line 4")
+
+	_, err = renderFastSimplePlan(&out, ctx, bindings, &fastSimplePlan{
+		nameIndexes: []int{2},
+		ops: []fastSimpleOp{
+			{op: &fastMixedOp{kind: fastMixedOpProperty, nameIndex: 2, value: "user", property: "Missing", receiver: "user", full: "user.Missing", line: 5}, lookupIndex: 0},
+		},
+	})
+	require.ErrorContains(t, err, "line 5")
+
+	_, err = renderFastSimplePlan(&out, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, &fastSimplePlan{
+		nameIndexes: []int{2},
+		ops: []fastSimpleOp{
+			{op: &fastMixedOp{kind: fastMixedOpProperty, nameIndex: 2, value: "user", property: "Name", receiver: "user", full: "user.Name", line: 51}, lookupIndex: 0},
+		},
+	})
+	require.ErrorContains(t, err, "line 51")
+
+	ok, err = renderFastSimplePlan(&out, ctx, bindings, &fastSimplePlan{
+		nameIndexes: []int{3},
+		ops: []fastSimpleOp{
+			{op: &fastMixedOp{
+				kind:      fastMixedOpAccessChain,
+				nameIndex: 3,
+				valuePlan: compiler.FastValuePlan{
+					Kind:      compiler.FastValuePath,
+					NameIndex: 3,
+					Value:     "scalar",
+					Path:      []compiler.FastPathStep{{Kind: compiler.FastPathStepProperty, Value: "Name"}},
+					Line:      6,
+				},
+				line: 6,
+			}, lookupIndex: 0},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	out.Reset()
+	ok, err = renderFastSimplePlan(&out, ctx, bindings, &fastSimplePlan{
+		nameIndexes: []int{99},
+		ops: []fastSimpleOp{
+			{op: &fastMixedOp{
+				kind: fastMixedOpAccessChain,
+				valuePlan: compiler.FastValuePlan{
+					Kind:          compiler.FastValuePath,
+					NameIndex:     99,
+					Value:         "missing",
+					NullOnMissing: true,
+					Path:          vmAccessProfileNamePlan(99).Path,
+					Line:          61,
+				},
+				line: 61,
+			}, lookupIndex: 0},
+			{op: &fastMixedOp{kind: fastMixedOpStatic, prefix: "after"}},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "after", out.String())
+
+	_, err = renderFastSimplePlan(&out, ctx, bindings, &fastSimplePlan{
+		nameIndexes: []int{99},
+		ops: []fastSimpleOp{
+			{op: &fastMixedOp{
+				kind: fastMixedOpAccessChain,
+				valuePlan: compiler.FastValuePlan{
+					Kind:      compiler.FastValuePath,
+					NameIndex: 99,
+					Value:     "missing",
+					Path:      vmAccessProfileNamePlan(99).Path,
+					Line:      62,
+				},
+				line: 62,
+			}, lookupIndex: 0},
+		},
+	})
+	require.ErrorContains(t, err, "line 62")
+
+	accessCtx := plush.NewContextWith(map[string]interface{}{"user": vmAccessUser{Profile: &vmAccessProfile{Name: "Bender"}}})
+	accessBindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"user"}}, accessCtx)
+	_, err = renderFastSimplePlan(&out, plush.NewContext().WithBudget(plush.NewBudget(0)), accessBindings, &fastSimplePlan{
+		nameIndexes: []int{0},
+		ops: []fastSimpleOp{
+			{op: &fastMixedOp{
+				kind:      fastMixedOpAccessChain,
+				valuePlan: *vmAccessProfileNamePlan(0),
+				line:      63,
+			}, lookupIndex: 0},
+		},
+	})
+	require.ErrorContains(t, err, "line 1")
+
+	ok, err = renderFastSimplePlan(&out, ctx, bindings, &fastSimplePlan{
+		ops: []fastSimpleOp{{op: &fastMixedOp{kind: fastMixedOpValue, valuePlan: compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "x"}}}},
+	})
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	infixPlan := compiler.FastValuePlan{
+		Kind:     compiler.FastValueInfix,
+		Operator: "??",
+		Value:    "bad",
+		Left:     &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "Mido"},
+		Right:    &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "Mido"},
+	}
+	_, err = renderFastSimplePlan(&out, ctx, bindings, &fastSimplePlan{
+		ops: []fastSimpleOp{{op: &fastMixedOp{kind: fastMixedOpValue, valuePlan: infixPlan, line: 7}, value: &fastSimpleValuePlan{
+			value: &infixPlan,
+			left:  &fastSimpleValuePlan{value: infixPlan.Left},
+			right: &fastSimpleValuePlan{value: infixPlan.Right},
+		}}},
+	})
+	require.ErrorContains(t, err, "unknown fast infix operator")
+
+	_, err = renderFastSimplePlan(&out, ctx, bindings, &fastSimplePlan{
+		ops: []fastSimpleOp{{op: &fastMixedOp{kind: fastMixedOpValue, valuePlan: compiler.FastValuePlan{Kind: compiler.FastValueInfix, Value: "missing"}, line: 71}, value: &fastSimpleValuePlan{
+			value: &compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing"},
+		}}},
+	})
+	require.ErrorContains(t, err, "line 71")
+
+	out.Reset()
+	ok, err = renderFastSimplePlan(&out, ctx, bindings, &fastSimplePlan{
+		ops: []fastSimpleOp{{op: &fastMixedOp{kind: fastMixedOpValue, valuePlan: compiler.FastValuePlan{Kind: compiler.FastValueInfix}, line: 72}, value: &fastSimpleValuePlan{
+			value: &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "<raw>"},
+		}}},
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "&lt;raw&gt;", out.String())
+
+	ok, err = renderFastSimplePlan(&out, ctx, bindings, &fastSimplePlan{
+		ops: []fastSimpleOp{{op: &fastMixedOp{kind: fastMixedOpKind(255)}}},
+	})
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	wideCtx := plush.NewContextWith(map[string]interface{}{
+		"n0": "zero", "n1": "one", "n2": "two", "n3": "three", "n4": "four",
+		"n5": "five", "n6": "six", "n7": "seven", "n8": "eight",
+	})
+	wideBindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"n0", "n1", "n2", "n3", "n4", "n5", "n6", "n7", "n8"}}, wideCtx)
+	out.Reset()
+	ok, err = renderFastSimplePlan(&out, wideCtx, wideBindings, &fastSimplePlan{
+		nameIndexes: []int{0, 1, 2, 3, 4, 5, 6, 7, 8},
+		ops: []fastSimpleOp{
+			{op: &fastMixedOp{kind: fastMixedOpName, nameIndex: 8, value: "n8", line: 73}, lookupIndex: 8},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "eight", out.String())
+
+	ok, err = renderFastSimpleConditionalPlan(nil, ctx, bindings, &fastSimpleConditionalPlan{})
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	ok, err = renderFastSimpleConditionalPlan(&out, ctx, bindings, nil)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	ok, err = renderFastSimpleConditionalPlan(&out, ctx, bindings, &fastSimpleConditionalPlan{
+		branches: []fastSimpleConditionalBranch{{condition: &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true}}, line: 8}},
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	out.Reset()
+	ok, err = renderFastSimpleConditionalPlan(&out, ctx, bindings, &fastSimpleConditionalPlan{
+		branches:     []fastSimpleConditionalBranch{{condition: &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: false}}, line: 9}},
+		elseSegments: &fastSimplePlan{ops: []fastSimpleOp{{op: &fastMixedOp{kind: fastMixedOpStatic, prefix: "else"}}}},
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "else", out.String())
+}
+
+func Test_VM_Fast_Static_Name_Inline_Safe_Edge_Branches(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"n0":          "zero",
+		"n1":          "one",
+		"n2":          "two",
+		"n3":          "three",
+		"n4":          "four",
+		"n5":          "five",
+		"n6":          "six",
+		"n7":          "seven",
+		"n8":          "eight",
+		"unsupported": &object.Builtin{},
+	})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{
+		"n0", "n1", "n2", "n3", "n4", "n5", "n6", "n7", "n8", "unsupported",
+	}}, ctx)
+
+	ok, err := renderFastStaticNamePlanInlineSafe(nil, ctx, bindings, &fastStaticNamePlan{})
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	var out strings.Builder
+	ok, err = renderFastStaticNamePlanInlineSafe(&out, ctx, bindings, nil)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	ok, err = renderFastStaticNamePlanInlineSafe(&out, ctx, bindings, &fastStaticNamePlan{
+		nameIndexes: []int{0, 1, 2, 3, 4, 5, 6, 7, 8},
+		ops: []fastStaticNameOp{
+			{prefix: "pre:", nameIndex: -1},
+			{nameIndex: 8, lookupIndex: 8, value: "n8", line: 1},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "pre:eight", out.String())
+
+	out.Reset()
+	ok, err = renderFastStaticNamePlanInlineSafe(&out, ctx, bindings, &fastStaticNamePlan{
+		nameIndexes: []int{99},
+		ops: []fastStaticNameOp{
+			{nameIndex: 99, lookupIndex: 0, value: "missing", nullOnMissing: true, line: 2},
+			{prefix: "after", nameIndex: -1},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "after", out.String())
+
+	_, err = renderFastStaticNamePlanInlineSafe(&out, ctx, bindings, &fastStaticNamePlan{
+		nameIndexes: []int{99},
+		ops: []fastStaticNameOp{
+			{nameIndex: 99, lookupIndex: 0, value: "missing", line: 3},
+		},
+	})
+	require.ErrorContains(t, err, "line 3")
+
+	ok, err = renderFastStaticNamePlanInlineSafe(&out, ctx, bindings, &fastStaticNamePlan{
+		nameIndexes: []int{9},
+		ops: []fastStaticNameOp{
+			{nameIndex: 9, lookupIndex: 0, value: "unsupported", line: 4},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	ok, err = renderFastStaticNamePlan(&out, ctx, bindings, nil)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	out.Reset()
+	ok, err = renderFastStaticNamePlan(&out, ctx, bindings, &fastStaticNamePlan{
+		ops: []fastStaticNameOp{
+			{prefix: "pre:", nameIndex: -1},
+			{nameIndex: 0, lookupIndex: -1, value: "n0", line: 5},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "pre:zero", out.String())
+
+	out.Reset()
+	ok, err = renderFastStaticNamePlan(&out, ctx, bindings, &fastStaticNamePlan{
+		ops: []fastStaticNameOp{
+			{nameIndex: 99, lookupIndex: -1, value: "missing", nullOnMissing: true, line: 6},
+			{prefix: "after", nameIndex: -1},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "after", out.String())
+
+	ok, err = renderFastStaticNamePlan(&out, ctx, bindings, &fastStaticNamePlan{
+		ops: []fastStaticNameOp{
+			{nameIndex: 9, lookupIndex: -1, value: "unsupported", line: 7},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func Test_VM_Fast_Property_Reflect_Output_Edges(t *testing.T) {
+	ctx := plush.NewContext()
+	var out strings.Builder
+	access := object.PropertyAccess{Receiver: "user", Full: "user.Name"}
+	user := vmFastPropertyUser{Name: "<mido>", Count: 7}
+	var nameSlot object.InlineCacheSlot
+
+	require.NoError(t, writeFastPropertyReflectOutput(&out, ctx, reflect.Value{}, "Name", access, &nameSlot))
+	require.Empty(t, out.String())
+
+	var nilUser *vmFastPropertyUser
+	require.NoError(t, writeFastPropertyReflectOutput(&out, ctx, reflect.ValueOf(nilUser), "Name", access, &nameSlot))
+	require.Empty(t, out.String())
+
+	require.NoError(t, writeFastPropertyReflectOutput(&out, ctx, reflect.ValueOf(user), "Name", access, &nameSlot))
+	require.Equal(t, "&lt;mido&gt;", out.String())
+
+	out.Reset()
+	require.NoError(t, writeFastPropertyReflectOutput(&out, ctx, reflect.ValueOf(&user), "Name", access, &nameSlot))
+	require.Equal(t, "&lt;mido&gt;", out.String())
+
+	out.Reset()
+	err := writeFastPropertyReflectOutput(&out, ctx, reflect.ValueOf(user), "Name", object.PropertyAccess{Receiver: "user", Full: "user.Name()", Method: true}, &nameSlot)
+	require.ErrorContains(t, err, "does not have a method")
+	require.Empty(t, out.String())
+
+	out.Reset()
+	var echoSlot object.InlineCacheSlot
+	require.NoError(t, writeFastPropertyReflectOutput(&out, ctx, reflect.ValueOf(user), "Echo", object.PropertyAccess{Receiver: "user", Full: "user.Echo()", Method: true}, &echoSlot))
+	require.Empty(t, out.String())
+}
+
+func Test_VM_Fast_Property_Value_From_Reflect_Manual_Entries(t *testing.T) {
+	user := vmFastPropertyUser{Name: "Mido", Count: 7}
+	rv := reflect.ValueOf(user)
+
+	valueLookup := cachedPropertyLookup(rv.Type(), "Echo")
+	value, err := fastPropertyValueFromReflect(rv, user, "Echo", object.PropertyAccess{Receiver: "user", Full: "user.Echo()", Method: true}, &propertyInlineCacheEntry{lookup: valueLookup})
+	require.NoError(t, err)
+	require.IsType(t, func() string { return "" }, value)
+
+	pointerLookup := cachedPropertyLookup(rv.Type(), "PointerEcho")
+	value, err = fastPropertyValueFromReflect(rv, user, "PointerEcho", object.PropertyAccess{Receiver: "user", Full: "user.PointerEcho()", Method: true}, &propertyInlineCacheEntry{lookup: pointerLookup})
+	require.NoError(t, err)
+	require.IsType(t, func() string { return "" }, value)
+
+	fieldLookup := cachedPropertyLookup(rv.Type(), "Count")
+	value, err = fastPropertyValueFromReflect(rv, user, "Count", object.PropertyAccess{Receiver: "user", Full: "user.Count"}, &propertyInlineCacheEntry{lookup: fieldLookup})
+	require.NoError(t, err)
+	require.Equal(t, int32(7), value)
+
+	_, err = fastPropertyValueFromReflect(rv, user, "Count", object.PropertyAccess{Receiver: "user", Full: "user.Count()", Method: true}, &propertyInlineCacheEntry{lookup: fieldLookup})
+	require.ErrorContains(t, err, "does not have a method")
+
+	_, err = fastPropertyValueFromReflect(reflect.ValueOf(3), 3, "Missing", object.PropertyAccess{Receiver: "value", Full: "value.Missing"}, &propertyInlineCacheEntry{lookup: propertyLookup{kind: propertyLookupMissing}})
+	require.ErrorContains(t, err, "does not have a field or method")
+
+	nilString := (*string)(nil)
+	value, err = fastFieldValue(reflect.ValueOf(&nilString).Elem(), object.PropertyAccess{}, "Name")
+	require.NoError(t, err)
+	require.Nil(t, value)
+
+	privateField := reflect.ValueOf(vmFastPropertyUser{hidden: "secret"}).FieldByName("hidden")
+	_, err = fastFieldValue(privateField, object.PropertyAccess{}, "hidden")
+	require.ErrorContains(t, err, "cannot return value obtained from unexported field or method")
+}
+
+func Test_VM_Partial_Overlay_Update_And_Name_For_ID_Edges(t *testing.T) {
+	parent := &lookupTestContext{values: map[string]interface{}{"parent": "old"}}
+	ctx := borrowPartialOverlayContext(parent)
+	defer releasePartialOverlayContext(ctx)
+
+	require.False(t, (*partialOverlayContext)(nil).Update("x", "y"))
+	require.False(t, (*partialOverlayContext)(nil).Update("x", nil))
+	_, ok := (*partialOverlayContext)(nil).nameForID(0)
+	require.False(t, ok)
+
+	id := ctx.InternID("parent")
+	name, ok := ctx.nameForID(id)
+	require.True(t, ok)
+	require.Equal(t, "parent", name)
+	require.True(t, ctx.UpdateID(id, "new"))
+	require.Equal(t, "new", parent.values["parent"])
+
+	ctx.Set("local", "first")
+	require.True(t, ctx.Update("local", "second"))
+	value, ok := ctx.Lookup("local")
+	require.True(t, ok)
+	require.Equal(t, "second", value)
+	require.False(t, ctx.Update("missing", "value"))
+
+	ctx.rememberIDName(-1, "bad")
+	ctx.rememberIDName(99, "")
+	_, ok = ctx.nameForID(-1)
+	require.False(t, ok)
+}
+
+func Test_VM_Loop_Predicate_Unknown_Opcode_Branches(t *testing.T) {
+	block := executeForClosure(code.Instructions{byte(255)}, 0)
+	require.False(t, loopCanUseRawValues(block))
+	require.False(t, loopNeedsContextWrites(block))
+}

--- a/VM/vm/fast_render_segments_test.go
+++ b/VM/vm/fast_render_segments_test.go
@@ -1,0 +1,628 @@
+package vm
+
+import (
+	"fmt"
+	"html/template"
+	"strings"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/stretchr/testify/require"
+)
+
+type vmSegmentUser struct {
+	Name string
+}
+
+func Test_VM_Render_Fast_Segments_Mixed_Kinds(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name": "Mido",
+		"user": vmSegmentUser{Name: "<Bender>"},
+		"upper": func(value string) string {
+			return strings.ToUpper(value)
+		},
+		"items": []string{"a", "b"},
+		"partialFeeder": func(string) (string, error) {
+			return `<em><%= name %></em>`, nil
+		},
+	})
+	plan := &compiler.FastRenderPlan{Bindings: []string{"name", "user", "upper", "items"}}
+	bindings := newFastRenderBindings(plan, ctx)
+	segments := []compiler.FastRenderSegment{
+		{Kind: compiler.FastRenderSegmentStatic, Value: "S:"},
+		{Kind: compiler.FastRenderSegmentName, NameIndex: 0, Value: "name", Line: 1},
+		{Kind: compiler.FastRenderSegmentStatic, Value: "|P:"},
+		{Kind: compiler.FastRenderSegmentProperty, NameIndex: 1, Value: "user", Property: "Name", Receiver: "user", Full: "user.Name", Line: 1},
+		{Kind: compiler.FastRenderSegmentStatic, Value: "|V:"},
+		{Kind: compiler.FastRenderSegmentValue, ValuePlan: compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "<value>"}, Line: 1},
+		{Kind: compiler.FastRenderSegmentStatic, Value: "|C:"},
+		{Kind: compiler.FastRenderSegmentCall, Call: &compiler.FastCallPlan{
+			Name:      "upper",
+			NameIndex: 2,
+			Args:      []compiler.FastValuePlan{{Kind: compiler.FastValueString, Value: "go"}},
+			Line:      1,
+		}},
+		{Kind: compiler.FastRenderSegmentStatic, Value: "|IF:"},
+		{Kind: compiler.FastRenderSegmentConditional, Conditional: &compiler.FastConditionalPlan{
+			Branches: []compiler.FastConditionalBranch{
+				{
+					Condition: compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true},
+					Segments:  []compiler.FastRenderSegment{{Kind: compiler.FastRenderSegmentStatic, Value: "yes"}},
+					Line:      1,
+				},
+			},
+		}},
+		{Kind: compiler.FastRenderSegmentStatic, Value: "|L:"},
+		{Kind: compiler.FastRenderSegmentLoop, Loop: &compiler.FastLoopPlan{
+			IterableName:      "items",
+			IterableNameIndex: 3,
+			Line:              1,
+			Parts: []compiler.FastLoopPart{
+				{Kind: compiler.FastLoopPartKey},
+				{Kind: compiler.FastLoopPartStatic, Value: "="},
+				{Kind: compiler.FastLoopPartValue},
+				{Kind: compiler.FastLoopPartStatic, Value: ";"},
+			},
+		}},
+		{Kind: compiler.FastRenderSegmentStatic, Value: "|PART:"},
+		{Kind: compiler.FastRenderSegmentPartial, Partial: &compiler.FastPartialPlan{Name: "row.plush", Line: 1}},
+	}
+
+	var out strings.Builder
+	ok, err := renderFastSegments(&out, ctx, bindings, segments)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "S:Mido|P:&lt;Bender&gt;|V:&lt;value&gt;|C:GO|IF:yes|L:0=a;1=b;|PART:<em>Mido</em>", out.String())
+}
+
+func Test_VM_Render_Fast_Segments_Missing_And_Default_Branches(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{"name": "Mido"})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"name"}}, ctx)
+
+	var out strings.Builder
+	ok, err := renderFastSegments(&out, ctx, bindings, []compiler.FastRenderSegment{
+		{Kind: compiler.FastRenderSegmentName, NameIndex: 99, Value: "missing", NullOnMissing: true, Line: 1},
+		{Kind: compiler.FastRenderSegmentStatic, Value: "after"},
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "after", out.String())
+
+	_, err = renderFastSegments(&out, ctx, bindings, []compiler.FastRenderSegment{
+		{Kind: compiler.FastRenderSegmentName, NameIndex: 99, Value: "missing", Line: 1},
+	})
+	require.ErrorContains(t, err, `"missing": unknown identifier`)
+
+	ok, err = renderFastSegments(&out, ctx, bindings, []compiler.FastRenderSegment{{Kind: 255}})
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func Test_VM_Render_Fast_Mixed_Plan_All_Optimized_Op_Kinds(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name": "Mido",
+		"user": vmAccessUser{Profile: &vmAccessProfile{Name: "<Bender>"}},
+		"upper": func(value string) string {
+			return strings.ToUpper(value)
+		},
+		"items": []string{"a", "b"},
+		"partialFeeder": func(string) (string, error) {
+			return `<span><%= name %></span>`, nil
+		},
+	})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"name", "unsupported", "user", "upper", "items"}}, ctx)
+	var out strings.Builder
+
+	ok, err := renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{
+		{
+			kind:      fastMixedOpAccessChain,
+			prefix:    " access=",
+			valuePlan: *vmAccessProfileNamePlan(2),
+			line:      12,
+		},
+		{
+			kind: fastMixedOpCall,
+			call: &compiler.FastCallPlan{
+				Name:      "upper",
+				NameIndex: 3,
+				Args:      []compiler.FastValuePlan{{Kind: compiler.FastValueString, Value: "go"}},
+				Line:      13,
+			},
+		},
+		{
+			kind: fastMixedOpConditional,
+			conditional: &compiler.FastConditionalPlan{
+				Branches: []compiler.FastConditionalBranch{{
+					Condition: compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true},
+					Segments:  []compiler.FastRenderSegment{{Kind: compiler.FastRenderSegmentStatic, Value: " yes"}},
+					Line:      14,
+				}},
+			},
+		},
+		{
+			kind:    fastMixedOpPartial,
+			partial: &compiler.FastPartialPlan{Name: "edge_mixed_partial.plush", Line: 15},
+		},
+		{
+			kind: fastMixedOpLoop,
+			loop: &compiler.FastLoopPlan{
+				IterableName:      "items",
+				IterableNameIndex: 4,
+				Parts: []compiler.FastLoopPart{
+					{Kind: compiler.FastLoopPartValue},
+				},
+				Line: 16,
+			},
+		},
+	}})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, ` access=&lt;Bender&gt;GO yes<span>Mido</span>ab`, out.String())
+}
+
+func Test_VM_Render_Fast_Mixed_Plan_Error_And_Fallback_Edges(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name":   "Mido",
+		"user":   vmAccessUser{Profile: &vmAccessProfile{Name: "<Bender>"}},
+		"hidden": vmFastPropertyUser{hidden: "secret"},
+		"scalar": 12,
+		"partialFeeder": func(string) (string, error) {
+			return "", fmt.Errorf("missing partial")
+		},
+	})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"name", "user", "hidden", "scalar"}}, ctx)
+	var out strings.Builder
+
+	_, err := renderFastMixedPlan(&out, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, &fastMixedPlan{ops: []fastMixedOp{{
+		kind:      fastMixedOpProperty,
+		nameIndex: 1,
+		value:     "user",
+		property:  "Profile",
+		line:      21,
+	}}})
+	require.ErrorContains(t, err, "line 21")
+
+	_, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{{
+		kind: fastMixedOpValue,
+		valuePlan: compiler.FastValuePlan{
+			Kind:     compiler.FastValueInfix,
+			Operator: "??",
+			Left:     &compiler.FastValuePlan{Kind: compiler.FastValueInteger, IntValue: 1},
+			Right:    &compiler.FastValuePlan{Kind: compiler.FastValueInteger, IntValue: 2},
+			Line:     22,
+		},
+		line: 22,
+	}}})
+	require.ErrorContains(t, err, "line 22")
+
+	_, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{{
+		kind: fastMixedOpValue,
+		valuePlan: compiler.FastValuePlan{
+			Kind:      compiler.FastValuePath,
+			NameIndex: 99,
+			Value:     "missing",
+			Path:      []compiler.FastPathStep{{Kind: compiler.FastPathStepProperty, Value: "Name", Line: 23}},
+		},
+		line: 23,
+	}}})
+	require.ErrorContains(t, err, "line 23")
+
+	_, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{{
+		kind: fastMixedOpAccessChain,
+		valuePlan: compiler.FastValuePlan{
+			Kind:      compiler.FastValuePath,
+			NameIndex: 99,
+			Value:     "missing",
+			Path:      vmAccessProfileNamePlan(99).Path,
+		},
+		line: 24,
+	}}})
+	require.ErrorContains(t, err, "line 24")
+
+	out.Reset()
+	ok, err := renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{{
+		kind:      fastMixedOpAccessChain,
+		valuePlan: compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "fallback"},
+		line:      25,
+	}}})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "fallback", out.String())
+
+	_, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{{
+		kind: fastMixedOpCall,
+		call: &compiler.FastCallPlan{Name: "missing", NameIndex: 99, Line: 26},
+	}}})
+	require.ErrorContains(t, err, "line 26")
+
+	ok, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{{
+		kind: fastMixedOpConditional,
+		simpleCond: &fastSimpleConditionalPlan{
+			branches: []fastSimpleConditionalBranch{{
+				condition: &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing"}},
+				segments:  &fastSimplePlan{ops: []fastSimpleOp{{op: &fastMixedOp{kind: fastMixedOpStatic, prefix: "nope"}}}},
+				line:      27,
+			}},
+		},
+	}}})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	_, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{{
+		kind:    fastMixedOpPartial,
+		partial: &compiler.FastPartialPlan{Name: "edge_mixed_missing_partial.plush", Line: 28},
+	}}})
+	require.ErrorContains(t, err, "line 28")
+
+	ok, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{{
+		kind: fastMixedOpLoop,
+		loop: &compiler.FastLoopPlan{IterableName: "scalar", IterableNameIndex: 3, Line: 29},
+	}}})
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func Test_VM_Render_Fast_Segments_And_Mixed_Edge_Branches(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name":        "Mido",
+		"unsupported": &object.Builtin{},
+		"user":        vmSegmentUser{Name: "Bender"},
+		"scalar":      3,
+		"partialFeeder": func(string) (string, error) {
+			return "", fmt.Errorf("partial boom")
+		},
+	})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"name", "unsupported", "user", "scalar"}}, ctx)
+	var out strings.Builder
+
+	ok, err := renderFastSegments(&out, ctx, bindings, []compiler.FastRenderSegment{
+		{Kind: compiler.FastRenderSegmentName, NameIndex: 1, Value: "unsupported", Line: 1},
+	})
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	_, err = renderFastSegments(&out, ctx, bindings, []compiler.FastRenderSegment{
+		{Kind: compiler.FastRenderSegmentProperty, NameIndex: 99, Value: "missing", Property: "Name", Line: 2},
+	})
+	require.ErrorContains(t, err, "line 2")
+
+	_, err = renderFastSegments(&out, ctx, bindings, []compiler.FastRenderSegment{
+		{Kind: compiler.FastRenderSegmentProperty, NameIndex: 2, Value: "user", Property: "Missing", Receiver: "user", Full: "user.Missing", Line: 3},
+	})
+	require.ErrorContains(t, err, "line 3")
+
+	_, err = renderFastSegments(&out, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, []compiler.FastRenderSegment{
+		{Kind: compiler.FastRenderSegmentProperty, NameIndex: 2, Value: "user", Property: "Name", Receiver: "user", Full: "user.Name", Line: 31},
+	})
+	require.ErrorContains(t, err, "line 31")
+
+	out.Reset()
+	ok, err = renderFastSegments(&out, ctx, bindings, []compiler.FastRenderSegment{
+		{
+			Kind: compiler.FastRenderSegmentValue,
+			ValuePlan: compiler.FastValuePlan{
+				Kind:     compiler.FastValueInfix,
+				Operator: "==",
+				Left:     &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "x"},
+				Right:    &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "x"},
+				Line:     32,
+			},
+			Line: 32,
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "true", out.String())
+
+	_, err = renderFastSegments(&out, ctx, bindings, []compiler.FastRenderSegment{
+		{
+			Kind: compiler.FastRenderSegmentValue,
+			ValuePlan: compiler.FastValuePlan{
+				Kind:     compiler.FastValueInfix,
+				Operator: "??",
+				Left:     &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "x"},
+				Right:    &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "y"},
+				Line:     33,
+			},
+			Line: 33,
+		},
+	})
+	require.ErrorContains(t, err, "line 33")
+
+	_, err = renderFastSegments(&out, ctx, bindings, []compiler.FastRenderSegment{
+		{
+			Kind: compiler.FastRenderSegmentValue,
+			ValuePlan: compiler.FastValuePlan{
+				Kind:      compiler.FastValuePath,
+				NameIndex: 99,
+				Value:     "missingPath",
+				Path:      []compiler.FastPathStep{{Kind: compiler.FastPathStepProperty, Value: "Name", Line: 34}},
+			},
+			Line: 34,
+		},
+	})
+	require.ErrorContains(t, err, "line 34")
+
+	_, err = renderFastSegments(&out, ctx, bindings, []compiler.FastRenderSegment{
+		{Kind: compiler.FastRenderSegmentValue, ValuePlan: compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing"}, Line: 4},
+	})
+	require.ErrorContains(t, err, "line 4")
+
+	_, err = renderFastSegments(&out, ctx, bindings, []compiler.FastRenderSegment{
+		{
+			Kind: compiler.FastRenderSegmentValue,
+			ValuePlan: compiler.FastValuePlan{
+				Kind: compiler.FastValueCall,
+				Call: &compiler.FastCallPlan{Name: "scalar", NameIndex: 3, Line: 35},
+			},
+			Line: 35,
+		},
+	})
+	require.ErrorContains(t, err, "line 35")
+
+	_, err = renderFastSegments(&out, ctx, bindings, []compiler.FastRenderSegment{
+		{Kind: compiler.FastRenderSegmentCall, Call: &compiler.FastCallPlan{Name: "missing", NameIndex: 99, Line: 36}},
+	})
+	require.ErrorContains(t, err, "line 36")
+
+	ok, err = renderFastSegments(&out, ctx, bindings, []compiler.FastRenderSegment{
+		{Kind: compiler.FastRenderSegmentConditional},
+	})
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	_, err = renderFastSegments(&out, ctx, bindings, []compiler.FastRenderSegment{
+		{Kind: compiler.FastRenderSegmentPartial, Partial: &compiler.FastPartialPlan{Name: "missing.plush", Line: 37}},
+	})
+	require.ErrorContains(t, err, "line 37")
+
+	ok, err = renderFastSegments(&out, ctx, bindings, []compiler.FastRenderSegment{
+		{Kind: compiler.FastRenderSegmentLoop, Loop: &compiler.FastLoopPlan{IterableName: "scalar", IterableNameIndex: 3, Line: 5}},
+	})
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	ok, err = renderFastMixedPlan(&out, ctx, bindings, nil)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	out.Reset()
+	ok, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{
+		{kind: fastMixedOpStatic, prefix: "prefix"},
+		{kind: fastMixedOpName, nameIndex: 99, value: "missing", nullOnMissing: true, line: 6},
+		{kind: fastMixedOpName, nameIndex: 0, value: "name", line: 6},
+	}})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "prefixMido", out.String())
+
+	ok, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{
+		{kind: fastMixedOpName, nameIndex: 1, value: "unsupported", line: 7},
+	}})
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	_, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{
+		{kind: fastMixedOpName, nameIndex: 99, value: "missing", line: 8},
+	}})
+	require.ErrorContains(t, err, "line 8")
+
+	_, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{
+		{kind: fastMixedOpProperty, nameIndex: 99, value: "missing", property: "Name", line: 9},
+	}})
+	require.ErrorContains(t, err, "line 9")
+
+	_, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{
+		{kind: fastMixedOpProperty, nameIndex: 2, value: "user", property: "Missing", receiver: "user", full: "user.Missing", line: 10},
+	}})
+	require.ErrorContains(t, err, "line 10")
+
+	_, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{
+		{kind: fastMixedOpValue, valuePlan: compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing"}, line: 11},
+	}})
+	require.ErrorContains(t, err, "line 11")
+
+	ok, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{{kind: fastMixedOpKind(255)}}})
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func Test_VM_Render_Fast_Data_Partial_Slow_Branches(t *testing.T) {
+	var out strings.Builder
+	handled, err := renderFastDataPartialInto(&out, &compiler.FastPartialPlan{Name: "row.plush", Line: 7}, nil, fastRenderBindings{}, nil)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 7: invalid context")
+
+	ctx := plush.NewContext()
+	handled, err = renderFastDataPartialInto(&out, &compiler.FastPartialPlan{Name: "row.plush", Line: 7}, ctx, fastRenderBindings{}, nil)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "could not find partial feeder")
+
+	ctx = plush.NewContextWith(map[string]interface{}{
+		"contentType": "application/javascript",
+		"partialFeeder": func(string) (string, error) {
+			return `<span><%= name %></span>`, nil
+		},
+	})
+	out.Reset()
+	partial := &compiler.FastPartialPlan{
+		Name: "row.html",
+		Data: []compiler.FastPartialDataPair{
+			{Key: "name", Value: compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "Mido"}, Line: 7},
+		},
+		Line: 7,
+	}
+	handled, err = renderFastDataPartialInto(&out, partial, ctx, fastRenderBindings{}, nil)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, template.JSEscapeString("<span>Mido</span>"), out.String())
+
+	ctx = plush.NewContextWith(map[string]interface{}{
+		"partialFeeder": func(string) (string, error) {
+			return "", fmt.Errorf("missing")
+		},
+	})
+	out.Reset()
+	handled, err = renderFastDataPartialInto(&out, partial, ctx, fastRenderBindings{}, nil)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 7: missing")
+}
+
+func Test_VM_Fast_Iterable_Len_And_Grow_Size_Branches(t *testing.T) {
+	length, ok := fastIterableLen(&object.Array{Elements: []object.Object{&object.String{Value: "a"}}})
+	require.True(t, ok)
+	require.Equal(t, 1, length)
+
+	length, ok = fastIterableLen(&object.Hash{Pairs: map[object.HashKey]object.HashPair{
+		(&object.String{Value: "k"}).HashKey(): {Key: &object.String{Value: "k"}, Value: &object.String{Value: "v"}},
+	}})
+	require.True(t, ok)
+	require.Equal(t, 1, length)
+
+	length, ok = fastIterableLen([]interface{}{"a", "b"})
+	require.True(t, ok)
+	require.Equal(t, 2, length)
+
+	length, ok = fastIterableLen([]string{"a", "b", "c"})
+	require.True(t, ok)
+	require.Equal(t, 3, length)
+
+	length, ok = fastIterableLen([]object.Object{&object.String{Value: "a"}, &object.String{Value: "b"}})
+	require.True(t, ok)
+	require.Equal(t, 2, length)
+
+	length, ok = fastIterableLen([2]string{"a", "b"})
+	require.True(t, ok)
+	require.Equal(t, 2, length)
+
+	length, ok = fastIterableLen(map[string]int{"a": 1})
+	require.True(t, ok)
+	require.Equal(t, 1, length)
+
+	length, ok = fastIterableLen(nil)
+	require.True(t, ok)
+	require.Zero(t, length)
+
+	length, ok = fastIterableLen(&object.String{Value: "scalar"})
+	require.False(t, ok)
+	require.Zero(t, length)
+
+	length, ok = fastIterableLen(struct{}{})
+	require.False(t, ok)
+	require.Zero(t, length)
+
+	require.Zero(t, fastLoopConditionalGrowSize(nil))
+	require.Equal(t, 48, fastLoopConditionalGrowSize(&compiler.FastLoopConditionalPlan{
+		Branches: []compiler.FastLoopConditionalBranch{{
+			Parts: []compiler.FastLoopPart{
+				{Kind: compiler.FastLoopPartStatic, Value: "ignored"},
+				{Kind: compiler.FastLoopPartKey},
+				{Kind: compiler.FastLoopPartValue},
+				{Kind: compiler.FastLoopPartConditional, Conditional: &compiler.FastLoopConditionalPlan{
+					ElseParts: []compiler.FastLoopPart{{Kind: compiler.FastLoopPartKey}},
+				}},
+			},
+		}},
+		ElseParts: []compiler.FastLoopPart{
+			{Kind: compiler.FastLoopPartValueProperty},
+			{Kind: compiler.FastLoopPartValuePath},
+			{Kind: compiler.FastLoopPartCall},
+		},
+	}))
+	require.Zero(t, fastLoopPartsGrowSize([]compiler.FastLoopPart{{Kind: compiler.FastLoopPartKind(255)}}))
+
+	ctx := plush.NewContextWith(map[string]interface{}{"items": []string{"a", "b"}})
+	plan := &compiler.FastRenderPlan{Bindings: []string{"items"}}
+	bindings := newFastRenderBindings(plan, ctx)
+	size := fastOutputGrowSize(&fastMixedPlan{
+		staticSize: 3,
+		nameCount:  1,
+		ops: []fastMixedOp{{
+			loop: &compiler.FastLoopPlan{
+				IterableNameIndex: 0,
+				StaticSize:        1,
+				Parts: []compiler.FastLoopPart{
+					{Kind: compiler.FastLoopPartKey},
+					{Kind: compiler.FastLoopPartValue},
+				},
+			},
+		}},
+	}, bindings)
+	require.Positive(t, size)
+	require.Zero(t, fastOutputGrowSize(nil, bindings))
+}
+
+func Test_VM_Fast_Mixed_Plan_Builder_Branches(t *testing.T) {
+	require.Nil(t, prepareFastMixedPlan(nil))
+
+	cachedPlan := &compiler.FastRenderPlan{}
+	cachedMixed := &fastMixedPlan{staticSize: 7}
+	cachedPlan.Prepared.Store(cachedMixed)
+	require.Same(t, cachedMixed, prepareFastMixedPlan(cachedPlan))
+
+	require.Nil(t, buildFastSimplePlanFromSegments(nil))
+	require.Empty(t, fastMixedOpsFromSegments(nil))
+
+	ops := fastMixedOpsFromSegments([]compiler.FastRenderSegment{
+		{Kind: compiler.FastRenderSegmentStatic, Value: "prefix"},
+		{Kind: compiler.FastRenderSegmentName, NameIndex: 0, Value: "name"},
+		{Kind: compiler.FastRenderSegmentProperty, NameIndex: 1, Value: "user", Property: "Name"},
+		{Kind: compiler.FastRenderSegmentValue, ValuePlan: compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "value"}},
+		{Kind: compiler.FastRenderSegmentValue, ValuePlan: *vmAccessProfileNamePlan(2)},
+		{Kind: compiler.FastRenderSegmentCall, Call: &compiler.FastCallPlan{Name: "helper"}},
+		{Kind: compiler.FastRenderSegmentConditional, Conditional: &compiler.FastConditionalPlan{
+			Branches: []compiler.FastConditionalBranch{{Condition: compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true}}},
+		}},
+		{Kind: compiler.FastRenderSegmentPartial, Partial: &compiler.FastPartialPlan{Name: "row.plush"}},
+		{Kind: compiler.FastRenderSegmentLoop, Loop: &compiler.FastLoopPlan{IterableName: "items"}},
+		{Kind: compiler.FastRenderSegmentKind(255)},
+	})
+	require.Len(t, ops, 9)
+	require.Equal(t, fastMixedOpName, ops[0].kind)
+	require.Equal(t, "prefix", ops[0].prefix)
+	require.Equal(t, fastMixedOpProperty, ops[1].kind)
+	require.Equal(t, fastMixedOpValue, ops[2].kind)
+	require.Equal(t, fastMixedOpAccessChain, ops[3].kind)
+	require.Equal(t, fastMixedOpCall, ops[4].kind)
+	require.Equal(t, fastMixedOpConditional, ops[5].kind)
+	require.NotNil(t, ops[5].simpleCond)
+	require.Equal(t, fastMixedOpPartial, ops[6].kind)
+	require.Equal(t, fastMixedOpLoop, ops[7].kind)
+	require.Equal(t, fastMixedOpStatic, ops[8].kind)
+
+	staticOps := fastMixedOpsFromSegments([]compiler.FastRenderSegment{{Kind: compiler.FastRenderSegmentStatic, Value: "only"}})
+	require.Len(t, staticOps, 1)
+	require.Equal(t, fastMixedOpStatic, staticOps[0].kind)
+	require.Equal(t, "only", staticOps[0].prefix)
+
+	simple := buildFastSimplePlanFromSegments([]compiler.FastRenderSegment{
+		{Kind: compiler.FastRenderSegmentName, NameIndex: 0, Value: "name"},
+		{Kind: compiler.FastRenderSegmentProperty, NameIndex: 1, Value: "user", Property: "Name"},
+	})
+	require.NotNil(t, simple)
+	require.Equal(t, []int{0, 1}, simple.nameIndexes)
+
+	binder := &fastSimplePlan{}
+	require.Nil(t, buildFastSimpleValuePlan(nil, &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "x"}))
+	require.Nil(t, buildFastSimpleValuePlan(binder, nil))
+	require.Nil(t, buildFastSimpleValuePlan(binder, &compiler.FastValuePlan{Kind: compiler.FastValueInfix, Left: &compiler.FastValuePlan{Kind: compiler.FastValueInteger, IntValue: 1}}))
+	require.Nil(t, buildFastSimpleValuePlan(binder, &compiler.FastValuePlan{Kind: compiler.FastValueCall}))
+	require.Nil(t, buildFastSimpleValuePlan(binder, &compiler.FastValuePlan{
+		Kind: compiler.FastValueCall,
+		Call: &compiler.FastCallPlan{NameIndex: 0, Args: []compiler.FastValuePlan{{Kind: compiler.FastValueKind(255)}}},
+	}))
+	require.Nil(t, buildFastSimpleValuePlan(binder, &compiler.FastValuePlan{Kind: compiler.FastValueKind(255)}))
+
+	binder = &fastSimplePlan{}
+	value := buildFastSimpleValuePlan(binder, &compiler.FastValuePlan{
+		Kind:  compiler.FastValueCall,
+		Call:  &compiler.FastCallPlan{NameIndex: 3, Args: []compiler.FastValuePlan{{Kind: compiler.FastValueName, NameIndex: 4, Value: "arg"}}},
+		Value: "helper",
+	})
+	require.NotNil(t, value)
+	require.Equal(t, 0, value.lookupIndex)
+	require.Len(t, value.args, 1)
+	require.Equal(t, []int{3, 4}, binder.nameIndexes)
+}

--- a/VM/vm/fast_script_plan_test.go
+++ b/VM/vm/fast_script_plan_test.go
@@ -1,0 +1,195 @@
+package vm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/stretchr/testify/require"
+)
+
+type fastScriptPlanMenu struct {
+	Items []fastScriptPlanItem
+}
+
+type fastScriptPlanItem struct {
+	Name  string
+	Count int
+}
+
+func Test_VM_Fast_Render_Literal_Lets_And_Path_Loops(t *testing.T) {
+	tmpl, err := Compile(`<% let title = "Default" %><title><%= title %></title><%= for (item) in menu.Items { %><%= item.Name %>;<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"menu": fastScriptPlanMenu{Items: []fastScriptPlanItem{
+			{Name: "One"},
+			{Name: "Two"},
+		}},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `<title>Default</title>One;Two;`, out)
+}
+
+func Test_VM_Fast_Render_Loop_Let_With_Helper_And_Arithmetic_Arg(t *testing.T) {
+	tmpl, err := Compile(`<%= for (_, product) in products { %><% let categorySeo = replace(category.CategorySeoUrl, "-outofstock", "", 0 - 1) %><%= categorySeo %>:<%= product.Name %>;<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"category": struct {
+			CategorySeoUrl string
+		}{CategorySeoUrl: "pizza-outofstock"},
+		"products": []fastScriptPlanItem{
+			{Name: "One"},
+			{Name: "Two"},
+		},
+		"replace": strings.Replace,
+	})
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `pizza:One;pizza:Two;`, out)
+
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, plush.RenderFastPathFast, diagnostics.FastPath)
+	require.Empty(t, diagnostics.FastReject)
+}
+
+func Test_VM_Fast_Render_Loop_Let_Spends_Assignment_Budget(t *testing.T) {
+	tmpl, err := Compile(`<%= for (_, item) in items { %><% let label = item.Name %><%= label %>;<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	costs := plush.ZeroCosts()
+	costs.Assignment = 1
+	budget := plush.NewBudgetWithCosts(1, costs)
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"items": []fastScriptPlanItem{
+			{Name: "One"},
+			{Name: "Two"},
+		},
+	}).WithBudget(budget)
+
+	_, err = tmpl.Render(ctx)
+	require.ErrorIs(t, err, plush.ErrBudgetExceeded)
+	require.Equal(t, int64(2), budget.Stats().Assignments)
+}
+
+func Test_VM_Fast_Render_Prefix_Condition_And_Loop_Concat(t *testing.T) {
+	tmpl, err := Compile(`<%= if (!userSignedIn) { %>Guest<% } else { %>User<% } %><%= for (item) in menu.Items { %><%= item.Name + " x " + item.Count %>;<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"userSignedIn": false,
+		"menu": fastScriptPlanMenu{Items: []fastScriptPlanItem{
+			{Name: "One", Count: 2},
+			{Name: "Two", Count: 3},
+		}},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `GuestOne x 2;Two x 3;`, out)
+}
+
+func Test_VM_Fast_Render_Nested_Loop_Uses_Outer_Key(t *testing.T) {
+	tmpl, err := Compile(`<%= for (i, row) in rows { %><%= for (j, col) in row { %><%= i %>,<%= j %>:<%= col %>;<% } %><% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"rows": [][]string{{"a", "b"}, {"c"}},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `0,0:a;0,1:b;1,0:c;`, out)
+}
+
+func Test_VM_Fast_Render_Nested_Loop_Condition_Uses_Outer_Value(t *testing.T) {
+	tmpl, err := Compile(`<%= for (k, messages) in flash { %><%= for (msg) in messages { %><%= if (len(messages) && messages[0] != "skip") { %><%= k %>:<%= msg %>;<% } %><% } %><% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"flash": map[string][]string{"notice": {"Hello", "Bye"}},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `notice:Hello;notice:Bye;`, out)
+}
+
+func Test_VM_Fast_Render_Silent_Script_If_Discards_Output_But_Evaluates_Selected_Branch(t *testing.T) {
+	tmpl, err := Compile(`<% if (show) { %>hidden<%= touch(name) %><% } else { %><%= touch("else") %><% } %>done`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	require.True(t, tmpl.bytecode.FastRenderPlan.Segments[0].Conditional.Silent)
+
+	calls := []string{}
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"show": true,
+		"name": "Mido",
+		"touch": func(value string) string {
+			calls = append(calls, value)
+			return "called " + value
+		},
+	})
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "done", out)
+	require.Equal(t, []string{"Mido"}, calls)
+
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, plush.RenderFastPathFast, diagnostics.FastPath)
+
+	calls = calls[:0]
+	out, err = tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"show": false,
+		"name": "Mido",
+		"touch": func(value string) string {
+			calls = append(calls, value)
+			return "called " + value
+		},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "done", out)
+	require.Equal(t, []string{"else"}, calls)
+}
+
+func Test_VM_Fast_Render_Silent_Script_If_Inside_Loop(t *testing.T) {
+	type item struct {
+		Name   string
+		Hidden bool
+		Stop   bool
+	}
+
+	tmpl, err := Compile(`<%= for (_, item) in items { %><% if (item.Hidden) { %>hidden<%= touch(item.Name) %><% } %><% if (item.Stop) { %><%= break %><% } %><%= item.Name %>;<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+
+	calls := []string{}
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"items": []item{
+			{Name: "A"},
+			{Name: "B", Hidden: true},
+			{Name: "C", Stop: true},
+			{Name: "D"},
+		},
+		"touch": func(value string) string {
+			calls = append(calls, value)
+			return value
+		},
+	})
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "A;B;", out)
+	require.Equal(t, []string{"B"}, calls)
+
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, plush.RenderFastPathFast, diagnostics.FastPath)
+}

--- a/VM/vm/fast_struct_loop_call_paths_test.go
+++ b/VM/vm/fast_struct_loop_call_paths_test.go
@@ -1,0 +1,422 @@
+package vm
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_VM_Fast_Struct_Loop_Call_Part_Branches(t *testing.T) {
+	item := reflect.ValueOf(vmStructLoopProduct{Name: "<bot>"})
+
+	t.Run("nil plan", func(t *testing.T) {
+		require.NoError(t, writeFastStructLoopCallPart(&strings.Builder{}, plush.NewContext(), fastRenderBindings{}, &fastStructLoopRenderState{}, nil, 0, item))
+	})
+
+	t.Run("registered helper wins", func(t *testing.T) {
+		ctx := plush.NewContextWith(map[string]interface{}{
+			"label": func(value string) string { return "direct:" + value },
+		})
+		SetFastHelper(ctx, "label", func(w FastWriter, args FastArgs) error {
+			value, ok := args.String(0)
+			require.True(t, ok)
+			w.WriteEscapedString("fast:" + value)
+			return nil
+		})
+		bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label"}}, ctx)
+		plan := structLoopCallPlan(t, structLoopNameArg())
+
+		var out strings.Builder
+		require.NoError(t, writeFastStructLoopCallPart(&out, ctx, bindings, &fastStructLoopRenderState{}, plan, 0, item))
+		require.Equal(t, "fast:&lt;bot&gt;", out.String())
+	})
+
+	t.Run("registered helper no args", func(t *testing.T) {
+		ctx := plush.NewContextWith(map[string]interface{}{
+			"label": func() string { return "slow" },
+		})
+		SetFastHelper(ctx, "label", func(w FastWriter, args FastArgs) error {
+			require.Zero(t, args.Len())
+			w.WriteEscapedString("fast")
+			return nil
+		})
+		bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label"}}, ctx)
+		plan := &fastStructLoopCallPlan{call: &compiler.FastCallPlan{Name: "label", NameIndex: 0, Line: 1}}
+
+		var out strings.Builder
+		require.NoError(t, writeFastStructLoopCallPart(&out, ctx, bindings, &fastStructLoopRenderState{}, plan, 0, item))
+		require.Equal(t, "fast", out.String())
+	})
+
+	t.Run("registered helper error", func(t *testing.T) {
+		ctx := plush.NewContextWith(map[string]interface{}{
+			"label": func(value string) string { return "direct:" + value },
+		})
+		SetFastHelper(ctx, "label", func(FastWriter, FastArgs) error {
+			return errors.New("fast helper boom")
+		})
+		bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label"}}, ctx)
+		plan := structLoopCallPlan(t, structLoopNameArg())
+
+		err := writeFastStructLoopCallPart(&strings.Builder{}, ctx, bindings, &fastStructLoopRenderState{}, plan, 0, item)
+		require.ErrorContains(t, err, "line 1")
+		require.ErrorContains(t, err, "fast helper boom")
+	})
+
+	t.Run("registered helper unsupported falls through", func(t *testing.T) {
+		ctx := plush.NewContextWith(map[string]interface{}{
+			"label": func(value string) string { return "direct:" + value },
+		})
+		SetFastHelper(ctx, "label", func(FastWriter, FastArgs) error {
+			return ErrFastUnsupported
+		})
+		bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label"}}, ctx)
+		plan := structLoopCallPlan(t, structLoopNameArg())
+
+		var out strings.Builder
+		require.NoError(t, writeFastStructLoopCallPart(&out, ctx, bindings, &fastStructLoopRenderState{}, plan, 0, item))
+		require.Equal(t, "direct:&lt;bot&gt;", out.String())
+	})
+
+	t.Run("registered helper arg error", func(t *testing.T) {
+		ctx := plush.NewContextWith(map[string]interface{}{
+			"label": func(value string) string { return "direct:" + value },
+		})
+		SetFastHelper(ctx, "label", func(FastWriter, FastArgs) error {
+			return nil
+		})
+		bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label"}}, ctx)
+		plan := structLoopCallPlan(t, compiler.FastValuePlan{
+			Kind:      compiler.FastValueName,
+			NameIndex: 99,
+			Value:     "missing",
+			Line:      4,
+		})
+
+		err := writeFastStructLoopCallPart(&strings.Builder{}, ctx, bindings, &fastStructLoopRenderState{}, plan, 0, item)
+		require.ErrorContains(t, err, "line 4")
+		require.ErrorContains(t, err, `"missing": unknown identifier`)
+	})
+
+	t.Run("direct writer", func(t *testing.T) {
+		ctx := plush.NewContextWith(map[string]interface{}{
+			"label": func(value string) string { return "direct:" + value },
+		})
+		bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label"}}, ctx)
+		plan := structLoopCallPlan(t, structLoopNameArg())
+
+		var out strings.Builder
+		state := &fastStructLoopRenderState{}
+		require.NoError(t, writeFastStructLoopCallPart(&out, ctx, bindings, state, plan, 0, item))
+		require.Equal(t, "direct:&lt;bot&gt;", out.String())
+		require.Same(t, plan, state.singleCall)
+		require.NotNil(t, state.singleResolvedCall)
+	})
+
+	t.Run("nil state resolves directly", func(t *testing.T) {
+		ctx := plush.NewContextWith(map[string]interface{}{
+			"label": func(value string) string { return "direct:" + value },
+		})
+		bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label"}}, ctx)
+		plan := structLoopCallPlan(t, structLoopNameArg())
+
+		var out strings.Builder
+		require.NoError(t, writeFastStructLoopCallPart(&out, ctx, bindings, nil, plan, 0, item))
+		require.Equal(t, "direct:&lt;bot&gt;", out.String())
+	})
+
+	t.Run("direct writer error", func(t *testing.T) {
+		ctx := plush.NewContextWith(map[string]interface{}{
+			"label": func(string) (string, error) {
+				return "", errors.New("direct writer boom")
+			},
+		})
+		bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label"}}, ctx)
+		plan := structLoopCallPlan(t, structLoopNameArg())
+
+		err := writeFastStructLoopCallPart(&strings.Builder{}, ctx, bindings, &fastStructLoopRenderState{}, plan, 0, item)
+		require.ErrorContains(t, err, "line 1")
+		require.ErrorContains(t, err, "direct writer boom")
+	})
+
+	t.Run("generic call signature", func(t *testing.T) {
+		ctx := plush.NewContextWith(map[string]interface{}{
+			"label": func(value string, count int) string {
+				return fmt.Sprintf("%s:%d", value, count)
+			},
+		})
+		bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label"}}, ctx)
+		plan := structLoopCallPlan(t, structLoopNameArg(), compiler.FastValuePlan{Kind: compiler.FastValueInteger, IntValue: 3, Line: 1})
+
+		var out strings.Builder
+		require.NoError(t, writeFastStructLoopCallPart(&out, ctx, bindings, &fastStructLoopRenderState{}, plan, 0, item))
+		require.Equal(t, "&lt;bot&gt;:3", out.String())
+	})
+
+	t.Run("entry invoker error", func(t *testing.T) {
+		ctx := plush.NewContextWith(map[string]interface{}{
+			"label": func(value int) (string, error) {
+				return "", errors.New("entry invoker boom")
+			},
+		})
+		bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label"}}, ctx)
+		plan := structLoopCallPlan(t, compiler.FastValuePlan{Kind: compiler.FastValueInteger, IntValue: 3, Line: 1})
+
+		err := writeFastStructLoopCallPart(&strings.Builder{}, ctx, bindings, &fastStructLoopRenderState{}, plan, 0, item)
+		require.ErrorContains(t, err, "line 1")
+		require.ErrorContains(t, err, "entry invoker boom")
+	})
+
+	t.Run("entry invoker arg error", func(t *testing.T) {
+		ctx := plush.NewContextWith(map[string]interface{}{
+			"label": func(value int) string { return fmt.Sprintf("%d", value) },
+		})
+		bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label"}}, ctx)
+		plan := structLoopCallPlan(t, compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing", Line: 6})
+
+		err := writeFastStructLoopCallPart(&strings.Builder{}, ctx, bindings, &fastStructLoopRenderState{}, plan, 0, item)
+		require.ErrorContains(t, err, `line 6: "missing": unknown identifier`)
+	})
+
+	t.Run("reflect fallback", func(t *testing.T) {
+		ctx := plush.NewContextWith(map[string]interface{}{
+			"label": func(value string, count int32) string {
+				return fmt.Sprintf("%s:%d", value, count)
+			},
+		})
+		bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label"}}, ctx)
+		plan := structLoopCallPlan(t, structLoopNameArg(), compiler.FastValuePlan{Kind: compiler.FastValueInteger, IntValue: 2, Line: 1})
+
+		var out strings.Builder
+		require.NoError(t, writeFastStructLoopCallPart(&out, ctx, bindings, &fastStructLoopRenderState{}, plan, 0, item))
+		require.Equal(t, "&lt;bot&gt;:2", out.String())
+	})
+
+	t.Run("variadic fallback", func(t *testing.T) {
+		ctx := plush.NewContextWith(map[string]interface{}{
+			"label": func(values ...string) string {
+				return strings.Join(values, ":")
+			},
+		})
+		bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label"}}, ctx)
+		plan := structLoopCallPlan(t, compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "<x>", Line: 1})
+
+		var out strings.Builder
+		require.NoError(t, writeFastStructLoopCallPart(&out, ctx, bindings, &fastStructLoopRenderState{}, plan, 0, item))
+		require.Equal(t, "&lt;x&gt;", out.String())
+	})
+
+	t.Run("missing helper", func(t *testing.T) {
+		ctx := plush.NewContext()
+		bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label"}}, ctx)
+		plan := structLoopCallPlan(t, structLoopNameArg())
+
+		err := writeFastStructLoopCallPart(&strings.Builder{}, ctx, bindings, &fastStructLoopRenderState{}, plan, 0, item)
+		require.ErrorContains(t, err, `"label": unknown identifier`)
+	})
+
+	t.Run("invalid helper", func(t *testing.T) {
+		ctx := plush.NewContextWith(map[string]interface{}{"label": 12})
+		bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label"}}, ctx)
+		plan := structLoopCallPlan(t, structLoopNameArg())
+
+		err := writeFastStructLoopCallPart(&strings.Builder{}, ctx, bindings, &fastStructLoopRenderState{}, plan, 0, item)
+		require.ErrorContains(t, err, "invalid function")
+	})
+
+	t.Run("nil helper value", func(t *testing.T) {
+		ctx := plush.NewContextWith(map[string]interface{}{"label": &object.Native{Value: nil}})
+		bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label"}}, ctx)
+		plan := structLoopCallPlan(t, structLoopNameArg())
+
+		err := writeFastStructLoopCallPart(&strings.Builder{}, ctx, bindings, &fastStructLoopRenderState{}, plan, 0, item)
+		require.ErrorContains(t, err, "invalid function")
+	})
+
+	t.Run("budget error", func(t *testing.T) {
+		ctx := plush.NewContextWith(map[string]interface{}{
+			"label": func(value string) string { return value },
+		}).WithBudget(plush.NewBudget(0))
+		bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label"}}, ctx)
+		plan := structLoopCallPlan(t, structLoopNameArg())
+
+		err := writeFastStructLoopCallPart(&strings.Builder{}, ctx, bindings, &fastStructLoopRenderState{}, plan, 0, item)
+		require.ErrorContains(t, err, "line 1")
+	})
+}
+
+func Test_VM_Fast_Struct_Loop_Reflect_Call_Eligibility_Branches(t *testing.T) {
+	entry := &fastBuilderCallCacheEntry{plan: &callPlan{numIn: 1, argTypes: []reflect.Type{stringType}}}
+	plan := structLoopCallPlan(t, structLoopNameArg())
+
+	require.False(t, canUseFastStructLoopReflectCall(nil, entry))
+	require.False(t, canUseFastStructLoopReflectCall(plan, nil))
+	require.False(t, canUseFastStructLoopReflectCall(plan, &fastBuilderCallCacheEntry{}))
+	require.False(t, canUseFastStructLoopReflectCall(plan, &fastBuilderCallCacheEntry{plan: &callPlan{numIn: 2}}))
+	require.False(t, canUseFastStructLoopReflectCall(plan, &fastBuilderCallCacheEntry{plan: &callPlan{numIn: 1, isVariadic: true}}))
+
+	genericPlan := &fastStructLoopCallPlan{
+		call: plan.call,
+		args: []fastStructLoopCallArgPlan{{kind: fastStructLoopCallArgGeneric}},
+	}
+	require.False(t, canUseFastStructLoopReflectCall(genericPlan, entry))
+	require.True(t, canUseFastStructLoopReflectCall(plan, entry))
+}
+
+func Test_VM_Fast_Struct_Loop_Call_Arg_Reflect_Branches(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{"prefix": "pre"})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"prefix"}}, ctx)
+	item := reflect.ValueOf(vmStructLoopProduct{Name: "bot"})
+	accessPlan := structLoopCallPlan(t, structLoopNameArg()).args[0].accessPlan
+
+	value, err := evalFastStructLoopCallArgReflect(nil, ctx, bindings, 0, item, stringType, "helper", 0)
+	require.NoError(t, err)
+	require.Equal(t, "", value.Interface())
+
+	value, err = evalFastStructLoopCallArgReflect(&fastStructLoopCallArgPlan{kind: fastStructLoopCallArgAccessChain, accessPlan: accessPlan}, ctx, bindings, 0, item, stringType, "helper", 0)
+	require.NoError(t, err)
+	require.Equal(t, "bot", value.Interface())
+
+	value, err = evalFastStructLoopCallArgReflect(&fastStructLoopCallArgPlan{kind: fastStructLoopCallArgAccessChain, accessPlan: accessPlan}, ctx, bindings, 0, reflect.Value{}, stringType, "helper", 0)
+	require.NoError(t, err)
+	require.Equal(t, "", value.Interface())
+
+	value, err = evalFastStructLoopCallArgReflect(&fastStructLoopCallArgPlan{kind: fastStructLoopCallArgBinding, nameIndex: 0}, ctx, bindings, 0, item, stringType, "helper", 1)
+	require.NoError(t, err)
+	require.Equal(t, "pre", value.Interface())
+
+	_, err = evalFastStructLoopCallArgReflect(&fastStructLoopCallArgPlan{
+		kind:      fastStructLoopCallArgBinding,
+		value:     compiler.FastValuePlan{Value: "missing"},
+		line:      9,
+		nameIndex: 99,
+	}, ctx, bindings, 0, item, stringType, "helper", 1)
+	require.ErrorContains(t, err, "line 9")
+
+	_, err = evalFastStructLoopCallArgReflect(&fastStructLoopCallArgPlan{
+		kind:       fastStructLoopCallArgAccessChain,
+		accessPlan: accessPlan,
+	}, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, 0, item, stringType, "helper", 2)
+	require.ErrorContains(t, err, "line 1")
+
+	value, err = evalFastStructLoopCallArgReflect(&fastStructLoopCallArgPlan{
+		kind: fastStructLoopCallArgAccessChain,
+		accessPlan: &fastAccessChainPlan{steps: []fastAccessChainStep{{
+			kind: fastAccessStepField,
+		}}},
+	}, ctx, bindings, 0, reflect.ValueOf(12), stringType, "helper", 3)
+	require.NoError(t, err)
+	require.Equal(t, "", value.Interface())
+
+	_, err = evalFastStructLoopCallArgReflect(&fastStructLoopCallArgPlan{
+		kind: fastStructLoopCallArgGeneric,
+		value: compiler.FastValuePlan{
+			Kind:      compiler.FastValuePath,
+			NameIndex: -1,
+			Path:      structLoopNameArg().Path,
+		},
+	}, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, 0, item, stringType, "helper", 4)
+	require.ErrorContains(t, err, "line 1")
+}
+
+func Test_VM_Fast_Struct_Loop_Access_Chain_Reflect_Value_Edges(t *testing.T) {
+	ctx := plush.NewContext()
+
+	_, ok, err := evalFastAccessChainReflectValue(&fastAccessChainPlan{steps: []fastAccessChainStep{{
+		kind: fastAccessStepField,
+	}}}, reflect.ValueOf(12), ctx)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	_, ok, err = evalFastAccessChainReflectValue(&fastAccessChainPlan{steps: []fastAccessChainStep{{
+		kind:  fastAccessStepIndex,
+		index: 1,
+		line:  2,
+	}}}, reflect.ValueOf([]string{}), ctx)
+	require.ErrorContains(t, err, "line 2")
+	require.True(t, ok)
+
+	_, ok, err = evalFastAccessChainReflectValue(&fastAccessChainPlan{steps: []fastAccessChainStep{{
+		kind:   fastAccessStepIndex,
+		mapKey: reflect.ValueOf("missing"),
+		line:   3,
+	}}}, reflect.ValueOf(map[string]string{}), ctx)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	_, ok, err = evalFastAccessChainReflectValue(&fastAccessChainPlan{steps: []fastAccessChainStep{
+		{kind: fastAccessStepIndex, index: 0, line: 4},
+		{kind: fastAccessStepField, line: 4},
+	}}, reflect.ValueOf([]*vmAccessProfile{nil}), ctx)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	_, ok, err = evalFastAccessChainReflectValue(&fastAccessChainPlan{steps: []fastAccessChainStep{
+		{
+			kind:     fastAccessStepField,
+			line:     5,
+			name:     "hidden",
+			receiver: "private",
+			full:     "private.hidden",
+			lookup: propertyLookup{
+				kind:       propertyLookupField,
+				fieldIndex: []int{0},
+			},
+		},
+		{kind: fastAccessStepField, line: 5},
+	}}, reflect.ValueOf(vmReflectPrivate{hidden: "secret"}), ctx)
+	require.ErrorContains(t, err, "line 5")
+	require.False(t, ok)
+
+	_, ok, err = evalFastAccessChainReflectValue(&fastAccessChainPlan{steps: []fastAccessChainStep{{
+		kind: fastAccessStepKind(255),
+	}}}, reflect.ValueOf(vmStructLoopProduct{}), ctx)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func Test_VM_Fast_Struct_Loop_Resolved_Call_Cache_Branches(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"one": func(value string) string { return value },
+		"two": func(value string) string { return value },
+	})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"one", "two"}}, ctx)
+	first := structLoopCallPlan(t, structLoopNameArg())
+	first.call.Name = "one"
+	first.call.NameIndex = 0
+	second := structLoopCallPlan(t, structLoopNameArg())
+	second.call.Name = "two"
+	second.call.NameIndex = 1
+
+	state := &fastStructLoopRenderState{}
+	resolved, err := state.resolvedCall(first, bindings)
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+	require.Same(t, first, state.singleCall)
+
+	again, err := state.resolvedCall(first, bindings)
+	require.NoError(t, err)
+	require.Same(t, resolved, again)
+
+	other, err := state.resolvedCall(second, bindings)
+	require.NoError(t, err)
+	require.NotNil(t, other)
+	require.NotNil(t, state.calls)
+	require.Same(t, resolved, state.calls[first])
+	require.Same(t, other, state.calls[second])
+
+	cachedOther, err := state.resolvedCall(second, bindings)
+	require.NoError(t, err)
+	require.Same(t, other, cachedOther)
+
+	nilResolved, err := state.resolvedCall(nil, bindings)
+	require.NoError(t, err)
+	require.Nil(t, nilResolved)
+}

--- a/VM/vm/fast_struct_loop_helpers_test.go
+++ b/VM/vm/fast_struct_loop_helpers_test.go
@@ -1,0 +1,1159 @@
+package vm
+
+import (
+	"errors"
+	"html/template"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/stretchr/testify/require"
+)
+
+type vmStructLoopProduct struct {
+	Name string
+}
+
+func (p vmStructLoopProduct) Echo() string {
+	return p.Name + "!"
+}
+
+func (p *vmStructLoopProduct) PointerEcho() string {
+	return p.Name + "?"
+}
+
+type vmStructLoopStringer struct {
+	value string
+}
+
+func (s vmStructLoopStringer) String() string {
+	return "stringer:" + s.value
+}
+
+type vmStructLoopStringerProduct struct {
+	Title vmStructLoopStringer
+}
+
+func structLoopCallPlan(t *testing.T, args ...compiler.FastValuePlan) *fastStructLoopCallPlan {
+	t.Helper()
+	plan, ok := buildFastStructLoopCallPlan(&compiler.FastCallPlan{
+		Name:      "label",
+		NameIndex: 0,
+		Args:      args,
+		Line:      1,
+	}, reflect.TypeOf(vmStructLoopProduct{}))
+	require.True(t, ok)
+	require.NotNil(t, plan)
+	return plan
+}
+
+func structLoopNameArg() compiler.FastValuePlan {
+	return compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: -1,
+		Path: []compiler.FastPathStep{
+			{Kind: compiler.FastPathStepProperty, Value: "Name", Receiver: "product", Full: "product.Name", Line: 1},
+		},
+		Line: 1,
+	}
+}
+
+func Test_VM_Fast_Struct_Loop_Direct_Call_Writers(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{"prefix": "<pre>"})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label", "prefix"}}, ctx)
+	item := reflect.ValueOf(vmStructLoopProduct{Name: "<bot>"})
+
+	oneArgPlan := structLoopCallPlan(t, structLoopNameArg())
+	twoArgPlan := structLoopCallPlan(t, structLoopNameArg(), compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 1, Value: "prefix", Line: 1})
+
+	tests := []struct {
+		name     string
+		raw      interface{}
+		plan     *fastStructLoopCallPlan
+		expected string
+	}{
+		{"string", func(value string) string { return value + "!" }, oneArgPlan, "&lt;bot&gt;!"},
+		{"string_string", func(value, prefix string) string { return prefix + value }, twoArgPlan, "&lt;pre&gt;&lt;bot&gt;"},
+		{"string_error", func(value string) (string, error) { return value + "?", nil }, oneArgPlan, "&lt;bot&gt;?"},
+		{"string_string_error", func(value, prefix string) (string, error) { return prefix + value, nil }, twoArgPlan, "&lt;pre&gt;&lt;bot&gt;"},
+		{"html", func(value string) template.HTML { return template.HTML("<b>" + value + "</b>") }, oneArgPlan, "<b><bot></b>"},
+		{"html_string", func(value, prefix string) template.HTML { return template.HTML(prefix + value) }, twoArgPlan, "<pre><bot>"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writer := fastStructLoopDirectCallWriterForRaw(tt.raw, tt.plan)
+			require.NotNil(t, writer)
+			var out strings.Builder
+			handled, err := writer(&out, ctx, bindings, tt.plan, 0, item)
+			require.NoError(t, err)
+			require.True(t, handled)
+			require.Equal(t, tt.expected, out.String())
+		})
+	}
+
+	raw := func(string) (string, error) { return "", errors.New("boom") }
+	writer := fastStructLoopDirectCallWriterForRaw(raw, oneArgPlan)
+	require.NotNil(t, writer)
+	handled, err := writer(&strings.Builder{}, ctx, bindings, oneArgPlan, 0, item)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "could not call label function")
+
+	missingArgPlan := structLoopCallPlan(t, compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing"})
+	writer = fastStructLoopDirectCallWriterForRaw(func(value string) string { return value }, missingArgPlan)
+	require.NotNil(t, writer)
+	handled, err = writer(&strings.Builder{}, ctx, bindings, missingArgPlan, 0, item)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	secondMissingArgPlan := structLoopCallPlan(t, structLoopNameArg(), compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing"})
+	for _, tt := range []struct {
+		name string
+		raw  interface{}
+		plan *fastStructLoopCallPlan
+	}{
+		{"string_string_second_missing", func(value, prefix string) string { return prefix + value }, secondMissingArgPlan},
+		{"string_error_missing", func(value string) (string, error) { return value, nil }, missingArgPlan},
+		{"string_string_error_second_missing", func(value, prefix string) (string, error) { return prefix + value, nil }, secondMissingArgPlan},
+		{"html_missing", func(value string) template.HTML { return template.HTML(value) }, missingArgPlan},
+		{"html_string_second_missing", func(value, prefix string) template.HTML { return template.HTML(prefix + value) }, secondMissingArgPlan},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			writer := fastStructLoopDirectCallWriterForRaw(tt.raw, tt.plan)
+			require.NotNil(t, writer)
+			handled, err := writer(&strings.Builder{}, ctx, bindings, tt.plan, 0, item)
+			require.NoError(t, err)
+			require.False(t, handled)
+		})
+	}
+
+	require.Nil(t, fastStructLoopDirectCallWriterForRaw(func(string) string { return "" }, twoArgPlan))
+	require.Nil(t, fastStructLoopDirectCallWriterForRaw(func(string, string) string { return "" }, oneArgPlan))
+	require.Nil(t, fastStructLoopDirectCallWriterForRaw(func(string) (string, error) { return "", nil }, twoArgPlan))
+	require.Nil(t, fastStructLoopDirectCallWriterForRaw(func(string, string) (string, error) { return "", nil }, oneArgPlan))
+	require.Nil(t, fastStructLoopDirectCallWriterForRaw(func(string) template.HTML { return "" }, twoArgPlan))
+	require.Nil(t, fastStructLoopDirectCallWriterForRaw(func(string, string) template.HTML { return "" }, oneArgPlan))
+	require.Nil(t, fastStructLoopDirectCallWriterForRaw("not helper", oneArgPlan))
+	require.Nil(t, fastStructLoopDirectCallWriterForRaw(func(string) string { return "" }, nil))
+}
+
+func Test_VM_Fast_Struct_Loop_Call_Arg_Values(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{"prefix": "pre"})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"prefix"}}, ctx)
+	item := reflect.ValueOf(vmStructLoopProduct{Name: "bot"})
+	accessPlan := structLoopCallPlan(t, structLoopNameArg()).args[0].accessPlan
+
+	callPlan, ok := buildFastStructLoopCallPlan(nil, reflect.TypeOf(vmStructLoopProduct{}))
+	require.False(t, ok)
+	require.Nil(t, callPlan)
+
+	nilArgPlan := buildFastStructLoopCallArgPlan(nil, reflect.TypeOf(vmStructLoopProduct{}))
+	require.Equal(t, fastStructLoopCallArgNil, nilArgPlan.kind)
+
+	nameNilPlan := buildFastStructLoopCallArgPlan(&compiler.FastValuePlan{Kind: compiler.FastValueName, Value: "nil"}, reflect.TypeOf(vmStructLoopProduct{}))
+	require.Equal(t, fastStructLoopCallArgNil, nameNilPlan.kind)
+
+	genericPathPlan := buildFastStructLoopCallArgPlan(&compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: -1,
+		Path: []compiler.FastPathStep{
+			{Kind: compiler.FastPathStepProperty, Value: "Missing"},
+		},
+	}, reflect.TypeOf(vmStructLoopProduct{}))
+	require.Equal(t, fastStructLoopCallArgGeneric, genericPathPlan.kind)
+
+	tests := []struct {
+		name     string
+		plan     *fastStructLoopCallArgPlan
+		expected interface{}
+		ok       bool
+	}{
+		{"nil plan", nil, nil, true},
+		{"key", &fastStructLoopCallArgPlan{kind: fastStructLoopCallArgKey}, 7, true},
+		{"binding", &fastStructLoopCallArgPlan{kind: fastStructLoopCallArgBinding, nameIndex: 0}, "pre", true},
+		{"nil", &fastStructLoopCallArgPlan{kind: fastStructLoopCallArgNil}, nil, true},
+		{"string", &fastStructLoopCallArgPlan{kind: fastStructLoopCallArgString, stringVal: "x"}, "x", true},
+		{"int", &fastStructLoopCallArgPlan{kind: fastStructLoopCallArgInt, intVal: 3}, 3, true},
+		{"float", &fastStructLoopCallArgPlan{kind: fastStructLoopCallArgFloat, floatVal: 1.5}, 1.5, true},
+		{"bool", &fastStructLoopCallArgPlan{kind: fastStructLoopCallArgBool, boolVal: true}, true, true},
+		{"access", &fastStructLoopCallArgPlan{kind: fastStructLoopCallArgAccessChain, accessPlan: accessPlan}, "bot", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, ok, err := evalFastStructLoopCallArgValue(tt.plan, ctx, bindings, 7, item)
+			require.NoError(t, err)
+			require.Equal(t, tt.ok, ok)
+			require.Equal(t, tt.expected, value)
+		})
+	}
+
+	value, ok, err := evalFastStructLoopCallArgValue(&fastStructLoopCallArgPlan{
+		kind:  fastStructLoopCallArgGeneric,
+		value: compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "generic"},
+	}, ctx, bindings, 7, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "generic", value)
+
+	_, ok, err = evalFastStructLoopCallArgValue(&fastStructLoopCallArgPlan{kind: fastStructLoopCallArgBinding, nameIndex: 99}, ctx, bindings, 7, item)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	value, ok, err = evalFastStructLoopCallArgValue(&fastStructLoopCallArgPlan{kind: fastStructLoopCallArgAccessChain, accessPlan: accessPlan}, ctx, bindings, 7, reflect.Value{})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Nil(t, value)
+
+	_, ok, err = evalFastStructLoopCallArgValue(&fastStructLoopCallArgPlan{kind: fastStructLoopCallArgAccessChain}, ctx, bindings, 7, item)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	args := &fastCallArgs{}
+	require.NoError(t, evalFastStructLoopCallPlanArgs(nil, ctx, bindings, 7, item, args))
+	require.NoError(t, evalFastStructLoopCallPlanArgs(&fastStructLoopCallPlan{}, ctx, bindings, 7, item, args))
+	err = evalFastStructLoopCallPlanArgs(&fastStructLoopCallPlan{
+		args: []fastStructLoopCallArgPlan{{
+			kind:      fastStructLoopCallArgBinding,
+			nameIndex: 99,
+			line:      8,
+			value:     compiler.FastValuePlan{Value: "missing"},
+		}},
+	}, ctx, bindings, 7, item, args)
+	require.ErrorContains(t, err, `line 8: "missing": unknown identifier`)
+}
+
+func Test_VM_Fast_Struct_Loop_Value_And_Condition_Edges(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{"flag": true, "prefix": "pre"})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"flag", "prefix"}}, ctx)
+	item := reflect.ValueOf(vmStructLoopProduct{Name: "bot"})
+	namePlan := structLoopNameArg()
+	nameArgPlan := structLoopCallPlan(t, namePlan).args[0]
+
+	value, ok, err := evalFastStructLoopValue(nil, ctx, bindings, "key", item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Nil(t, value)
+
+	value, ok, err = evalFastStructLoopValue(&compiler.FastValuePlan{Kind: compiler.FastValueLoopKey}, ctx, bindings, "key", item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "key", value)
+
+	value, ok, err = evalFastStructLoopValue(&compiler.FastValuePlan{Kind: compiler.FastValuePath, NameIndex: 1, Value: "prefix"}, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "pre", value)
+
+	value, ok, err = evalFastStructLoopValue(&compiler.FastValuePlan{Kind: compiler.FastValuePath, NameIndex: -1}, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, vmStructLoopProduct{Name: "bot"}, value)
+
+	value, ok, err = evalFastStructLoopPathValue(&namePlan, ctx, bindings, reflect.Value{})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Nil(t, value)
+
+	truthy, ok, err := isTruthyFastStructLoopValue(&namePlan, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.True(t, truthy)
+
+	truthy, ok, err = isTruthyFastStructLoopValue(&compiler.FastValuePlan{Kind: compiler.FastValuePath, NameIndex: -1}, ctx, bindings, nil, reflect.Value{})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.False(t, truthy)
+
+	truthy, ok, err = isTruthyFastStructLoopValue(nil, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.False(t, truthy)
+
+	truthy, ok, err = isTruthyFastStructLoopValue(&compiler.FastValuePlan{Kind: compiler.FastValuePath, NameIndex: -1}, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.True(t, truthy)
+
+	infix := &compiler.FastValuePlan{
+		Kind:     compiler.FastValueInfix,
+		Operator: "==",
+		Left:     &namePlan,
+		Right:    &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "bot"},
+		Line:     11,
+	}
+	value, ok, err = evalFastStructLoopInfixValue(infix, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, true, value)
+
+	value, ok, err = evalFastStructLoopInfixValue(&compiler.FastValuePlan{
+		Kind:     compiler.FastValueInfix,
+		Operator: "&&",
+		Left:     &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: false},
+		Right:    &compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing"},
+	}, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, false, value)
+
+	value, ok, err = evalFastStructLoopInfixValue(nil, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, value)
+
+	value, ok, err = evalFastStructLoopInfixValue(&compiler.FastValuePlan{
+		Kind:     compiler.FastValueInfix,
+		Operator: "==",
+		Left:     &compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "missingLeft"},
+		Right:    &compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 100, Value: "missingRight"},
+	}, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, true, value)
+
+	_, ok, err = evalFastStructLoopInfixValue(&compiler.FastValuePlan{
+		Kind:     compiler.FastValueInfix,
+		Operator: "==",
+		Left:     &namePlan,
+		Right:    &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "bot"},
+	}, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, nil, item)
+	require.ErrorContains(t, err, "line 1")
+	require.True(t, ok)
+
+	_, ok, err = evalFastStructLoopInfixValue(&compiler.FastValuePlan{
+		Kind:     compiler.FastValueInfix,
+		Operator: "==",
+		Left:     &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "bot"},
+		Right:    &namePlan,
+	}, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, nil, item)
+	require.ErrorContains(t, err, "line 1")
+	require.True(t, ok)
+
+	_, ok, err = evalFastStructLoopInfixValue(&compiler.FastValuePlan{
+		Kind:     compiler.FastValueInfix,
+		Operator: "??",
+		Left:     &namePlan,
+		Right:    &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "bot"},
+		Line:     12,
+	}, ctx, bindings, nil, item)
+	require.True(t, ok)
+	require.ErrorContains(t, err, "line 12")
+
+	value, ok, err = evalFastStructLoopLogicalInfixValue(&compiler.FastValuePlan{
+		Operator: "??",
+		Left:     &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true},
+		Right:    &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true},
+	}, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, value)
+
+	value, ok, err = evalFastStructLoopLogicalInfixValue(&compiler.FastValuePlan{
+		Operator: "&&",
+		Left:     &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true},
+		Right:    &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: false},
+	}, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, false, value)
+
+	value, ok, err = evalFastStructLoopLogicalInfixValue(&compiler.FastValuePlan{
+		Operator: "||",
+		Left:     &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: false},
+		Right:    &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true},
+	}, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, true, value)
+
+	value, ok, err = evalFastStructLoopLogicalInfixValue(&compiler.FastValuePlan{
+		Operator: "&&",
+		Left:     &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: false},
+		Right:    &compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing"},
+	}, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, false, value)
+
+	value, ok, err = evalFastStructLoopLogicalInfixValue(&compiler.FastValuePlan{
+		Operator: "||",
+		Left:     &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true},
+		Right:    &compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing"},
+	}, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, true, value)
+
+	_, ok, err = evalFastStructLoopLogicalInfixValue(&compiler.FastValuePlan{
+		Operator: "&&",
+		Left:     &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true},
+		Right:    &namePlan,
+	}, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, nil, item)
+	require.ErrorContains(t, err, "line 1")
+	require.True(t, ok)
+
+	truthy, ok, err = isTruthyFastStructLoopCondition(nil, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.False(t, truthy)
+
+	truthy, ok, err = isTruthyFastStructLoopCondition(&fastStructLoopConditionalWriterBranch{
+		condition: compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true},
+	}, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.True(t, truthy)
+
+	truthy, ok, err = isTruthyFastStructLoopCondition(&fastStructLoopConditionalWriterBranch{
+		conditionPlan: &fastStructLoopConditionPlan{
+			kind:  fastStructLoopConditionTruthy,
+			value: fastStructLoopCallArgPlan{kind: fastStructLoopCallArgBool, boolVal: false},
+		},
+	}, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.False(t, truthy)
+
+	truthy, ok, err = evalFastStructLoopConditionPlan(nil, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.False(t, truthy)
+
+	truthy, ok, err = evalFastStructLoopConditionPlan(&fastStructLoopConditionPlan{
+		kind:  fastStructLoopConditionTruthy,
+		value: nameArgPlan,
+	}, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.True(t, truthy)
+
+	truthy, ok, err = evalFastStructLoopConditionPlan(&fastStructLoopConditionPlan{
+		kind:     fastStructLoopConditionLogical,
+		operator: "&&",
+		left: &fastStructLoopConditionPlan{
+			kind:  fastStructLoopConditionTruthy,
+			value: fastStructLoopCallArgPlan{kind: fastStructLoopCallArgBool, boolVal: false},
+		},
+		right: &fastStructLoopConditionPlan{
+			kind:  fastStructLoopConditionTruthy,
+			value: nameArgPlan,
+		},
+	}, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.False(t, truthy)
+
+	truthy, ok, err = evalFastStructLoopConditionPlan(&fastStructLoopConditionPlan{
+		kind:     fastStructLoopConditionLogical,
+		operator: "||",
+		left: &fastStructLoopConditionPlan{
+			kind:  fastStructLoopConditionTruthy,
+			value: fastStructLoopCallArgPlan{kind: fastStructLoopCallArgBool, boolVal: true},
+		},
+		right: &fastStructLoopConditionPlan{
+			kind:  fastStructLoopConditionTruthy,
+			value: fastStructLoopCallArgPlan{kind: fastStructLoopCallArgBinding, nameIndex: 99},
+		},
+	}, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.True(t, truthy)
+
+	truthy, ok, err = evalFastStructLoopConditionPlan(&fastStructLoopConditionPlan{
+		kind:     fastStructLoopConditionLogical,
+		operator: "??",
+		left: &fastStructLoopConditionPlan{
+			kind:  fastStructLoopConditionTruthy,
+			value: fastStructLoopCallArgPlan{kind: fastStructLoopCallArgBool, boolVal: true},
+		},
+		right: &fastStructLoopConditionPlan{
+			kind:  fastStructLoopConditionTruthy,
+			value: nameArgPlan,
+		},
+	}, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.False(t, truthy)
+
+	truthy, ok, err = evalFastStructLoopConditionPlan(&fastStructLoopConditionPlan{
+		kind:       fastStructLoopConditionInfix,
+		operator:   "==",
+		leftValue:  nameArgPlan,
+		rightValue: fastStructLoopCallArgPlan{kind: fastStructLoopCallArgString, stringVal: "bot"},
+	}, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.True(t, truthy)
+
+	truthy, ok, err = evalFastStructLoopConditionPlan(&fastStructLoopConditionPlan{
+		kind:       fastStructLoopConditionInfix,
+		operator:   "==",
+		leftValue:  fastStructLoopCallArgPlan{kind: fastStructLoopCallArgBinding, nameIndex: 99},
+		rightValue: fastStructLoopCallArgPlan{kind: fastStructLoopCallArgBinding, nameIndex: 100},
+	}, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.True(t, truthy)
+
+	_, ok, err = evalFastStructLoopConditionPlan(&fastStructLoopConditionPlan{
+		kind:       fastStructLoopConditionInfix,
+		operator:   "??",
+		leftValue:  nameArgPlan,
+		rightValue: fastStructLoopCallArgPlan{kind: fastStructLoopCallArgString, stringVal: "bot"},
+		line:       13,
+	}, ctx, bindings, nil, item)
+	require.True(t, ok)
+	require.ErrorContains(t, err, "line 13")
+
+	truthy, ok, err = evalFastStructLoopConditionPlan(&fastStructLoopConditionPlan{kind: fastStructLoopConditionKind(99)}, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.False(t, truthy)
+
+	operand, ok, err := evalFastStructLoopConditionOperand(nil, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.True(t, operand.isNil())
+
+	operand, ok, err = evalFastStructLoopConditionOperand(&fastStructLoopCallArgPlan{kind: fastStructLoopCallArgAccessChain}, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.True(t, operand.isNil())
+
+	operand, ok, err = evalFastStructLoopConditionOperand(&fastStructLoopCallArgPlan{kind: fastStructLoopCallArgAccessChain, accessPlan: nameArgPlan.accessPlan}, ctx, bindings, nil, reflect.Value{})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.True(t, operand.isNil())
+
+	_, ok, err = evalFastStructLoopConditionOperand(&fastStructLoopCallArgPlan{kind: fastStructLoopCallArgAccessChain, accessPlan: nameArgPlan.accessPlan}, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, nil, item)
+	require.ErrorContains(t, err, "line 1")
+	require.True(t, ok)
+
+	_, ok, err = evalFastStructLoopConditionPlan(&fastStructLoopConditionPlan{
+		kind:  fastStructLoopConditionTruthy,
+		value: nameArgPlan,
+	}, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, nil, item)
+	require.ErrorContains(t, err, "line 1")
+	require.True(t, ok)
+
+	_, ok, err = evalFastStructLoopConditionPlan(&fastStructLoopConditionPlan{
+		kind:     fastStructLoopConditionLogical,
+		operator: "&&",
+		left:     &fastStructLoopConditionPlan{kind: fastStructLoopConditionTruthy, value: nameArgPlan},
+		right:    &fastStructLoopConditionPlan{kind: fastStructLoopConditionTruthy, value: fastStructLoopCallArgPlan{kind: fastStructLoopCallArgBool, boolVal: true}},
+	}, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, nil, item)
+	require.ErrorContains(t, err, "line 1")
+	require.True(t, ok)
+
+	_, ok, err = evalFastStructLoopConditionPlan(&fastStructLoopConditionPlan{
+		kind:     fastStructLoopConditionLogical,
+		operator: "&&",
+		left:     &fastStructLoopConditionPlan{kind: fastStructLoopConditionTruthy, value: fastStructLoopCallArgPlan{kind: fastStructLoopCallArgBool, boolVal: true}},
+		right:    &fastStructLoopConditionPlan{kind: fastStructLoopConditionTruthy, value: nameArgPlan},
+	}, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, nil, item)
+	require.ErrorContains(t, err, "line 1")
+	require.True(t, ok)
+
+	_, ok, err = evalFastStructLoopConditionPlan(&fastStructLoopConditionPlan{
+		kind:       fastStructLoopConditionInfix,
+		operator:   "==",
+		leftValue:  nameArgPlan,
+		rightValue: fastStructLoopCallArgPlan{kind: fastStructLoopCallArgString, stringVal: "bot"},
+	}, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, nil, item)
+	require.ErrorContains(t, err, "line 1")
+	require.True(t, ok)
+
+	_, ok, err = evalFastStructLoopConditionPlan(&fastStructLoopConditionPlan{
+		kind:       fastStructLoopConditionInfix,
+		operator:   "==",
+		leftValue:  fastStructLoopCallArgPlan{kind: fastStructLoopCallArgString, stringVal: "bot"},
+		rightValue: nameArgPlan,
+	}, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, nil, item)
+	require.ErrorContains(t, err, "line 1")
+	require.True(t, ok)
+
+	arg, ok, err := evalFastStructLoopCallArgString(nil, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Empty(t, arg)
+
+	arg, ok, err = evalFastStructLoopCallArgString(&fastStructLoopCallArgPlan{kind: fastStructLoopCallArgAccessChain}, ctx, bindings, nil, reflect.Value{})
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Empty(t, arg)
+
+	arg, ok, err = evalFastStructLoopCallArgString(&fastStructLoopCallArgPlan{kind: fastStructLoopCallArgAccessChain}, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Empty(t, arg)
+
+	arg, ok, err = evalFastStructLoopCallArgString(&nameArgPlan, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "bot", arg)
+
+	_, ok, err = evalFastStructLoopCallArgString(&nameArgPlan, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, nil, item)
+	require.ErrorContains(t, err, "line 1")
+	require.True(t, ok)
+
+	childValuePlan := compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: -1,
+		Path: []compiler.FastPathStep{
+			{Kind: compiler.FastPathStepProperty, Value: "Child", Receiver: "product", Full: "product.Child", Line: 1},
+		},
+		Line: 1,
+	}
+	childArgPlan := buildFastStructLoopCallArgPlan(&childValuePlan, reflect.TypeOf(vmFastPropertyUser{}))
+	arg, ok, err = evalFastStructLoopCallArgString(&childArgPlan, ctx, bindings, nil, reflect.ValueOf(vmFastPropertyUser{}))
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Empty(t, arg)
+
+	stringerValuePlan := compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: -1,
+		Path: []compiler.FastPathStep{
+			{Kind: compiler.FastPathStepProperty, Value: "Title", Receiver: "product", Full: "product.Title", Line: 1},
+		},
+		Line: 1,
+	}
+	stringerArgPlan := buildFastStructLoopCallArgPlan(&stringerValuePlan, reflect.TypeOf(vmStructLoopStringerProduct{}))
+	arg, ok, err = evalFastStructLoopCallArgString(&stringerArgPlan, ctx, bindings, nil, reflect.ValueOf(vmStructLoopStringerProduct{Title: vmStructLoopStringer{value: "title"}}))
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "stringer:title", arg)
+
+	arg, ok, err = evalFastStructLoopCallArgString(&fastStructLoopCallArgPlan{kind: fastStructLoopCallArgInt, intVal: 7}, ctx, bindings, nil, item)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Empty(t, arg)
+
+	var stringIface interface{} = "iface"
+	reflectedString, ok := (fastConditionOperandValue{hasReflect: true, reflect: reflect.ValueOf(stringIface)}).stringValue()
+	require.True(t, ok)
+	require.Equal(t, "iface", reflectedString)
+
+	var nilBoolIface interface{}
+	_, ok = (fastConditionOperandValue{hasReflect: true, reflect: reflect.ValueOf(&nilBoolIface).Elem()}).boolValue()
+	require.False(t, ok)
+
+	var boolIface interface{} = true
+	reflectedBool, ok := (fastConditionOperandValue{hasReflect: true, reflect: reflect.ValueOf(boolIface)}).boolValue()
+	require.True(t, ok)
+	require.True(t, reflectedBool)
+
+	var nilStringReflectIface interface{}
+	_, ok = (fastConditionOperandValue{hasReflect: true, reflect: reflect.ValueOf(&nilStringReflectIface).Elem()}).stringValue()
+	require.False(t, ok)
+
+	var nilStringIface interface{} = (*string)(nil)
+	_, ok = (fastConditionOperandValue{hasReflect: true, reflect: reflect.ValueOf(nilStringIface)}).stringValue()
+	require.False(t, ok)
+}
+
+func Test_VM_Fast_Struct_Loop_Writer_Op_Edges(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"label": func(value string) string { return value + "!" },
+	})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label"}}, ctx)
+	item := reflect.ValueOf(vmStructLoopProduct{Name: "<bot>"})
+	nameLookup := cachedPropertyLookup(reflect.TypeOf(vmStructLoopProduct{}), "Name")
+	callPlan := structLoopCallPlan(t, structLoopNameArg())
+	nameAccessPlan := callPlan.args[0].accessPlan
+
+	ops := []fastStructLoopWriterOp{
+		{kind: fastStructLoopWriterStatic, value: "key="},
+		{kind: fastStructLoopWriterKey},
+		{kind: fastStructLoopWriterStatic, value: " name="},
+		{
+			kind:       fastStructLoopWriterField,
+			name:       "Name",
+			receiver:   "product",
+			full:       "product.Name",
+			line:       2,
+			fieldIndex: nameLookup.fieldIndex,
+			fieldType:  stringType,
+		},
+		{kind: fastStructLoopWriterStatic, value: " chain="},
+		{kind: fastStructLoopWriterAccessChain, accessPlan: nameAccessPlan},
+		{kind: fastStructLoopWriterStatic, value: " call="},
+		{kind: fastStructLoopWriterCall, call: callPlan},
+		{kind: fastStructLoopWriterStatic, value: " method="},
+		{
+			kind: fastStructLoopWriterMethodCall,
+			methodPlan: &fastLoopMethodCallPlan{
+				method: compiler.FastPathStep{Value: "Echo", Receiver: "product", Full: "product.Echo", Line: 3},
+				call:   compiler.FastPathStep{Value: "Echo", Line: 3},
+				lookup: cachedPropertyLookup(reflect.TypeOf(vmStructLoopProduct{}), "Echo"),
+			},
+		},
+	}
+
+	var out strings.Builder
+	err := renderFastStructLoopWriterOps(&out, ctx, bindings, &fastStructLoopRenderState{}, nil, ops, 4, item)
+	require.NoError(t, err)
+	require.Equal(t, "key=4 name=&lt;bot&gt; chain=&lt;bot&gt; call=&lt;bot&gt;! method=&lt;bot&gt;!", out.String())
+
+	out.Reset()
+	err = renderFastStructLoopWriterOps(&out, ctx, bindings, &fastStructLoopRenderState{}, nil, []fastStructLoopWriterOp{ops[3]}, 0, reflect.Value{})
+	require.NoError(t, err)
+	require.Empty(t, out.String())
+
+	err = renderFastStructLoopWriterOps(&strings.Builder{}, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, &fastStructLoopRenderState{}, nil, []fastStructLoopWriterOp{ops[3]}, 0, item)
+	require.ErrorContains(t, err, "line 2")
+
+	profileLookup := cachedPropertyLookup(reflect.TypeOf(vmAccessWrapper{}), "Profile")
+	out.Reset()
+	err = renderFastStructLoopWriterOps(&out, ctx, bindings, &fastStructLoopRenderState{}, nil, []fastStructLoopWriterOp{{
+		kind:       fastStructLoopWriterField,
+		name:       "Profile",
+		receiver:   "wrapper",
+		full:       "wrapper.Profile",
+		line:       6,
+		fieldIndex: profileLookup.fieldIndex,
+		fieldType:  reflect.TypeOf(vmAccessProfile{}),
+	}}, 0, reflect.ValueOf(vmAccessWrapper{Profile: vmAccessProfile{Name: "profile"}}))
+	require.NoError(t, err)
+	require.Empty(t, out.String())
+
+	hiddenLookup := cachedPropertyLookup(reflect.TypeOf(vmFastPropertyUser{}), "hidden")
+	err = renderFastStructLoopWriterOps(&strings.Builder{}, ctx, bindings, &fastStructLoopRenderState{}, nil, []fastStructLoopWriterOp{{
+		kind:       fastStructLoopWriterField,
+		name:       "hidden",
+		receiver:   "user",
+		full:       "user.hidden",
+		line:       7,
+		fieldIndex: hiddenLookup.fieldIndex,
+		fieldType:  stringType,
+	}}, 0, reflect.ValueOf(vmFastPropertyUser{hidden: "secret"}))
+	require.ErrorContains(t, err, "line 7")
+
+	err = renderFastStructLoopWriterOps(&strings.Builder{}, ctx, bindings, &fastStructLoopRenderState{}, nil, []fastStructLoopWriterOp{{
+		kind: fastStructLoopWriterAccessChain,
+		accessPlan: &fastAccessChainPlan{steps: []fastAccessChainStep{{
+			kind:      fastAccessStepField,
+			name:      "hidden",
+			receiver:  "user",
+			full:      "user.hidden",
+			line:      7,
+			fieldType: stringType,
+			lookup:    hiddenLookup,
+		}}},
+	}}, 0, reflect.ValueOf(vmFastPropertyUser{hidden: "secret"}))
+	require.ErrorContains(t, err, "line 7")
+
+	out.Reset()
+	err = renderFastStructLoopWriterOps(&out, ctx, bindings, &fastStructLoopRenderState{}, nil, []fastStructLoopWriterOp{{
+		kind:       fastStructLoopWriterAccessChain,
+		accessPlan: &fastAccessChainPlan{steps: []fastAccessChainStep{{kind: fastAccessStepKind(99)}}},
+	}}, 0, item)
+	require.NoError(t, err)
+	require.Empty(t, out.String())
+
+	err = renderFastStructLoopWriterOps(&strings.Builder{}, ctx, bindings, &fastStructLoopRenderState{}, nil, []fastStructLoopWriterOp{{
+		kind: fastStructLoopWriterMethodCall,
+		methodPlan: &fastLoopMethodCallPlan{
+			method: compiler.FastPathStep{Value: "Missing", Receiver: "product", Full: "product.Missing", Line: 8},
+			call:   compiler.FastPathStep{Value: "Missing", Line: 8},
+			lookup: propertyLookup{kind: propertyLookupMissing},
+		},
+	}}, 0, item)
+	require.ErrorContains(t, err, "line 8")
+
+	err = renderFastStructLoopWriterOps(&strings.Builder{}, plush.NewContext(), fastRenderBindings{}, &fastStructLoopRenderState{}, nil, []fastStructLoopWriterOp{{
+		kind: fastStructLoopWriterCall,
+		call: structLoopCallPlan(t, structLoopNameArg()),
+	}}, 0, item)
+	require.ErrorContains(t, err, `"label": unknown identifier`)
+
+	out.Reset()
+	conditional := &fastStructLoopConditionalWriterPlan{
+		branches: []fastStructLoopConditionalWriterBranch{{
+			conditionPlan: &fastStructLoopConditionPlan{
+				kind:  fastStructLoopConditionTruthy,
+				value: fastStructLoopCallArgPlan{kind: fastStructLoopCallArgBool, boolVal: false},
+			},
+			ops:  []fastStructLoopWriterOp{{kind: fastStructLoopWriterStatic, value: "branch"}},
+			line: 8,
+		}},
+		elseOps: []fastStructLoopWriterOp{{kind: fastStructLoopWriterStatic, value: "else"}},
+	}
+	err = renderFastStructLoopWriterOps(&out, ctx, bindings, &fastStructLoopRenderState{}, &compiler.FastLoopPlan{Line: 8}, []fastStructLoopWriterOp{{
+		kind:        fastStructLoopWriterConditional,
+		conditional: conditional,
+	}}, 0, item)
+	require.NoError(t, err)
+	require.Equal(t, "else", out.String())
+
+	require.NoError(t, renderFastStructLoopConditional(&out, ctx, bindings, &fastStructLoopRenderState{}, nil, nil, 0, item))
+	require.NoError(t, renderFastStructLoopConditional(&out, ctx, bindings, &fastStructLoopRenderState{}, nil, &fastStructLoopConditionalWriterPlan{}, 0, item))
+
+	err = renderFastStructLoopConditional(&strings.Builder{}, plush.NewContext().WithBudget(plush.NewBudget(1)), bindings, &fastStructLoopRenderState{}, nil, &fastStructLoopConditionalWriterPlan{
+		branches: []fastStructLoopConditionalWriterBranch{{
+			condition: structLoopNameArg(),
+			line:      9,
+		}},
+	}, 0, item)
+	require.ErrorContains(t, err, "line 1")
+
+	err = renderFastStructLoopConditional(&strings.Builder{}, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, &fastStructLoopRenderState{}, nil, conditional, 0, item)
+	require.ErrorContains(t, err, "line 8")
+
+	err = renderFastStructLoopWriterOps(&strings.Builder{}, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, &fastStructLoopRenderState{}, nil, []fastStructLoopWriterOp{{
+		kind:        fastStructLoopWriterConditional,
+		conditional: conditional,
+	}}, 0, item)
+	require.ErrorContains(t, err, "line 8")
+}
+
+func Test_VM_Fast_Struct_Loop_Method_Call_And_Reflect_Edges(t *testing.T) {
+	ctx := plush.NewContext()
+	item := reflect.ValueOf(vmStructLoopProduct{Name: "<bot>"})
+
+	require.NoError(t, writeFastLoopMethodCall(&strings.Builder{}, ctx, nil, item))
+	require.NoError(t, writeFastLoopMethodCall(&strings.Builder{}, ctx, &fastLoopMethodCallPlan{
+		method: compiler.FastPathStep{Value: "Echo", Receiver: "product", Full: "product.Echo", Line: 3},
+		call:   compiler.FastPathStep{Value: "Echo", Line: 3},
+		lookup: cachedPropertyLookup(reflect.TypeOf(vmStructLoopProduct{}), "Echo"),
+	}, reflect.Value{}))
+
+	var out strings.Builder
+	valueMethod := &fastLoopMethodCallPlan{
+		method: compiler.FastPathStep{Value: "Echo", Receiver: "product", Full: "product.Echo", Line: 4},
+		call:   compiler.FastPathStep{Value: "Echo", Line: 4},
+		lookup: cachedPropertyLookup(reflect.TypeOf(vmStructLoopProduct{}), "Echo"),
+	}
+	require.NoError(t, writeFastLoopMethodCall(&out, ctx, valueMethod, item))
+	require.Equal(t, "&lt;bot&gt;!", out.String())
+
+	out.Reset()
+	pointerMethod := &fastLoopMethodCallPlan{
+		method: compiler.FastPathStep{Value: "PointerEcho", Receiver: "product", Full: "product.PointerEcho", Line: 5},
+		call:   compiler.FastPathStep{Value: "PointerEcho", Line: 5},
+		lookup: cachedPropertyLookup(reflect.TypeOf(vmStructLoopProduct{}), "PointerEcho"),
+	}
+	require.NoError(t, writeFastLoopMethodCall(&out, ctx, pointerMethod, item))
+	require.Equal(t, "&lt;bot&gt;?", out.String())
+
+	addressable := reflect.ValueOf(&vmStructLoopProduct{Name: "addr"}).Elem()
+	method, ok := fastBoundMethodValue(addressable, cachedPropertyLookup(reflect.TypeOf(vmStructLoopProduct{}), "PointerEcho"))
+	require.True(t, ok)
+	results := method.Call(nil)
+	require.Len(t, results, 1)
+	require.Equal(t, "addr?", results[0].Interface())
+
+	_, ok = fastBoundMethodValue(reflect.Value{}, cachedPropertyLookup(reflect.TypeOf(vmStructLoopProduct{}), "Echo"))
+	require.False(t, ok)
+	_, ok = fastBoundMethodValue(item, propertyLookup{kind: propertyLookupMissing})
+	require.False(t, ok)
+
+	missing := &fastLoopMethodCallPlan{
+		method: compiler.FastPathStep{Value: "Missing", Receiver: "product", Full: "product.Missing", Line: 6},
+		call:   compiler.FastPathStep{Value: "Missing", Line: 6},
+		lookup: propertyLookup{kind: propertyLookupMissing},
+	}
+	err := writeFastLoopMethodCall(&strings.Builder{}, ctx, missing, item)
+	require.ErrorContains(t, err, "line 6")
+
+	err = writeFastLoopMethodCall(&strings.Builder{}, plush.NewContext().WithBudget(plush.NewBudget(0)), valueMethod, item)
+	require.ErrorContains(t, err, "line 4")
+
+	err = writeFastLoopMethodCall(&strings.Builder{}, plush.NewContext().WithBudget(plush.NewBudget(1)), valueMethod, item)
+	require.ErrorContains(t, err, "line 4")
+
+	out.Reset()
+	require.NoError(t, writeFastReflectCallResults(&out, ctx, "struct", []reflect.Value{reflect.ValueOf(vmSegmentUser{Name: "ignored"})}))
+	require.Empty(t, out.String())
+
+	receiver, ok, err := fastLoopMethodReceiver(nil, reflect.Value{}, ctx)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.False(t, receiver.IsValid())
+
+	defaultChain := &fastAccessChainPlan{steps: []fastAccessChainStep{{kind: fastAccessStepKind(99)}}}
+	receiver, ok, err = fastLoopMethodReceiver(defaultChain, item, ctx)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.False(t, receiver.IsValid())
+
+	fieldChain, ok := fastAccessChainPlanFor(&compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: -1,
+		Path: []compiler.FastPathStep{
+			{Kind: compiler.FastPathStepProperty, Value: "Child", Receiver: "user", Full: "user.Child", Line: 9},
+		},
+	}, reflect.TypeOf(vmFastPropertyUser{}))
+	require.True(t, ok)
+	value, ok, err := evalFastAccessChainReflectValue(fieldChain, reflect.ValueOf(vmFastPropertyUser{}), ctx)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.False(t, value.IsValid())
+
+	_, ok, err = evalFastAccessChainReflectValue(fieldChain, reflect.ValueOf(vmFastPropertyUser{Child: &vmFastPropertyChild{Name: "kid"}}), plush.NewContext().WithBudget(plush.NewBudget(0)))
+	require.ErrorContains(t, err, "line 9")
+	require.True(t, ok)
+}
+
+func Test_VM_Fast_Struct_Loop_Builder_Edge_Branches(t *testing.T) {
+	elemType := reflect.TypeOf(vmStructLoopProduct{})
+
+	writerPlan, ok := buildFastStructLoopWriterPlan(nil, elemType)
+	require.False(t, ok)
+	require.Nil(t, writerPlan)
+
+	ops, ok := buildFastStructLoopWriterOps([]compiler.FastLoopPart{{Kind: compiler.FastLoopPartKind(99)}}, elemType)
+	require.False(t, ok)
+	require.Nil(t, ops)
+
+	ops, ok = buildFastStructLoopWriterOps([]compiler.FastLoopPart{{Kind: compiler.FastLoopPartValueProperty}}, elemType)
+	require.False(t, ok)
+	require.Nil(t, ops)
+
+	ops, ok = buildFastStructLoopWriterOps([]compiler.FastLoopPart{{Kind: compiler.FastLoopPartValueProperty, Value: "Missing"}}, elemType)
+	require.False(t, ok)
+	require.Nil(t, ops)
+
+	ops, ok = buildFastStructLoopWriterOps([]compiler.FastLoopPart{{
+		Kind:      compiler.FastLoopPartValuePath,
+		ValuePlan: compiler.FastValuePlan{Kind: compiler.FastValuePath},
+	}}, elemType)
+	require.False(t, ok)
+	require.Nil(t, ops)
+
+	ops, ok = buildFastStructLoopWriterOps([]compiler.FastLoopPart{{Kind: compiler.FastLoopPartCall}}, elemType)
+	require.False(t, ok)
+	require.Nil(t, ops)
+
+	ops, ok = buildFastStructLoopWriterOps([]compiler.FastLoopPart{{Kind: compiler.FastLoopPartConditional}}, elemType)
+	require.False(t, ok)
+	require.Nil(t, ops)
+
+	conditional, ok := buildFastStructLoopConditionalWriterPlan(nil, elemType)
+	require.False(t, ok)
+	require.Nil(t, conditional)
+
+	conditional, ok = buildFastStructLoopConditionalWriterPlan(&compiler.FastLoopConditionalPlan{
+		Branches: []compiler.FastLoopConditionalBranch{{
+			Condition: compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true},
+			Parts:     []compiler.FastLoopPart{{Kind: compiler.FastLoopPartValueProperty, Value: "Missing"}},
+			Line:      2,
+		}},
+	}, elemType)
+	require.False(t, ok)
+	require.Nil(t, conditional)
+
+	conditional, ok = buildFastStructLoopConditionalWriterPlan(&compiler.FastLoopConditionalPlan{
+		ElseParts: []compiler.FastLoopPart{{Kind: compiler.FastLoopPartValueProperty, Value: "Missing"}},
+	}, elemType)
+	require.False(t, ok)
+	require.Nil(t, conditional)
+
+	require.Nil(t, buildFastStructLoopConditionPlan(nil, elemType))
+	require.Nil(t, buildFastStructLoopConditionPlan(&compiler.FastValuePlan{Kind: compiler.FastValueInfix, Operator: "==", Left: nil, Right: &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true}}, elemType))
+	require.Nil(t, buildFastStructLoopConditionPlan(&compiler.FastValuePlan{
+		Kind:     compiler.FastValueInfix,
+		Operator: "&&",
+		Left: &compiler.FastValuePlan{
+			Kind:      compiler.FastValuePath,
+			NameIndex: -1,
+			Path:      []compiler.FastPathStep{{Kind: compiler.FastPathStepProperty, Value: "Missing"}},
+		},
+		Right: &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true},
+	}, elemType))
+	require.Nil(t, buildFastStructLoopConditionPlan(&compiler.FastValuePlan{
+		Kind:     compiler.FastValueInfix,
+		Operator: "==",
+		Left: &compiler.FastValuePlan{
+			Kind:      compiler.FastValuePath,
+			NameIndex: -1,
+			Path:      []compiler.FastPathStep{{Kind: compiler.FastPathStepProperty, Value: "Missing"}},
+		},
+		Right: &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true},
+	}, elemType))
+	require.Nil(t, buildFastStructLoopConditionPlan(&compiler.FastValuePlan{
+		Kind:     compiler.FastValueInfix,
+		Operator: "==",
+		Left:     &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true},
+		Right: &compiler.FastValuePlan{
+			Kind:      compiler.FastValuePath,
+			NameIndex: -1,
+			Path:      []compiler.FastPathStep{{Kind: compiler.FastPathStepProperty, Value: "Missing"}},
+		},
+	}, elemType))
+	require.Nil(t, buildFastStructLoopConditionPlan(&compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: -1,
+		Path:      []compiler.FastPathStep{{Kind: compiler.FastPathStepProperty, Value: "Missing"}},
+	}, elemType))
+
+	methodPlan, ok := buildFastLoopMethodCallPlan(nil, elemType)
+	require.False(t, ok)
+	require.Nil(t, methodPlan)
+
+	methodPlan, ok = buildFastLoopMethodCallPlan(&compiler.FastValuePlan{Kind: compiler.FastValuePath}, elemType)
+	require.False(t, ok)
+	require.Nil(t, methodPlan)
+
+	methodPlan, ok = buildFastLoopMethodCallPlan(&compiler.FastValuePlan{
+		Kind: compiler.FastValuePath,
+		Path: []compiler.FastPathStep{
+			{Kind: compiler.FastPathStepProperty, Value: "Echo"},
+			{Kind: compiler.FastPathStepProperty, Value: "Echo"},
+		},
+	}, elemType)
+	require.False(t, ok)
+	require.Nil(t, methodPlan)
+
+	methodPlan, ok = buildFastLoopMethodCallPlan(&compiler.FastValuePlan{
+		Kind: compiler.FastValuePath,
+		Path: []compiler.FastPathStep{
+			{Kind: compiler.FastPathStepProperty, Value: "Echo", Method: false},
+			{Kind: compiler.FastPathStepCall, Value: "Echo"},
+		},
+	}, elemType)
+	require.False(t, ok)
+	require.Nil(t, methodPlan)
+
+	methodPlan, ok = buildFastLoopMethodCallPlan(&compiler.FastValuePlan{
+		Kind: compiler.FastValuePath,
+		Path: []compiler.FastPathStep{
+			{Kind: compiler.FastPathStepProperty, Value: "Missing", Method: true},
+			{Kind: compiler.FastPathStepCall, Value: "Missing"},
+		},
+	}, elemType)
+	require.False(t, ok)
+	require.Nil(t, methodPlan)
+
+	methodPlan, ok = buildFastLoopMethodCallPlan(&compiler.FastValuePlan{
+		Kind: compiler.FastValuePath,
+		Path: []compiler.FastPathStep{
+			{Kind: compiler.FastPathStepProperty, Value: "Missing"},
+			{Kind: compiler.FastPathStepProperty, Value: "Echo", Method: true},
+			{Kind: compiler.FastPathStepCall, Value: "Echo"},
+		},
+	}, elemType)
+	require.False(t, ok)
+	require.Nil(t, methodPlan)
+
+	partWithBadCachedField := compiler.FastLoopPart{Kind: compiler.FastLoopPartValueProperty, Value: "Name"}
+	partWithBadCachedField.PropertyCache.Store(&propertyInlineCacheEntry{
+		typ:    elemType,
+		lookup: propertyLookup{kind: propertyLookupField, fieldIndex: []int{99}},
+	})
+	ops, ok = buildFastStructLoopWriterOps([]compiler.FastLoopPart{partWithBadCachedField}, elemType)
+	require.False(t, ok)
+	require.Nil(t, ops)
+}
+
+func Test_VM_Fast_Struct_Field_Loop_Render_And_Cache_Branches(t *testing.T) {
+	ctx := plush.NewContext()
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{}, ctx)
+	iter := reflect.ValueOf([]vmStructLoopProduct{{Name: "<bot>"}, {Name: "fry"}})
+	elemType := reflect.TypeOf(vmStructLoopProduct{})
+	var out strings.Builder
+
+	handled, err := renderFastStructFieldLoop(&out, ctx, bindings, nil, iter)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	handled, err = renderFastStructFieldLoop(&out, ctx, bindings, &compiler.FastLoopPlan{}, reflect.ValueOf([]string{"not-struct"}))
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	invalidLoop := &compiler.FastLoopPlan{Parts: []compiler.FastLoopPart{{
+		Kind:  compiler.FastLoopPartValueProperty,
+		Value: "Missing",
+		Line:  2,
+	}}}
+	handled, err = renderFastStructFieldLoop(&out, ctx, bindings, invalidLoop, iter)
+	require.NoError(t, err)
+	require.False(t, handled)
+	_, ok := fastStructLoopWriterPlanFor(invalidLoop, elemType)
+	require.False(t, ok)
+	_, ok = fastStructLoopWriterPlanFor(invalidLoop, elemType)
+	require.False(t, ok)
+
+	validLoop := &compiler.FastLoopPlan{
+		Line: 3,
+		Parts: []compiler.FastLoopPart{
+			{Kind: compiler.FastLoopPartKey},
+			{Kind: compiler.FastLoopPartStatic, Value: ":"},
+			{Kind: compiler.FastLoopPartValueProperty, Value: "Name", Receiver: "product", Full: "product.Name", Line: 3},
+			{Kind: compiler.FastLoopPartStatic, Value: ";"},
+		},
+	}
+	plan, ok := fastStructLoopWriterPlanFor(validLoop, elemType)
+	require.True(t, ok)
+	require.NotNil(t, plan)
+	cached, ok := fastStructLoopWriterPlanFor(validLoop, elemType)
+	require.True(t, ok)
+	require.Same(t, plan, cached)
+
+	out.Reset()
+	handled, err = renderFastStructFieldLoop(&out, ctx, bindings, validLoop, iter)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "0:&lt;bot&gt;;1:fry;", out.String())
+
+	handled, err = renderFastStructFieldLoop(&strings.Builder{}, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, validLoop, iter)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 3")
+
+	hiddenLoop := &compiler.FastLoopPlan{Line: 4, Parts: []compiler.FastLoopPart{{
+		Kind:     compiler.FastLoopPartValueProperty,
+		Value:    "hidden",
+		Receiver: "product",
+		Full:     "product.hidden",
+		Line:     4,
+	}}}
+	handled, err = renderFastStructFieldLoop(&strings.Builder{}, ctx, bindings, hiddenLoop, reflect.ValueOf([]vmFastPropertyUser{{hidden: "secret"}}))
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 4")
+}
+
+func Test_VM_Fast_String_Key_Value_Loop_Edges(t *testing.T) {
+	var out strings.Builder
+
+	separator, suffix, ok := fastStringKeyValueLoopParts(nil)
+	require.False(t, ok)
+	require.Empty(t, separator)
+	require.Empty(t, suffix)
+
+	separator, suffix, ok = fastStringKeyValueLoopParts(&compiler.FastLoopPlan{Parts: []compiler.FastLoopPart{
+		{Kind: compiler.FastLoopPartValue},
+		{Kind: compiler.FastLoopPartStatic, Value: ":"},
+		{Kind: compiler.FastLoopPartValue},
+		{Kind: compiler.FastLoopPartStatic, Value: ";"},
+	}})
+	require.False(t, ok)
+	require.Empty(t, separator)
+	require.Empty(t, suffix)
+
+	handled, err := renderFastStringKeyValueLoop(&out, plush.NewContext(), &compiler.FastLoopPlan{}, []string{"nope"})
+	require.NoError(t, err)
+	require.False(t, handled)
+	require.Empty(t, out.String())
+
+	loop := &compiler.FastLoopPlan{
+		Line: 5,
+		Parts: []compiler.FastLoopPart{
+			{Kind: compiler.FastLoopPartKey},
+			{Kind: compiler.FastLoopPartStatic, Value: ":"},
+			{Kind: compiler.FastLoopPartValue},
+			{Kind: compiler.FastLoopPartStatic, Value: ";"},
+		},
+	}
+
+	handled, err = renderFastStringKeyValueLoop(&out, plush.NewContext(), loop, []string{"<a>", "b"})
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "0:&lt;a&gt;;1:b;", out.String())
+
+	handled, err = renderFastStringKeyValueLoop(&strings.Builder{}, plush.NewContext().WithBudget(plush.NewBudget(0)), loop, []string{"blocked"})
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 5")
+}

--- a/VM/vm/fast_struct_loops.go
+++ b/VM/vm/fast_struct_loops.go
@@ -1,0 +1,1494 @@
+package vm
+
+import (
+	"errors"
+	"fmt"
+	"html/template"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/gobuffalo/plush/v5/VM/code"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+)
+
+func renderFastStringKeyValueLoop(out *strings.Builder, ctx hctx.Context, loop *compiler.FastLoopPlan, iter []string) (bool, error) {
+	separator, suffix, ok := fastStringKeyValueLoopParts(loop)
+	if !ok {
+		return false, nil
+	}
+	for i, value := range iter {
+		if err := spendFastLoop(ctx, loop.Line); err != nil {
+			return true, err
+		}
+		writeBuilderFastInt(out, int64(i))
+		out.WriteString(separator)
+		writeFastEscapedString(out, value)
+		out.WriteString(suffix)
+	}
+	return true, nil
+}
+
+func fastStringKeyValueLoopParts(loop *compiler.FastLoopPlan) (string, string, bool) {
+	if loop == nil || len(loop.Parts) != 4 {
+		return "", "", false
+	}
+	if loop.Parts[0].Kind != compiler.FastLoopPartKey ||
+		loop.Parts[1].Kind != compiler.FastLoopPartStatic ||
+		loop.Parts[2].Kind != compiler.FastLoopPartValue ||
+		loop.Parts[3].Kind != compiler.FastLoopPartStatic {
+		return "", "", false
+	}
+	return loop.Parts[1].Value, loop.Parts[3].Value, true
+}
+
+func renderFastStructFieldLoop(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, loop *compiler.FastLoopPlan, iter reflect.Value) (bool, error) {
+	elemType, ok := fastStructLoopElementType(iter.Type())
+	if !ok {
+		return false, nil
+	}
+	plan, ok := fastStructLoopWriterPlanFor(loop, elemType)
+	if !ok {
+		return false, nil
+	}
+
+	state := &fastStructLoopRenderState{}
+	for i := 0; i < iter.Len(); i++ {
+		if err := spendFastLoop(ctx, loop.Line); err != nil {
+			return true, err
+		}
+
+		if err := renderFastStructLoopWriterOps(out, ctx, bindings, state, loop, plan.ops, i, iter.Index(i)); err != nil {
+			return true, err
+		}
+	}
+	return true, nil
+}
+
+func renderFastStructLoopWriterOps(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, state *fastStructLoopRenderState, loop *compiler.FastLoopPlan, ops []fastStructLoopWriterOp, key interface{}, item reflect.Value) error {
+	for opIndex := range ops {
+		op := &ops[opIndex]
+		switch op.kind {
+		case fastStructLoopWriterStatic:
+			out.WriteString(op.value)
+		case fastStructLoopWriterKey:
+			writeFastGoValue(out, ctx, key)
+		case fastStructLoopWriterField:
+			if err := spendFastTraversal(ctx, op.line); err != nil {
+				return err
+			}
+			rv := unwrapFastFieldChainValue(item)
+			if !rv.IsValid() {
+				continue
+			}
+			field := rv.FieldByIndex(op.fieldIndex)
+			access := object.PropertyAccess{
+				Receiver: op.receiver,
+				Full:     op.full,
+			}
+			written, err := writeFastField(out, ctx, field, access, op.name, op.fieldType)
+			if err != nil {
+				return fastLineError(op.line, err)
+			}
+			if written {
+				continue
+			}
+			value, _ := fastFieldValue(field, access, op.name)
+			writeFastGoValue(out, ctx, value)
+		case fastStructLoopWriterAccessChain:
+			handled, err := writeFastAccessChainPlanOutput(out, ctx, op.accessPlan, item)
+			if err != nil {
+				return err
+			}
+			_ = handled
+		case fastStructLoopWriterMethodCall:
+			if err := writeFastLoopMethodCall(out, ctx, op.methodPlan, item); err != nil {
+				return err
+			}
+		case fastStructLoopWriterCall:
+			if err := writeFastStructLoopCallPart(out, ctx, bindings, state, op.call, key, item); err != nil {
+				return err
+			}
+		case fastStructLoopWriterConditional:
+			if err := renderFastStructLoopConditional(out, ctx, bindings, state, loop, op.conditional, key, item); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func renderFastStructLoopConditional(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, state *fastStructLoopRenderState, loop *compiler.FastLoopPlan, conditional *fastStructLoopConditionalWriterPlan, key interface{}, item reflect.Value) error {
+	if conditional == nil {
+		return nil
+	}
+	for i := range conditional.branches {
+		branch := &conditional.branches[i]
+		if err := spendFastCondition(ctx, branch.line); err != nil {
+			return err
+		}
+		truthy, ok, err := isTruthyFastStructLoopCondition(branch, ctx, bindings, key, item)
+		if err != nil {
+			return err
+		}
+		if ok && truthy {
+			return renderFastStructLoopWriterOps(out, ctx, bindings, state, loop, branch.ops, key, item)
+		}
+	}
+	if len(conditional.elseOps) > 0 {
+		return renderFastStructLoopWriterOps(out, ctx, bindings, state, loop, conditional.elseOps, key, item)
+	}
+	return nil
+}
+
+func isTruthyFastStructLoopCondition(branch *fastStructLoopConditionalWriterBranch, ctx hctx.Context, bindings fastRenderBindings, loopKey interface{}, item reflect.Value) (bool, bool, error) {
+	if branch == nil {
+		return false, false, nil
+	}
+	if branch.conditionPlan != nil {
+		return evalFastStructLoopConditionPlan(branch.conditionPlan, ctx, bindings, loopKey, item)
+	}
+	return isTruthyFastStructLoopValue(&branch.condition, ctx, bindings, loopKey, item)
+}
+
+func writeFastStructLoopCallPart(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, state *fastStructLoopRenderState, plan *fastStructLoopCallPlan, loopKey interface{}, item reflect.Value) error {
+	if plan == nil || plan.call == nil {
+		return nil
+	}
+	call := plan.call
+	if err := spendFastFunctionCall(ctx, call.Name, call.Line); err != nil {
+		return err
+	}
+
+	resolved, err := state.resolvedCall(plan, bindings)
+	if err != nil {
+		return fastLineError(call.Line, err)
+	}
+
+	var args fastCallArgs
+	argsReady := false
+	if helper, ok := fastHelperForContext(ctx, call.Name); ok {
+		if len(plan.args) > 0 {
+			if err := evalFastStructLoopCallPlanArgs(plan, ctx, bindings, loopKey, item, &args); err != nil {
+				return err
+			}
+			argsReady = true
+		}
+		if handled, err := writeRegisteredFastHelperNamed(out, ctx, call.Name, helper, fastCallArgsOrNil(&args, len(plan.args))); handled || err != nil {
+			if err != nil {
+				return fastLineError(call.Line, err)
+			}
+			return nil
+		}
+	}
+	if resolved.directWriter != nil {
+		if handled, err := resolved.directWriter(out, ctx, bindings, plan, loopKey, item); err != nil {
+			return fastLineError(call.Line, err)
+		} else if handled {
+			return nil
+		}
+	}
+	if resolved.entry != nil && resolved.entry.invoker != nil {
+		if len(plan.args) > 0 && !argsReady {
+			if err := evalFastStructLoopCallPlanArgs(plan, ctx, bindings, loopKey, item, &args); err != nil {
+				return err
+			}
+			argsReady = true
+		}
+		if err := resolved.entry.invoker(out, ctx, call.Name, resolved.raw, fastCallArgsOrNil(&args, len(plan.args))); err != nil {
+			if !errors.Is(err, errFastWriteUnsupported) {
+				return fastLineError(call.Line, err)
+			}
+		} else {
+			return nil
+		}
+	}
+
+	if resolved.canReflect {
+		if err := writeFastStructLoopReflectCall(out, ctx, bindings, plan, resolved, loopKey, item); err != nil {
+			return fastLineError(call.Line, err)
+		}
+		return nil
+	}
+
+	if len(plan.args) > 0 && !argsReady {
+		if err := evalFastStructLoopCallPlanArgs(plan, ctx, bindings, loopKey, item, &args); err != nil {
+			return err
+		}
+		argsReady = true
+	}
+	if err := writeFastCallValueWithEntry(out, ctx, call.Name, resolved.raw, fastCallArgsOrNil(&args, len(plan.args)), resolved.entry); err != nil {
+		return fastLineError(call.Line, err)
+	}
+	return nil
+}
+
+func fastCallArgsOrNil(args *fastCallArgs, count int) *fastCallArgs {
+	if count == 0 {
+		return nil
+	}
+	return args
+}
+
+func (s *fastStructLoopRenderState) resolvedCall(plan *fastStructLoopCallPlan, bindings fastRenderBindings) (*fastStructLoopResolvedCall, error) {
+	if plan == nil || plan.call == nil {
+		return nil, nil
+	}
+	if s == nil {
+		return resolveFastStructLoopCall(plan, bindings)
+	}
+	if s.singleCall == plan {
+		return s.singleResolvedCall, nil
+	}
+	if s.calls != nil {
+		if resolved := s.calls[plan]; resolved != nil {
+			return resolved, nil
+		}
+	}
+	resolved, err := resolveFastStructLoopCall(plan, bindings)
+	if err != nil {
+		return nil, err
+	}
+	if s.singleCall == nil {
+		s.singleCall = plan
+		s.singleResolvedCall = resolved
+		return resolved, nil
+	}
+	if s.calls == nil {
+		s.calls = map[*fastStructLoopCallPlan]*fastStructLoopResolvedCall{
+			s.singleCall: s.singleResolvedCall,
+		}
+	}
+	s.calls[plan] = resolved
+	return resolved, nil
+}
+
+func resolveFastStructLoopCall(plan *fastStructLoopCallPlan, bindings fastRenderBindings) (*fastStructLoopResolvedCall, error) {
+	call := plan.call
+	raw, ok := bindings.value(call.NameIndex)
+	if !ok {
+		return nil, fmt.Errorf("%q: unknown identifier", call.Name)
+	}
+	if obj, ok := raw.(object.Object); ok {
+		raw = object.ToGo(obj)
+	}
+	rv := reflect.ValueOf(raw)
+	if !rv.IsValid() {
+		return nil, fmt.Errorf("%T is an invalid function", raw)
+	}
+	if rv.Kind() != reflect.Func {
+		return nil, fmt.Errorf("%+v (%T) is an invalid function", raw, raw)
+	}
+	entry := cachedFastCallEntry(rv.Type(), raw, &call.Cache)
+	resolved := &fastStructLoopResolvedCall{
+		raw:          raw,
+		fn:           rv,
+		entry:        entry,
+		directWriter: fastStructLoopDirectCallWriterForRaw(raw, plan),
+	}
+	if canUseFastStructLoopReflectCall(plan, entry) {
+		resolved.canReflect = true
+		resolved.reflectArgs = make([]reflect.Value, 0, len(plan.args))
+		if err := resolved.prepareStaticReflectArgs(plan, bindings); err != nil {
+			return nil, err
+		}
+	}
+	return resolved, nil
+}
+
+func canUseFastStructLoopReflectCall(plan *fastStructLoopCallPlan, entry *fastBuilderCallCacheEntry) bool {
+	if plan == nil || entry == nil || entry.plan == nil || entry.plan.isVariadic || len(plan.args) != entry.plan.numIn {
+		return false
+	}
+	for i := range plan.args {
+		if plan.args[i].kind == fastStructLoopCallArgGeneric {
+			return false
+		}
+	}
+	return true
+}
+
+func writeFastStructLoopReflectCall(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, plan *fastStructLoopCallPlan, resolved *fastStructLoopResolvedCall, loopKey interface{}, item reflect.Value) error {
+	if plan == nil || plan.call == nil || resolved == nil || resolved.entry == nil || resolved.entry.plan == nil {
+		return errFastWriteUnsupported
+	}
+	callPlan := resolved.entry.plan
+	args := resolved.reflectArgs[:0]
+	for i := range plan.args {
+		var arg reflect.Value
+		if i < len(resolved.staticReflectArgOK) && resolved.staticReflectArgOK[i] {
+			arg = resolved.staticReflectArgs[i]
+		} else {
+			var err error
+			arg, err = evalFastStructLoopCallArgReflect(&plan.args[i], ctx, bindings, loopKey, item, callPlan.argTypes[i], plan.call.Name, i)
+			if err != nil {
+				return err
+			}
+		}
+		args = append(args, arg)
+	}
+	resolved.reflectArgs = args[:0]
+	results := resolved.fn.Call(args)
+	return writeFastReflectCallResults(out, ctx, plan.call.Name, results)
+}
+
+func (r *fastStructLoopResolvedCall) prepareStaticReflectArgs(plan *fastStructLoopCallPlan, bindings fastRenderBindings) error {
+	if r == nil || r.entry == nil || r.entry.plan == nil || plan == nil || len(plan.args) == 0 {
+		return nil
+	}
+	r.staticReflectArgs = make([]reflect.Value, len(plan.args))
+	r.staticReflectArgOK = make([]bool, len(plan.args))
+	for i := range plan.args {
+		if !fastStructLoopCallArgStatic(plan.args[i].kind) {
+			continue
+		}
+		arg, err := evalFastStructLoopStaticCallArgReflect(&plan.args[i], bindings, r.entry.plan.argTypes[i], plan.call.Name, i)
+		if err != nil {
+			return err
+		}
+		r.staticReflectArgs[i] = arg
+		r.staticReflectArgOK[i] = true
+	}
+	return nil
+}
+
+func fastStructLoopCallArgStatic(kind fastStructLoopCallArgKind) bool {
+	switch kind {
+	case fastStructLoopCallArgBinding,
+		fastStructLoopCallArgNil,
+		fastStructLoopCallArgString,
+		fastStructLoopCallArgInt,
+		fastStructLoopCallArgFloat,
+		fastStructLoopCallArgBool:
+		return true
+	default:
+		return false
+	}
+}
+
+func evalFastStructLoopStaticCallArgReflect(plan *fastStructLoopCallArgPlan, bindings fastRenderBindings, expected reflect.Type, name string, pos int) (reflect.Value, error) {
+	value, ok := evalFastStructLoopStaticCallArgValue(plan, bindings)
+	if !ok {
+		return reflect.Value{}, fastLineError(plan.line, fmt.Errorf("%q: unknown identifier", plan.value.Value))
+	}
+	return fastReflectArgForCall(name, pos, value, expected)
+}
+
+func evalFastStructLoopStaticCallArgValue(plan *fastStructLoopCallArgPlan, bindings fastRenderBindings) (interface{}, bool) {
+	if plan == nil {
+		return nil, true
+	}
+	switch plan.kind {
+	case fastStructLoopCallArgBinding:
+		raw, ok := bindings.value(plan.nameIndex)
+		return raw, ok
+	case fastStructLoopCallArgNil:
+		return nil, true
+	case fastStructLoopCallArgString:
+		return plan.stringVal, true
+	case fastStructLoopCallArgInt:
+		return int(plan.intVal), true
+	case fastStructLoopCallArgFloat:
+		return plan.floatVal, true
+	case fastStructLoopCallArgBool:
+		return plan.boolVal, true
+	default:
+		return nil, false
+	}
+}
+
+func buildFastStructLoopCallPlan(call *compiler.FastCallPlan, elemType reflect.Type) (*fastStructLoopCallPlan, bool) {
+	if call == nil {
+		return nil, false
+	}
+	plan := &fastStructLoopCallPlan{
+		call: call,
+		args: make([]fastStructLoopCallArgPlan, 0, len(call.Args)),
+	}
+	for i := range call.Args {
+		plan.args = append(plan.args, buildFastStructLoopCallArgPlan(&call.Args[i], elemType))
+	}
+	return plan, true
+}
+
+func buildFastStructLoopCallArgPlan(value *compiler.FastValuePlan, elemType reflect.Type) fastStructLoopCallArgPlan {
+	if value == nil {
+		return fastStructLoopCallArgPlan{kind: fastStructLoopCallArgNil}
+	}
+	plan := fastStructLoopCallArgPlan{
+		kind:  fastStructLoopCallArgGeneric,
+		value: *value,
+		line:  value.Line,
+	}
+	switch value.Kind {
+	case compiler.FastValueLoopKey:
+		plan.kind = fastStructLoopCallArgKey
+	case compiler.FastValueName:
+		if value.Value == "nil" {
+			plan.kind = fastStructLoopCallArgNil
+			break
+		}
+		plan.kind = fastStructLoopCallArgBinding
+		plan.nameIndex = value.NameIndex
+	case compiler.FastValueString:
+		plan.kind = fastStructLoopCallArgString
+		plan.stringVal = value.Value
+	case compiler.FastValueInteger:
+		plan.kind = fastStructLoopCallArgInt
+		plan.intVal = value.IntValue
+	case compiler.FastValueFloat:
+		plan.kind = fastStructLoopCallArgFloat
+		plan.floatVal = value.FloatValue
+	case compiler.FastValueBool:
+		plan.kind = fastStructLoopCallArgBool
+		plan.boolVal = value.BoolValue
+	case compiler.FastValuePath:
+		if value.NameIndex < 0 {
+			if accessPlan, ok := fastAccessChainPlanFor(value, elemType); ok {
+				plan.kind = fastStructLoopCallArgAccessChain
+				plan.accessPlan = accessPlan
+			}
+		}
+	}
+	return plan
+}
+
+func evalFastStructLoopCallPlanArgs(plan *fastStructLoopCallPlan, ctx hctx.Context, bindings fastRenderBindings, loopKey interface{}, item reflect.Value, args *fastCallArgs) error {
+	if plan == nil || len(plan.args) == 0 {
+		return nil
+	}
+	args.Reset()
+	for i := range plan.args {
+		value, ok, err := evalFastStructLoopCallArgValue(&plan.args[i], ctx, bindings, loopKey, item)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fastLineError(plan.args[i].line, fmt.Errorf("%q: unknown identifier", plan.args[i].value.Value))
+		}
+		args.Append(value)
+	}
+	return nil
+}
+
+func evalFastStructLoopCallArgValue(plan *fastStructLoopCallArgPlan, ctx hctx.Context, bindings fastRenderBindings, loopKey interface{}, item reflect.Value) (interface{}, bool, error) {
+	if plan == nil {
+		return nil, true, nil
+	}
+	switch plan.kind {
+	case fastStructLoopCallArgKey:
+		return loopKey, true, nil
+	case fastStructLoopCallArgBinding:
+		raw, ok := bindings.value(plan.nameIndex)
+		return raw, ok, nil
+	case fastStructLoopCallArgNil:
+		return nil, true, nil
+	case fastStructLoopCallArgString:
+		return plan.stringVal, true, nil
+	case fastStructLoopCallArgInt:
+		return int(plan.intVal), true, nil
+	case fastStructLoopCallArgFloat:
+		return plan.floatVal, true, nil
+	case fastStructLoopCallArgBool:
+		return plan.boolVal, true, nil
+	case fastStructLoopCallArgAccessChain:
+		rv := unwrapFastFieldChainValue(item)
+		if !rv.IsValid() {
+			return nil, true, nil
+		}
+		if plan.accessPlan == nil {
+			return nil, false, nil
+		}
+		return evalFastAccessChainPlanValue(plan.accessPlan, rv, ctx)
+	default:
+		return evalFastStructLoopValue(&plan.value, ctx, bindings, loopKey, item)
+	}
+}
+
+func fastStructLoopDirectCallWriterForRaw(raw interface{}, plan *fastStructLoopCallPlan) fastStructLoopDirectCallWriter {
+	if plan == nil {
+		return nil
+	}
+	switch raw := raw.(type) {
+	case func(string) string:
+		if len(plan.args) != 1 {
+			return nil
+		}
+		return func(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, plan *fastStructLoopCallPlan, loopKey interface{}, item reflect.Value) (bool, error) {
+			arg, ok, err := evalFastStructLoopCallArgString(&plan.args[0], ctx, bindings, loopKey, item)
+			if err != nil || !ok {
+				return ok, err
+			}
+			writeFastEscapedString(out, raw(arg))
+			return true, nil
+		}
+	case func(string, string) string:
+		if len(plan.args) != 2 {
+			return nil
+		}
+		return func(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, plan *fastStructLoopCallPlan, loopKey interface{}, item reflect.Value) (bool, error) {
+			first, ok, err := evalFastStructLoopCallArgString(&plan.args[0], ctx, bindings, loopKey, item)
+			if err != nil || !ok {
+				return ok, err
+			}
+			second, ok, err := evalFastStructLoopCallArgString(&plan.args[1], ctx, bindings, loopKey, item)
+			if err != nil || !ok {
+				return ok, err
+			}
+			writeFastEscapedString(out, raw(first, second))
+			return true, nil
+		}
+	case func(string) (string, error):
+		if len(plan.args) != 1 {
+			return nil
+		}
+		return func(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, plan *fastStructLoopCallPlan, loopKey interface{}, item reflect.Value) (bool, error) {
+			arg, ok, err := evalFastStructLoopCallArgString(&plan.args[0], ctx, bindings, loopKey, item)
+			if err != nil || !ok {
+				return ok, err
+			}
+			value, err := raw(arg)
+			if err != nil {
+				return true, fmt.Errorf("could not call %s function: %w", plan.call.Name, err)
+			}
+			writeFastEscapedString(out, value)
+			return true, nil
+		}
+	case func(string, string) (string, error):
+		if len(plan.args) != 2 {
+			return nil
+		}
+		return func(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, plan *fastStructLoopCallPlan, loopKey interface{}, item reflect.Value) (bool, error) {
+			first, ok, err := evalFastStructLoopCallArgString(&plan.args[0], ctx, bindings, loopKey, item)
+			if err != nil || !ok {
+				return ok, err
+			}
+			second, ok, err := evalFastStructLoopCallArgString(&plan.args[1], ctx, bindings, loopKey, item)
+			if err != nil || !ok {
+				return ok, err
+			}
+			value, err := raw(first, second)
+			if err != nil {
+				return true, fmt.Errorf("could not call %s function: %w", plan.call.Name, err)
+			}
+			writeFastEscapedString(out, value)
+			return true, nil
+		}
+	case func(string) template.HTML:
+		if len(plan.args) != 1 {
+			return nil
+		}
+		return func(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, plan *fastStructLoopCallPlan, loopKey interface{}, item reflect.Value) (bool, error) {
+			arg, ok, err := evalFastStructLoopCallArgString(&plan.args[0], ctx, bindings, loopKey, item)
+			if err != nil || !ok {
+				return ok, err
+			}
+			out.WriteString(string(raw(arg)))
+			return true, nil
+		}
+	case func(string, string) template.HTML:
+		if len(plan.args) != 2 {
+			return nil
+		}
+		return func(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, plan *fastStructLoopCallPlan, loopKey interface{}, item reflect.Value) (bool, error) {
+			first, ok, err := evalFastStructLoopCallArgString(&plan.args[0], ctx, bindings, loopKey, item)
+			if err != nil || !ok {
+				return ok, err
+			}
+			second, ok, err := evalFastStructLoopCallArgString(&plan.args[1], ctx, bindings, loopKey, item)
+			if err != nil || !ok {
+				return ok, err
+			}
+			out.WriteString(string(raw(first, second)))
+			return true, nil
+		}
+	}
+	return nil
+}
+
+func evalFastStructLoopCallArgString(plan *fastStructLoopCallArgPlan, ctx hctx.Context, bindings fastRenderBindings, loopKey interface{}, item reflect.Value) (string, bool, error) {
+	if plan == nil {
+		return "", true, nil
+	}
+	if plan.kind == fastStructLoopCallArgAccessChain {
+		rv := unwrapFastFieldChainValue(item)
+		if !rv.IsValid() || plan.accessPlan == nil {
+			return "", false, nil
+		}
+		value, ok, err := evalFastAccessChainReflectValue(plan.accessPlan, rv, ctx)
+		if err != nil || !ok {
+			return "", ok, err
+		}
+		value = unwrapFastFieldChainValue(value)
+		if !value.IsValid() || isNilReflectValue(value) {
+			return "", false, nil
+		}
+		if value.Kind() == reflect.String {
+			return value.String(), true, nil
+		}
+		if value.CanInterface() {
+			arg, ok := fastWriteRawStringArg(value.Interface())
+			return arg, ok, nil
+		}
+		return "", false, nil
+	}
+	value, ok, err := evalFastStructLoopCallArgValue(plan, ctx, bindings, loopKey, item)
+	if err != nil || !ok {
+		return "", ok, err
+	}
+	arg, ok := fastWriteRawStringArg(value)
+	return arg, ok, nil
+}
+
+func evalFastStructLoopCallArgReflect(plan *fastStructLoopCallArgPlan, ctx hctx.Context, bindings fastRenderBindings, loopKey interface{}, item reflect.Value, expected reflect.Type, name string, pos int) (reflect.Value, error) {
+	if plan == nil {
+		return reflect.Zero(expected), nil
+	}
+	switch plan.kind {
+	case fastStructLoopCallArgAccessChain:
+		rv := unwrapFastFieldChainValue(item)
+		if !rv.IsValid() {
+			return reflect.Zero(expected), nil
+		}
+		value, ok, err := evalFastAccessChainReflectValue(plan.accessPlan, rv, ctx)
+		if err != nil {
+			return reflect.Value{}, err
+		}
+		if !ok {
+			return reflect.Zero(expected), nil
+		}
+		return fastReflectArgValueForCall(name, pos, value, expected)
+	default:
+		value, ok, err := evalFastStructLoopCallArgValue(plan, ctx, bindings, loopKey, item)
+		if err != nil {
+			return reflect.Value{}, err
+		}
+		if !ok {
+			return reflect.Value{}, fastLineError(plan.line, fmt.Errorf("%q: unknown identifier", plan.value.Value))
+		}
+		return fastReflectArgForCall(name, pos, value, expected)
+	}
+}
+
+func fastReflectArgValueForCall(name string, pos int, value reflect.Value, expected reflect.Type) (reflect.Value, error) {
+	if !value.IsValid() || isNilReflectValue(value) {
+		return reflect.Zero(expected), nil
+	}
+	if value.Kind() == reflect.Interface && !value.Type().AssignableTo(expected) {
+		value = value.Elem()
+	}
+	if value.Type().AssignableTo(expected) {
+		return value, nil
+	}
+	if value.Type().ConvertibleTo(expected) {
+		return value.Convert(expected), nil
+	}
+	if value.CanInterface() {
+		return fastReflectArgForCall(name, pos, value.Interface(), expected)
+	}
+	return reflect.Value{}, fmt.Errorf("%+v (%s) is an invalid argument for %s at pos %d: expected (%s)", value, value.Type(), name, pos, expected)
+}
+
+func evalFastStructLoopValue(value *compiler.FastValuePlan, ctx hctx.Context, bindings fastRenderBindings, loopKey interface{}, item reflect.Value) (interface{}, bool, error) {
+	if value == nil {
+		return nil, true, nil
+	}
+	switch value.Kind {
+	case compiler.FastValueLoopKey:
+		return loopKey, true, nil
+	case compiler.FastValueInfix:
+		return evalFastStructLoopInfixValue(value, ctx, bindings, loopKey, item)
+	case compiler.FastValuePrefix:
+		return evalFastStructLoopPrefixValue(value, ctx, bindings, loopKey, item)
+	case compiler.FastValueConcat:
+		return evalFastStructLoopConcatValue(value, ctx, bindings, loopKey, item)
+	case compiler.FastValuePath:
+		if value.NameIndex >= 0 {
+			return evalFastValue(value, ctx, bindings, nil)
+		}
+		return evalFastStructLoopPathValue(value, ctx, bindings, item)
+	default:
+		return evalFastValue(value, ctx, bindings, nil)
+	}
+}
+
+func isTruthyFastStructLoopValue(value *compiler.FastValuePlan, ctx hctx.Context, bindings fastRenderBindings, loopKey interface{}, item reflect.Value) (bool, bool, error) {
+	if value != nil && value.Kind == compiler.FastValuePath && value.NameIndex < 0 {
+		rv := unwrapFastFieldChainValue(item)
+		if !rv.IsValid() {
+			return false, true, nil
+		}
+		if len(value.Path) == 0 {
+			return isTruthyFastReflectValue(rv), true, nil
+		}
+		if chain, ok := fastAccessChainPlanFor(value, rv.Type()); ok {
+			field, ok, err := evalFastAccessChainReflectValue(chain, rv, ctx)
+			if err != nil || !ok {
+				return false, ok, err
+			}
+			return isTruthyFastReflectValue(field), true, nil
+		}
+	}
+	result, ok, err := evalFastStructLoopValue(value, ctx, bindings, loopKey, item)
+	if err != nil || !ok {
+		return false, ok, err
+	}
+	return isTruthyFastValue(result), true, nil
+}
+
+func isTruthyFastReflectValue(value reflect.Value) bool {
+	if !value.IsValid() {
+		return false
+	}
+	if value.Kind() == reflect.Interface {
+		if value.IsNil() {
+			return false
+		}
+		if value.CanInterface() {
+			if obj, ok := value.Interface().(object.Object); ok {
+				return isTruthy(obj)
+			}
+		}
+		value = value.Elem()
+	}
+	switch value.Kind() {
+	case reflect.Bool:
+		return value.Bool()
+	case reflect.String:
+		return value.Len() != 0
+	case reflect.Ptr:
+		return !value.IsNil()
+	default:
+		return true
+	}
+}
+
+func evalFastStructLoopPathValue(value *compiler.FastValuePlan, ctx hctx.Context, bindings fastRenderBindings, item reflect.Value) (interface{}, bool, error) {
+	rv := unwrapFastFieldChainValue(item)
+	if !rv.IsValid() {
+		return nil, true, nil
+	}
+	if len(value.Path) == 0 {
+		return fastReflectInterface(rv), true, nil
+	}
+	if chain, ok := fastAccessChainPlanFor(value, rv.Type()); ok {
+		return evalFastAccessChainPlanValue(chain, rv, ctx)
+	}
+	return evalFastValue(value, ctx, bindings, fastReflectInterface(rv))
+}
+
+func evalFastStructLoopInfixValue(value *compiler.FastValuePlan, ctx hctx.Context, bindings fastRenderBindings, loopKey interface{}, item reflect.Value) (interface{}, bool, error) {
+	if value == nil || value.Kind != compiler.FastValueInfix || value.Left == nil || value.Right == nil {
+		return nil, false, nil
+	}
+	if value.Operator == "&&" || value.Operator == "||" {
+		return evalFastStructLoopLogicalInfixValue(value, ctx, bindings, loopKey, item)
+	}
+	left, ok, err := evalFastStructLoopValue(value.Left, ctx, bindings, loopKey, item)
+	if err != nil {
+		return nil, true, err
+	}
+	if !ok {
+		left = nil
+	}
+	right, ok, err := evalFastStructLoopValue(value.Right, ctx, bindings, loopKey, item)
+	if err != nil {
+		return nil, true, err
+	}
+	if !ok {
+		right = nil
+	}
+	result, err := evalFastInfixOperator(value.Operator, left, right)
+	if err != nil {
+		return nil, true, fastLineError(value.Line, err)
+	}
+	return result, true, nil
+}
+
+func evalFastStructLoopPrefixValue(value *compiler.FastValuePlan, ctx hctx.Context, bindings fastRenderBindings, loopKey interface{}, item reflect.Value) (interface{}, bool, error) {
+	if value == nil || value.Kind != compiler.FastValuePrefix || value.Right == nil {
+		return nil, false, nil
+	}
+	if value.Operator != "!" {
+		return nil, true, fastLineError(value.Line, fmt.Errorf("unknown fast prefix operator: %s", value.Operator))
+	}
+	right, ok, err := evalFastStructLoopValue(value.Right, ctx, bindings, loopKey, item)
+	if err != nil {
+		return nil, true, err
+	}
+	return !(ok && isTruthyFastValue(right)), true, nil
+}
+
+func evalFastStructLoopConcatValue(value *compiler.FastValuePlan, ctx hctx.Context, bindings fastRenderBindings, loopKey interface{}, item reflect.Value) (interface{}, bool, error) {
+	if value == nil || value.Kind != compiler.FastValueConcat || value.Left == nil || value.Right == nil {
+		return nil, false, nil
+	}
+	left, ok, err := evalFastStructLoopValue(value.Left, ctx, bindings, loopKey, item)
+	if err != nil {
+		return nil, true, err
+	}
+	if !ok {
+		return nil, false, nil
+	}
+	right, ok, err := evalFastStructLoopValue(value.Right, ctx, bindings, loopKey, item)
+	if err != nil {
+		return nil, true, err
+	}
+	if !ok {
+		return nil, false, nil
+	}
+	result, err := evalFastAddOperator(left, right)
+	if err != nil {
+		return nil, true, fastLineError(value.Line, err)
+	}
+	return result, true, nil
+}
+
+func evalFastStructLoopLogicalInfixValue(value *compiler.FastValuePlan, ctx hctx.Context, bindings fastRenderBindings, loopKey interface{}, item reflect.Value) (interface{}, bool, error) {
+	left, ok, err := evalFastStructLoopValue(value.Left, ctx, bindings, loopKey, item)
+	if err != nil {
+		return nil, true, err
+	}
+	leftTruthy := ok && isTruthyFastValue(left)
+	switch value.Operator {
+	case "&&":
+		if !leftTruthy {
+			return false, true, nil
+		}
+	case "||":
+		if leftTruthy {
+			return true, true, nil
+		}
+	default:
+		return nil, false, nil
+	}
+	right, ok, err := evalFastStructLoopValue(value.Right, ctx, bindings, loopKey, item)
+	if err != nil {
+		return nil, true, err
+	}
+	return ok && isTruthyFastValue(right), true, nil
+}
+
+func evalFastStructLoopConditionPlan(plan *fastStructLoopConditionPlan, ctx hctx.Context, bindings fastRenderBindings, loopKey interface{}, item reflect.Value) (bool, bool, error) {
+	if plan == nil {
+		return false, false, nil
+	}
+	switch plan.kind {
+	case fastStructLoopConditionTruthy:
+		value, ok, err := evalFastStructLoopConditionOperand(&plan.value, ctx, bindings, loopKey, item)
+		if err != nil || !ok {
+			return false, ok, err
+		}
+		return isTruthyFastConditionOperand(value), true, nil
+	case fastStructLoopConditionLogical:
+		leftTruthy, leftOK, err := evalFastStructLoopConditionPlan(plan.left, ctx, bindings, loopKey, item)
+		if err != nil {
+			return false, true, err
+		}
+		switch plan.operator {
+		case "&&":
+			if !leftOK || !leftTruthy {
+				return false, true, nil
+			}
+		case "||":
+			if leftOK && leftTruthy {
+				return true, true, nil
+			}
+		default:
+			return false, false, nil
+		}
+		rightTruthy, rightOK, err := evalFastStructLoopConditionPlan(plan.right, ctx, bindings, loopKey, item)
+		if err != nil {
+			return false, true, err
+		}
+		return rightOK && rightTruthy, true, nil
+	case fastStructLoopConditionInfix:
+		left, leftOK, err := evalFastStructLoopConditionOperand(&plan.leftValue, ctx, bindings, loopKey, item)
+		if err != nil {
+			return false, true, err
+		}
+		right, rightOK, err := evalFastStructLoopConditionOperand(&plan.rightValue, ctx, bindings, loopKey, item)
+		if err != nil {
+			return false, true, err
+		}
+		if !leftOK {
+			left = fastConditionOperandValue{}
+		}
+		if !rightOK {
+			right = fastConditionOperandValue{}
+		}
+		result, err := evalFastConditionInfixOperator(plan.operator, left, right)
+		if err != nil {
+			return false, true, fastLineError(plan.line, err)
+		}
+		return result, true, nil
+	default:
+		return false, false, nil
+	}
+}
+
+func evalFastStructLoopConditionOperand(plan *fastStructLoopCallArgPlan, ctx hctx.Context, bindings fastRenderBindings, loopKey interface{}, item reflect.Value) (fastConditionOperandValue, bool, error) {
+	if plan == nil {
+		return fastConditionOperandValue{}, true, nil
+	}
+	if plan.kind == fastStructLoopCallArgAccessChain {
+		rv := unwrapFastFieldChainValue(item)
+		if !rv.IsValid() {
+			return fastConditionOperandValue{}, true, nil
+		}
+		if plan.accessPlan == nil {
+			return fastConditionOperandValue{}, false, nil
+		}
+		value, ok, err := evalFastAccessChainReflectValue(plan.accessPlan, rv, ctx)
+		if err != nil || !ok {
+			return fastConditionOperandValue{}, ok, err
+		}
+		return fastConditionOperandValue{
+			raw:        fastReflectInterface(value),
+			reflect:    value,
+			hasReflect: true,
+		}, true, nil
+	}
+	value, ok, err := evalFastStructLoopCallArgValue(plan, ctx, bindings, loopKey, item)
+	if err != nil || !ok {
+		return fastConditionOperandValue{}, ok, err
+	}
+	return fastConditionOperandValue{raw: value}, true, nil
+}
+
+func evalFastConditionInfixOperator(operator string, left, right fastConditionOperandValue) (bool, error) {
+	switch operator {
+	case "==":
+		return compareFastConditionEquality(operator, left, right)
+	case "!=":
+		result, err := compareFastConditionEquality(operator, left, right)
+		return !result, err
+	case ">":
+		return compareFastConditionOrdered(code.OpGreaterThan, left, right)
+	case ">=":
+		return compareFastConditionOrdered(code.OpGreaterEqual, left, right)
+	case "<":
+		return compareFastConditionOrdered(code.OpGreaterThan, right, left)
+	case "<=":
+		return compareFastConditionOrdered(code.OpGreaterEqual, right, left)
+	default:
+		return false, fmt.Errorf("unknown fast infix operator: %s", operator)
+	}
+}
+
+func compareFastConditionEquality(operator string, left, right fastConditionOperandValue) (bool, error) {
+	if left.isNil() || right.isNil() {
+		return left.isNil() && right.isNil(), nil
+	}
+	if value, ok := left.boolValue(); ok {
+		return value == isTruthyFastConditionOperand(right), nil
+	}
+	if value, ok := left.stringValue(); ok {
+		return value == fmt.Sprint(right.goValue()), nil
+	}
+	l, lok := left.numericValue()
+	r, rok := right.numericValue()
+	if lok && rok {
+		return compareNumericEquality(l, r), nil
+	}
+	if lok || rok {
+		return false, fmt.Errorf("unable to operate (%s) on %s and %s ", operator, fastConditionTypeName(left), fastConditionTypeName(right))
+	}
+	return reflect.DeepEqual(left.goValue(), right.goValue()), nil
+}
+
+func compareFastConditionOrdered(op code.Opcode, left, right fastConditionOperandValue) (bool, error) {
+	l, lok := left.numericValue()
+	r, rok := right.numericValue()
+	if lok && rok {
+		return compareNumericOrdered(op, l, r)
+	}
+	if lok || rok {
+		return false, fmt.Errorf("unable to operate (%s) on %s and %s ", orderedOperatorString(op), fastConditionTypeName(left), fastConditionTypeName(right))
+	}
+	lString := fmt.Sprint(left.goValue())
+	rString := fmt.Sprint(right.goValue())
+	switch op {
+	case code.OpGreaterThan:
+		return lString > rString, nil
+	case code.OpGreaterEqual:
+		return lString >= rString, nil
+	default:
+		return false, fmt.Errorf("unknown ordered comparison: %d", op)
+	}
+}
+
+func isTruthyFastConditionOperand(value fastConditionOperandValue) bool {
+	if value.hasReflect {
+		return isTruthyFastReflectValue(value.reflect)
+	}
+	return isTruthyFastValue(value.raw)
+}
+
+func (v fastConditionOperandValue) isNil() bool {
+	if v.hasReflect {
+		return !v.reflect.IsValid() || isNilReflectValue(v.reflect)
+	}
+	if obj, ok := v.raw.(object.Object); ok {
+		return object.IsNull(obj)
+	}
+	return v.raw == nil
+}
+
+func (v fastConditionOperandValue) boolValue() (bool, bool) {
+	if v.hasReflect {
+		value := v.reflect
+		if !value.IsValid() || isNilReflectValue(value) {
+			return false, false
+		}
+		if value.Kind() == reflect.Interface {
+			value = value.Elem()
+		}
+		if value.Type() == boolType {
+			return value.Bool(), true
+		}
+		return false, false
+	}
+	switch value := v.raw.(type) {
+	case bool:
+		return value, true
+	case *object.Boolean:
+		return value.Value, true
+	default:
+		return false, false
+	}
+}
+
+func (v fastConditionOperandValue) stringValue() (string, bool) {
+	if v.hasReflect {
+		value := v.reflect
+		if !value.IsValid() || isNilReflectValue(value) {
+			return "", false
+		}
+		if value.Kind() == reflect.Interface {
+			value = value.Elem()
+		}
+		if value.Type() == stringType {
+			return value.String(), true
+		}
+		return "", false
+	}
+	switch value := v.raw.(type) {
+	case string:
+		return value, true
+	case *object.String:
+		return value.Value, true
+	default:
+		return "", false
+	}
+}
+
+func (v fastConditionOperandValue) numericValue() (numericValue, bool) {
+	if v.hasReflect {
+		return numericValueFromReflectValue(v.reflect)
+	}
+	if obj, ok := v.raw.(object.Object); ok {
+		return numericValueFromObject(obj)
+	}
+	return numericValueFromGo(v.raw)
+}
+
+func (v fastConditionOperandValue) goValue() interface{} {
+	if v.hasReflect {
+		return fastReflectInterface(v.reflect)
+	}
+	if obj, ok := v.raw.(object.Object); ok {
+		return object.ToGo(obj)
+	}
+	return v.raw
+}
+
+func fastConditionTypeName(value fastConditionOperandValue) string {
+	if value.hasReflect && value.reflect.IsValid() {
+		return value.reflect.Type().String()
+	}
+	return plushTypeName(object.Wrap(value.raw))
+}
+
+func fastStructLoopElementType(iterType reflect.Type) (reflect.Type, bool) {
+	if iterType.Kind() != reflect.Array && iterType.Kind() != reflect.Slice {
+		return nil, false
+	}
+	elemType := iterType.Elem()
+	if elemType.Kind() == reflect.Ptr {
+		elemType = elemType.Elem()
+	}
+	if elemType.Kind() != reflect.Struct {
+		return nil, false
+	}
+	return elemType, true
+}
+
+func fastStructLoopWriterPlanFor(loop *compiler.FastLoopPlan, elemType reflect.Type) (*fastStructLoopWriterPlan, bool) {
+	if loop == nil {
+		return nil, false
+	}
+	key := fastStructLoopWriterPlanKey{loop: loop, typ: elemType}
+	if cached, ok := fastStructLoopWriterPlanCache.Load(key); ok {
+		plan, _ := cached.(*fastStructLoopWriterPlan)
+		return plan, plan != nil
+	}
+	plan, ok := buildFastStructLoopWriterPlan(loop, elemType)
+	if !ok {
+		fastStructLoopWriterPlanCache.Store(key, (*fastStructLoopWriterPlan)(nil))
+		return nil, false
+	}
+	actual, _ := fastStructLoopWriterPlanCache.LoadOrStore(key, plan)
+	plan, _ = actual.(*fastStructLoopWriterPlan)
+	return plan, plan != nil
+}
+
+func buildFastStructLoopWriterPlan(loop *compiler.FastLoopPlan, elemType reflect.Type) (*fastStructLoopWriterPlan, bool) {
+	if loop == nil {
+		return nil, false
+	}
+	ops, ok := buildFastStructLoopWriterOps(loop.Parts, elemType)
+	if !ok {
+		return nil, false
+	}
+	return &fastStructLoopWriterPlan{ops: ops}, true
+}
+
+func buildFastStructLoopWriterOps(parts []compiler.FastLoopPart, elemType reflect.Type) ([]fastStructLoopWriterOp, bool) {
+	ops := make([]fastStructLoopWriterOp, 0, len(parts))
+	for i := range parts {
+		part := &parts[i]
+		switch part.Kind {
+		case compiler.FastLoopPartStatic:
+			ops = append(ops, fastStructLoopWriterOp{
+				kind:  fastStructLoopWriterStatic,
+				value: part.Value,
+			})
+		case compiler.FastLoopPartKey:
+			ops = append(ops, fastStructLoopWriterOp{kind: fastStructLoopWriterKey})
+		case compiler.FastLoopPartValueProperty:
+			if part.Value == "" {
+				return nil, false
+			}
+			entry := inlinePropertyEntry(&part.PropertyCache, elemType, part.Value)
+			if entry == nil || entry.lookup.kind != propertyLookupField {
+				return nil, false
+			}
+			field, ok := fieldByIndex(elemType, entry.lookup.fieldIndex)
+			if !ok {
+				return nil, false
+			}
+			ops = append(ops, fastStructLoopWriterOp{
+				kind:       fastStructLoopWriterField,
+				name:       part.Value,
+				receiver:   part.Receiver,
+				full:       part.Full,
+				line:       part.Line,
+				fieldIndex: entry.lookup.fieldIndex,
+				fieldType:  field.Type,
+			})
+		case compiler.FastLoopPartValuePath:
+			if methodPlan, ok := buildFastLoopMethodCallPlan(&part.ValuePlan, elemType); ok {
+				ops = append(ops, fastStructLoopWriterOp{
+					kind:       fastStructLoopWriterMethodCall,
+					methodPlan: methodPlan,
+					line:       part.Line,
+				})
+				continue
+			}
+			accessPlan, ok := fastAccessChainPlanFor(&part.ValuePlan, elemType)
+			if !ok {
+				return nil, false
+			}
+			ops = append(ops, fastStructLoopWriterOp{
+				kind:       fastStructLoopWriterAccessChain,
+				accessPlan: accessPlan,
+				line:       part.Line,
+			})
+		case compiler.FastLoopPartCall:
+			if part.Call == nil {
+				return nil, false
+			}
+			call, _ := buildFastStructLoopCallPlan(part.Call, elemType)
+			ops = append(ops, fastStructLoopWriterOp{
+				kind: fastStructLoopWriterCall,
+				call: call,
+				line: part.Line,
+			})
+		case compiler.FastLoopPartConditional:
+			conditional, ok := buildFastStructLoopConditionalWriterPlan(part.Conditional, elemType)
+			if !ok {
+				return nil, false
+			}
+			ops = append(ops, fastStructLoopWriterOp{
+				kind:        fastStructLoopWriterConditional,
+				conditional: conditional,
+				line:        part.Line,
+			})
+		default:
+			return nil, false
+		}
+	}
+	return ops, true
+}
+
+func buildFastStructLoopConditionalWriterPlan(conditional *compiler.FastLoopConditionalPlan, elemType reflect.Type) (*fastStructLoopConditionalWriterPlan, bool) {
+	if conditional == nil {
+		return nil, false
+	}
+	plan := &fastStructLoopConditionalWriterPlan{
+		branches: make([]fastStructLoopConditionalWriterBranch, 0, len(conditional.Branches)),
+	}
+	for i := range conditional.Branches {
+		branch := &conditional.Branches[i]
+		ops, ok := buildFastStructLoopWriterOps(branch.Parts, elemType)
+		if !ok {
+			return nil, false
+		}
+		plan.branches = append(plan.branches, fastStructLoopConditionalWriterBranch{
+			condition:     branch.Condition,
+			conditionPlan: buildFastStructLoopConditionPlan(&branch.Condition, elemType),
+			ops:           ops,
+			line:          branch.Line,
+		})
+	}
+	if len(conditional.ElseParts) > 0 {
+		ops, ok := buildFastStructLoopWriterOps(conditional.ElseParts, elemType)
+		if !ok {
+			return nil, false
+		}
+		plan.elseOps = ops
+	}
+	return plan, true
+}
+
+func buildFastStructLoopConditionPlan(value *compiler.FastValuePlan, elemType reflect.Type) *fastStructLoopConditionPlan {
+	if value == nil {
+		return nil
+	}
+	if value.Kind == compiler.FastValueInfix {
+		if value.Left == nil || value.Right == nil {
+			return nil
+		}
+		if value.Operator == "&&" || value.Operator == "||" {
+			left := buildFastStructLoopConditionPlan(value.Left, elemType)
+			right := buildFastStructLoopConditionPlan(value.Right, elemType)
+			if left == nil || right == nil {
+				return nil
+			}
+			return &fastStructLoopConditionPlan{
+				kind:     fastStructLoopConditionLogical,
+				operator: value.Operator,
+				left:     left,
+				right:    right,
+				line:     value.Line,
+			}
+		}
+		left, ok := buildFastStructLoopConditionOperand(value.Left, elemType)
+		if !ok {
+			return nil
+		}
+		right, ok := buildFastStructLoopConditionOperand(value.Right, elemType)
+		if !ok {
+			return nil
+		}
+		return &fastStructLoopConditionPlan{
+			kind:       fastStructLoopConditionInfix,
+			operator:   value.Operator,
+			leftValue:  left,
+			rightValue: right,
+			line:       value.Line,
+		}
+	}
+	operand, ok := buildFastStructLoopConditionOperand(value, elemType)
+	if !ok {
+		return nil
+	}
+	return &fastStructLoopConditionPlan{
+		kind:  fastStructLoopConditionTruthy,
+		value: operand,
+		line:  value.Line,
+	}
+}
+
+func buildFastStructLoopConditionOperand(value *compiler.FastValuePlan, elemType reflect.Type) (fastStructLoopCallArgPlan, bool) {
+	operand := buildFastStructLoopCallArgPlan(value, elemType)
+	return operand, operand.kind != fastStructLoopCallArgGeneric
+}
+
+func buildFastLoopMethodCallPlan(value *compiler.FastValuePlan, elemType reflect.Type) (*fastLoopMethodCallPlan, bool) {
+	if value == nil || value.Kind != compiler.FastValuePath || len(value.Path) < 2 {
+		return nil, false
+	}
+	call := value.Path[len(value.Path)-1]
+	method := value.Path[len(value.Path)-2]
+	if call.Kind != compiler.FastPathStepCall ||
+		method.Kind != compiler.FastPathStepProperty ||
+		!method.Method {
+		return nil, false
+	}
+	receiver, receiverType, ok := buildFastAccessChainPlanForSteps(value.Path[:len(value.Path)-2], elemType)
+	if !ok {
+		return nil, false
+	}
+	receiverType = unwrapReflectType(receiverType)
+	lookup := cachedPropertyLookup(receiverType, method.Value)
+	if lookup.kind != propertyLookupValueMethod && lookup.kind != propertyLookupPointerMethod {
+		return nil, false
+	}
+	return &fastLoopMethodCallPlan{
+		receiver: receiver,
+		method:   method,
+		call:     call,
+		lookup:   lookup,
+	}, true
+}
+
+func writeFastLoopMethodCall(out *strings.Builder, ctx hctx.Context, plan *fastLoopMethodCallPlan, item reflect.Value) error {
+	if plan == nil {
+		return nil
+	}
+	receiver, ok, err := fastLoopMethodReceiver(plan.receiver, item, ctx)
+	if err != nil || !ok {
+		return err
+	}
+	if err := spendFastTraversal(ctx, plan.method.Line); err != nil {
+		return err
+	}
+	method, ok := fastBoundMethodValue(receiver, plan.lookup)
+	if !ok {
+		return fastLineError(plan.method.Line, propertyMissingError(object.PropertyAccess{
+			Receiver: plan.method.Receiver,
+			Full:     plan.method.Full,
+			Method:   true,
+		}, fastReflectInterface(receiver), plan.method.Value))
+	}
+	if err := spendFastFunctionCall(ctx, plan.call.Value, plan.call.Line); err != nil {
+		return err
+	}
+	results := method.Call(nil)
+	return writeFastReflectCallResults(out, ctx, plan.call.Value, results)
+}
+
+func fastLoopMethodReceiver(plan *fastAccessChainPlan, item reflect.Value, ctx hctx.Context) (reflect.Value, bool, error) {
+	if plan == nil || len(plan.steps) == 0 {
+		rv := unwrapFastFieldChainValue(item)
+		if !rv.IsValid() {
+			return reflect.Value{}, false, nil
+		}
+		return rv, true, nil
+	}
+	value, ok, err := evalFastAccessChainReflectValue(plan, item, ctx)
+	if err != nil || !ok {
+		return reflect.Value{}, ok, err
+	}
+	return value, true, nil
+}
+
+func evalFastAccessChainReflectValue(chain *fastAccessChainPlan, rv reflect.Value, ctx hctx.Context) (reflect.Value, bool, error) {
+	current := rv
+	for i := range chain.steps {
+		step := &chain.steps[i]
+		switch step.kind {
+		case fastAccessStepField:
+			if err := spendFastTraversal(ctx, step.line); err != nil {
+				return reflect.Value{}, true, err
+			}
+			field, ok, err := fastAccessFieldValue(current, step)
+			if !ok || err != nil {
+				return reflect.Value{}, ok, err
+			}
+			current, ok, err = fastAccessIntermediateValue(field, step)
+			if !ok || err != nil {
+				return reflect.Value{}, ok, err
+			}
+		case fastAccessStepIndex:
+			indexed, ok, err := fastAccessIndexValue(current, step)
+			if err != nil {
+				return reflect.Value{}, true, fastLineError(step.line, err)
+			}
+			if !ok {
+				return reflect.Value{}, false, nil
+			}
+			current, ok, err = fastAccessIntermediateValue(indexed, step)
+			if !ok || err != nil {
+				return reflect.Value{}, ok, err
+			}
+		default:
+			return reflect.Value{}, false, nil
+		}
+	}
+	return current, true, nil
+}
+
+func fastBoundMethodValue(receiver reflect.Value, lookup propertyLookup) (reflect.Value, bool) {
+	receiver = unwrapFastFieldChainValue(receiver)
+	if !receiver.IsValid() {
+		return reflect.Value{}, false
+	}
+	switch lookup.kind {
+	case propertyLookupValueMethod:
+		method := receiver.Method(lookup.index)
+		return method, method.IsValid()
+	case propertyLookupPointerMethod:
+		if receiver.CanAddr() {
+			method := receiver.Addr().Method(lookup.index)
+			return method, method.IsValid()
+		}
+		ptr := reflect.New(receiver.Type())
+		ptr.Elem().Set(receiver)
+		method := ptr.Method(lookup.index)
+		return method, method.IsValid()
+	default:
+		return reflect.Value{}, false
+	}
+}
+
+func writeFastReflectCallResults(out *strings.Builder, ctx hctx.Context, name string, results []reflect.Value) error {
+	if len(results) == 0 {
+		return nil
+	}
+	if err := lastReturnError(results); err != nil {
+		return fmt.Errorf("could not call %s function: %w", name, err)
+	}
+	if isNilReflectValue(results[0]) {
+		return nil
+	}
+	value := results[0]
+	if !value.IsValid() {
+		return nil
+	}
+	if value.Type() == templateHTMLType {
+		out.WriteString(value.String())
+		return nil
+	}
+	if value.Type() == stringType {
+		writeFastEscapedString(out, value.String())
+		return nil
+	}
+	if value.Type().Implements(objectInterfaceType) && value.CanInterface() {
+		if obj, ok := value.Interface().(object.Object); ok {
+			writeFastObject(out, ctx, obj)
+			return nil
+		}
+	}
+	if value.Type().PkgPath() == "" {
+		switch value.Kind() {
+		case reflect.Bool:
+			out.WriteString(strconv.FormatBool(value.Bool()))
+			return nil
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			writeBuilderFastInt(out, value.Int())
+			return nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+			writeBuilderFastUint(out, value.Uint())
+			return nil
+		case reflect.Float32, reflect.Float64:
+			writeBuilderFastFloat(out, value.Float(), int(value.Type().Bits()))
+			return nil
+		}
+	}
+	return writeFastReflectValue(out, ctx, value)
+}

--- a/VM/vm/fast_types.go
+++ b/VM/vm/fast_types.go
@@ -1,0 +1,404 @@
+package vm
+
+import (
+	"reflect"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+)
+
+type callCacheEntry struct {
+	rt      reflect.Type
+	plan    *callPlan
+	invoker writeFastInvoker
+	noFast  bool
+}
+
+type fastBuilderCallCacheEntry struct {
+	rt                     reflect.Type
+	plan                   *callPlan
+	invoker                writeFastBuilderInvoker
+	valueInvoker           valueFastInvoker
+	contextualValueInvoker contextualValueFastInvoker
+}
+
+type fastCallArgs struct {
+	inline  [4]interface{}
+	n       int
+	extra   []interface{}
+	objects []object.Object
+}
+
+type propertyLookupKind uint8
+
+const (
+	propertyLookupMissing propertyLookupKind = iota
+	propertyLookupValueMethod
+	propertyLookupPointerMethod
+	propertyLookupField
+)
+
+type propertyLookupKey struct {
+	typ  reflect.Type
+	name string
+}
+
+type propertyLookup struct {
+	kind       propertyLookupKind
+	index      int
+	fieldIndex []int
+}
+
+type propertyInlineCacheEntry struct {
+	typ    reflect.Type
+	lookup propertyLookup
+	reader fastPropertyReader
+	writer fastPropertyWriter
+	next   *propertyInlineCacheEntry
+}
+
+type fastPropertyReader func(reflect.Value, object.PropertyAccess, string) (interface{}, error)
+type fastPropertyWriter func(*strings.Builder, hctx.Context, reflect.Value, object.PropertyAccess, string) (bool, error)
+
+const propertyInlineCacheDepth = 4
+
+type fastStructLoopWriterPlanKey struct {
+	loop *compiler.FastLoopPlan
+	typ  reflect.Type
+}
+
+type fastStructLoopWriterOpKind uint8
+
+const (
+	fastStructLoopWriterStatic fastStructLoopWriterOpKind = iota
+	fastStructLoopWriterKey
+	fastStructLoopWriterField
+	fastStructLoopWriterAccessChain
+	fastStructLoopWriterMethodCall
+	fastStructLoopWriterCall
+	fastStructLoopWriterConditional
+)
+
+type fastStructLoopWriterPlan struct {
+	ops []fastStructLoopWriterOp
+}
+
+type fastStructLoopWriterOp struct {
+	kind        fastStructLoopWriterOpKind
+	value       string
+	name        string
+	receiver    string
+	full        string
+	line        int
+	fieldIndex  []int
+	fieldType   reflect.Type
+	accessPlan  *fastAccessChainPlan
+	methodPlan  *fastLoopMethodCallPlan
+	call        *fastStructLoopCallPlan
+	conditional *fastStructLoopConditionalWriterPlan
+}
+
+type fastStructLoopConditionalWriterPlan struct {
+	branches []fastStructLoopConditionalWriterBranch
+	elseOps  []fastStructLoopWriterOp
+}
+
+type fastStructLoopConditionalWriterBranch struct {
+	condition     compiler.FastValuePlan
+	conditionPlan *fastStructLoopConditionPlan
+	ops           []fastStructLoopWriterOp
+	line          int
+}
+
+type fastStructLoopConditionKind uint8
+
+const (
+	fastStructLoopConditionTruthy fastStructLoopConditionKind = iota
+	fastStructLoopConditionInfix
+	fastStructLoopConditionLogical
+)
+
+type fastStructLoopConditionPlan struct {
+	kind       fastStructLoopConditionKind
+	operator   string
+	value      fastStructLoopCallArgPlan
+	leftValue  fastStructLoopCallArgPlan
+	rightValue fastStructLoopCallArgPlan
+	left       *fastStructLoopConditionPlan
+	right      *fastStructLoopConditionPlan
+	line       int
+}
+
+type fastConditionOperandValue struct {
+	raw        interface{}
+	reflect    reflect.Value
+	hasReflect bool
+}
+
+type fastFieldChainPlanKey struct {
+	plan *compiler.FastValuePlan
+	typ  reflect.Type
+}
+
+type fastFieldChainPlan struct {
+	steps []fastFieldChainStep
+}
+
+type fastFieldChainStep struct {
+	name      string
+	receiver  string
+	full      string
+	line      int
+	fieldType reflect.Type
+	lookup    propertyLookup
+}
+
+type fastAccessChainPlanKey struct {
+	plan *compiler.FastValuePlan
+	typ  reflect.Type
+}
+
+type fastAccessStepKind uint8
+
+const (
+	fastAccessStepField fastAccessStepKind = iota
+	fastAccessStepIndex
+)
+
+type fastMapDirectKind uint8
+
+const (
+	fastMapDirectNone fastMapDirectKind = iota
+	fastMapDirectStringString
+	fastMapDirectStringInt
+	fastMapDirectStringUint32
+	fastMapDirectStringInterface
+)
+
+type fastAccessChainPlan struct {
+	steps []fastAccessChainStep
+}
+
+type fastAccessChainStep struct {
+	kind       fastAccessStepKind
+	name       string
+	receiver   string
+	full       string
+	line       int
+	index      int
+	fieldType  reflect.Type
+	lookup     propertyLookup
+	mapKey     reflect.Value
+	mapString  string
+	mapDirect  fastMapDirectKind
+	resultType reflect.Type
+}
+
+type fastTopLevelAccessKind uint8
+
+const (
+	fastTopLevelAccessUnsupported fastTopLevelAccessKind = iota
+	fastTopLevelAccessFieldChain
+	fastTopLevelAccessChain
+	fastTopLevelAccessMethodCall
+)
+
+type fastTopLevelAccessCacheEntry struct {
+	typ        reflect.Type
+	kind       fastTopLevelAccessKind
+	fieldChain *fastFieldChainPlan
+	chain      *fastAccessChainPlan
+	method     *fastLoopMethodCallPlan
+	next       *fastTopLevelAccessCacheEntry
+}
+
+type fastLoopMethodCallPlan struct {
+	receiver *fastAccessChainPlan
+	method   compiler.FastPathStep
+	call     compiler.FastPathStep
+	lookup   propertyLookup
+}
+
+type fastStructLoopCallArgKind uint8
+
+const (
+	fastStructLoopCallArgGeneric fastStructLoopCallArgKind = iota
+	fastStructLoopCallArgKey
+	fastStructLoopCallArgBinding
+	fastStructLoopCallArgNil
+	fastStructLoopCallArgString
+	fastStructLoopCallArgInt
+	fastStructLoopCallArgFloat
+	fastStructLoopCallArgBool
+	fastStructLoopCallArgAccessChain
+)
+
+type fastStructLoopCallPlan struct {
+	call *compiler.FastCallPlan
+	args []fastStructLoopCallArgPlan
+}
+
+type fastStructLoopCallArgPlan struct {
+	kind       fastStructLoopCallArgKind
+	value      compiler.FastValuePlan
+	nameIndex  int
+	stringVal  string
+	intVal     int64
+	floatVal   float64
+	boolVal    bool
+	accessPlan *fastAccessChainPlan
+	line       int
+}
+
+type fastStructLoopRenderState struct {
+	singleCall         *fastStructLoopCallPlan
+	singleResolvedCall *fastStructLoopResolvedCall
+	calls              map[*fastStructLoopCallPlan]*fastStructLoopResolvedCall
+}
+
+type fastStructLoopResolvedCall struct {
+	raw                interface{}
+	fn                 reflect.Value
+	entry              *fastBuilderCallCacheEntry
+	directWriter       fastStructLoopDirectCallWriter
+	reflectArgs        []reflect.Value
+	staticReflectArgs  []reflect.Value
+	staticReflectArgOK []bool
+	canReflect         bool
+}
+
+type fastMixedOpKind uint8
+
+const (
+	fastMixedOpStatic fastMixedOpKind = iota
+	fastMixedOpName
+	fastMixedOpProperty
+	fastMixedOpValue
+	fastMixedOpAccessChain
+	fastMixedOpCall
+	fastMixedOpBlockCall
+	fastMixedOpConditional
+	fastMixedOpPartial
+	fastMixedOpLoop
+	fastMixedOpLet
+	fastMixedOpAssign
+)
+
+type fastMixedPlan struct {
+	ops        []fastMixedOp
+	staticName *fastStaticNamePlan
+	simple     *fastSimplePlan
+	staticSize int
+	nameCount  int
+}
+
+type fastMixedOp struct {
+	kind          fastMixedOpKind
+	prefix        string
+	value         string
+	nameIndex     int
+	nullOnMissing bool
+	property      string
+	receiver      string
+	full          string
+	line          int
+	loop          *compiler.FastLoopPlan
+	valuePlan     compiler.FastValuePlan
+	call          *compiler.FastCallPlan
+	blockCall     *compiler.FastBlockCallPlan
+	conditional   *compiler.FastConditionalPlan
+	partial       *compiler.FastPartialPlan
+	partialData   *fastPartialDataBindingPlan
+	simpleCond    *fastSimpleConditionalPlan
+	accessCache   object.InlineCacheSlot
+	propertyCache object.InlineCacheSlot
+	outputCache   object.InlineCacheSlot
+}
+
+type fastStaticNamePlan struct {
+	ops         []fastStaticNameOp
+	nameIndexes []int
+}
+
+type fastStaticNameOp struct {
+	prefix        string
+	value         string
+	nameIndex     int
+	lookupIndex   int
+	nullOnMissing bool
+	line          int
+	outputCache   *object.InlineCacheSlot
+}
+
+type fastSimplePlan struct {
+	ops         []fastSimpleOp
+	nameIndexes []int
+}
+
+type fastSimpleOp struct {
+	op          *fastMixedOp
+	lookupIndex int
+	value       *fastSimpleValuePlan
+}
+
+type fastSimpleValuePlan struct {
+	value       *compiler.FastValuePlan
+	lookupIndex int
+	left        *fastSimpleValuePlan
+	right       *fastSimpleValuePlan
+	args        []*fastSimpleValuePlan
+}
+
+type fastSimpleConditionalPlan struct {
+	branches     []fastSimpleConditionalBranch
+	elseSegments *fastSimplePlan
+	nameIndexes  []int
+}
+
+type fastSimpleConditionalBranch struct {
+	condition *fastSimpleValuePlan
+	segments  *fastSimplePlan
+	line      int
+}
+
+type fastPartialDataBindingPlan struct {
+	pairs       []fastPartialDataBindingPair
+	nameIndexes []int
+	keys        []string
+}
+
+type fastPartialDataBindingPair struct {
+	key   string
+	value *fastSimpleValuePlan
+	line  int
+}
+
+type fastSimpleNameBinder interface {
+	bindNameIndex(int) int
+}
+
+type regexCacheEntry struct {
+	re  *regexp.Regexp
+	err error
+}
+
+type partialBytecodeLink struct {
+	mu          sync.RWMutex
+	sourceHash  uint64
+	source      string
+	bytecode    *compiler.Bytecode
+	bindingPlan *fastRenderBindingPlan
+}
+
+type partialBytecodeLinkCache struct {
+	mu          sync.RWMutex
+	entries     map[string]*partialBytecodeLink
+	feederID    int
+	hasFeederID bool
+	metaIDs     partialMetaIDs
+	hasMetaIDs  bool
+}

--- a/VM/vm/fast_value_helpers_test.go
+++ b/VM/vm/fast_value_helpers_test.go
@@ -1,0 +1,838 @@
+package vm
+
+import (
+	"errors"
+	"html/template"
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/code"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/stretchr/testify/require"
+)
+
+type vmFastValueInterface struct {
+	value interface{}
+}
+
+func (v vmFastValueInterface) Interface() interface{} {
+	return v.value
+}
+
+type vmHTMLValue string
+
+func (v vmHTMLValue) HTML() template.HTML {
+	return template.HTML(v)
+}
+
+type vmFastOutputStringer string
+
+func (s vmFastOutputStringer) String() string {
+	return "stringer:" + string(s)
+}
+
+type vmFastValueHiddenChild struct {
+	child vmFastPropertyChild
+}
+
+func Test_VM_Eval_Fast_Value_Edge_Branches(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name": "Mido",
+		"say":  func() string { return "hello" },
+		"user": vmAccessUser{
+			Labels: map[string]string{"status": "<ready>"},
+		},
+	})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"name", "say", "user"}}, ctx)
+
+	value, ok, err := evalFastValue(nil, ctx, bindings, nil)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Nil(t, value)
+
+	tests := []struct {
+		name     string
+		plan     compiler.FastValuePlan
+		expected interface{}
+		ok       bool
+	}{
+		{"name nil", compiler.FastValuePlan{Kind: compiler.FastValueName, Value: "nil"}, nil, true},
+		{"name binding", compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 0, Value: "name"}, "Mido", true},
+		{"name missing null", compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing", NullOnMissing: true}, nil, true},
+		{"name missing hard", compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing"}, nil, false},
+		{"string", compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "x"}, "x", true},
+		{"integer", compiler.FastValuePlan{Kind: compiler.FastValueInteger, IntValue: 3}, 3, true},
+		{"float", compiler.FastValuePlan{Kind: compiler.FastValueFloat, FloatValue: 1.25}, 1.25, true},
+		{"bool", compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true}, true, true},
+		{"loop key outside loop", compiler.FastValuePlan{Kind: compiler.FastValueLoopKey}, nil, false},
+		{"invalid", compiler.FastValuePlan{Kind: compiler.FastValueInvalid}, nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, ok, err := evalFastValue(&tt.plan, ctx, bindings, nil)
+			require.NoError(t, err)
+			require.Equal(t, tt.ok, ok)
+			require.Equal(t, tt.expected, value)
+		})
+	}
+
+	value, ok, err = evalFastValue(&compiler.FastValuePlan{
+		Kind:     compiler.FastValueInfix,
+		Operator: "==",
+		Left:     &compiler.FastValuePlan{Kind: compiler.FastValueInteger, IntValue: 1},
+		Right:    &compiler.FastValuePlan{Kind: compiler.FastValueFloat, FloatValue: 1},
+	}, ctx, bindings, nil)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, true, value)
+
+	value, ok, err = evalFastValue(&compiler.FastValuePlan{
+		Kind: compiler.FastValueCall,
+		Call: &compiler.FastCallPlan{Name: "say", NameIndex: 1},
+	}, ctx, bindings, nil)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "hello", value)
+
+	value, ok, err = evalFastValue(&compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: 99,
+		Value:     "missing",
+	}, ctx, bindings, nil)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, value)
+
+	value, ok, err = evalFastValue(&compiler.FastValuePlan{
+		Kind:          compiler.FastValuePath,
+		NameIndex:     99,
+		Value:         "missing",
+		NullOnMissing: true,
+	}, ctx, bindings, nil)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Nil(t, value)
+
+	value, ok, err = evalFastValue(&compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: 2,
+		Value:     "user",
+		Path: []compiler.FastPathStep{
+			{Kind: compiler.FastPathStepProperty, Value: "Labels", Receiver: "user", Full: "user.Labels", Line: 6},
+			{Kind: compiler.FastPathStepIndexString, Value: "status", Line: 6},
+		},
+	}, ctx, bindings, nil)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "<ready>", value)
+
+	value, ok, err = evalFastLoopValue(nil, ctx, bindings, "key", "value")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Nil(t, value)
+
+	value, ok, err = evalFastLoopValue(&compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "loop"}, ctx, bindings, "key", "value")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "loop", value)
+
+	value, ok, err = evalFastInfixValue(nil, ctx, bindings, nil, nil, nil, false)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, value)
+
+	value, ok, err = evalFastInfixValue(&compiler.FastValuePlan{
+		Kind:     compiler.FastValueInfix,
+		Operator: "==",
+		Left:     &compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "missingLeft"},
+		Right:    &compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 100, Value: "missingRight"},
+	}, ctx, bindings, nil, nil, nil, false)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, true, value)
+
+	_, ok, err = evalFastInfixValue(&compiler.FastValuePlan{
+		Kind:     compiler.FastValueInfix,
+		Operator: "==",
+		Left: &compiler.FastValuePlan{
+			Kind: compiler.FastValueCall,
+			Call: &compiler.FastCallPlan{Name: "say", NameIndex: 1, Line: 7},
+		},
+		Right: &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "hello"},
+	}, plush.NewContextWith(map[string]interface{}{"say": func() string { return "hello" }}).WithBudget(plush.NewBudget(0)), bindings, nil, nil, nil, false)
+	require.ErrorContains(t, err, "line 7")
+	require.True(t, ok)
+
+	_, ok, err = evalFastInfixValue(&compiler.FastValuePlan{
+		Kind:     compiler.FastValueInfix,
+		Operator: "==",
+		Left:     &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "hello"},
+		Right: &compiler.FastValuePlan{
+			Kind: compiler.FastValueCall,
+			Call: &compiler.FastCallPlan{Name: "say", NameIndex: 1, Line: 8},
+		},
+	}, plush.NewContextWith(map[string]interface{}{"say": func() string { return "hello" }}).WithBudget(plush.NewBudget(0)), bindings, nil, nil, nil, false)
+	require.ErrorContains(t, err, "line 8")
+	require.True(t, ok)
+
+	_, ok, err = evalFastInfixValue(&compiler.FastValuePlan{
+		Kind:     compiler.FastValueInfix,
+		Operator: "??",
+		Line:     9,
+		Left:     &compiler.FastValuePlan{Kind: compiler.FastValueInteger, IntValue: 1},
+		Right:    &compiler.FastValuePlan{Kind: compiler.FastValueInteger, IntValue: 2},
+	}, ctx, bindings, nil, nil, nil, false)
+	require.ErrorContains(t, err, "line 9")
+	require.True(t, ok)
+
+	_, ok, err = evalFastLogicalInfixValue(&compiler.FastValuePlan{
+		Operator: "&&",
+		Left: &compiler.FastValuePlan{
+			Kind: compiler.FastValueCall,
+			Call: &compiler.FastCallPlan{Name: "say", NameIndex: 1, Line: 11},
+		},
+		Right: &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true},
+	}, plush.NewContextWith(map[string]interface{}{"say": func() string { return "hello" }}).WithBudget(plush.NewBudget(0)), bindings, nil, nil, nil, false)
+	require.ErrorContains(t, err, "line 11")
+	require.True(t, ok)
+
+	_, ok, err = evalFastLogicalInfixValue(&compiler.FastValuePlan{
+		Operator: "&&",
+		Left:     &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true},
+		Right: &compiler.FastValuePlan{
+			Kind: compiler.FastValueCall,
+			Call: &compiler.FastCallPlan{Name: "say", NameIndex: 1, Line: 12},
+		},
+	}, plush.NewContextWith(map[string]interface{}{"say": func() string { return "hello" }}).WithBudget(plush.NewBudget(0)), bindings, nil, nil, nil, false)
+	require.ErrorContains(t, err, "line 12")
+	require.True(t, ok)
+
+	var out strings.Builder
+	handled, written, err := writeFastValuePlanOutput(&out, ctx, bindings, &compiler.FastValuePlan{
+		Kind:     compiler.FastValueInfix,
+		Operator: ">",
+		Left:     &compiler.FastValuePlan{Kind: compiler.FastValueInteger, IntValue: 3},
+		Right:    &compiler.FastValuePlan{Kind: compiler.FastValueInteger, IntValue: 2},
+	})
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.True(t, written)
+	require.Equal(t, "true", out.String())
+
+	out.Reset()
+	handled, written, err = writeFastValuePlanOutput(&out, ctx, bindings, &compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: 2,
+		Value:     "user",
+		Path: []compiler.FastPathStep{
+			{Kind: compiler.FastPathStepProperty, Value: "Labels", Receiver: "user", Full: "user.Labels", Line: 10},
+			{Kind: compiler.FastPathStepIndexString, Value: "status", Line: 10},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.True(t, written)
+	require.Equal(t, "&lt;ready&gt;", out.String())
+}
+
+func Test_VM_Fast_Value_Field_And_Access_Edge_Branches(t *testing.T) {
+	ctx := plush.NewContext()
+	nilChildPlan := &compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: -1,
+		Path: []compiler.FastPathStep{
+			{Kind: compiler.FastPathStepProperty, Value: "Child", Receiver: "user", Full: "user.Child", Line: 21},
+			{Kind: compiler.FastPathStepProperty, Value: "Name", Receiver: "user", Full: "user.Child.Name", Line: 21},
+		},
+	}
+
+	value, handled, err := evalFastFieldChainValue(nilChildPlan, vmFastPropertyUser{}, ctx)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Nil(t, value)
+
+	hiddenPlan := &compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: -1,
+		Path: []compiler.FastPathStep{
+			{Kind: compiler.FastPathStepProperty, Value: "child", Receiver: "user", Full: "user.child", Line: 22},
+			{Kind: compiler.FastPathStepProperty, Value: "Name", Receiver: "user", Full: "user.child.Name", Line: 22},
+		},
+	}
+	_, handled, err = evalFastFieldChainValue(hiddenPlan, vmFastValueHiddenChild{child: vmFastPropertyChild{Name: "hidden"}}, ctx)
+	require.ErrorContains(t, err, "line 22")
+	require.True(t, handled)
+
+	chain, ok := fastFieldChainPlanFor(&compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: -1,
+		Path: []compiler.FastPathStep{
+			{Kind: compiler.FastPathStepProperty, Value: "Name"},
+			{Kind: compiler.FastPathStepProperty, Value: "Missing"},
+		},
+	}, reflect.TypeOf(vmStructLoopProduct{}))
+	require.False(t, ok)
+	require.Nil(t, chain)
+
+	value, handled, err = evalFastAccessChainValue(&compiler.FastValuePlan{Kind: compiler.FastValuePath}, nil, ctx)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Nil(t, value)
+
+	chainPlan, next, ok := buildFastAccessChainPlanForSteps([]compiler.FastPathStep{{Kind: compiler.FastPathStepKind(255)}}, reflect.TypeOf(vmStructLoopProduct{}))
+	require.False(t, ok)
+	require.Nil(t, chainPlan)
+	require.Nil(t, next)
+
+	indexStep, next, ok := buildFastIndexAccessStep(reflect.TypeOf([2]string{}), &compiler.FastPathStep{Kind: compiler.FastPathStepIndexInteger, Index: 1, Line: 23})
+	require.True(t, ok)
+	require.Equal(t, fastAccessStepIndex, indexStep.kind)
+	require.Equal(t, stringType, next)
+
+	key, keyOK := fastAccessMapKeyValue(reflect.TypeOf(""), &compiler.FastPathStep{Kind: compiler.FastPathStepKind(255)})
+	require.False(t, keyOK)
+	require.False(t, key.IsValid())
+
+	value, ok, err = evalFastAccessChainPlanValue(&fastAccessChainPlan{steps: []fastAccessChainStep{{
+		kind:      fastAccessStepField,
+		name:      "Child",
+		receiver:  "user",
+		full:      "user.Child",
+		line:      24,
+		fieldType: reflect.TypeOf((*vmFastPropertyChild)(nil)),
+		lookup:    cachedPropertyLookup(reflect.TypeOf(vmFastPropertyUser{}), "Child"),
+	}, {
+		kind:      fastAccessStepField,
+		name:      "Name",
+		receiver:  "user",
+		full:      "user.Child.Name",
+		line:      24,
+		fieldType: stringType,
+		lookup:    cachedPropertyLookup(reflect.TypeOf(vmFastPropertyChild{}), "Name"),
+	}}}, reflect.ValueOf(vmFastPropertyUser{}), ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Nil(t, value)
+
+	var out strings.Builder
+	handledOut, err := writeFastAccessChainPlanOutput(&out, ctx, &fastAccessChainPlan{steps: []fastAccessChainStep{{
+		kind:      fastAccessStepField,
+		name:      "Child",
+		receiver:  "user",
+		full:      "user.Child",
+		line:      25,
+		fieldType: reflect.TypeOf((*vmFastPropertyChild)(nil)),
+		lookup:    cachedPropertyLookup(reflect.TypeOf(vmFastPropertyUser{}), "Child"),
+	}, {
+		kind:      fastAccessStepField,
+		name:      "Name",
+		receiver:  "user",
+		full:      "user.Child.Name",
+		line:      25,
+		fieldType: stringType,
+		lookup:    cachedPropertyLookup(reflect.TypeOf(vmFastPropertyChild{}), "Name"),
+	}}}, reflect.ValueOf(vmFastPropertyUser{}))
+	require.NoError(t, err)
+	require.True(t, handledOut)
+	require.Empty(t, out.String())
+
+	directValue, found, directHandled := fastAccessDirectMapIndex(reflect.ValueOf(map[string]string{"key": "value"}), &fastAccessChainStep{mapString: "key", mapDirect: fastMapDirectKind(255)})
+	require.False(t, directHandled)
+	require.False(t, found)
+	require.False(t, directValue.IsValid())
+
+	handledOut, err = writeFastDirectMapIndexOutput(&out, ctx, reflect.ValueOf(map[string]string{"key": "value"}), &fastAccessChainStep{mapString: "key", mapDirect: fastMapDirectKind(255)})
+	require.NoError(t, err)
+	require.False(t, handledOut)
+}
+
+func Test_VM_Fast_Index_Value_Branches(t *testing.T) {
+	arrayValue, err := fastIndexValue(&object.Array{Elements: []object.Object{&object.String{Value: "zero"}}}, 0)
+	require.NoError(t, err)
+	require.Equal(t, &object.String{Value: "zero"}, arrayValue)
+
+	missingArrayValue, err := fastIndexValue(&object.Array{}, 0)
+	require.NoError(t, err)
+	require.Nil(t, missingArrayValue)
+
+	hashKey := (&object.Integer{Value: 3}).HashKey()
+	hashValue, err := fastIndexValue(&object.Hash{Pairs: map[object.HashKey]object.HashPair{
+		hashKey: {Key: &object.Integer{Value: 3}, Value: &object.String{Value: "three"}},
+	}}, 3)
+	require.NoError(t, err)
+	require.Equal(t, &object.String{Value: "three"}, hashValue)
+
+	missingHashValue, err := fastIndexValue(&object.Hash{Pairs: map[object.HashKey]object.HashPair{}}, 3)
+	require.NoError(t, err)
+	require.Nil(t, missingHashValue)
+
+	nilValue, err := fastIndexValue(nil, 0)
+	require.NoError(t, err)
+	require.Nil(t, nilValue)
+
+	var nilSlice *[]string
+	nilValue, err = fastIndexValue(nilSlice, 0)
+	require.NoError(t, err)
+	require.Nil(t, nilValue)
+
+	sliceValue, err := fastIndexValue([]string{"a", "b"}, 1)
+	require.NoError(t, err)
+	require.Equal(t, "b", sliceValue)
+
+	rawSlice := []string{"ptr"}
+	sliceValue, err = fastIndexValue(&rawSlice, 0)
+	require.NoError(t, err)
+	require.Equal(t, "ptr", sliceValue)
+
+	_, err = fastIndexValue([]string{"a"}, 2)
+	require.ErrorContains(t, err, "out of bounds")
+
+	mapValue, err := fastIndexValue(map[int]string{7: "seven"}, 7)
+	require.NoError(t, err)
+	require.Equal(t, "seven", mapValue)
+
+	mapInterfaceValue, err := fastIndexValue(map[interface{}]string{8: "eight"}, 8)
+	require.NoError(t, err)
+	require.Equal(t, "eight", mapInterfaceValue)
+
+	missingMapValue, err := fastIndexValue(map[int]string{}, 7)
+	require.NoError(t, err)
+	require.Nil(t, missingMapValue)
+
+	_, err = fastIndexValue(map[bool]string{}, 7)
+	require.ErrorContains(t, err, "cannot use")
+
+	_, err = fastIndexValue(struct{}{}, 1)
+	require.ErrorContains(t, err, "could not index")
+
+	_, err = fastIndexValue(&object.String{Value: "not-indexable"}, 1)
+	require.ErrorContains(t, err, "could not index")
+}
+
+func Test_VM_Fast_String_Index_Value_Branches(t *testing.T) {
+	hashKey := (&object.String{Value: "name"}).HashKey()
+	hashValue, err := fastStringIndexValue(&object.Hash{Pairs: map[object.HashKey]object.HashPair{
+		hashKey: {Key: &object.String{Value: "name"}, Value: &object.String{Value: "Mido"}},
+	}}, "name")
+	require.NoError(t, err)
+	require.Equal(t, &object.String{Value: "Mido"}, hashValue)
+
+	missingHashValue, err := fastStringIndexValue(&object.Hash{Pairs: map[object.HashKey]object.HashPair{}}, "name")
+	require.NoError(t, err)
+	require.Nil(t, missingHashValue)
+
+	nilValue, err := fastStringIndexValue(nil, "name")
+	require.NoError(t, err)
+	require.Nil(t, nilValue)
+
+	var nilMap *map[string]int
+	nilValue, err = fastStringIndexValue(nilMap, "name")
+	require.NoError(t, err)
+	require.Nil(t, nilValue)
+
+	mapValue, err := fastStringIndexValue(map[string]int{"count": 4}, "count")
+	require.NoError(t, err)
+	require.Equal(t, 4, mapValue)
+
+	rawMap := map[string]int{"count": 5}
+	mapValue, err = fastStringIndexValue(&rawMap, "count")
+	require.NoError(t, err)
+	require.Equal(t, 5, mapValue)
+
+	mapInterfaceValue, err := fastStringIndexValue(map[interface{}]string{"name": "Mido"}, "name")
+	require.NoError(t, err)
+	require.Equal(t, "Mido", mapInterfaceValue)
+
+	missingMapValue, err := fastStringIndexValue(map[string]int{}, "count")
+	require.NoError(t, err)
+	require.Nil(t, missingMapValue)
+
+	_, err = fastStringIndexValue(map[int]string{}, "name")
+	require.ErrorContains(t, err, "cannot use")
+
+	_, err = fastStringIndexValue([]string{"a"}, "name")
+	require.ErrorContains(t, err, "non int")
+
+	_, err = fastStringIndexValue(struct{}{}, "name")
+	require.ErrorContains(t, err, "could not index")
+
+	_, err = fastStringIndexValue(&object.String{Value: "not-indexable"}, "name")
+	require.ErrorContains(t, err, "could not index")
+}
+
+func Test_VM_Fast_Direct_Map_Index_Helpers(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      interface{}
+		kind     fastMapDirectKind
+		expected string
+	}{
+		{"string", map[string]string{"key": "<value>"}, fastMapDirectStringString, "&lt;value&gt;"},
+		{"int", map[string]int{"key": 12}, fastMapDirectStringInt, "12"},
+		{"uint32", map[string]uint32{"key": 13}, fastMapDirectStringUint32, "13"},
+		{"interface", map[string]interface{}{"key": template.HTML("<b>")}, fastMapDirectStringInterface, "<b>"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			step := &fastAccessChainStep{mapString: "key", mapDirect: tt.kind}
+			value, found, handled := fastAccessDirectMapIndex(reflect.ValueOf(tt.raw), step)
+			require.True(t, handled)
+			require.True(t, found)
+			require.True(t, value.IsValid())
+
+			var out strings.Builder
+			handled, err := writeFastDirectMapIndexOutput(&out, plush.NewContext(), reflect.ValueOf(tt.raw), step)
+			require.NoError(t, err)
+			require.True(t, handled)
+			require.Equal(t, tt.expected, out.String())
+		})
+	}
+
+	step := &fastAccessChainStep{mapString: "missing", mapDirect: fastMapDirectStringString}
+	value, found, handled := fastAccessDirectMapIndex(reflect.ValueOf(map[string]string{}), step)
+	require.True(t, handled)
+	require.False(t, found)
+	require.False(t, value.IsValid())
+
+	value, found, handled = fastAccessDirectMapIndex(reflect.ValueOf(map[string]string{"key": "value"}), &fastAccessChainStep{mapString: "key", mapDirect: fastMapDirectStringInt})
+	require.False(t, handled)
+	require.False(t, found)
+	require.False(t, value.IsValid())
+
+	value, found, handled = fastAccessDirectMapIndex(reflect.ValueOf(map[string]int{}), &fastAccessChainStep{mapString: "missing", mapDirect: fastMapDirectStringInt})
+	require.True(t, handled)
+	require.False(t, found)
+	require.False(t, value.IsValid())
+
+	value, found, handled = fastAccessDirectMapIndex(reflect.ValueOf(map[string]string{"key": "value"}), &fastAccessChainStep{mapString: "key", mapDirect: fastMapDirectStringUint32})
+	require.False(t, handled)
+	require.False(t, found)
+	require.False(t, value.IsValid())
+
+	value, found, handled = fastAccessDirectMapIndex(reflect.ValueOf(map[string]uint32{}), &fastAccessChainStep{mapString: "missing", mapDirect: fastMapDirectStringUint32})
+	require.True(t, handled)
+	require.False(t, found)
+	require.False(t, value.IsValid())
+
+	value, found, handled = fastAccessDirectMapIndex(reflect.ValueOf(map[string]string{"key": "value"}), &fastAccessChainStep{mapString: "key", mapDirect: fastMapDirectStringInterface})
+	require.False(t, handled)
+	require.False(t, found)
+	require.False(t, value.IsValid())
+
+	value, found, handled = fastAccessDirectMapIndex(reflect.ValueOf(map[string]interface{}{}), &fastAccessChainStep{mapString: "missing", mapDirect: fastMapDirectStringInterface})
+	require.True(t, handled)
+	require.False(t, found)
+	require.False(t, value.IsValid())
+
+	value, found, handled = fastAccessDirectMapIndex(reflect.ValueOf(map[string]interface{}{"nil": nil}), &fastAccessChainStep{mapString: "nil", mapDirect: fastMapDirectStringInterface})
+	require.True(t, handled)
+	require.True(t, found)
+	require.True(t, value.IsValid())
+	require.Nil(t, value.Interface())
+
+	key, keyOK := fastAccessMapKeyValue(nil, &compiler.FastPathStep{Kind: compiler.FastPathStepIndexString, Value: "x"})
+	require.False(t, keyOK)
+	require.False(t, key.IsValid())
+
+	key, keyOK = fastAccessMapKeyValue(reflect.TypeOf(true), &compiler.FastPathStep{Kind: compiler.FastPathStepIndexInteger, Index: 1})
+	require.False(t, keyOK)
+	require.False(t, key.IsValid())
+
+	key, keyOK = fastRuntimeMapKeyValue(nil, &fastAccessChainStep{index: 1})
+	require.False(t, keyOK)
+	require.False(t, key.IsValid())
+
+	key, keyOK = fastRuntimeMapKeyValue(reflect.TypeOf(true), &fastAccessChainStep{index: 1})
+	require.False(t, keyOK)
+	require.False(t, key.IsValid())
+
+	handled, err := writeFastDirectMapIndexOutput(&strings.Builder{}, nil, reflect.ValueOf(map[int]string{}), step)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	handled, err = writeFastDirectMapIndexOutput(&strings.Builder{}, nil, reflect.ValueOf(map[string]string{"key": "value"}), &fastAccessChainStep{mapString: "key", mapDirect: fastMapDirectStringInt})
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	handled, err = writeFastDirectMapIndexOutput(&strings.Builder{}, nil, reflect.ValueOf(map[string]string{"key": "value"}), &fastAccessChainStep{mapString: "key", mapDirect: fastMapDirectStringUint32})
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	handled, err = writeFastDirectMapIndexOutput(&strings.Builder{}, nil, reflect.ValueOf(map[string]string{"key": "value"}), &fastAccessChainStep{mapString: "key", mapDirect: fastMapDirectStringInterface})
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	var missingOut strings.Builder
+	handled, err = writeFastDirectMapIndexOutput(&missingOut, nil, reflect.ValueOf(map[string]int{}), &fastAccessChainStep{mapString: "missing", mapDirect: fastMapDirectStringInt})
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Empty(t, missingOut.String())
+
+	handled, err = writeFastDirectMapIndexOutput(&missingOut, nil, reflect.ValueOf(map[string]uint32{}), &fastAccessChainStep{mapString: "missing", mapDirect: fastMapDirectStringUint32})
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Empty(t, missingOut.String())
+
+	handled, err = writeFastDirectMapIndexOutput(&missingOut, nil, reflect.ValueOf(map[string]interface{}{}), &fastAccessChainStep{mapString: "missing", mapDirect: fastMapDirectStringInterface})
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Empty(t, missingOut.String())
+}
+
+func Test_VM_Write_Fast_Reflect_And_Go_Values(t *testing.T) {
+	ctx := plush.NewContext()
+	machine := newRuntimeHelperTestVM(ctx)
+	var out strings.Builder
+
+	require.NoError(t, writeFastReflectValue(&out, ctx, reflect.ValueOf(template.HTML("<b>"))))
+	require.NoError(t, writeFastReflectValue(&out, ctx, reflect.ValueOf("<str>")))
+	require.NoError(t, writeFastReflectValue(&out, ctx, reflect.ValueOf(true)))
+	require.NoError(t, writeFastReflectValue(&out, ctx, reflect.ValueOf(int32(3))))
+	require.NoError(t, writeFastReflectValue(&out, ctx, reflect.ValueOf(uint32(4))))
+	require.NoError(t, writeFastReflectValue(&out, ctx, reflect.ValueOf(float32(1.5))))
+	require.NoError(t, writeFastReflectValue(&out, ctx, reflect.ValueOf(vmFastOutputStringer("value"))))
+	require.Equal(t, "<b>&lt;str&gt;true341.5stringer:value", out.String())
+
+	var nilInterface interface{}
+	require.Nil(t, fastReflectInterface(reflect.ValueOf(&nilInterface).Elem()))
+	require.NoError(t, writeFastReflectValue(&out, ctx, reflect.ValueOf(&nilInterface).Elem()))
+
+	out.Reset()
+	machine.writeGoValue(&out, vmHole{input: `"hole"`})
+	machine.writeGoValue(&out, vmFastValueInterface{value: "<iface>"})
+	machine.writeGoValue(&out, vmHTMLValue("<safe>"))
+	machine.writeGoValue(&out, []interface{}{"<x>", template.HTML("<y>")})
+	machine.writeGoValue(&out, [2]int{1, 2})
+	require.Contains(t, out.String(), plush.PunchHoleMarkerName(0))
+	require.Contains(t, out.String(), "&lt;iface&gt;")
+	require.Contains(t, out.String(), "<safe>")
+	require.Contains(t, out.String(), "&lt;x&gt;<y>12")
+	require.Len(t, *machine.holes, 1)
+}
+
+func Test_VM_Can_Write_Fast_Go_Value_Branches(t *testing.T) {
+	require.True(t, canWriteFastGoValue(nil))
+	require.True(t, canWriteFastGoValue(template.HTML("<b>")))
+	require.True(t, canWriteFastGoValue(vmFastValueInterface{value: "<iface>"}))
+	require.True(t, canWriteFastGoValue([]interface{}{"x", 1, template.HTML("<b>")}))
+	require.True(t, canWriteFastGoValue([]string{"a", "b"}))
+	require.True(t, canWriteFastGoValue(&object.String{Value: "ok"}))
+	require.False(t, canWriteFastGoValue(&object.Builtin{}))
+	require.False(t, canWriteFastGoValue([]interface{}{&object.Builtin{}}))
+}
+
+func Test_VM_Write_Fast_Go_Value_Output_Branches(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{"TIME_FORMAT": "2006"})
+	when := time.Date(2024, 5, 6, 7, 8, 9, 0, time.UTC)
+	var out strings.Builder
+
+	require.True(t, writeFastGoValue(&out, ctx, nil))
+	require.True(t, writeFastGoValue(&out, ctx, when))
+	require.True(t, writeFastGoValue(&out, ctx, &when))
+
+	var nilTime *time.Time
+	require.True(t, writeFastGoValue(&out, ctx, nilTime))
+
+	require.True(t, writeFastGoValue(&out, ctx, vmFastValueInterface{value: "<iface>"}))
+	require.True(t, writeFastGoValue(&out, ctx, template.HTML("<html>")))
+	require.True(t, writeFastGoValue(&out, ctx, vmHTMLValue("<safe>")))
+	require.True(t, writeFastGoValue(&out, ctx, "<str>"))
+	require.True(t, writeFastGoValue(&out, ctx, true))
+	require.True(t, writeFastGoValue(&out, ctx, int(-1)))
+	require.True(t, writeFastGoValue(&out, ctx, int8(-2)))
+	require.True(t, writeFastGoValue(&out, ctx, int16(-3)))
+	require.True(t, writeFastGoValue(&out, ctx, int32(-4)))
+	require.True(t, writeFastGoValue(&out, ctx, int64(-5)))
+	require.True(t, writeFastGoValue(&out, ctx, uint(1)))
+	require.True(t, writeFastGoValue(&out, ctx, uint8(2)))
+	require.True(t, writeFastGoValue(&out, ctx, uint16(3)))
+	require.True(t, writeFastGoValue(&out, ctx, uint32(4)))
+	require.True(t, writeFastGoValue(&out, ctx, uint64(5)))
+	require.True(t, writeFastGoValue(&out, ctx, uintptr(6)))
+	require.True(t, writeFastGoValue(&out, ctx, float32(1.25)))
+	require.True(t, writeFastGoValue(&out, ctx, float64(2.5)))
+	require.True(t, writeFastGoValue(&out, ctx, vmFastOutputStringer("value")))
+	require.True(t, writeFastGoValue(&out, ctx, []string{"<a>", "b"}))
+	require.True(t, writeFastGoValue(&out, ctx, [2]string{"x", "<y>"}))
+	require.True(t, writeFastGoValue(&out, ctx, struct{ Name string }{Name: "ignored"}))
+
+	rendered := out.String()
+	require.Contains(t, rendered, "20242024")
+	require.Contains(t, rendered, "&lt;iface&gt;<html><safe>&lt;str&gt;true")
+	require.Contains(t, rendered, "-1-2-3-4-51234561.252.5")
+	require.Contains(t, rendered, "stringer:value&lt;a&gt;bx&lt;y&gt;")
+
+	out.Reset()
+	require.False(t, writeFastGoValue(&out, ctx, []interface{}{"ok", &object.Builtin{}}))
+	require.Equal(t, "ok", out.String())
+}
+
+func Test_VM_Write_Fast_Object_Output_Branches(t *testing.T) {
+	ctx := plush.NewContext()
+	var out strings.Builder
+	obj := &object.Array{Elements: []object.Object{
+		&object.String{Value: "<a>"},
+		&object.Integer{Value: 2},
+		&object.Float{Value: 1.25},
+		&object.Boolean{Value: true},
+		&object.Native{Value: template.HTML("<b>")},
+		object.NullObject,
+	}}
+
+	require.True(t, writeFastObject(&out, ctx, nil))
+	require.True(t, writeFastObject(&out, ctx, object.NullObject))
+	require.True(t, writeFastObject(&out, ctx, obj))
+	require.Equal(t, "&lt;a&gt;21.25true<b>", out.String())
+
+	require.True(t, canWriteFastObject(nil))
+	require.True(t, canWriteFastObject(object.NullObject))
+	require.True(t, canWriteFastObject(obj))
+	require.False(t, writeFastObject(&out, ctx, &object.Builtin{}))
+	require.False(t, writeFastObject(&out, ctx, &object.Array{Elements: []object.Object{&object.Builtin{}}}))
+	require.False(t, canWriteFastObject(&object.Builtin{}))
+	require.False(t, canWriteFastObject(&object.Array{Elements: []object.Object{&object.Builtin{}}}))
+}
+
+func Test_VM_Write_Go_Value_Output_Branches(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{"TIME_FORMAT": "2006-01-02"})
+	machine := newRuntimeHelperTestVM(ctx)
+	when := time.Date(2025, 2, 3, 4, 5, 6, 0, time.UTC)
+	var out strings.Builder
+
+	machine.writeGoValue(&out, nil)
+	machine.writeGoValue(&out, &object.Array{Elements: []object.Object{
+		&object.String{Value: "<a>"},
+		&object.Integer{Value: 7},
+		&object.Float{Value: 1.5},
+		&object.Boolean{Value: false},
+		object.NullObject,
+	}})
+	machine.writeGoValue(&out, when)
+	machine.writeGoValue(&out, &when)
+
+	var nilTime *time.Time
+	machine.writeGoValue(&out, nilTime)
+
+	machine.writeGoValue(&out, vmFastValueInterface{value: "<iface>"})
+	machine.writeGoValue(&out, template.HTML("<html>"))
+	machine.writeGoValue(&out, vmHTMLValue("<safe>"))
+	machine.writeGoValue(&out, "<str>")
+	machine.writeGoValue(&out, true)
+	machine.writeGoValue(&out, uint32(4))
+	machine.writeGoValue(&out, int32(-5))
+	machine.writeGoValue(&out, float32(1.25))
+	machine.writeGoValue(&out, vmFastOutputStringer("value"))
+	machine.writeGoValue(&out, []string{"<x>", "y"})
+	machine.writeGoValue(&out, []interface{}{template.HTML("<z>"), "<w>"})
+	machine.writeGoValue(&out, [2]uint8{1, 2})
+	machine.writeGoValue(&out, struct{ Name string }{Name: "ignored"})
+
+	rendered := out.String()
+	require.Contains(t, rendered, "&lt;a&gt;71.5false")
+	require.Contains(t, rendered, "2025-02-032025-02-03")
+	require.Contains(t, rendered, "&lt;iface&gt;<html><safe>&lt;str&gt;true4-51.25")
+	require.Contains(t, rendered, "stringer:value&lt;x&gt;y<z>&lt;w&gt;12")
+
+	out.Reset()
+	machine.writeObject(&out, &object.Native{Value: "<native>"})
+	require.Equal(t, "&lt;native&gt;", out.String())
+
+	out.Reset()
+	machine.ctx = nil
+	machine.writeGoValue(&out, when)
+	require.Equal(t, when.Format(plush.DefaultTimeFormat), out.String())
+
+	require.True(t, isTruthy(&object.Native{Value: 1}))
+	require.True(t, isTruthyFastValue(1))
+}
+
+func Test_VM_Numeric_Operation_Branches(t *testing.T) {
+	result, err := numericOperationObject(code.OpAdd, numericValue{kind: numericFloat, f: 1.5}, numericValue{kind: numericSigned, i: 2})
+	require.NoError(t, err)
+	require.Equal(t, &object.Float{Value: 3.5}, result)
+
+	result, err = numericOperationObject(code.OpSub, numericValue{kind: numericSigned, i: 7}, numericValue{kind: numericSigned, i: 2})
+	require.NoError(t, err)
+	require.Equal(t, &object.Integer{Value: 5}, result)
+
+	result, err = numericOperationObject(code.OpMul, numericValue{kind: numericSigned, i: 3}, numericValue{kind: numericSigned, i: 4})
+	require.NoError(t, err)
+	require.Equal(t, &object.Integer{Value: 12}, result)
+
+	result, err = numericOperationObject(code.OpDiv, numericValue{kind: numericUnsigned, u: 9}, numericValue{kind: numericUnsigned, u: 3})
+	require.NoError(t, err)
+	require.Equal(t, &object.Integer{Value: 3}, result)
+
+	_, err = numericOperationObject(code.OpDiv, numericValue{kind: numericFloat, f: 1}, numericValue{kind: numericFloat, f: 0})
+	require.ErrorContains(t, err, "division by zero")
+
+	_, err = numericOperationObject(code.OpDiv, numericValue{kind: numericSigned, i: 1}, numericValue{kind: numericSigned, i: 0})
+	require.ErrorContains(t, err, "division by zero")
+
+	_, err = numericOperationObject(code.OpAdd, numericValue{kind: numericUnsigned, u: math.MaxUint64}, numericValue{kind: numericUnsigned, u: 1})
+	require.ErrorContains(t, err, "integer overflow")
+
+	_, err = numericOperationObject(code.OpSub, numericValue{kind: numericUnsigned, u: uint64(math.MaxInt64) + 1}, numericValue{kind: numericUnsigned, u: uint64(math.MaxInt64) + 2})
+	require.ErrorContains(t, err, "integer underflow")
+
+	_, err = numericOperationObject(code.OpMul, numericValue{kind: numericUnsigned, u: math.MaxUint64}, numericValue{kind: numericUnsigned, u: 2})
+	require.ErrorContains(t, err, "integer overflow")
+
+	_, err = numericOperationObject(code.OpDiv, numericValue{kind: numericUnsigned, u: 1}, numericValue{kind: numericUnsigned, u: 0})
+	require.ErrorContains(t, err, "division by zero")
+
+	_, err = numericOperationObject(code.OpPop, numericValue{kind: numericSigned, i: -1}, numericValue{kind: numericUnsigned, u: uint64(math.MaxInt64) + 1})
+	require.ErrorContains(t, err, "unsupported mixed signed/unsigned operation")
+
+	require.Equal(t, ">", orderedOperatorString(code.OpGreaterThan))
+	require.Equal(t, ">=", orderedOperatorString(code.OpGreaterEqual))
+	require.Equal(t, "0", orderedOperatorString(code.OpConstant))
+}
+
+func Test_VM_Fast_Runtime_Map_Key_Value_Branches(t *testing.T) {
+	step := &fastAccessChainStep{mapKey: reflect.ValueOf("name")}
+	key, ok := fastRuntimeMapKeyValue(stringType, step)
+	require.True(t, ok)
+	require.Equal(t, "name", key.Interface())
+
+	step = &fastAccessChainStep{index: 3}
+	key, ok = fastRuntimeMapKeyValue(reflect.TypeOf(int64(0)), step)
+	require.True(t, ok)
+	require.Equal(t, int64(3), key.Interface())
+
+	_, ok = fastRuntimeMapKeyValue(boolType, &fastAccessChainStep{index: 3})
+	require.False(t, ok)
+
+	_, ok = fastRuntimeMapKeyValue(nil, nil)
+	require.False(t, ok)
+}
+
+func Test_VM_Fast_Path_Step_Call_And_Default(t *testing.T) {
+	ctx := plush.NewContext()
+	value, err := evalFastPathStep(func() string { return "<called>" }, &compiler.FastPathStep{Kind: compiler.FastPathStepCall, Value: "call", Line: 1}, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "<called>", value)
+
+	_, err = evalFastPathStep(vmSegmentUser{Name: "Mido"}, &compiler.FastPathStep{Kind: compiler.FastPathStepProperty, Value: "Name", Line: 2}, plush.NewContext().WithBudget(plush.NewBudget(0)))
+	require.ErrorContains(t, err, "line 2")
+
+	value, err = evalFastPathStep(map[string]string{"name": "Mido"}, &compiler.FastPathStep{Kind: compiler.FastPathStepIndexString, Value: "name", Line: 3}, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "Mido", value)
+
+	_, err = evalFastPathStep(func() (string, error) { return "", errors.New("boom") }, &compiler.FastPathStep{Kind: compiler.FastPathStepCall, Value: "call", Line: 5}, ctx)
+	require.ErrorContains(t, err, "line 5")
+	require.ErrorContains(t, err, "boom")
+
+	_, err = evalFastPathStep(func() string { return "blocked" }, &compiler.FastPathStep{Kind: compiler.FastPathStepCall, Value: "call", Line: 4}, plush.NewContext().WithBudget(plush.NewBudget(0)))
+	require.ErrorContains(t, err, "line 4")
+
+	value, err = evalFastPathStep("base", &compiler.FastPathStep{Kind: 255}, ctx)
+	require.NoError(t, err)
+	require.Nil(t, value)
+}

--- a/VM/vm/fast_values.go
+++ b/VM/vm/fast_values.go
@@ -1,0 +1,1462 @@
+package vm
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/gobuffalo/plush/v5/VM/code"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+)
+
+func evalFastValue(value *compiler.FastValuePlan, ctx hctx.Context, bindings fastRenderBindings, base interface{}) (interface{}, bool, error) {
+	if value == nil {
+		return nil, true, nil
+	}
+	switch value.Kind {
+	case compiler.FastValueName:
+		if value.Value == "nil" {
+			return nil, true, nil
+		}
+		raw, ok := bindings.value(value.NameIndex)
+		if !ok {
+			if value.NullOnMissing {
+				return nil, true, nil
+			}
+			return nil, false, nil
+		}
+		return raw, true, nil
+	case compiler.FastValueString:
+		return value.Value, true, nil
+	case compiler.FastValueInteger:
+		return int(value.IntValue), true, nil
+	case compiler.FastValueFloat:
+		return value.FloatValue, true, nil
+	case compiler.FastValueBool:
+		return value.BoolValue, true, nil
+	case compiler.FastValueLoopKey:
+		return nil, false, nil
+	case compiler.FastValueInfix:
+		return evalFastInfixValue(value, ctx, bindings, nil, nil, base, false)
+	case compiler.FastValuePrefix:
+		return evalFastPrefixValue(value, ctx, bindings, nil, nil, base, false)
+	case compiler.FastValueConcat:
+		return evalFastConcatValue(value, ctx, bindings, nil, nil, base, false)
+	case compiler.FastValueCall:
+		return evalFastCallValuePlan(value.Call, nil, ctx, bindings, nil, nil, nil)
+	case compiler.FastValueArray:
+		return evalFastArrayValue(value.Elements, ctx, bindings, base)
+	case compiler.FastValueHash:
+		return evalFastHashValue(value.Pairs, ctx, bindings, base)
+	case compiler.FastValuePath:
+		raw := base
+		if value.NameIndex >= 0 {
+			var ok bool
+			raw, ok = bindings.value(value.NameIndex)
+			if !ok {
+				if value.NullOnMissing {
+					return nil, true, nil
+				}
+				return nil, false, nil
+			}
+		}
+		if result, handled, err := evalFastFieldChainValue(value, raw, ctx); handled || err != nil {
+			return result, true, err
+		}
+		if result, handled, err := evalFastAccessChainValue(value, raw, ctx); handled || err != nil {
+			return result, true, err
+		}
+		for i := range value.Path {
+			step := &value.Path[i]
+			var err error
+			raw, err = evalFastPathStep(raw, step, ctx)
+			if err != nil {
+				return nil, true, err
+			}
+		}
+		return raw, true, nil
+	default:
+		return nil, false, nil
+	}
+}
+
+func evalFastArrayValue(elements []compiler.FastValuePlan, ctx hctx.Context, bindings fastRenderBindings, base interface{}) ([]interface{}, bool, error) {
+	out := make([]interface{}, 0, len(elements))
+	for i := range elements {
+		value, ok, err := evalFastValue(&elements[i], ctx, bindings, base)
+		if err != nil || !ok {
+			return nil, ok, err
+		}
+		out = append(out, value)
+	}
+	return out, true, nil
+}
+
+func evalFastHashValue(pairs []compiler.FastValuePair, ctx hctx.Context, bindings fastRenderBindings, base interface{}) (map[string]interface{}, bool, error) {
+	out := make(map[string]interface{}, len(pairs))
+	for i := range pairs {
+		value, ok, err := evalFastValue(&pairs[i].Value, ctx, bindings, base)
+		if err != nil || !ok {
+			return nil, ok, err
+		}
+		out[pairs[i].Key] = value
+	}
+	return out, true, nil
+}
+
+func evalFastLoopValue(value *compiler.FastValuePlan, ctx hctx.Context, bindings fastRenderBindings, loopKey, loopValue interface{}) (interface{}, bool, error) {
+	if value == nil {
+		return nil, true, nil
+	}
+	switch value.Kind {
+	case compiler.FastValueLoopKey:
+		return loopKey, true, nil
+	case compiler.FastValueInfix:
+		return evalFastInfixValue(value, ctx, bindings, loopKey, loopValue, nil, true)
+	case compiler.FastValuePrefix:
+		return evalFastPrefixValue(value, ctx, bindings, loopKey, loopValue, nil, true)
+	case compiler.FastValueConcat:
+		return evalFastConcatValue(value, ctx, bindings, loopKey, loopValue, nil, true)
+	case compiler.FastValueCall:
+		return evalFastLoopCallValuePlan(value.Call, ctx, bindings, loopKey, loopValue)
+	case compiler.FastValueArray:
+		return evalFastLoopArrayValue(value.Elements, ctx, bindings, loopKey, loopValue)
+	case compiler.FastValueHash:
+		return evalFastLoopHashValue(value.Pairs, ctx, bindings, loopKey, loopValue)
+	default:
+		return evalFastValue(value, ctx, bindings, loopValue)
+	}
+}
+
+func evalFastLoopArrayValue(elements []compiler.FastValuePlan, ctx hctx.Context, bindings fastRenderBindings, loopKey, loopValue interface{}) ([]interface{}, bool, error) {
+	out := make([]interface{}, 0, len(elements))
+	for i := range elements {
+		value, ok, err := evalFastLoopValue(&elements[i], ctx, bindings, loopKey, loopValue)
+		if err != nil || !ok {
+			return nil, ok, err
+		}
+		out = append(out, value)
+	}
+	return out, true, nil
+}
+
+func evalFastLoopHashValue(pairs []compiler.FastValuePair, ctx hctx.Context, bindings fastRenderBindings, loopKey, loopValue interface{}) (map[string]interface{}, bool, error) {
+	out := make(map[string]interface{}, len(pairs))
+	for i := range pairs {
+		value, ok, err := evalFastLoopValue(&pairs[i].Value, ctx, bindings, loopKey, loopValue)
+		if err != nil || !ok {
+			return nil, ok, err
+		}
+		out[pairs[i].Key] = value
+	}
+	return out, true, nil
+}
+
+func evalFastLoopCallValuePlan(call *compiler.FastCallPlan, ctx hctx.Context, bindings fastRenderBindings, loopKey, loopValue interface{}) (interface{}, bool, error) {
+	if call == nil {
+		return nil, true, nil
+	}
+	raw, ok := bindings.value(call.NameIndex)
+	if !ok {
+		return nil, false, nil
+	}
+	if err := spendFastFunctionCall(ctx, call.Name, call.Line); err != nil {
+		return nil, true, err
+	}
+	var argStore fastCallArgs
+	args, err := evalFastLoopCallArgsInto(call.Args, ctx, bindings, loopKey, loopValue, &argStore)
+	if err != nil {
+		return nil, true, err
+	}
+	result, err := fastCallValue(call.Name, raw, args, ctx, &call.Cache)
+	if err != nil {
+		return nil, true, fastLineError(call.Line, err)
+	}
+	return result, true, nil
+}
+
+func evalFastPrefixValue(value *compiler.FastValuePlan, ctx hctx.Context, bindings fastRenderBindings, loopKey, loopValue, base interface{}, loopAware bool) (interface{}, bool, error) {
+	if value == nil || value.Kind != compiler.FastValuePrefix || value.Right == nil {
+		return nil, false, nil
+	}
+	if value.Operator != "!" {
+		return nil, true, fastLineError(value.Line, fmt.Errorf("unknown fast prefix operator: %s", value.Operator))
+	}
+	right, ok, err := evalFastCompoundOperand(value.Right, ctx, bindings, loopKey, loopValue, base, loopAware)
+	if err != nil {
+		return nil, true, err
+	}
+	return !(ok && isTruthyFastValue(right)), true, nil
+}
+
+func evalFastConcatValue(value *compiler.FastValuePlan, ctx hctx.Context, bindings fastRenderBindings, loopKey, loopValue, base interface{}, loopAware bool) (interface{}, bool, error) {
+	if value == nil || value.Kind != compiler.FastValueConcat || value.Left == nil || value.Right == nil {
+		return nil, false, nil
+	}
+	left, ok, err := evalFastCompoundOperand(value.Left, ctx, bindings, loopKey, loopValue, base, loopAware)
+	if err != nil {
+		return nil, true, err
+	}
+	if !ok {
+		return nil, false, nil
+	}
+	right, ok, err := evalFastCompoundOperand(value.Right, ctx, bindings, loopKey, loopValue, base, loopAware)
+	if err != nil {
+		return nil, true, err
+	}
+	if !ok {
+		return nil, false, nil
+	}
+	result, err := evalFastAddOperator(left, right)
+	if err != nil {
+		return nil, true, fastLineError(value.Line, err)
+	}
+	return result, true, nil
+}
+
+func evalFastCompoundOperand(value *compiler.FastValuePlan, ctx hctx.Context, bindings fastRenderBindings, loopKey, loopValue, base interface{}, loopAware bool) (interface{}, bool, error) {
+	if loopAware {
+		return evalFastLoopValue(value, ctx, bindings, loopKey, loopValue)
+	}
+	return evalFastValue(value, ctx, bindings, base)
+}
+
+func evalFastAddOperator(left, right interface{}) (interface{}, error) {
+	left = fastAddGoValue(left)
+	right = fastAddGoValue(right)
+	if _, ok := left.(string); ok {
+		return fmt.Sprint(left) + fmt.Sprint(right), nil
+	}
+	if _, ok := right.(string); ok {
+		return fmt.Sprint(left) + fmt.Sprint(right), nil
+	}
+	if _, ok := left.(bool); ok {
+		return isTruthyFastValue(left) && isTruthyFastValue(right), nil
+	}
+	if _, ok := right.(bool); ok {
+		return isTruthyFastValue(left) && isTruthyFastValue(right), nil
+	}
+	if lnum, ok := numericValueFromGo(left); ok {
+		if rnum, ok := numericValueFromGo(right); ok {
+			result, err := numericOperationObject(code.OpAdd, lnum, rnum)
+			if err != nil {
+				return nil, err
+			}
+			return object.ToGo(result), nil
+		}
+	}
+	return nil, fmt.Errorf("unable to operate (+) on %T and %T", left, right)
+}
+
+func fastAddGoValue(value interface{}) interface{} {
+	if obj, ok := value.(object.Object); ok {
+		return object.ToGo(obj)
+	}
+	return value
+}
+
+func evalFastInfixValue(value *compiler.FastValuePlan, ctx hctx.Context, bindings fastRenderBindings, loopKey, loopValue, base interface{}, loopAware bool) (interface{}, bool, error) {
+	if value == nil || value.Kind != compiler.FastValueInfix || value.Left == nil || value.Right == nil {
+		return nil, false, nil
+	}
+	if value.Operator == "&&" || value.Operator == "||" {
+		return evalFastLogicalInfixValue(value, ctx, bindings, loopKey, loopValue, base, loopAware)
+	}
+	var left interface{}
+	var right interface{}
+	var ok bool
+	var err error
+	if loopAware {
+		left, ok, err = evalFastLoopValue(value.Left, ctx, bindings, loopKey, loopValue)
+	} else {
+		left, ok, err = evalFastValue(value.Left, ctx, bindings, base)
+	}
+	if err != nil {
+		return nil, true, err
+	}
+	if !ok {
+		left = nil
+	}
+	if loopAware {
+		right, ok, err = evalFastLoopValue(value.Right, ctx, bindings, loopKey, loopValue)
+	} else {
+		right, ok, err = evalFastValue(value.Right, ctx, bindings, base)
+	}
+	if err != nil {
+		return nil, true, err
+	}
+	if !ok {
+		right = nil
+	}
+	result, err := evalFastInfixOperator(value.Operator, left, right)
+	if err != nil {
+		return nil, true, fastLineError(value.Line, err)
+	}
+	return result, true, nil
+}
+
+func evalFastLogicalInfixValue(value *compiler.FastValuePlan, ctx hctx.Context, bindings fastRenderBindings, loopKey, loopValue, base interface{}, loopAware bool) (interface{}, bool, error) {
+	var left interface{}
+	var ok bool
+	var err error
+	if loopAware {
+		left, ok, err = evalFastLoopValue(value.Left, ctx, bindings, loopKey, loopValue)
+	} else {
+		left, ok, err = evalFastValue(value.Left, ctx, bindings, base)
+	}
+	if err != nil {
+		return nil, true, err
+	}
+	leftTruthy := ok && isTruthyFastValue(left)
+	switch value.Operator {
+	case "&&":
+		if !leftTruthy {
+			return false, true, nil
+		}
+	case "||":
+		if leftTruthy {
+			return true, true, nil
+		}
+	default:
+		return nil, false, nil
+	}
+
+	var right interface{}
+	if loopAware {
+		right, ok, err = evalFastLoopValue(value.Right, ctx, bindings, loopKey, loopValue)
+	} else {
+		right, ok, err = evalFastValue(value.Right, ctx, bindings, base)
+	}
+	if err != nil {
+		return nil, true, err
+	}
+	return ok && isTruthyFastValue(right), true, nil
+}
+
+func evalFastInfixOperator(operator string, left, right interface{}) (interface{}, error) {
+	leftValue := fastConditionOperandValue{raw: left}
+	rightValue := fastConditionOperandValue{raw: right}
+	switch operator {
+	case "&&":
+		return isTruthyFastValue(left) && isTruthyFastValue(right), nil
+	case "||":
+		return isTruthyFastValue(left) || isTruthyFastValue(right), nil
+	case "==":
+		return evalFastConditionInfixOperator(operator, leftValue, rightValue)
+	case "!=":
+		return evalFastConditionInfixOperator(operator, leftValue, rightValue)
+	case ">":
+		return evalFastConditionInfixOperator(operator, leftValue, rightValue)
+	case ">=":
+		return evalFastConditionInfixOperator(operator, leftValue, rightValue)
+	case "<":
+		return evalFastConditionInfixOperator(operator, leftValue, rightValue)
+	case "<=":
+		return evalFastConditionInfixOperator(operator, leftValue, rightValue)
+	case "-", "*", "/":
+		return evalFastNumericArithmeticOperator(operator, left, right)
+	default:
+		return nil, fmt.Errorf("unknown fast infix operator: %s", operator)
+	}
+}
+
+func evalFastNumericArithmeticOperator(operator string, left, right interface{}) (interface{}, error) {
+	left = fastAddGoValue(left)
+	right = fastAddGoValue(right)
+	lnum, lok := numericValueFromGo(left)
+	rnum, rok := numericValueFromGo(right)
+	if !lok || !rok {
+		return nil, fmt.Errorf("unable to operate (%s) on %T and %T", operator, left, right)
+	}
+	op, ok := fastArithmeticOpcode(operator)
+	if !ok {
+		return nil, fmt.Errorf("unknown fast arithmetic operator: %s", operator)
+	}
+	result, err := numericOperationObject(op, lnum, rnum)
+	if err != nil {
+		return nil, err
+	}
+	return object.ToGo(result), nil
+}
+
+func fastArithmeticOpcode(operator string) (code.Opcode, bool) {
+	switch operator {
+	case "-":
+		return code.OpSub, true
+	case "*":
+		return code.OpMul, true
+	case "/":
+		return code.OpDiv, true
+	default:
+		return 0, false
+	}
+}
+
+func writeFastValuePlanOutput(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, value *compiler.FastValuePlan) (bool, bool, error) {
+	if value == nil {
+		return false, false, nil
+	}
+	if value.Kind == compiler.FastValueInfix {
+		result, ok, err := evalFastInfixValue(value, ctx, bindings, nil, nil, nil, false)
+		if err != nil || !ok {
+			return true, ok, err
+		}
+		if truth, ok := result.(bool); ok {
+			out.WriteString(strconv.FormatBool(truth))
+		} else {
+			writeFastGoValue(out, ctx, result)
+		}
+		return true, true, nil
+	}
+	if value.Kind == compiler.FastValuePrefix || value.Kind == compiler.FastValueConcat {
+		result, ok, err := evalFastValue(value, ctx, bindings, nil)
+		if err != nil || !ok {
+			return true, ok, err
+		}
+		writeFastGoValue(out, ctx, result)
+		return true, true, nil
+	}
+	if value.Kind != compiler.FastValuePath || value.NameIndex < 0 {
+		return false, false, nil
+	}
+	raw, ok := bindings.value(value.NameIndex)
+	if !ok {
+		if value.NullOnMissing {
+			return true, true, nil
+		}
+		return true, false, nil
+	}
+	if handled, err := writeFastFieldChainValue(out, ctx, value, raw); handled || err != nil {
+		return handled, true, err
+	}
+	if handled, err := writeFastAccessChainValue(out, ctx, value, raw); handled || err != nil {
+		return handled, true, err
+	}
+	return false, false, nil
+}
+
+func canUseFastTopLevelAccessChain(value *compiler.FastValuePlan) bool {
+	if value == nil ||
+		value.Kind != compiler.FastValuePath ||
+		value.NameIndex < 0 ||
+		len(value.Path) == 0 {
+		return false
+	}
+	for i := range value.Path {
+		step := &value.Path[i]
+		switch step.Kind {
+		case compiler.FastPathStepProperty:
+			if step.Method {
+				return i == len(value.Path)-2 &&
+					value.Path[len(value.Path)-1].Kind == compiler.FastPathStepCall
+			}
+		case compiler.FastPathStepIndexInteger, compiler.FastPathStepIndexString:
+			continue
+		case compiler.FastPathStepCall:
+			return i == len(value.Path)-1 &&
+				i > 0 &&
+				value.Path[i-1].Kind == compiler.FastPathStepProperty &&
+				value.Path[i-1].Method
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func writeFastTopLevelAccessChainOutput(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, value *compiler.FastValuePlan, cacheSlot *object.InlineCacheSlot) (bool, bool, error) {
+	if !canUseFastTopLevelAccessChain(value) {
+		return false, false, nil
+	}
+	raw, ok := bindings.value(value.NameIndex)
+	if !ok {
+		if value.NullOnMissing {
+			return true, true, nil
+		}
+		return true, false, nil
+	}
+	handled, err := writeFastTopLevelAccessChainRaw(out, ctx, value, raw, cacheSlot)
+	return handled, true, err
+}
+
+func writeFastTopLevelAccessChainRaw(out *strings.Builder, ctx hctx.Context, value *compiler.FastValuePlan, raw interface{}, cacheSlot *object.InlineCacheSlot) (bool, error) {
+	if !canUseFastTopLevelAccessChain(value) {
+		return false, nil
+	}
+	rv, nilValue, ok := fastAccessChainRootValue(raw)
+	if nilValue {
+		return true, nil
+	}
+	if !ok {
+		return false, nil
+	}
+	entry := fastTopLevelAccessCacheEntryFor(cacheSlot, value, rv.Type())
+	if entry == nil || entry.kind == fastTopLevelAccessUnsupported {
+		return false, nil
+	}
+	switch entry.kind {
+	case fastTopLevelAccessFieldChain:
+		return true, writeFastFieldChainPlanOutput(out, ctx, entry.fieldChain, rv)
+	case fastTopLevelAccessChain:
+		_, err := writeFastAccessChainPlanOutput(out, ctx, entry.chain, rv)
+		return true, err
+	case fastTopLevelAccessMethodCall:
+		return true, writeFastLoopMethodCall(out, ctx, entry.method, rv)
+	default:
+		return false, nil
+	}
+}
+
+func fastTopLevelAccessCacheEntryFor(slot *object.InlineCacheSlot, value *compiler.FastValuePlan, rt reflect.Type) *fastTopLevelAccessCacheEntry {
+	if slot == nil {
+		return buildFastTopLevelAccessCacheEntry(value, rt)
+	}
+	if cached, ok := slot.Load().(*fastTopLevelAccessCacheEntry); ok {
+		for entry := cached; entry != nil; entry = entry.next {
+			if entry.typ == rt {
+				return entry
+			}
+		}
+	}
+	current, _ := slot.Load().(*fastTopLevelAccessCacheEntry)
+	entry := buildFastTopLevelAccessCacheEntry(value, rt)
+	entry.next = cloneFastTopLevelAccessCache(current, propertyInlineCacheDepth-1)
+	slot.Store(entry)
+	return entry
+}
+
+func buildFastTopLevelAccessCacheEntry(value *compiler.FastValuePlan, rt reflect.Type) *fastTopLevelAccessCacheEntry {
+	entry := &fastTopLevelAccessCacheEntry{
+		typ:  rt,
+		kind: fastTopLevelAccessUnsupported,
+	}
+	if method, ok := buildFastLoopMethodCallPlan(value, rt); ok {
+		entry.kind = fastTopLevelAccessMethodCall
+		entry.method = method
+		return entry
+	}
+	if chain, ok := fastFieldChainPlanFor(value, rt); ok {
+		entry.kind = fastTopLevelAccessFieldChain
+		entry.fieldChain = chain
+		return entry
+	}
+	if chain, ok := fastAccessChainPlanFor(value, rt); ok {
+		entry.kind = fastTopLevelAccessChain
+		entry.chain = chain
+		return entry
+	}
+	return entry
+}
+
+func cloneFastTopLevelAccessCache(head *fastTopLevelAccessCacheEntry, limit int) *fastTopLevelAccessCacheEntry {
+	if head == nil || limit <= 0 {
+		return nil
+	}
+	clone := &fastTopLevelAccessCacheEntry{
+		typ:        head.typ,
+		kind:       head.kind,
+		fieldChain: head.fieldChain,
+		chain:      head.chain,
+		method:     head.method,
+	}
+	tail := clone
+	count := 1
+	for entry := head.next; entry != nil && count < limit; entry = entry.next {
+		tail.next = &fastTopLevelAccessCacheEntry{
+			typ:        entry.typ,
+			kind:       entry.kind,
+			fieldChain: entry.fieldChain,
+			chain:      entry.chain,
+			method:     entry.method,
+		}
+		tail = tail.next
+		count++
+	}
+	return clone
+}
+
+func evalFastFieldChainValue(value *compiler.FastValuePlan, raw interface{}, ctx hctx.Context) (interface{}, bool, error) {
+	rv, nilValue, ok := fastFieldChainRootValue(raw)
+	if nilValue {
+		return nil, true, nil
+	}
+	if !ok {
+		return nil, false, nil
+	}
+	chain, ok := fastFieldChainPlanFor(value, rv.Type())
+	if !ok {
+		return nil, false, nil
+	}
+	for i := range chain.steps {
+		step := &chain.steps[i]
+		if err := spendFastTraversal(ctx, step.line); err != nil {
+			return nil, true, err
+		}
+		rv = unwrapFastFieldChainValue(rv)
+		field := rv.FieldByIndex(step.lookup.fieldIndex)
+		if i == len(chain.steps)-1 {
+			result, err := fastFieldValue(field, object.PropertyAccess{
+				Receiver: step.receiver,
+				Full:     step.full,
+			}, step.name)
+			if err != nil {
+				return nil, true, fastLineError(step.line, err)
+			}
+			return result, true, nil
+		}
+		if field.Kind() == reflect.Ptr {
+			if field.IsNil() {
+				return nil, true, nil
+			}
+			field = field.Elem()
+		}
+		if !field.CanInterface() {
+			return nil, true, fastLineError(step.line, fieldAccessError(step.receiver, step.full, step.name))
+		}
+		rv = field
+	}
+	return raw, true, nil
+}
+
+func writeFastFieldChainValue(out *strings.Builder, ctx hctx.Context, value *compiler.FastValuePlan, raw interface{}) (bool, error) {
+	rv, nilValue, ok := fastFieldChainRootValue(raw)
+	if nilValue {
+		return true, nil
+	}
+	if !ok {
+		return false, nil
+	}
+	chain, ok := fastFieldChainPlanFor(value, rv.Type())
+	if !ok {
+		return false, nil
+	}
+	return true, writeFastFieldChainPlanOutput(out, ctx, chain, rv)
+}
+
+func writeFastFieldChainPlanOutput(out *strings.Builder, ctx hctx.Context, chain *fastFieldChainPlan, rv reflect.Value) error {
+	if chain == nil {
+		return nil
+	}
+	for i := range chain.steps {
+		step := &chain.steps[i]
+		if err := spendFastTraversal(ctx, step.line); err != nil {
+			return err
+		}
+		rv = unwrapFastFieldChainValue(rv)
+		if !rv.IsValid() {
+			return nil
+		}
+		field := rv.FieldByIndex(step.lookup.fieldIndex)
+		if i == len(chain.steps)-1 {
+			written, err := writeFastField(out, ctx, field, object.PropertyAccess{
+				Receiver: step.receiver,
+				Full:     step.full,
+			}, step.name, step.fieldType)
+			if err != nil {
+				return fastLineError(step.line, err)
+			}
+			if written {
+				return nil
+			}
+			value, _ := fastFieldValue(field, object.PropertyAccess{
+				Receiver: step.receiver,
+				Full:     step.full,
+			}, step.name)
+			writeFastGoValue(out, ctx, value)
+			return nil
+		}
+		if field.Kind() == reflect.Ptr {
+			if field.IsNil() {
+				return nil
+			}
+			field = field.Elem()
+		}
+		if !field.CanInterface() {
+			return fastLineError(step.line, fieldAccessError(step.receiver, step.full, step.name))
+		}
+		rv = field
+	}
+	return nil
+}
+
+func fastFieldChainRootValue(raw interface{}) (reflect.Value, bool, bool) {
+	if obj, ok := raw.(object.Object); ok {
+		if object.IsNull(obj) {
+			return reflect.Value{}, true, true
+		}
+		raw = object.ToGo(obj)
+	}
+	if raw == nil {
+		return reflect.Value{}, true, true
+	}
+	rv := reflect.ValueOf(raw)
+	rv = unwrapFastFieldChainValue(rv)
+	if !rv.IsValid() {
+		return reflect.Value{}, true, true
+	}
+	if rv.Kind() != reflect.Struct {
+		return reflect.Value{}, false, false
+	}
+	return rv, false, true
+}
+
+func unwrapFastFieldChainValue(rv reflect.Value) reflect.Value {
+	for rv.IsValid() && rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			return reflect.Value{}
+		}
+		rv = rv.Elem()
+	}
+	return rv
+}
+
+func fastFieldChainPlanFor(value *compiler.FastValuePlan, root reflect.Type) (*fastFieldChainPlan, bool) {
+	if value == nil || value.Kind != compiler.FastValuePath || len(value.Path) == 0 {
+		return nil, false
+	}
+	key := fastFieldChainPlanKey{plan: value, typ: root}
+	if cached, ok := fastFieldChainPlanCache.Load(key); ok {
+		chain, _ := cached.(*fastFieldChainPlan)
+		return chain, chain != nil
+	}
+	chain, ok := buildFastFieldChainPlan(value, root)
+	if !ok {
+		fastFieldChainPlanCache.Store(key, (*fastFieldChainPlan)(nil))
+		return nil, false
+	}
+	actual, _ := fastFieldChainPlanCache.LoadOrStore(key, chain)
+	chain, _ = actual.(*fastFieldChainPlan)
+	return chain, chain != nil
+}
+
+func buildFastFieldChainPlan(value *compiler.FastValuePlan, root reflect.Type) (*fastFieldChainPlan, bool) {
+	current := root
+	chain := &fastFieldChainPlan{steps: make([]fastFieldChainStep, 0, len(value.Path))}
+	for i := range value.Path {
+		step := &value.Path[i]
+		if step.Kind != compiler.FastPathStepProperty || step.Method {
+			return nil, false
+		}
+		current = unwrapReflectType(current)
+		if current.Kind() != reflect.Struct {
+			return nil, false
+		}
+		lookup := cachedPropertyLookup(current, step.Value)
+		if lookup.kind != propertyLookupField {
+			return nil, false
+		}
+		field, _ := fieldByIndex(current, lookup.fieldIndex)
+		chain.steps = append(chain.steps, fastFieldChainStep{
+			name:      step.Value,
+			receiver:  step.Receiver,
+			full:      step.Full,
+			line:      step.Line,
+			fieldType: field.Type,
+			lookup:    lookup,
+		})
+		current = field.Type
+	}
+	return chain, len(chain.steps) > 0
+}
+
+func evalFastAccessChainValue(value *compiler.FastValuePlan, raw interface{}, ctx hctx.Context) (interface{}, bool, error) {
+	rv, nilValue, ok := fastAccessChainRootValue(raw)
+	if nilValue {
+		return nil, true, nil
+	}
+	if !ok {
+		return nil, false, nil
+	}
+	chain, ok := fastAccessChainPlanFor(value, rv.Type())
+	if !ok {
+		return nil, false, nil
+	}
+	result, ok, err := evalFastAccessChainPlanValue(chain, rv, ctx)
+	return result, ok, err
+}
+
+func writeFastAccessChainValue(out *strings.Builder, ctx hctx.Context, value *compiler.FastValuePlan, raw interface{}) (bool, error) {
+	rv, nilValue, ok := fastAccessChainRootValue(raw)
+	if nilValue {
+		return true, nil
+	}
+	if !ok {
+		return false, nil
+	}
+	chain, ok := fastAccessChainPlanFor(value, rv.Type())
+	if !ok {
+		return false, nil
+	}
+	return writeFastAccessChainPlanOutput(out, ctx, chain, rv)
+}
+
+func fastAccessChainRootValue(raw interface{}) (reflect.Value, bool, bool) {
+	if obj, ok := raw.(object.Object); ok {
+		if object.IsNull(obj) {
+			return reflect.Value{}, true, true
+		}
+		raw = object.ToGo(obj)
+	}
+	if raw == nil {
+		return reflect.Value{}, true, true
+	}
+	rv := reflect.ValueOf(raw)
+	rv = unwrapFastFieldChainValue(rv)
+	if !rv.IsValid() {
+		return reflect.Value{}, true, true
+	}
+	switch rv.Kind() {
+	case reflect.Struct, reflect.Array, reflect.Slice, reflect.Map:
+		return rv, false, true
+	default:
+		return reflect.Value{}, false, false
+	}
+}
+
+func fastAccessChainPlanFor(value *compiler.FastValuePlan, root reflect.Type) (*fastAccessChainPlan, bool) {
+	if value == nil || value.Kind != compiler.FastValuePath || len(value.Path) == 0 {
+		return nil, false
+	}
+	key := fastAccessChainPlanKey{plan: value, typ: root}
+	if cached, ok := fastAccessChainPlanCache.Load(key); ok {
+		chain, _ := cached.(*fastAccessChainPlan)
+		return chain, chain != nil
+	}
+	chain, _, ok := buildFastAccessChainPlanForSteps(value.Path, root)
+	if !ok || len(chain.steps) == 0 {
+		fastAccessChainPlanCache.Store(key, (*fastAccessChainPlan)(nil))
+		return nil, false
+	}
+	actual, _ := fastAccessChainPlanCache.LoadOrStore(key, chain)
+	chain, _ = actual.(*fastAccessChainPlan)
+	return chain, chain != nil
+}
+
+func buildFastAccessChainPlanForSteps(steps []compiler.FastPathStep, root reflect.Type) (*fastAccessChainPlan, reflect.Type, bool) {
+	current := root
+	chain := &fastAccessChainPlan{steps: make([]fastAccessChainStep, 0, len(steps))}
+	for i := range steps {
+		step := &steps[i]
+		current = unwrapReflectType(current)
+		switch step.Kind {
+		case compiler.FastPathStepProperty:
+			if step.Method || current.Kind() != reflect.Struct {
+				return nil, nil, false
+			}
+			lookup := cachedPropertyLookup(current, step.Value)
+			if lookup.kind != propertyLookupField {
+				return nil, nil, false
+			}
+			field, _ := fieldByIndex(current, lookup.fieldIndex)
+			chain.steps = append(chain.steps, fastAccessChainStep{
+				kind:      fastAccessStepField,
+				name:      step.Value,
+				receiver:  step.Receiver,
+				full:      step.Full,
+				line:      step.Line,
+				fieldType: field.Type,
+				lookup:    lookup,
+			})
+			current = field.Type
+		case compiler.FastPathStepIndexInteger, compiler.FastPathStepIndexString:
+			indexStep, next, ok := buildFastIndexAccessStep(current, step)
+			if !ok {
+				return nil, nil, false
+			}
+			chain.steps = append(chain.steps, indexStep)
+			current = next
+		default:
+			return nil, nil, false
+		}
+	}
+	return chain, current, true
+}
+
+func buildFastIndexAccessStep(current reflect.Type, step *compiler.FastPathStep) (fastAccessChainStep, reflect.Type, bool) {
+	current = unwrapReflectType(current)
+	switch current.Kind() {
+	case reflect.Array:
+		if step.Kind != compiler.FastPathStepIndexInteger {
+			return fastAccessChainStep{}, nil, false
+		}
+		if step.Index < 0 || step.Index >= current.Len() {
+			return fastAccessChainStep{}, nil, false
+		}
+		return fastAccessChainStep{
+			kind:       fastAccessStepIndex,
+			line:       step.Line,
+			index:      step.Index,
+			resultType: current.Elem(),
+		}, current.Elem(), true
+	case reflect.Slice:
+		if step.Kind != compiler.FastPathStepIndexInteger {
+			return fastAccessChainStep{}, nil, false
+		}
+		if step.Index < 0 {
+			return fastAccessChainStep{}, nil, false
+		}
+		return fastAccessChainStep{
+			kind:       fastAccessStepIndex,
+			line:       step.Line,
+			index:      step.Index,
+			resultType: current.Elem(),
+		}, current.Elem(), true
+	case reflect.Map:
+		key, ok := fastAccessMapKeyValue(current.Key(), step)
+		if !ok {
+			return fastAccessChainStep{}, nil, false
+		}
+		return fastAccessChainStep{
+			kind:       fastAccessStepIndex,
+			line:       step.Line,
+			index:      step.Index,
+			mapKey:     key,
+			mapString:  step.Value,
+			mapDirect:  fastMapDirectKindFor(current, step),
+			resultType: current.Elem(),
+		}, current.Elem(), true
+	default:
+		return fastAccessChainStep{}, nil, false
+	}
+}
+
+func fastMapDirectKindFor(mapType reflect.Type, step *compiler.FastPathStep) fastMapDirectKind {
+	if mapType == nil || step == nil || step.Kind != compiler.FastPathStepIndexString || mapType.Kind() != reflect.Map || mapType.Key() != stringType {
+		return fastMapDirectNone
+	}
+	switch mapType.Elem() {
+	case stringType:
+		return fastMapDirectStringString
+	case reflect.TypeOf(int(0)):
+		return fastMapDirectStringInt
+	case reflect.TypeOf(uint32(0)):
+		return fastMapDirectStringUint32
+	case emptyInterfaceType:
+		return fastMapDirectStringInterface
+	default:
+		return fastMapDirectNone
+	}
+}
+
+func fastAccessMapKeyValue(keyType reflect.Type, step *compiler.FastPathStep) (reflect.Value, bool) {
+	var key reflect.Value
+	switch step.Kind {
+	case compiler.FastPathStepIndexInteger:
+		key = reflect.ValueOf(step.Index)
+	case compiler.FastPathStepIndexString:
+		key = reflect.ValueOf(step.Value)
+	default:
+		return reflect.Value{}, false
+	}
+	if !key.IsValid() || keyType == nil {
+		return reflect.Value{}, false
+	}
+	if key.Type() != keyType {
+		if key.Type().ConvertibleTo(keyType) {
+			key = key.Convert(keyType)
+		} else if keyType.Kind() != reflect.Interface {
+			return reflect.Value{}, false
+		}
+	}
+	return key, true
+}
+
+func fastRuntimeMapKeyValue(keyType reflect.Type, step *fastAccessChainStep) (reflect.Value, bool) {
+	if step == nil {
+		return reflect.Value{}, false
+	}
+	if step.mapKey.IsValid() {
+		return step.mapKey, true
+	}
+	key := reflect.ValueOf(step.index)
+	if !key.IsValid() || keyType == nil {
+		return reflect.Value{}, false
+	}
+	if key.Type() != keyType {
+		if key.Type().ConvertibleTo(keyType) {
+			key = key.Convert(keyType)
+		} else if keyType.Kind() != reflect.Interface {
+			return reflect.Value{}, false
+		}
+	}
+	return key, true
+}
+
+func evalFastAccessChainPlanValue(chain *fastAccessChainPlan, rv reflect.Value, ctx hctx.Context) (interface{}, bool, error) {
+	current := rv
+	for i := range chain.steps {
+		step := &chain.steps[i]
+		last := i == len(chain.steps)-1
+		switch step.kind {
+		case fastAccessStepField:
+			if err := spendFastTraversal(ctx, step.line); err != nil {
+				return nil, true, err
+			}
+			field, ok, err := fastAccessFieldValue(current, step)
+			if !ok || err != nil {
+				return nil, true, err
+			}
+			if last {
+				value, err := fastFieldValue(field, object.PropertyAccess{
+					Receiver: step.receiver,
+					Full:     step.full,
+				}, step.name)
+				if err != nil {
+					return nil, true, fastLineError(step.line, err)
+				}
+				return value, true, nil
+			}
+			current, ok, err = fastAccessIntermediateValue(field, step)
+			if !ok || err != nil {
+				return nil, true, err
+			}
+		case fastAccessStepIndex:
+			indexed, ok, err := fastAccessIndexValue(current, step)
+			if err != nil {
+				return nil, true, fastLineError(step.line, err)
+			}
+			if !ok {
+				return nil, true, nil
+			}
+			if last {
+				return fastReflectInterface(indexed), true, nil
+			}
+			current, ok, err = fastAccessIntermediateValue(indexed, step)
+			if !ok || err != nil {
+				return nil, true, err
+			}
+		}
+	}
+	return fastReflectInterface(current), true, nil
+}
+
+func writeFastAccessChainPlanOutput(out *strings.Builder, ctx hctx.Context, chain *fastAccessChainPlan, rv reflect.Value) (bool, error) {
+	current := rv
+	for i := range chain.steps {
+		step := &chain.steps[i]
+		last := i == len(chain.steps)-1
+		switch step.kind {
+		case fastAccessStepField:
+			if err := spendFastTraversal(ctx, step.line); err != nil {
+				return true, err
+			}
+			field, ok, err := fastAccessFieldValue(current, step)
+			if !ok || err != nil {
+				return true, err
+			}
+			if last {
+				written, err := writeFastField(out, ctx, field, object.PropertyAccess{
+					Receiver: step.receiver,
+					Full:     step.full,
+				}, step.name, step.fieldType)
+				if err != nil {
+					return true, fastLineError(step.line, err)
+				}
+				if written {
+					return true, nil
+				}
+				value, _ := fastFieldValue(field, object.PropertyAccess{
+					Receiver: step.receiver,
+					Full:     step.full,
+				}, step.name)
+				writeFastGoValue(out, ctx, value)
+				return true, nil
+			}
+			current, ok, err = fastAccessIntermediateValue(field, step)
+			if !ok || err != nil {
+				return true, err
+			}
+		case fastAccessStepIndex:
+			if last {
+				if handled, err := writeFastDirectMapIndexOutput(out, ctx, current, step); handled || err != nil {
+					return true, err
+				}
+			}
+			indexed, ok, err := fastAccessIndexValue(current, step)
+			if err != nil {
+				return true, fastLineError(step.line, err)
+			}
+			if !ok {
+				return true, nil
+			}
+			if last {
+				return true, writeFastReflectValue(out, ctx, indexed)
+			}
+			current, ok, err = fastAccessIntermediateValue(indexed, step)
+			if !ok || err != nil {
+				return true, err
+			}
+		}
+	}
+	return true, nil
+}
+
+func fastAccessFieldValue(current reflect.Value, step *fastAccessChainStep) (reflect.Value, bool, error) {
+	current = unwrapFastFieldChainValue(current)
+	if !current.IsValid() {
+		return reflect.Value{}, false, nil
+	}
+	if current.Kind() != reflect.Struct {
+		return reflect.Value{}, false, nil
+	}
+	return current.FieldByIndex(step.lookup.fieldIndex), true, nil
+}
+
+func fastAccessIndexValue(current reflect.Value, step *fastAccessChainStep) (reflect.Value, bool, error) {
+	current = unwrapFastFieldChainValue(current)
+	if !current.IsValid() {
+		return reflect.Value{}, false, nil
+	}
+	switch current.Kind() {
+	case reflect.Array, reflect.Slice:
+		if step.index < 0 || step.index >= current.Len() {
+			return reflect.Value{}, false, fmt.Errorf("array index out of bounds, got index %d, while array size is %d", step.index, current.Len())
+		}
+		return current.Index(step.index), true, nil
+	case reflect.Map:
+		if value, found, handled := fastAccessDirectMapIndex(current, step); handled {
+			return value, found, nil
+		}
+		key, ok := fastRuntimeMapKeyValue(current.Type().Key(), step)
+		if !ok {
+			return reflect.Value{}, false, nil
+		}
+		value := current.MapIndex(key)
+		if !value.IsValid() {
+			return reflect.Value{}, false, nil
+		}
+		return value, true, nil
+	default:
+		return reflect.Value{}, false, nil
+	}
+}
+
+func fastAccessDirectMapIndex(current reflect.Value, step *fastAccessChainStep) (reflect.Value, bool, bool) {
+	if step == nil || step.mapDirect == fastMapDirectNone || !current.IsValid() || current.Kind() != reflect.Map || !current.CanInterface() {
+		return reflect.Value{}, false, false
+	}
+	key := step.mapString
+	switch step.mapDirect {
+	case fastMapDirectStringString:
+		m, ok := current.Interface().(map[string]string)
+		if !ok {
+			return reflect.Value{}, false, false
+		}
+		value, found := m[key]
+		if !found {
+			return reflect.Value{}, false, true
+		}
+		return reflect.ValueOf(value), true, true
+	case fastMapDirectStringInt:
+		m, ok := current.Interface().(map[string]int)
+		if !ok {
+			return reflect.Value{}, false, false
+		}
+		value, found := m[key]
+		if !found {
+			return reflect.Value{}, false, true
+		}
+		return reflect.ValueOf(value), true, true
+	case fastMapDirectStringUint32:
+		m, ok := current.Interface().(map[string]uint32)
+		if !ok {
+			return reflect.Value{}, false, false
+		}
+		value, found := m[key]
+		if !found {
+			return reflect.Value{}, false, true
+		}
+		return reflect.ValueOf(value), true, true
+	case fastMapDirectStringInterface:
+		m, ok := current.Interface().(map[string]interface{})
+		if !ok {
+			return reflect.Value{}, false, false
+		}
+		value, found := m[key]
+		if !found {
+			return reflect.Value{}, false, true
+		}
+		if value == nil {
+			return reflect.Zero(emptyInterfaceType), true, true
+		}
+		return reflect.ValueOf(value), true, true
+	default:
+		return reflect.Value{}, false, false
+	}
+}
+
+func writeFastDirectMapIndexOutput(out *strings.Builder, ctx hctx.Context, current reflect.Value, step *fastAccessChainStep) (bool, error) {
+	if step == nil || step.mapDirect == fastMapDirectNone || !current.IsValid() || current.Kind() != reflect.Map || !current.CanInterface() {
+		return false, nil
+	}
+	key := step.mapString
+	switch step.mapDirect {
+	case fastMapDirectStringString:
+		m, ok := current.Interface().(map[string]string)
+		if !ok {
+			return false, nil
+		}
+		value, found := m[key]
+		if found {
+			writeFastEscapedString(out, value)
+		}
+		return true, nil
+	case fastMapDirectStringInt:
+		m, ok := current.Interface().(map[string]int)
+		if !ok {
+			return false, nil
+		}
+		value, found := m[key]
+		if found {
+			writeBuilderFastInt(out, int64(value))
+		}
+		return true, nil
+	case fastMapDirectStringUint32:
+		m, ok := current.Interface().(map[string]uint32)
+		if !ok {
+			return false, nil
+		}
+		value, found := m[key]
+		if found {
+			writeBuilderFastUint(out, uint64(value))
+		}
+		return true, nil
+	case fastMapDirectStringInterface:
+		m, ok := current.Interface().(map[string]interface{})
+		if !ok {
+			return false, nil
+		}
+		value, found := m[key]
+		if found {
+			writeFastGoValue(out, ctx, value)
+		}
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+func fastAccessIntermediateValue(value reflect.Value, step *fastAccessChainStep) (reflect.Value, bool, error) {
+	value = unwrapFastFieldChainValue(value)
+	if !value.IsValid() {
+		return reflect.Value{}, false, nil
+	}
+	if !value.CanInterface() {
+		return reflect.Value{}, false, fastLineError(step.line, fieldAccessError(step.receiver, step.full, step.name))
+	}
+	return value, true, nil
+}
+
+func fastReflectInterface(value reflect.Value) interface{} {
+	if !value.IsValid() || isNilReflectValue(value) {
+		return nil
+	}
+	if value.Kind() == reflect.Interface {
+		value = value.Elem()
+	}
+	if !value.CanInterface() {
+		return nil
+	}
+	return value.Interface()
+}
+
+func writeFastReflectValue(out *strings.Builder, ctx hctx.Context, value reflect.Value) error {
+	value = unwrapFastFieldChainValue(value)
+	if !value.IsValid() || isNilReflectValue(value) {
+		return nil
+	}
+	if value.Kind() == reflect.Interface {
+		value = value.Elem()
+	}
+	if !value.CanInterface() {
+		return nil
+	}
+	if value.Type() == templateHTMLType {
+		out.WriteString(value.String())
+		return nil
+	}
+	if value.Type().Implements(objectInterfaceType) {
+		if obj, ok := value.Interface().(object.Object); ok {
+			writeFastObject(out, ctx, obj)
+			return nil
+		}
+	}
+	if value.Type().PkgPath() == "" {
+		switch value.Kind() {
+		case reflect.String:
+			writeFastEscapedString(out, value.String())
+			return nil
+		case reflect.Bool:
+			out.WriteString(strconv.FormatBool(value.Bool()))
+			return nil
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			writeBuilderFastInt(out, value.Int())
+			return nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+			writeBuilderFastUint(out, value.Uint())
+			return nil
+		case reflect.Float32, reflect.Float64:
+			writeBuilderFastFloat(out, value.Float(), int(value.Type().Bits()))
+			return nil
+		}
+	}
+	raw := value.Interface()
+	writeFastGoValue(out, ctx, raw)
+	return nil
+}
+
+func unwrapReflectType(rt reflect.Type) reflect.Type {
+	for rt.Kind() == reflect.Ptr {
+		rt = rt.Elem()
+	}
+	return rt
+}
+
+func fieldAccessError(receiver, full, name string) error {
+	if receiver != "" && full != "" {
+		return fmt.Errorf("'%s'cannot return value obtained from unexported field or method '%s' (%s)", receiver, name, full)
+	}
+	return fmt.Errorf("cannot return value obtained from unexported field or method '%s'", name)
+}
+
+func evalFastPathStep(base interface{}, step *compiler.FastPathStep, ctx hctx.Context) (interface{}, error) {
+	switch step.Kind {
+	case compiler.FastPathStepProperty:
+		if err := spendFastTraversal(ctx, step.Line); err != nil {
+			return nil, err
+		}
+		value, err := fastPropertyValue(base, step.Value, object.PropertyAccess{
+			Receiver: step.Receiver,
+			Full:     step.Full,
+			Method:   step.Method,
+		}, &step.PropertyCache)
+		if err != nil {
+			return nil, fastLineError(step.Line, err)
+		}
+		return value, nil
+	case compiler.FastPathStepIndexInteger:
+		value, err := fastIndexValue(base, step.Index)
+		if err != nil {
+			return nil, fastLineError(step.Line, err)
+		}
+		return value, nil
+	case compiler.FastPathStepIndexString:
+		value, err := fastStringIndexValue(base, step.Value)
+		if err != nil {
+			return nil, fastLineError(step.Line, err)
+		}
+		return value, nil
+	case compiler.FastPathStepCall:
+		if err := spendFastFunctionCall(ctx, step.Value, step.Line); err != nil {
+			return nil, err
+		}
+		value, err := fastCallValue(step.Value, base, nil, ctx, &step.CallCache)
+		if err != nil {
+			return nil, fastLineError(step.Line, err)
+		}
+		return value, nil
+	default:
+		return nil, nil
+	}
+}
+
+func fastIndexValue(left interface{}, index int) (interface{}, error) {
+	if obj, ok := left.(object.Object); ok {
+		switch obj := obj.(type) {
+		case *object.Array:
+			if index < 0 || index >= len(obj.Elements) {
+				return nil, nil
+			}
+			return obj.Elements[index], nil
+		case *object.Hash:
+			key := (&object.Integer{Value: int64(index)}).HashKey()
+			if pair, ok := obj.Pairs[key]; ok {
+				return pair.Value, nil
+			}
+			return nil, nil
+		default:
+			left = object.ToGo(obj)
+		}
+	}
+	if left == nil {
+		return nil, nil
+	}
+	rv := reflect.ValueOf(left)
+	if rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			return nil, nil
+		}
+		rv = rv.Elem()
+	}
+	switch rv.Kind() {
+	case reflect.Array, reflect.Slice:
+		if index < 0 || index >= rv.Len() {
+			return nil, fmt.Errorf("array index out of bounds, got index %d, while array size is %d", index, rv.Len())
+		}
+		return rv.Index(index).Interface(), nil
+	case reflect.Map:
+		key := reflect.ValueOf(index)
+		if key.Type() != rv.Type().Key() {
+			if key.Type().ConvertibleTo(rv.Type().Key()) {
+				key = key.Convert(rv.Type().Key())
+			} else if rv.Type().Key().Kind() != reflect.Interface {
+				return nil, fmt.Errorf("cannot use %v (%s constant) as %s value in map index", index, key.Kind().String(), rv.Type().Key().Kind().String())
+			}
+		}
+		val := rv.MapIndex(key)
+		if !val.IsValid() {
+			return nil, nil
+		}
+		return val.Interface(), nil
+	default:
+		return nil, fmt.Errorf("could not index %T with %T", left, index)
+	}
+}
+
+func fastStringIndexValue(left interface{}, index string) (interface{}, error) {
+	if obj, ok := left.(object.Object); ok {
+		switch obj := obj.(type) {
+		case *object.Hash:
+			key := (&object.String{Value: index}).HashKey()
+			if pair, ok := obj.Pairs[key]; ok {
+				return pair.Value, nil
+			}
+			return nil, nil
+		default:
+			left = object.ToGo(obj)
+		}
+	}
+	if left == nil {
+		return nil, nil
+	}
+	rv := reflect.ValueOf(left)
+	if rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			return nil, nil
+		}
+		rv = rv.Elem()
+	}
+	switch rv.Kind() {
+	case reflect.Map:
+		key := reflect.ValueOf(index)
+		if key.Type() != rv.Type().Key() {
+			if key.Type().ConvertibleTo(rv.Type().Key()) {
+				key = key.Convert(rv.Type().Key())
+			} else if rv.Type().Key().Kind() != reflect.Interface {
+				return nil, fmt.Errorf("cannot use %v (%s constant) as %s value in map index", index, key.Kind().String(), rv.Type().Key().Kind().String())
+			}
+		}
+		val := rv.MapIndex(key)
+		if !val.IsValid() {
+			return nil, nil
+		}
+		return val.Interface(), nil
+	case reflect.Array, reflect.Slice:
+		return nil, fmt.Errorf("can't access Slice/Array with a non int Index (%v)", index)
+	default:
+		return nil, fmt.Errorf("could not index %T with %T", left, index)
+	}
+}

--- a/VM/vm/frame.go
+++ b/VM/vm/frame.go
@@ -1,0 +1,43 @@
+package vm
+
+import (
+	"strings"
+
+	"github.com/gobuffalo/plush/v5/VM/code"
+	"github.com/gobuffalo/plush/v5/VM/object"
+)
+
+type Frame struct {
+	cl            *object.Closure
+	ip            int
+	basePointer   int
+	output        strings.Builder
+	hasOutput     bool
+	block         *object.Closure
+	pooled        bool
+	writeReturn   bool
+	calleeOnStack bool
+}
+
+func NewFrame(cl *object.Closure, basePointer int) *Frame {
+	return &Frame{
+		cl:          cl,
+		ip:          -1,
+		basePointer: basePointer,
+	}
+}
+
+func (f *Frame) reset(cl *object.Closure, basePointer int) {
+	f.cl = cl
+	f.ip = -1
+	f.basePointer = basePointer
+	f.output.Reset()
+	f.hasOutput = false
+	f.block = nil
+	f.writeReturn = false
+	f.calleeOnStack = false
+}
+
+func (f *Frame) Instructions() code.Instructions {
+	return f.cl.Fn.Instructions
+}

--- a/VM/vm/interpreter_fallback_test.go
+++ b/VM/vm/interpreter_fallback_test.go
@@ -1,0 +1,57 @@
+package vm
+
+import (
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Render_Interpreter_Fallback_With_Partial_Overlay_Context(t *testing.T) {
+	parent := plush.NewContext()
+	parent.Set("partial", vmPartialHelper)
+
+	ctx := newPartialOverlayContext(parent)
+	ctx.Set("show", true)
+	require.True(t, ctx.Has("show"))
+	require.Equal(t, true, ctx.Value("show"))
+
+	out, err := renderInterpreterFallback(`<%= if (show) { %>Mido<% } %>`, ctx, "partial.plush.html")
+	require.NoError(t, err)
+	require.Equal(t, "Mido", out)
+}
+
+func Test_VM_Partial_Helper_Delegates_During_Interpreter_Render(t *testing.T) {
+	ctx := plush.NewContext()
+	ctx.Set("partial", vmPartialHelper)
+	ctx.Set("partialFeeder", func(name string) (string, error) {
+		require.Equal(t, "row.plush", name)
+		return `<% let title = "Row" %><%= title %>`, nil
+	})
+	plush.SetRenderDiagnostics(ctx, plush.RenderDiagnostics{})
+
+	out, err := plush.RenderInterpreter(`<%= partial("row.plush", {}) %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "Row", out)
+
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Zero(t, diagnostics.VMHotspots.PartialCalls)
+}
+
+func Test_VM_Partial_Helper_Interpreter_Render_With_Overlay_If(t *testing.T) {
+	parent := plush.NewContext()
+	parent.Set("partial", vmPartialHelper)
+	parent.Set("partialFeeder", func(name string) (string, error) {
+		require.Equal(t, "row.plush", name)
+		return `<%= if (show) { %><%= name %><% } else { %>Hidden<% } %>`, nil
+	})
+
+	ctx := newPartialOverlayContext(parent)
+	ctx.Set("show", true)
+	ctx.Set("name", "Mido")
+
+	out, err := plush.RenderInterpreter(`<%= partial("row.plush", {}) %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "Mido", out)
+}

--- a/VM/vm/loops_context.go
+++ b/VM/vm/loops_context.go
@@ -1,0 +1,835 @@
+package vm
+
+import (
+	"fmt"
+	"html/template"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/gobuffalo/plush/v5/VM/code"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+)
+
+func (vm *VM) executeFor(iterable object.Object, block *object.Closure, keyName, valueName string) (object.Object, error) {
+	writeLoopContext := loopNeedsContextWrites(block)
+	oldCtx := vm.ctx
+	loopCtx := vm.ctx
+	if writeLoopContext && vm.ctx != nil {
+		loopCtx = vm.ctx.New()
+		vm.ctx = loopCtx
+		defer func() { vm.ctx = oldCtx }()
+	}
+
+	ret := []object.Object{}
+	iter := object.ToGo(iterable)
+	if iter == nil {
+		return &object.Array{Elements: ret}, nil
+	}
+
+	child := vm.childVM(block, nil, loopCtx)
+	defer child.Release()
+	child.deferHolePositions = true
+	rawLoopValues := loopCanUseRawValues(block)
+
+	run := func(key, value object.Object) (bool, error) {
+		if err := vm.spendLoop(); err != nil {
+			return false, err
+		}
+		if writeLoopContext && loopCtx != nil {
+			loopCtx.Set(keyName, object.ToGo(key))
+			loopCtx.Set(valueName, object.ToGo(value))
+		}
+		child.resetChild(block, []object.Object{key, value}, loopCtx)
+		if err := child.Run(); err != nil {
+			return false, child.wrapRuntimeError(err)
+		}
+		result := child.lastPopped
+		if result == nil {
+			result = child.frameOutputObject(child.frames[0])
+		}
+		if control, ok := result.(*object.Control); ok {
+			ret = append(ret, control.Value...)
+			return control.Kind == object.ControlBreak, nil
+		}
+		if !object.IsNull(result) {
+			ret = append(ret, result)
+		}
+		return false, nil
+	}
+
+	switch iter := iter.(type) {
+	case []string:
+		ret = make([]object.Object, 0, len(iter))
+		for i, value := range iter {
+			var keyObj, valueObj object.Object
+			if rawLoopValues {
+				keyObj, valueObj = loopObjects(i, value, true)
+			} else {
+				keyObj, valueObj = &object.Integer{Value: int64(i)}, &object.String{Value: value}
+			}
+			stop, err := run(keyObj, valueObj)
+			if err != nil || stop {
+				return &object.Array{Elements: ret}, err
+			}
+		}
+		return &object.Array{Elements: ret}, nil
+	case []interface{}:
+		ret = make([]object.Object, 0, len(iter))
+		for i, value := range iter {
+			var keyObj, valueObj object.Object
+			if rawLoopValues {
+				keyObj, valueObj = loopObjects(i, value, true)
+			} else {
+				keyObj, valueObj = &object.Integer{Value: int64(i)}, object.Wrap(value)
+			}
+			stop, err := run(keyObj, valueObj)
+			if err != nil || stop {
+				return &object.Array{Elements: ret}, err
+			}
+		}
+		return &object.Array{Elements: ret}, nil
+	case []object.Object:
+		ret = make([]object.Object, 0, len(iter))
+		for i, value := range iter {
+			stop, err := run(&object.Integer{Value: int64(i)}, value)
+			if err != nil || stop {
+				return &object.Array{Elements: ret}, err
+			}
+		}
+		return &object.Array{Elements: ret}, nil
+	}
+
+	rv := reflect.ValueOf(iter)
+	if rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			return &object.Array{Elements: ret}, nil
+		}
+		rv = rv.Elem()
+	}
+	switch rv.Kind() {
+	case reflect.Map, reflect.Array, reflect.Slice:
+		ret = make([]object.Object, 0, rv.Len())
+	}
+	switch rv.Kind() {
+	case reflect.Map:
+		keys := rv.MapKeys()
+		for _, key := range keys {
+			rawKey := key.Interface()
+			rawValue := rv.MapIndex(key).Interface()
+			keyObj, valueObj := loopObjects(rawKey, rawValue, rawLoopValues)
+			stop, err := run(keyObj, valueObj)
+			if err != nil || stop {
+				return &object.Array{Elements: ret}, err
+			}
+		}
+	case reflect.Array, reflect.Slice:
+		for i := 0; i < rv.Len(); i++ {
+			rawValue := rv.Index(i).Interface()
+			var keyObj, valueObj object.Object
+			if rawLoopValues {
+				keyObj, valueObj = loopObjects(i, rawValue, true)
+			} else {
+				keyObj, valueObj = &object.Integer{Value: int64(i)}, object.Wrap(rawValue)
+			}
+			stop, err := run(keyObj, valueObj)
+			if err != nil || stop {
+				return &object.Array{Elements: ret}, err
+			}
+		}
+	default:
+		if iterator, ok := iter.(interface{ Next() interface{} }); ok {
+			i := 0
+			for next := iterator.Next(); next != nil; next = iterator.Next() {
+				var keyObj, valueObj object.Object
+				if rawLoopValues {
+					keyObj, valueObj = loopObjects(i, next, true)
+				} else {
+					keyObj, valueObj = &object.Integer{Value: int64(i)}, object.Wrap(next)
+				}
+				stop, err := run(keyObj, valueObj)
+				if err != nil || stop {
+					return &object.Array{Elements: ret}, err
+				}
+				i++
+			}
+		} else {
+			return nil, fmt.Errorf("could not iterate over %T", iter)
+		}
+	}
+
+	return &object.Array{Elements: ret}, nil
+}
+
+func loopObjects(key, value interface{}, raw bool) (object.Object, object.Object) {
+	if raw {
+		return rawLoopObject(key), rawLoopObject(value)
+	}
+	return object.Wrap(key), object.Wrap(value)
+}
+
+func rawLoopObject(value interface{}) object.Object {
+	if obj, ok := value.(object.Object); ok {
+		return obj
+	}
+	if value == nil {
+		return Null
+	}
+	return &object.Native{Value: value}
+}
+
+func loopCanUseRawValues(block *object.Closure) bool {
+	if block == nil || block.Fn == nil {
+		return false
+	}
+	hasLocalPropertyWrite := false
+	ins := block.Fn.Instructions
+	for i := 0; i < len(ins); {
+		op := code.Opcode(ins[i])
+		if op == code.OpWriteLocalProperty {
+			hasLocalPropertyWrite = true
+		}
+		switch op {
+		case code.OpWriteLocal, code.OpWriteLocalProperty,
+			code.OpWriteConstant, code.OpWriteString, code.OpWriteHTML,
+			code.OpNull, code.OpPop, code.OpReturn, code.OpReturnValue,
+			code.OpJump, code.OpBreak, code.OpContinue:
+		default:
+			return false
+		}
+
+		def, _ := code.Lookup(byte(op))
+		_, read := code.ReadOperands(def, ins[i+1:])
+		i += 1 + read
+	}
+	return hasLocalPropertyWrite
+}
+
+func loopNeedsContextWrites(block *object.Closure) bool {
+	if block == nil || block.Fn == nil {
+		return true
+	}
+	ins := block.Fn.Instructions
+	for i := 0; i < len(ins); {
+		op := code.Opcode(ins[i])
+		switch op {
+		case code.OpGetName, code.OpGetNameOrNull, code.OpSetName, code.OpAssignName,
+			code.OpWriteName, code.OpWriteNameOrNull, code.OpWriteNameProperty,
+			code.OpWriteGlobalProperty,
+			code.OpCall, code.OpWriteCall, code.OpWriteNameCall, code.OpCallBlock, code.OpRenderTemplate, code.OpHole:
+			return true
+		}
+
+		def, err := code.Lookup(byte(op))
+		if err != nil {
+			i++
+			continue
+		}
+		_, read := code.ReadOperands(def, ins[i+1:])
+		i += 1 + read
+	}
+	return false
+}
+
+func (vm *VM) pushName(nameIndex int) error {
+	name := vm.stringConstant(nameIndex)
+	if name == "nil" {
+		return vm.push(Null)
+	}
+	if value, ok := vm.contextValue(name); ok {
+		return vm.push(object.Wrap(value))
+	}
+	return fmt.Errorf("%q: unknown identifier", name)
+}
+
+func (vm *VM) pushNameOrNull(nameIndex int) error {
+	name := vm.stringConstant(nameIndex)
+	if name == "nil" {
+		return vm.push(Null)
+	}
+	if value, ok := vm.contextValue(name); ok {
+		return vm.push(object.Wrap(value))
+	}
+	return vm.push(Null)
+}
+
+func (vm *VM) contextValue(name string) (interface{}, bool) {
+	if vm.ctx == nil {
+		return nil, false
+	}
+	if lookup, ok := vm.ctx.(contextLookup); ok {
+		return lookup.Lookup(name)
+	}
+	if vm.ctx.Has(name) {
+		return vm.ctx.Value(name), true
+	}
+	return nil, false
+}
+
+func (vm *VM) contextValueByNameIndex(nameIndex int) (interface{}, bool) {
+	if vm.ctx == nil {
+		return nil, false
+	}
+	if lookup, ok := vm.ctx.(contextIDLookup); ok {
+		id := vm.contextNameID(lookup, nameIndex)
+		return lookup.LookupID(id)
+	}
+	return vm.contextValue(vm.stringConstant(nameIndex))
+}
+
+func (vm *VM) contextNameID(lookup contextIDLookup, nameIndex int) int {
+	name := vm.stringConstant(nameIndex)
+	for i := 0; i < vm.nameIDCacheLen; i++ {
+		if vm.nameIDCache[i].name == name {
+			return vm.nameIDCache[i].id
+		}
+	}
+	for _, entry := range vm.nameIDOverflow {
+		if entry.name == name {
+			return entry.id
+		}
+	}
+
+	id := lookup.InternID(name)
+	entry := nameIDEntry{name: name, id: id}
+	if vm.nameIDCacheLen < len(vm.nameIDCache) {
+		vm.nameIDCache[vm.nameIDCacheLen] = entry
+		vm.nameIDCacheLen++
+	} else {
+		vm.nameIDOverflow = append(vm.nameIDOverflow, entry)
+	}
+	return id
+}
+
+func (vm *VM) clearNameIDCache() {
+	for i := 0; i < vm.nameIDCacheLen; i++ {
+		vm.nameIDCache[i] = nameIDEntry{}
+	}
+	vm.nameIDCacheLen = 0
+	if len(vm.nameIDOverflow) > 0 {
+		clear(vm.nameIDOverflow)
+		vm.nameIDOverflow = vm.nameIDOverflow[:0]
+	}
+}
+
+func (vm *VM) setName(nameIndex int, value object.Object) {
+	if vm.ctx != nil {
+		raw := object.ToGo(value)
+		if lookup, ok := vm.ctx.(contextIDLookup); ok {
+			lookup.SetID(vm.contextNameID(lookup, nameIndex), raw)
+			return
+		}
+		vm.ctx.Set(vm.stringConstant(nameIndex), raw)
+	}
+}
+
+func (vm *VM) writeConstant(frame *Frame, constIndex int) {
+	if constIndex < 0 || constIndex >= len(vm.constants) {
+		return
+	}
+	vm.writeFrameOutput(frame, vm.constants[constIndex])
+}
+
+func (vm *VM) writeStringConstant(frame *Frame, constIndex int) {
+	if frame == nil {
+		return
+	}
+	frame.hasOutput = true
+	frame.output.WriteString(template.HTMLEscapeString(vm.stringConstant(constIndex)))
+}
+
+func (vm *VM) writeHTMLConstant(frame *Frame, constIndex int) {
+	if frame == nil {
+		return
+	}
+	frame.hasOutput = true
+	frame.output.WriteString(vm.htmlConstantString(constIndex))
+}
+
+func (vm *VM) writeName(frame *Frame, nameIndex int, nullOnMissing bool) error {
+	name := vm.stringConstant(nameIndex)
+	if name == "nil" {
+		return nil
+	}
+	value, ok := vm.contextValueByNameIndex(nameIndex)
+	if !ok {
+		if nullOnMissing {
+			return nil
+		}
+		return fmt.Errorf("%q: unknown identifier", name)
+	}
+	if frame == nil {
+		return nil
+	}
+	frame.hasOutput = true
+	writeFastGoValue(&frame.output, vm.ctx, value)
+	return nil
+}
+
+func (vm *VM) writeGlobal(frame *Frame, globalIndex int) {
+	value := vm.globalValue(globalIndex)
+	if value != nil {
+		vm.writeFrameOutput(frame, value)
+		return
+	}
+	name, ok := vm.globalNames[globalIndex]
+	if !ok {
+		return
+	}
+	if raw, ok := vm.contextValue(name); ok {
+		if frame == nil {
+			return
+		}
+		frame.hasOutput = true
+		vm.writeGoValue(&frame.output, raw)
+	}
+}
+
+func (vm *VM) writeLocalProperty(frame *Frame, localIndex, propertyNameIndex, ip int) error {
+	if frame == nil {
+		return nil
+	}
+	stackIndex := frame.basePointer + localIndex
+	if stackIndex < 0 || stackIndex >= len(vm.stack) {
+		return nil
+	}
+	return vm.writePropertyValue(frame, vm.stack[stackIndex], propertyNameIndex, ip)
+}
+
+func (vm *VM) writeGlobalProperty(frame *Frame, globalIndex, propertyNameIndex, ip int) error {
+	value := vm.globalValue(globalIndex)
+	if value != nil {
+		return vm.writePropertyValue(frame, value, propertyNameIndex, ip)
+	}
+	name, ok := vm.globalNames[globalIndex]
+	if !ok {
+		return nil
+	}
+	raw, ok := vm.contextValue(name)
+	if !ok {
+		return nil
+	}
+	return vm.writePropertyValue(frame, raw, propertyNameIndex, ip)
+}
+
+func (vm *VM) writeNameProperty(frame *Frame, baseNameIndex, propertyNameIndex, ip int) error {
+	name := vm.stringConstant(baseNameIndex)
+	if name == "nil" {
+		return nil
+	}
+	value, ok := vm.contextValueByNameIndex(baseNameIndex)
+	if !ok {
+		return fmt.Errorf("%q: unknown identifier", name)
+	}
+	return vm.writePropertyValue(frame, value, propertyNameIndex, ip)
+}
+
+func (vm *VM) writePropertyValue(frame *Frame, base interface{}, propertyNameIndex, ip int) error {
+	if frame == nil {
+		return nil
+	}
+	if err := vm.spendTraversal(1); err != nil {
+		return err
+	}
+	propertyName := vm.stringConstant(propertyNameIndex)
+	value, err := vm.propertyValue(base, propertyName, vm.currentPropertyAccess(ip), vm.currentPropertyCacheSlot(ip))
+	if err != nil {
+		return err
+	}
+	frame.hasOutput = true
+	vm.writeGoValue(&frame.output, value)
+	return nil
+}
+
+func (vm *VM) assignName(nameIndex int, value object.Object) error {
+	if err := vm.spendAssignment(); err != nil {
+		return err
+	}
+	name := vm.stringConstant(nameIndex)
+	if vm.ctx != nil {
+		raw := object.ToGo(value)
+		if lookup, ok := vm.ctx.(contextIDLookup); ok {
+			if lookup.UpdateID(vm.contextNameID(lookup, nameIndex), raw) {
+				return nil
+			}
+		} else if vm.ctx.Update(name, raw) {
+			return nil
+		}
+	}
+	return fmt.Errorf("%q: unknown identifier", name)
+}
+
+func (vm *VM) updateNamedGlobal(globalIndex int, value object.Object) {
+	name, ok := vm.globalNames[globalIndex]
+	if !ok || vm.ctx == nil {
+		return
+	}
+	vm.ctx.Set(name, object.ToGo(value))
+}
+
+func (vm *VM) globalFromContext(globalIndex int) object.Object {
+	name, ok := vm.globalNames[globalIndex]
+	if !ok {
+		return nil
+	}
+	value, ok := vm.contextValue(name)
+	if !ok {
+		return nil
+	}
+	return object.Wrap(value)
+}
+
+func (vm *VM) getProperty(obj object.Object, name string, access object.PropertyAccess, cacheSlot *object.InlineCacheSlot) error {
+	if err := vm.spendTraversal(1); err != nil {
+		return err
+	}
+
+	if hash, ok := obj.(*object.Hash); ok {
+		key := (&object.String{Value: name}).HashKey()
+		if pair, ok := hash.Pairs[key]; ok {
+			return vm.push(pair.Value)
+		}
+		return vm.push(Null)
+	}
+
+	raw := object.ToGo(obj)
+	if raw == nil {
+		return vm.push(Null)
+	}
+
+	rv := reflect.ValueOf(raw)
+	if rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			return vm.push(Null)
+		}
+		rv = rv.Elem()
+	}
+
+	lookup := inlinePropertyLookup(cacheSlot, rv.Type(), name)
+	switch lookup.kind {
+	case propertyLookupValueMethod:
+		method := rv.Method(lookup.index)
+		if method.IsValid() {
+			return vm.push(object.Wrap(method.Interface()))
+		}
+	case propertyLookupPointerMethod:
+		var method reflect.Value
+		if rv.CanAddr() {
+			method = rv.Addr().Method(lookup.index)
+		} else {
+			ptr := reflect.New(rv.Type())
+			ptr.Elem().Set(rv)
+			method = ptr.Method(lookup.index)
+		}
+		if method.IsValid() {
+			return vm.push(object.Wrap(method.Interface()))
+		}
+	case propertyLookupField:
+		if access.Method {
+			return propertyMissingError(access, raw, name)
+		}
+		field := rv.FieldByIndex(lookup.fieldIndex)
+		return vm.pushField(field, access, name)
+	}
+
+	if access.Method || rv.Kind() != reflect.Struct {
+		return propertyMissingError(access, raw, name)
+	}
+
+	return propertyMissingError(access, raw, name)
+}
+
+func (vm *VM) propertyValue(base interface{}, name string, access object.PropertyAccess, cacheSlot *object.InlineCacheSlot) (interface{}, error) {
+	if hash, ok := base.(*object.Hash); ok {
+		key := (&object.String{Value: name}).HashKey()
+		if pair, ok := hash.Pairs[key]; ok {
+			return pair.Value, nil
+		}
+		return nil, nil
+	}
+
+	if obj, ok := base.(object.Object); ok {
+		if object.IsNull(obj) {
+			return nil, nil
+		}
+		base = object.ToGo(obj)
+	}
+
+	if base == nil {
+		return nil, nil
+	}
+
+	rv := reflect.ValueOf(base)
+	if rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			return nil, nil
+		}
+		rv = rv.Elem()
+	}
+
+	lookup := inlinePropertyLookup(cacheSlot, rv.Type(), name)
+	switch lookup.kind {
+	case propertyLookupValueMethod:
+		method := rv.Method(lookup.index)
+		if method.IsValid() {
+			return method.Interface(), nil
+		}
+	case propertyLookupPointerMethod:
+		var method reflect.Value
+		if rv.CanAddr() {
+			method = rv.Addr().Method(lookup.index)
+		} else {
+			ptr := reflect.New(rv.Type())
+			ptr.Elem().Set(rv)
+			method = ptr.Method(lookup.index)
+		}
+		if method.IsValid() {
+			return method.Interface(), nil
+		}
+	case propertyLookupField:
+		if access.Method {
+			return nil, propertyMissingError(access, base, name)
+		}
+		field := rv.FieldByIndex(lookup.fieldIndex)
+		return vm.fieldValue(field, access, name)
+	}
+
+	if access.Method || rv.Kind() != reflect.Struct {
+		return nil, propertyMissingError(access, base, name)
+	}
+
+	return nil, propertyMissingError(access, base, name)
+}
+
+func inlinePropertyLookup(slot *object.InlineCacheSlot, rt reflect.Type, name string) propertyLookup {
+	return inlinePropertyEntry(slot, rt, name).lookup
+}
+
+func inlinePropertyEntry(slot *object.InlineCacheSlot, rt reflect.Type, name string) *propertyInlineCacheEntry {
+	if slot == nil {
+		lookup := cachedPropertyLookup(rt, name)
+		return newPropertyInlineCacheEntry(rt, lookup)
+	}
+
+	if cached, ok := slot.Load().(*propertyInlineCacheEntry); ok {
+		for entry := cached; entry != nil; entry = entry.next {
+			if entry.typ == rt {
+				return entry
+			}
+		}
+	}
+
+	lookup := cachedPropertyLookup(rt, name)
+	current, _ := slot.Load().(*propertyInlineCacheEntry)
+	entry := newPropertyInlineCacheEntry(rt, lookup)
+	entry.next = clonePropertyInlineCache(current, propertyInlineCacheDepth-1)
+	slot.Store(entry)
+	return entry
+}
+
+func newPropertyInlineCacheEntry(rt reflect.Type, lookup propertyLookup) *propertyInlineCacheEntry {
+	return &propertyInlineCacheEntry{
+		typ:    rt,
+		lookup: lookup,
+		reader: buildFastPropertyReader(lookup),
+		writer: buildFastPropertyWriter(rt, lookup),
+	}
+}
+
+func clonePropertyInlineCache(head *propertyInlineCacheEntry, limit int) *propertyInlineCacheEntry {
+	if head == nil || limit <= 0 {
+		return nil
+	}
+
+	clone := &propertyInlineCacheEntry{
+		typ:    head.typ,
+		lookup: head.lookup,
+		reader: head.reader,
+		writer: head.writer,
+	}
+	tail := clone
+	count := 1
+	for entry := head.next; entry != nil && count < limit; entry = entry.next {
+		tail.next = &propertyInlineCacheEntry{
+			typ:    entry.typ,
+			lookup: entry.lookup,
+			reader: entry.reader,
+			writer: entry.writer,
+		}
+		tail = tail.next
+		count++
+	}
+	return clone
+}
+
+func buildFastPropertyReader(lookup propertyLookup) fastPropertyReader {
+	switch lookup.kind {
+	case propertyLookupValueMethod:
+		return func(rv reflect.Value, access object.PropertyAccess, name string) (interface{}, error) {
+			return rv.Method(lookup.index).Interface(), nil
+		}
+	case propertyLookupPointerMethod:
+		return func(rv reflect.Value, access object.PropertyAccess, name string) (interface{}, error) {
+			var method reflect.Value
+			if rv.CanAddr() {
+				method = rv.Addr().Method(lookup.index)
+			} else {
+				ptr := reflect.New(rv.Type())
+				ptr.Elem().Set(rv)
+				method = ptr.Method(lookup.index)
+			}
+			return method.Interface(), nil
+		}
+	case propertyLookupField:
+		return func(rv reflect.Value, access object.PropertyAccess, name string) (interface{}, error) {
+			if access.Method {
+				return nil, propertyMissingError(access, rv.Interface(), name)
+			}
+			return fastFieldValue(rv.FieldByIndex(lookup.fieldIndex), access, name)
+		}
+	default:
+		return nil
+	}
+}
+
+func buildFastPropertyWriter(rt reflect.Type, lookup propertyLookup) fastPropertyWriter {
+	if lookup.kind != propertyLookupField {
+		return nil
+	}
+	field, ok := fieldByIndex(rt, lookup.fieldIndex)
+	if !ok {
+		return nil
+	}
+	return func(out *strings.Builder, ctx hctx.Context, rv reflect.Value, access object.PropertyAccess, name string) (bool, error) {
+		if access.Method {
+			return false, propertyMissingError(access, rv.Interface(), name)
+		}
+		return writeFastField(out, ctx, rv.FieldByIndex(lookup.fieldIndex), access, name, field.Type)
+	}
+}
+
+func fieldByIndex(rt reflect.Type, index []int) (reflect.StructField, bool) {
+	if rt.Kind() != reflect.Struct || len(index) == 0 {
+		return reflect.StructField{}, false
+	}
+	field := reflect.StructField{}
+	current := rt
+	for _, i := range index {
+		if current.Kind() == reflect.Ptr {
+			current = current.Elem()
+		}
+		if current.Kind() != reflect.Struct || i < 0 || i >= current.NumField() {
+			return reflect.StructField{}, false
+		}
+		field = current.Field(i)
+		current = field.Type
+	}
+	return field, true
+}
+
+func writeFastField(out *strings.Builder, ctx hctx.Context, field reflect.Value, access object.PropertyAccess, name string, fieldType reflect.Type) (bool, error) {
+	if field.Kind() == reflect.Ptr {
+		if field.IsNil() {
+			return true, nil
+		}
+		field = field.Elem()
+	}
+	if !field.CanInterface() {
+		if access.Receiver != "" && access.Full != "" {
+			return false, fmt.Errorf("'%s'cannot return value obtained from unexported field or method '%s' (%s)", access.Receiver, name, access.Full)
+		}
+		return false, fmt.Errorf("cannot return value obtained from unexported field or method '%s'", name)
+	}
+	if field.Type() == templateHTMLType {
+		out.WriteString(field.String())
+		return true, nil
+	}
+	if field.Type().PkgPath() != "" {
+		if stringer, ok := field.Interface().(fmt.Stringer); ok {
+			out.WriteString(stringer.String())
+			return true, nil
+		}
+	}
+	_ = fieldType
+	switch field.Kind() {
+	case reflect.String:
+		writeFastEscapedString(out, field.String())
+		return true, nil
+	case reflect.Bool:
+		out.WriteString(strconv.FormatBool(field.Bool()))
+		return true, nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		writeBuilderFastInt(out, field.Int())
+		return true, nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		writeBuilderFastUint(out, field.Uint())
+		return true, nil
+	case reflect.Float32, reflect.Float64:
+		writeBuilderFastFloat(out, field.Float(), int(field.Type().Bits()))
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+func cachedPropertyLookup(rt reflect.Type, name string) propertyLookup {
+	key := propertyLookupKey{typ: rt, name: name}
+	if lookup, ok := propertyLookupCache.Load(key); ok {
+		return lookup.(propertyLookup)
+	}
+
+	lookup := buildPropertyLookup(rt, name)
+	actual, _ := propertyLookupCache.LoadOrStore(key, lookup)
+	return actual.(propertyLookup)
+}
+
+func buildPropertyLookup(rt reflect.Type, name string) propertyLookup {
+	if method, ok := rt.MethodByName(name); ok {
+		return propertyLookup{kind: propertyLookupValueMethod, index: method.Index}
+	}
+	if method, ok := reflect.PtrTo(rt).MethodByName(name); ok {
+		return propertyLookup{kind: propertyLookupPointerMethod, index: method.Index}
+	}
+	if rt.Kind() == reflect.Struct {
+		if field, ok := rt.FieldByName(name); ok {
+			return propertyLookup{kind: propertyLookupField, fieldIndex: field.Index}
+		}
+	}
+	return propertyLookup{kind: propertyLookupMissing}
+}
+
+func (vm *VM) pushField(field reflect.Value, access object.PropertyAccess, name string) error {
+	value, err := vm.fieldValue(field, access, name)
+	if err != nil {
+		return err
+	}
+	return vm.push(object.Wrap(value))
+}
+
+func (vm *VM) fieldValue(field reflect.Value, access object.PropertyAccess, name string) (interface{}, error) {
+	if field.Kind() == reflect.Ptr {
+		if field.IsNil() {
+			return nil, nil
+		}
+		field = field.Elem()
+	}
+	if !field.CanInterface() {
+		if access.Receiver != "" && access.Full != "" {
+			return nil, fmt.Errorf("'%s'cannot return value obtained from unexported field or method '%s' (%s)", access.Receiver, name, access.Full)
+		}
+		return nil, fmt.Errorf("cannot return value obtained from unexported field or method '%s'", name)
+	}
+
+	return field.Interface(), nil
+}
+
+func propertyMissingError(access object.PropertyAccess, raw interface{}, name string) error {
+	if access.Receiver != "" && access.Full != "" {
+		if access.Method {
+			return fmt.Errorf("'%s' does not have a method named '%s' (%s)", access.Receiver, name, access.Full)
+		}
+		return fmt.Errorf("'%s' does not have a field or method named '%s' (%s)", access.Receiver, name, access.Full)
+	}
+	return fmt.Errorf("'%s' does not have a field or method named '%s'", fmt.Sprint(raw), name)
+}

--- a/VM/vm/native_calls.go
+++ b/VM/vm/native_calls.go
@@ -1,0 +1,689 @@
+package vm
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+)
+
+func writeFastCallValue(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs, cacheSlot *object.InlineCacheSlot) error {
+	if obj, ok := raw.(object.Object); ok {
+		raw = object.ToGo(obj)
+	}
+	rv := reflect.ValueOf(raw)
+	if !rv.IsValid() {
+		return fmt.Errorf("%T is an invalid function", raw)
+	}
+	if rv.Kind() != reflect.Func {
+		return fmt.Errorf("%+v (%T) is an invalid function", raw, raw)
+	}
+	entry := cachedFastCallEntry(rv.Type(), raw, cacheSlot)
+	return writeFastCallValueWithEntry(out, ctx, name, raw, args, entry)
+}
+
+func writeFastCallValueWithEntry(out *strings.Builder, ctx hctx.Context, name string, raw interface{}, args *fastCallArgs, entry *fastBuilderCallCacheEntry) error {
+	if entry == nil {
+		return fmt.Errorf("%+v (%T) is an invalid function", raw, raw)
+	}
+	if entry.invoker != nil {
+		start := time.Now()
+		if err := entry.invoker(out, ctx, name, raw, args); err != nil {
+			if !errors.Is(err, errFastWriteUnsupported) {
+				return err
+			}
+		} else {
+			plush.AddRenderDiagnosticVMHelperTiming(ctx, name, time.Since(start))
+			return nil
+		}
+	}
+	value, err := fastCallValueWithEntry(name, raw, args, ctx, entry)
+	if err != nil {
+		return err
+	}
+	writeFastGoValue(out, ctx, value)
+	return nil
+}
+
+func fastCallValue(name string, raw interface{}, args *fastCallArgs, ctx hctx.Context, cacheSlot *object.InlineCacheSlot) (interface{}, error) {
+	if obj, ok := raw.(object.Object); ok {
+		raw = object.ToGo(obj)
+	}
+	rv := reflect.ValueOf(raw)
+	if !rv.IsValid() {
+		return nil, fmt.Errorf("%T is an invalid function", raw)
+	}
+	if rv.Kind() != reflect.Func {
+		return nil, fmt.Errorf("%+v (%T) is an invalid function", raw, raw)
+	}
+	entry := cachedFastCallEntry(rv.Type(), raw, cacheSlot)
+	return fastCallValueWithEntry(name, raw, args, ctx, entry)
+}
+
+func fastCallValueWithEntry(name string, raw interface{}, args *fastCallArgs, ctx hctx.Context, entry *fastBuilderCallCacheEntry) (interface{}, error) {
+	rv := reflect.ValueOf(raw)
+	if entry == nil || entry.plan == nil {
+		return nil, fmt.Errorf("%+v (%T) is an invalid function", raw, raw)
+	}
+	helperStart := time.Now()
+	if value, handled, err := fastHelperContextCallValue(name, raw, args, ctx); handled || err != nil {
+		if handled {
+			plush.AddRenderDiagnosticVMHelperTiming(ctx, name, time.Since(helperStart))
+		}
+		return value, err
+	}
+	if entry.contextualValueInvoker != nil {
+		start := time.Now()
+		if value, err := entry.contextualValueInvoker(name, raw, args, ctx); err == nil {
+			plush.AddRenderDiagnosticVMHelperTiming(ctx, name, time.Since(start))
+			return value, nil
+		} else if !errors.Is(err, errFastWriteUnsupported) {
+			return nil, err
+		}
+	}
+	if entry.valueInvoker != nil {
+		start := time.Now()
+		if value, err := entry.valueInvoker(name, raw, args); err == nil {
+			plush.AddRenderDiagnosticVMHelperTiming(ctx, name, time.Since(start))
+			return value, nil
+		} else if !errors.Is(err, errFastWriteUnsupported) {
+			return nil, err
+		}
+	}
+	start := time.Now()
+	var scratch [4]reflect.Value
+	reflectArgs, err := fastReflectArgsInto(name, entry.plan, args, ctx, scratch[:0])
+	if err != nil {
+		return nil, err
+	}
+	res := rv.Call(reflectArgs)
+	plush.AddRenderDiagnosticVMHelperTiming(ctx, name, time.Since(start))
+	if len(res) == 0 {
+		return nil, nil
+	}
+	if err := lastReturnError(res); err != nil {
+		return nil, fmt.Errorf("could not call %s function: %w", name, err)
+	}
+	if isNilReflectValue(res[0]) {
+		return nil, nil
+	}
+	return res[0].Interface(), nil
+}
+
+func fastHelperContextCallValue(name string, raw interface{}, args *fastCallArgs, ctx hctx.Context) (interface{}, bool, error) {
+	if args.Len() != 0 {
+		return nil, false, nil
+	}
+	helperCtx := plush.NewHelperContext(ctx, nil)
+	switch fn := raw.(type) {
+	case func(plush.HelperContext) string:
+		return fn(helperCtx), true, nil
+	case func(hctx.HelperContext) string:
+		return fn(helperCtx), true, nil
+	case func(plush.HelperContext) (string, error):
+		value, err := fn(helperCtx)
+		if err != nil {
+			return nil, true, fmt.Errorf("could not call %s function: %w", name, err)
+		}
+		return value, true, nil
+	case func(hctx.HelperContext) (string, error):
+		value, err := fn(helperCtx)
+		if err != nil {
+			return nil, true, fmt.Errorf("could not call %s function: %w", name, err)
+		}
+		return value, true, nil
+	default:
+		return nil, false, nil
+	}
+}
+
+func cachedFastCallEntry(rt reflect.Type, raw interface{}, slot *object.InlineCacheSlot) *fastBuilderCallCacheEntry {
+	if slot != nil {
+		if cached, ok := slot.Load().(*fastBuilderCallCacheEntry); ok && cached != nil && cached.rt == rt {
+			return cached
+		}
+	}
+	entry := &fastBuilderCallCacheEntry{
+		rt:                     rt,
+		plan:                   cachedCallPlan(rt),
+		invoker:                writeFastBuilderInvokerForRaw(raw),
+		valueInvoker:           valueFastInvokerForRaw(raw),
+		contextualValueInvoker: contextualValueFastInvokerForRaw(raw),
+	}
+	if slot != nil {
+		slot.Store(entry)
+	}
+	return entry
+}
+
+func fastReflectArgsInto(name string, plan *callPlan, rawArgs *fastCallArgs, ctx hctx.Context, scratch []reflect.Value) ([]reflect.Value, error) {
+	numArgs := rawArgs.Len()
+	needed := plan.numIn
+	if plan.isVariadic && numArgs > needed {
+		needed = numArgs
+	}
+	args := scratch
+	if cap(args) < needed {
+		args = make([]reflect.Value, 0, needed)
+	} else {
+		args = args[:0]
+	}
+
+	if !plan.isVariadic && numArgs > plan.numIn {
+		return nil, fmt.Errorf("too many arguments (%d for %d)", numArgs, plan.numIn)
+	}
+	if plan.isVariadic && numArgs < plan.minArgs {
+		return nil, fmt.Errorf("too few arguments (%d for %d)", numArgs, plan.numIn)
+	}
+
+	fixed := numArgs
+	if plan.isVariadic {
+		fixed = plan.minArgs
+	}
+	for pos := 0; pos < fixed; pos++ {
+		arg, err := fastReflectArgForCall(name, pos, rawArgs.Raw(pos), plan.argTypes[pos])
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, arg)
+	}
+	if plan.isVariadic {
+		for pos := fixed; pos < numArgs; pos++ {
+			arg, err := fastReflectArgForCall(name, pos, rawArgs.Raw(pos), plan.variadicElem)
+			if err != nil {
+				return nil, err
+			}
+			args = append(args, arg)
+		}
+	} else if len(args) < plan.numIn {
+		for len(args) < plan.numIn {
+			arg, ok := fastOptionalArg(plan.optionalArgs[len(args)], plan.argTypes[len(args)], ctx)
+			if !ok {
+				break
+			}
+			args = append(args, arg)
+		}
+	}
+	if len(args) < plan.minArgs {
+		return nil, fmt.Errorf("too few arguments (%d for %d)", len(args), plan.numIn)
+	}
+	return args, nil
+}
+
+func fastReflectArgForCall(name string, pos int, raw interface{}, expected reflect.Type) (reflect.Value, error) {
+	if obj, ok := raw.(object.Object); ok {
+		if object.IsNull(obj) {
+			return reflect.New(expected).Elem(), nil
+		}
+		if value, ok := fastReflectArg(obj, expected); ok {
+			return value, nil
+		}
+		raw = object.ToGo(obj)
+	}
+	if raw == nil {
+		return reflect.New(expected).Elem(), nil
+	}
+	if value, ok := fastConvertibleValue(raw, expected); ok {
+		return value, nil
+	}
+	return reflect.Value{}, fmt.Errorf("%+v (%T) is an invalid argument for %s at pos %d: expected (%s)", raw, raw, name, pos, expected)
+}
+
+func fastOptionalArg(kind optionalArgKind, expected reflect.Type, ctx hctx.Context) (reflect.Value, bool) {
+	switch kind {
+	case optionalArgHelperContext:
+		hargs := plush.NewHelperContext(ctx, nil)
+		value := reflect.ValueOf(hargs)
+		if value.Type().AssignableTo(expected) {
+			return value, true
+		}
+		if value.Type().ConvertibleTo(expected) {
+			return value.Convert(expected), true
+		}
+	case optionalArgMap:
+		value := reflect.ValueOf(map[string]interface{}{})
+		if value.Type().AssignableTo(expected) {
+			return value, true
+		}
+	}
+	return reflect.Value{}, false
+}
+
+func isNilReflectValue(value reflect.Value) bool {
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+func (vm *VM) reflectArgs(name string, plan *callPlan, numArgs int, block *object.Closure, scratch []reflect.Value) ([]reflect.Value, error) {
+	rawArgs := vm.stack[vm.sp-numArgs : vm.sp]
+	needed := plan.numIn
+	if plan.isVariadic && numArgs > needed {
+		needed = numArgs
+	}
+	if cap(scratch) < needed {
+		scratch = make([]reflect.Value, 0, needed)
+	}
+	args := scratch[:0]
+
+	if !plan.isVariadic && numArgs > plan.numIn {
+		return nil, fmt.Errorf("too many arguments (%d for %d)", numArgs, plan.numIn)
+	}
+	if plan.isVariadic && numArgs < plan.minArgs {
+		return nil, fmt.Errorf("too few arguments (%d for %d)", numArgs, plan.numIn)
+	}
+
+	fixed := numArgs
+	if plan.isVariadic {
+		fixed = plan.minArgs
+	}
+
+	for pos := 0; pos < fixed; pos++ {
+		arg, err := vm.reflectArg(name, pos, rawArgs[pos], plan.argTypes[pos])
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, arg)
+	}
+
+	if plan.isVariadic {
+		for pos := fixed; pos < numArgs; pos++ {
+			arg, err := vm.reflectArg(name, pos, rawArgs[pos], plan.variadicElem)
+			if err != nil {
+				return nil, err
+			}
+			args = append(args, arg)
+		}
+	} else if len(args) < plan.numIn {
+		for len(args) < plan.numIn {
+			arg, ok := vm.optionalArg(plan.optionalArgs[len(args)], plan.argTypes[len(args)], block)
+			if !ok {
+				break
+			}
+			args = append(args, arg)
+		}
+	}
+
+	if len(args) < plan.minArgs {
+		return nil, fmt.Errorf("too few arguments (%d for %d)", len(args), plan.numIn)
+	}
+
+	return args, nil
+}
+
+func cachedCallPlanForSlot(rt reflect.Type, slot *object.InlineCacheSlot) *callPlan {
+	if slot != nil {
+		switch cached := slot.Load().(type) {
+		case *callCacheEntry:
+			if cached != nil && cached.rt == rt {
+				return cached.plan
+			}
+		case *callPlan:
+			if cached != nil && cached.rt == rt {
+				return cached
+			}
+		}
+	}
+	plan := cachedCallPlan(rt)
+	if slot != nil {
+		slot.Store(&callCacheEntry{rt: rt, plan: plan})
+	}
+	return plan
+}
+
+func cachedCallEntryForSlot(rt reflect.Type, raw interface{}, slot *object.InlineCacheSlot) *callCacheEntry {
+	if slot != nil {
+		switch cached := slot.Load().(type) {
+		case *callCacheEntry:
+			if cached != nil && cached.rt == rt {
+				if raw != nil && cached.invoker == nil && !cached.noFast {
+					entry := newCallCacheEntry(cached.plan, raw)
+					slot.Store(entry)
+					return entry
+				}
+				return cached
+			}
+		case *callPlan:
+			if cached != nil && cached.rt == rt {
+				return newCallCacheEntry(cached, raw)
+			}
+		}
+	}
+
+	entry := newCallCacheEntry(cachedCallPlan(rt), raw)
+	if slot != nil {
+		slot.Store(entry)
+	}
+	return entry
+}
+
+func newCallCacheEntry(plan *callPlan, raw interface{}) *callCacheEntry {
+	entry := &callCacheEntry{rt: plan.rt, plan: plan}
+	if raw != nil {
+		entry.invoker = writeFastInvokerForRaw(raw)
+		entry.noFast = entry.invoker == nil
+	}
+	return entry
+}
+
+func cachedCallPlan(rt reflect.Type) *callPlan {
+	if plan, ok := callPlanCache.Load(rt); ok {
+		return plan.(*callPlan)
+	}
+
+	plan := &callPlan{
+		rt:           rt,
+		numIn:        rt.NumIn(),
+		isVariadic:   rt.IsVariadic(),
+		argTypes:     make([]reflect.Type, rt.NumIn()),
+		optionalArgs: make([]optionalArgKind, rt.NumIn()),
+	}
+	plan.minArgs = plan.numIn
+	if plan.isVariadic {
+		plan.minArgs = plan.numIn - 1
+		plan.variadicElem = rt.In(plan.numIn - 1).Elem()
+	}
+	for i := 0; i < plan.numIn; i++ {
+		argType := rt.In(i)
+		plan.argTypes[i] = argType
+		plan.optionalArgs[i] = optionalArgKindFor(argType)
+	}
+	plan.returnKind = callReturnKindFor(rt)
+
+	actual, _ := callPlanCache.LoadOrStore(rt, plan)
+	return actual.(*callPlan)
+}
+
+func callReturnKindFor(rt reflect.Type) callReturnKind {
+	if rt.NumOut() == 0 {
+		return callReturnNone
+	}
+	out := rt.Out(0)
+	switch out {
+	case stringType:
+		return callReturnString
+	case templateHTMLType:
+		return callReturnHTML
+	}
+	if out.Implements(objectInterfaceType) {
+		return callReturnObject
+	}
+	if out.PkgPath() != "" {
+		return callReturnGeneric
+	}
+	switch out.Kind() {
+	case reflect.Bool:
+		return callReturnBool
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return callReturnInt
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return callReturnUint
+	case reflect.Float32, reflect.Float64:
+		return callReturnFloat
+	default:
+		return callReturnGeneric
+	}
+}
+
+func (vm *VM) reflectArg(name string, pos int, obj object.Object, expected reflect.Type) (reflect.Value, error) {
+	if object.IsNull(obj) {
+		return reflect.New(expected).Elem(), nil
+	}
+	if value, ok := fastReflectArg(obj, expected); ok {
+		return value, nil
+	}
+
+	value := object.ToGo(obj)
+	arg := reflect.ValueOf(value)
+	if arg.Type().AssignableTo(expected) {
+		return arg, nil
+	}
+	if arg.Type().ConvertibleTo(expected) {
+		return arg.Convert(expected), nil
+	}
+	return reflect.Value{}, fmt.Errorf("%+v (%T) is an invalid argument for %s at pos %d: expected (%s)", value, value, name, pos, expected)
+}
+
+func fastReflectArg(obj object.Object, expected reflect.Type) (reflect.Value, bool) {
+	switch obj := obj.(type) {
+	case *object.String:
+		return fastConvertibleValue(obj.Value, expected)
+	case *object.Boolean:
+		return fastConvertibleValue(obj.Value, expected)
+	case *object.Integer:
+		return fastConvertibleValue(int(obj.Value), expected)
+	case *object.Float:
+		return fastConvertibleValue(obj.Value, expected)
+	case *object.Native:
+		if obj.Value == nil {
+			return reflect.New(expected).Elem(), true
+		}
+		return fastConvertibleValue(obj.Value, expected)
+	}
+	return reflect.Value{}, false
+}
+
+func fastConvertibleValue(value interface{}, expected reflect.Type) (reflect.Value, bool) {
+	arg := reflect.ValueOf(value)
+	if !arg.IsValid() {
+		return reflect.New(expected).Elem(), true
+	}
+	if arg.Type().AssignableTo(expected) {
+		return arg, true
+	}
+	if arg.Type().ConvertibleTo(expected) {
+		return arg.Convert(expected), true
+	}
+	if expected.Kind() == reflect.Ptr {
+		elem := expected.Elem()
+		if arg.Type().AssignableTo(elem) {
+			ptr := reflect.New(elem)
+			ptr.Elem().Set(arg)
+			return ptr, true
+		}
+		if arg.Type().ConvertibleTo(elem) {
+			ptr := reflect.New(elem)
+			ptr.Elem().Set(arg.Convert(elem))
+			return ptr, true
+		}
+	}
+	return reflect.Value{}, false
+}
+
+func optionalArgKindFor(expected reflect.Type) optionalArgKind {
+	if plushHelperContextType.AssignableTo(expected) ||
+		plushHelperContextType.ConvertibleTo(expected) ||
+		expected.Implements(hctxHelperContextInterface) {
+		return optionalArgHelperContext
+	}
+	if emptyMapType.AssignableTo(expected) || emptyMapType.ConvertibleTo(expected) {
+		return optionalArgMap
+	}
+	return optionalArgNone
+}
+
+func (vm *VM) optionalArg(kind optionalArgKind, expected reflect.Type, block *object.Closure) (reflect.Value, bool) {
+	switch kind {
+	case optionalArgHelperContext:
+		hargs := vm.helperContext(block)
+		value := reflect.ValueOf(hargs)
+		if value.Type().AssignableTo(expected) {
+			return value, true
+		}
+		if value.Type().ConvertibleTo(expected) {
+			return value.Convert(expected), true
+		}
+	case optionalArgMap:
+		value := reflect.ValueOf(map[string]interface{}{})
+		if value.Type().AssignableTo(expected) {
+			return value, true
+		}
+	}
+
+	return reflect.Value{}, false
+}
+
+func (vm *VM) helperContext(block *object.Closure) plush.HelperContext {
+	var runner func(hctx.Context) (string, error)
+	if block != nil {
+		runner = func(ctx hctx.Context) (string, error) {
+			return vm.runBlock(block, ctx)
+		}
+	}
+	return plush.NewHelperContext(vm.contextWithFrameLocals(), runner)
+}
+
+func (vm *VM) contextWithFrameLocals() hctx.Context {
+	ctx := vm.ctx
+	frame := vm.currentFrame()
+	if ctx == nil || frame == nil || frame.cl == nil || frame.cl.Fn == nil || len(frame.cl.Fn.LocalNames) == 0 {
+		return ctx
+	}
+
+	scoped := ctx.New()
+	for index, name := range frame.cl.Fn.LocalNames {
+		stackIndex := frame.basePointer + index
+		if stackIndex < 0 || stackIndex >= len(vm.stack) {
+			continue
+		}
+		value := vm.stack[stackIndex]
+		if value == nil {
+			continue
+		}
+		scoped.Set(name, object.ToGo(value))
+	}
+	return scoped
+}
+
+func (vm *VM) runBlock(block *object.Closure, ctx hctx.Context) (string, error) {
+	if ctx == nil {
+		ctx = vm.ctx
+	}
+	blockCtx := ctx.New()
+	child := vm.childVM(block, nil, blockCtx)
+	defer child.Release()
+	child.deferHolePositions = true
+	if err := child.Run(); err != nil {
+		return "", child.wrapRuntimeError(err)
+	}
+	if !object.IsNull(child.lastPopped) && child.lastPopped != nil {
+		return child.renderObject(child.lastPopped), nil
+	}
+	return child.Rendered(), nil
+}
+
+func (vm *VM) childVM(cl *object.Closure, args []object.Object, ctx hctx.Context) *VM {
+	frame := newFrame(cl, 0, true)
+	frames := borrowFrames(true)
+	frames[0] = frame
+	child := &VM{
+		constants:   vm.constants,
+		stack:       borrowStack(true),
+		globals:     vm.globals,
+		globalNames: vm.globalNames,
+		frames:      frames,
+		framesIndex: 1,
+		ctx:         ctx,
+		holes:       vm.holes,
+		pooled:      true,
+	}
+	child.resetChild(cl, args, ctx)
+	return child
+}
+
+func (vm *VM) resetChild(cl *object.Closure, args []object.Object, ctx hctx.Context) {
+	if vm.stackMax > len(vm.stack) {
+		vm.stackMax = len(vm.stack)
+	}
+	if vm.stackMax > 0 {
+		clearObjectSlice(vm.stack[:vm.stackMax])
+	}
+	vm.stackMax = 0
+	for i := 1; i < vm.framesIndex && i < len(vm.frames); i++ {
+		releaseFrame(vm.frames[i])
+		vm.frames[i] = nil
+	}
+	vm.framesIndex = 1
+	if vm.frames[0] == nil {
+		vm.frames[0] = newFrame(cl, 0, true)
+	} else {
+		vm.frames[0].reset(cl, 0)
+	}
+	if vm.ctx != ctx {
+		vm.clearNameIDCache()
+	}
+	vm.ctx = ctx
+	vm.lastPopped = nil
+	vm.lastIP = 0
+	vm.halted = false
+	copy(vm.stack, args)
+	vm.sp = cl.Fn.NumLocals
+	if vm.sp < len(args) {
+		vm.sp = len(args)
+	}
+	vm.markStack()
+}
+
+func lastReturnError(res []reflect.Value) error {
+	last := res[len(res)-1]
+	if !last.IsValid() {
+		return nil
+	}
+	if !last.Type().Implements(errorType) {
+		return nil
+	}
+	switch last.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		if last.IsNil() {
+			return nil
+		}
+	}
+	return last.Interface().(error)
+}
+
+func (vm *VM) pushClosure(constIndex, numFree int) error {
+	cl, err := vm.closureFromConstant(constIndex)
+	if err != nil {
+		return err
+	}
+
+	free := make([]object.Object, numFree)
+	for i := 0; i < numFree; i++ {
+		free[i] = vm.stack[vm.sp-numFree+i]
+	}
+	vm.sp = vm.sp - numFree
+	cl.Free = free
+	return vm.push(cl)
+}
+
+func (vm *VM) closureFromConstant(constIndex int) (*object.Closure, error) {
+	constant := vm.constants[constIndex]
+	function, ok := constant.(*object.CompiledFunction)
+	if !ok {
+		return nil, fmt.Errorf("not a function: %+v", constant)
+	}
+	return &object.Closure{Fn: function}, nil
+}
+
+func (vm *VM) closureFromStack(constIndex, numFree int) (*object.Closure, error) {
+	block, err := vm.closureFromConstant(constIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	free := make([]object.Object, numFree)
+	for i := 0; i < numFree; i++ {
+		free[i] = vm.stack[vm.sp-numFree+i]
+	}
+	vm.sp -= numFree
+	block.Free = free
+	return block, nil
+}

--- a/VM/vm/native_calls_test.go
+++ b/VM/vm/native_calls_test.go
@@ -1,0 +1,555 @@
+package vm
+
+import (
+	"fmt"
+	"html/template"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/code"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+	"github.com/stretchr/testify/require"
+)
+
+type vmOptionalHelperContext plush.HelperContext
+type vmOptionalMap map[string]interface{}
+type vmNativeIntObject int
+type vmPointerArgSection struct {
+	Name string
+}
+
+func (v vmNativeIntObject) Type() object.ObjectType { return object.NATIVE_OBJ }
+func (v vmNativeIntObject) Inspect() string         { return fmt.Sprintf("%d", v) }
+
+func Test_VM_Fast_Reflect_Args_Into_Branches(t *testing.T) {
+	ctx := plush.NewContext()
+	plan := cachedCallPlan(reflect.TypeOf(func(string, int64) {}))
+	args, err := fastReflectArgsInto("helper", plan, fastArgs(&object.String{Value: "name"}, &object.Integer{Value: 7}), ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, args, 2)
+	require.Equal(t, "name", args[0].Interface())
+	require.Equal(t, int64(7), args[1].Interface())
+
+	_, err = fastReflectArgsInto("helper", plan, fastArgs("a", int64(1), "extra"), ctx, nil)
+	require.ErrorContains(t, err, "too many arguments")
+
+	_, err = fastReflectArgsInto("helper", plan, fastArgs("a"), ctx, nil)
+	require.ErrorContains(t, err, "too few arguments")
+
+	variadic := cachedCallPlan(reflect.TypeOf(func(string, ...int) {}))
+	args, err = fastReflectArgsInto("helper", variadic, fastArgs("n", 1, 2), ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, args, 3)
+	require.Equal(t, 2, args[2].Interface())
+
+	_, err = fastReflectArgsInto("helper", variadic, fastArgs("n", "bad"), ctx, nil)
+	require.ErrorContains(t, err, "invalid argument")
+
+	_, err = fastReflectArgsInto("helper", variadic, fastArgs(), ctx, nil)
+	require.ErrorContains(t, err, "too few arguments")
+
+	withMap := cachedCallPlan(reflect.TypeOf(func(string, map[string]interface{}) {}))
+	args, err = fastReflectArgsInto("helper", withMap, fastArgs("n"), ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, args, 2)
+	require.Equal(t, map[string]interface{}{}, args[1].Interface())
+
+	withHelperContext := cachedCallPlan(reflect.TypeOf(func(string, plush.HelperContext) {}))
+	args, err = fastReflectArgsInto("helper", withHelperContext, fastArgs("n"), ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, args, 2)
+	require.IsType(t, plush.HelperContext{}, args[1].Interface())
+
+	_, err = fastReflectArgsInto("helper", plan, fastArgs("a", struct{}{}), ctx, nil)
+	require.ErrorContains(t, err, "invalid argument")
+}
+
+func Test_VM_Reflect_Args_Branches(t *testing.T) {
+	machine := newRuntimeHelperTestVM(plush.NewContext())
+
+	plan := cachedCallPlan(reflect.TypeOf(func(string, map[string]interface{}) {}))
+	machine.stack[0] = &object.String{Value: "name"}
+	machine.sp = 1
+	args, err := machine.reflectArgs("helper", plan, 1, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, args, 2)
+	require.Equal(t, "name", args[0].Interface())
+	require.Equal(t, map[string]interface{}{}, args[1].Interface())
+
+	variadic := cachedCallPlan(reflect.TypeOf(func(string, ...int) {}))
+	machine.stack[0] = &object.String{Value: "name"}
+	machine.stack[1] = &object.Integer{Value: 3}
+	machine.sp = 2
+	args, err = machine.reflectArgs("helper", variadic, 2, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, args, 2)
+	require.Equal(t, 3, args[1].Interface())
+
+	tooMany := cachedCallPlan(reflect.TypeOf(func(string) {}))
+	machine.stack[0] = &object.String{Value: "a"}
+	machine.stack[1] = &object.String{Value: "b"}
+	machine.sp = 2
+	_, err = machine.reflectArgs("helper", tooMany, 2, nil, nil)
+	require.ErrorContains(t, err, "too many arguments")
+
+	machine.sp = 0
+	_, err = machine.reflectArgs("helper", variadic, 0, nil, nil)
+	require.ErrorContains(t, err, "too few arguments")
+
+	fixedBad := cachedCallPlan(reflect.TypeOf(func(int) {}))
+	machine.stack[0] = &object.String{Value: "bad"}
+	machine.sp = 1
+	_, err = machine.reflectArgs("helper", fixedBad, 1, nil, nil)
+	require.ErrorContains(t, err, "invalid argument")
+
+	machine.stack[0] = &object.String{Value: "name"}
+	machine.stack[1] = &object.String{Value: "bad"}
+	machine.sp = 2
+	_, err = machine.reflectArgs("helper", variadic, 2, nil, nil)
+	require.ErrorContains(t, err, "invalid argument")
+}
+
+func Test_VM_Fast_Call_Value_With_Entry_Branches(t *testing.T) {
+	ctx := plush.NewContext()
+	raw := func(value string) string { return value }
+	entry := cachedFastCallEntry(reflect.TypeOf(raw), raw, nil)
+
+	var out strings.Builder
+	require.NoError(t, writeFastCallValueWithEntry(&out, ctx, "helper", raw, fastArgs("<ok>"), entry))
+	require.Equal(t, "&lt;ok&gt;", out.String())
+
+	_, err := fastCallValueWithEntry("bad", raw, fastArgs(struct{}{}), ctx, entry)
+	require.ErrorContains(t, err, "invalid argument")
+
+	out.Reset()
+	require.ErrorContains(t, writeFastCallValueWithEntry(&out, ctx, "bad", raw, fastArgs(struct{}{}), entry), "invalid argument")
+
+	require.ErrorContains(t, writeFastCallValueWithEntry(&out, ctx, "nil", raw, fastArgs(), nil), "invalid function")
+
+	called := false
+	voidRaw := func() { called = true }
+	voidEntry := &fastBuilderCallCacheEntry{
+		rt:   reflect.TypeOf(voidRaw),
+		plan: cachedCallPlan(reflect.TypeOf(voidRaw)),
+	}
+	value, err := fastCallValueWithEntry("void", voidRaw, fastArgs(), ctx, voidEntry)
+	require.NoError(t, err)
+	require.Nil(t, value)
+	require.True(t, called)
+
+	failRaw := func() (string, error) { return "", fmt.Errorf("boom") }
+	failEntry := &fastBuilderCallCacheEntry{
+		rt:   reflect.TypeOf(failRaw),
+		plan: cachedCallPlan(reflect.TypeOf(failRaw)),
+	}
+	_, err = fastCallValueWithEntry("fail", failRaw, fastArgs(), ctx, failEntry)
+	require.ErrorContains(t, err, "could not call fail function")
+
+	valueErrEntry := &fastBuilderCallCacheEntry{
+		rt:   reflect.TypeOf(raw),
+		plan: cachedCallPlan(reflect.TypeOf(raw)),
+		valueInvoker: func(name string, raw interface{}, args *fastCallArgs) (interface{}, error) {
+			return nil, fmt.Errorf("value boom")
+		},
+	}
+	_, err = fastCallValueWithEntry("valueErr", raw, fastArgs("x"), ctx, valueErrEntry)
+	require.ErrorContains(t, err, "value boom")
+}
+
+func Test_VM_Fast_Call_Value_With_Helper_Context_Values(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{"name": "Mido"})
+
+	plushHelper := func(help plush.HelperContext) string {
+		return "plush:" + help.Value("name").(string)
+	}
+	value, err := fastCallValue("plushHelper", plushHelper, fastArgs(), ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, "plush:Mido", value)
+
+	hctxHelper := func(help hctx.HelperContext) string {
+		return "hctx:" + help.Value("name").(string)
+	}
+	value, err = fastCallValue("hctxHelper", hctxHelper, fastArgs(), ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, "hctx:Mido", value)
+
+	plushHelperErr := func(plush.HelperContext) (string, error) {
+		return "ignored", fmt.Errorf("boom")
+	}
+	_, err = fastCallValue("plushHelperErr", plushHelperErr, fastArgs(), ctx, nil)
+	require.ErrorContains(t, err, "could not call plushHelperErr function")
+}
+
+func Test_VM_Contextual_Value_Fast_Invoker_For_String_Helper_Context(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{"suffix": "-ctx"})
+
+	raw := func(value string, help plush.HelperContext) string {
+		return value + help.Value("suffix").(string)
+	}
+	entry := cachedFastCallEntry(reflect.TypeOf(raw), raw, nil)
+	require.NotNil(t, entry.contextualValueInvoker)
+
+	value, err := fastCallValueWithEntry("label", raw, fastArgs("name"), ctx, entry)
+	require.NoError(t, err)
+	require.Equal(t, "name-ctx", value)
+}
+
+func Test_VM_Contextual_Value_Fast_Invoker_For_Arbitrary_Return(t *testing.T) {
+	type menuLike struct {
+		Name string
+	}
+	ctx := plush.NewContextWith(map[string]interface{}{"suffix": "-ctx"})
+
+	raw := func(value string, help plush.HelperContext) *menuLike {
+		return &menuLike{Name: value + help.Value("suffix").(string)}
+	}
+	entry := cachedFastCallEntry(reflect.TypeOf(raw), raw, nil)
+	require.NotNil(t, entry.contextualValueInvoker)
+
+	value, err := fastCallValueWithEntry("menu_items", raw, fastArgs("main"), ctx, entry)
+	require.NoError(t, err)
+	require.Equal(t, &menuLike{Name: "main-ctx"}, value)
+}
+
+func Test_VM_Contextual_Value_Fast_Invoker_For_Hctx_Helper_Context_Error(t *testing.T) {
+	ctx := plush.NewContext()
+
+	raw := func(value string, help hctx.HelperContext) (template.HTML, error) {
+		return "", fmt.Errorf("boom %s", value)
+	}
+	entry := cachedFastCallEntry(reflect.TypeOf(raw), raw, nil)
+	require.NotNil(t, entry.contextualValueInvoker)
+
+	_, err := fastCallValueWithEntry("datetime", raw, fastArgs("date"), ctx, entry)
+	require.ErrorContains(t, err, "could not call datetime function: boom date")
+}
+
+func Test_VM_Reset_Child_Cleans_Reused_State(t *testing.T) {
+	oldCtx := plush.NewContext()
+	newCtx := plush.NewContext()
+	oldFrame := NewFrame(&object.Closure{Fn: &object.CompiledFunction{}}, 0)
+	extraFrame := NewFrame(&object.Closure{Fn: &object.CompiledFunction{}}, 0)
+	machine := &VM{
+		stack:       []object.Object{&object.String{Value: "old"}, &object.String{Value: "stale"}},
+		stackMax:    4,
+		frames:      []*Frame{oldFrame, extraFrame},
+		framesIndex: 2,
+		ctx:         oldCtx,
+		lastPopped:  &object.String{Value: "last"},
+		lastIP:      99,
+		halted:      true,
+	}
+	closure := &object.Closure{Fn: &object.CompiledFunction{NumLocals: 1}}
+	arg := &object.String{Value: "arg"}
+
+	machine.resetChild(closure, []object.Object{arg}, newCtx)
+
+	require.Same(t, arg, machine.stack[0])
+	require.Nil(t, machine.stack[1])
+	require.Equal(t, 1, machine.sp)
+	require.Equal(t, 1, machine.stackMax)
+	require.Equal(t, 1, machine.framesIndex)
+	require.NotNil(t, machine.frames[0])
+	require.Nil(t, machine.frames[1])
+	require.Same(t, newCtx, machine.ctx)
+	require.Nil(t, machine.lastPopped)
+	require.Zero(t, machine.lastIP)
+	require.False(t, machine.halted)
+
+	machine.frames[0] = nil
+	machine.resetChild(closure, nil, newCtx)
+	require.NotNil(t, machine.frames[0])
+}
+
+func Test_VM_Fast_Reflect_Arg_For_Call_Branches(t *testing.T) {
+	value, err := fastReflectArgForCall("helper", 0, Null, stringType)
+	require.NoError(t, err)
+	require.Equal(t, "", value.Interface())
+
+	value, err = fastReflectArgForCall("helper", 0, nil, reflect.TypeOf(0))
+	require.NoError(t, err)
+	require.Equal(t, 0, value.Interface())
+
+	value, err = fastReflectArgForCall("helper", 0, &object.Native{Value: int32(3)}, reflect.TypeOf(int64(0)))
+	require.NoError(t, err)
+	require.Equal(t, int64(3), value.Interface())
+
+	value, err = fastReflectArgForCall("helper", 0, int32(4), reflect.TypeOf(int64(0)))
+	require.NoError(t, err)
+	require.Equal(t, int64(4), value.Interface())
+
+	value, err = fastReflectArgForCall("helper", 0, "raw", stringType)
+	require.NoError(t, err)
+	require.Equal(t, "raw", value.Interface())
+
+	value, err = fastReflectArgForCall("helper", 0, &object.Array{Elements: []object.Object{&object.String{Value: "x"}}}, reflect.TypeOf([]interface{}{}))
+	require.NoError(t, err)
+	require.Equal(t, []interface{}{"x"}, value.Interface())
+
+	section := vmPointerArgSection{Name: "hero"}
+	value, err = fastReflectArgForCall("helper", 0, section, reflect.TypeOf(&vmPointerArgSection{}))
+	require.NoError(t, err)
+	require.Equal(t, "hero", value.Interface().(*vmPointerArgSection).Name)
+
+	value, err = fastReflectArgForCall("helper", 0, &object.Native{Value: section}, reflect.TypeOf(&vmPointerArgSection{}))
+	require.NoError(t, err)
+	require.Equal(t, "hero", value.Interface().(*vmPointerArgSection).Name)
+
+	_, err = fastReflectArgForCall("helper", 1, "bad", reflect.TypeOf(0))
+	require.ErrorContains(t, err, "invalid argument")
+}
+
+func Test_VM_Reflect_Arg_And_Convertible_Value_Branches(t *testing.T) {
+	machine := newRuntimeHelperTestVM(plush.NewContext())
+
+	value, err := machine.reflectArg("helper", 0, object.NullObject, stringType)
+	require.NoError(t, err)
+	require.Equal(t, "", value.Interface())
+
+	value, err = machine.reflectArg("helper", 1, &object.Native{Value: nil}, reflect.TypeOf(0))
+	require.NoError(t, err)
+	require.Equal(t, 0, value.Interface())
+
+	value, err = machine.reflectArg("helper", 2, &object.Native{Value: int32(7)}, reflect.TypeOf(int64(0)))
+	require.NoError(t, err)
+	require.Equal(t, int64(7), value.Interface())
+
+	value, err = machine.reflectArg("helper", 3, &object.Array{Elements: []object.Object{&object.String{Value: "x"}}}, reflect.TypeOf([]interface{}{}))
+	require.NoError(t, err)
+	require.Equal(t, []interface{}{"x"}, value.Interface())
+
+	value, err = machine.reflectArg("helper", 4, vmNativeIntObject(9), reflect.TypeOf(int64(0)))
+	require.NoError(t, err)
+	require.Equal(t, int64(9), value.Interface())
+
+	value, err = machine.reflectArg("helper", 5, &object.Native{Value: vmPointerArgSection{Name: "hero"}}, reflect.TypeOf(&vmPointerArgSection{}))
+	require.NoError(t, err)
+	require.Equal(t, "hero", value.Interface().(*vmPointerArgSection).Name)
+
+	_, err = machine.reflectArg("helper", 6, &object.Native{Value: struct{}{}}, stringType)
+	require.ErrorContains(t, err, "invalid argument")
+
+	value, ok := fastReflectArg(&object.Native{Value: nil}, stringType)
+	require.True(t, ok)
+	require.Equal(t, "", value.Interface())
+
+	value, ok = fastReflectArg(&object.String{Value: "fast"}, stringType)
+	require.True(t, ok)
+	require.Equal(t, "fast", value.Interface())
+
+	value, ok = fastReflectArg(object.TrueObject, reflect.TypeOf(false))
+	require.True(t, ok)
+	require.Equal(t, true, value.Interface())
+
+	value, ok = fastReflectArg(&object.Integer{Value: 5}, reflect.TypeOf(int64(0)))
+	require.True(t, ok)
+	require.Equal(t, int64(5), value.Interface())
+
+	value, ok = fastReflectArg(&object.Float{Value: 1.5}, reflect.TypeOf(float64(0)))
+	require.True(t, ok)
+	require.Equal(t, 1.5, value.Interface())
+
+	_, ok = fastReflectArg(&object.Array{}, stringType)
+	require.False(t, ok)
+
+	value, ok = fastConvertibleValue(nil, stringType)
+	require.True(t, ok)
+	require.Equal(t, "", value.Interface())
+
+	value, ok = fastConvertibleValue(vmFastOutputStringer("value"), reflect.TypeOf((*fmt.Stringer)(nil)).Elem())
+	require.True(t, ok)
+	require.Equal(t, "stringer:value", value.Interface().(fmt.Stringer).String())
+
+	value, ok = fastConvertibleValue(vmPointerArgSection{Name: "copy"}, reflect.TypeOf(&vmPointerArgSection{}))
+	require.True(t, ok)
+	require.Equal(t, "copy", value.Interface().(*vmPointerArgSection).Name)
+
+	_, ok = fastConvertibleValue(struct{}{}, stringType)
+	require.False(t, ok)
+}
+
+func Test_VM_Closure_From_Stack_Branches(t *testing.T) {
+	fn := &object.CompiledFunction{}
+	machine := &VM{
+		constants: []object.Object{fn},
+		stack:     make([]object.Object, StackSize),
+	}
+	machine.stack[0] = &object.String{Value: "one"}
+	machine.stack[1] = &object.String{Value: "two"}
+	machine.sp = 2
+
+	closure, err := machine.closureFromStack(0, 2)
+	require.NoError(t, err)
+	require.Same(t, fn, closure.Fn)
+	require.Len(t, closure.Free, 2)
+	require.Equal(t, &object.String{Value: "one"}, closure.Free[0])
+	require.Equal(t, &object.String{Value: "two"}, closure.Free[1])
+	require.Zero(t, machine.sp)
+
+	machine.constants[0] = &object.String{Value: "nope"}
+	_, err = machine.closureFromStack(0, 0)
+	require.ErrorContains(t, err, "not a function")
+}
+
+func Test_VM_Optional_Arg_Branches(t *testing.T) {
+	ctx := plush.NewContext()
+	machine := newRuntimeHelperTestVM(ctx)
+
+	value, ok := fastOptionalArg(optionalArgHelperContext, reflect.TypeOf(plush.HelperContext{}), ctx)
+	require.True(t, ok)
+	require.IsType(t, plush.HelperContext{}, value.Interface())
+
+	value, ok = fastOptionalArg(optionalArgHelperContext, reflect.TypeOf(vmOptionalHelperContext{}), ctx)
+	require.True(t, ok)
+	require.IsType(t, vmOptionalHelperContext{}, value.Interface())
+
+	value, ok = fastOptionalArg(optionalArgHelperContext, reflect.TypeOf((*hctx.HelperContext)(nil)).Elem(), ctx)
+	require.True(t, ok)
+	require.Implements(t, (*hctx.HelperContext)(nil), value.Interface())
+
+	value, ok = fastOptionalArg(optionalArgMap, reflect.TypeOf(map[string]interface{}{}), ctx)
+	require.True(t, ok)
+	require.Equal(t, map[string]interface{}{}, value.Interface())
+
+	value, ok = fastOptionalArg(optionalArgMap, reflect.TypeOf(vmOptionalMap{}), ctx)
+	require.True(t, ok)
+	require.Equal(t, map[string]interface{}{}, value.Interface())
+
+	_, ok = fastOptionalArg(optionalArgNone, stringType, ctx)
+	require.False(t, ok)
+
+	_, ok = fastOptionalArg(optionalArgMap, stringType, ctx)
+	require.False(t, ok)
+
+	value, ok = machine.optionalArg(optionalArgHelperContext, reflect.TypeOf(plush.HelperContext{}), nil)
+	require.True(t, ok)
+	require.IsType(t, plush.HelperContext{}, value.Interface())
+
+	value, ok = machine.optionalArg(optionalArgHelperContext, reflect.TypeOf(vmOptionalHelperContext{}), nil)
+	require.True(t, ok)
+	require.IsType(t, vmOptionalHelperContext{}, value.Interface())
+
+	value, ok = machine.optionalArg(optionalArgHelperContext, reflect.TypeOf((*hctx.HelperContext)(nil)).Elem(), nil)
+	require.True(t, ok)
+	require.Implements(t, (*hctx.HelperContext)(nil), value.Interface())
+
+	value, ok = machine.optionalArg(optionalArgMap, reflect.TypeOf(map[string]interface{}{}), nil)
+	require.True(t, ok)
+	require.Equal(t, map[string]interface{}{}, value.Interface())
+
+	value, ok = machine.optionalArg(optionalArgMap, reflect.TypeOf(vmOptionalMap{}), nil)
+	require.True(t, ok)
+	require.Equal(t, map[string]interface{}{}, value.Interface())
+
+	_, ok = machine.optionalArg(optionalArgNone, stringType, nil)
+	require.False(t, ok)
+
+	_, ok = machine.optionalArg(optionalArgMap, stringType, nil)
+	require.False(t, ok)
+}
+
+func Test_VM_Write_Native_Return_Value_Kinds(t *testing.T) {
+	machine := newRuntimeHelperTestVM(plush.NewContext())
+	frame := machine.currentFrame()
+
+	tests := []struct {
+		name     string
+		fn       interface{}
+		value    reflect.Value
+		expected string
+	}{
+		{"string", func() string { return "" }, reflect.ValueOf("<x>"), "&lt;x&gt;"},
+		{"html", func() template.HTML { return "" }, reflect.ValueOf(template.HTML("<b>")), "<b>"},
+		{"bool", func() bool { return false }, reflect.ValueOf(true), "true"},
+		{"int", func() int64 { return 0 }, reflect.ValueOf(int64(7)), "7"},
+		{"uint", func() uint64 { return 0 }, reflect.ValueOf(uint64(8)), "8"},
+		{"float", func() float32 { return 0 }, reflect.ValueOf(float32(1.5)), "1.5"},
+		{"object", func() object.Object { return nil }, reflect.ValueOf(&object.String{Value: "<obj>"}), "&lt;obj&gt;"},
+		{"generic", func() vmSegmentUser { return vmSegmentUser{} }, reflect.ValueOf(vmSegmentUser{Name: "ignored"}), ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			frame.output.Reset()
+			machine.writeNativeReturnValue(frame, tt.value, cachedCallPlan(reflect.TypeOf(tt.fn)))
+			require.Equal(t, tt.expected, frame.output.String())
+		})
+	}
+
+	frame.output.Reset()
+	machine.writeNativeReturnValue(frame, reflect.Value{}, &callPlan{returnKind: callReturnNone})
+	require.Empty(t, frame.output.String())
+
+	frame.output.Reset()
+	machine.writeNativeReturnValue(frame, reflect.ValueOf((*object.String)(nil)), cachedCallPlan(reflect.TypeOf(func() object.Object { return nil })))
+	require.Empty(t, frame.output.String())
+}
+
+func Test_VM_Context_With_Frame_Locals(t *testing.T) {
+	base := plush.NewContextWith(map[string]interface{}{"outer": "value"})
+	machine := newRuntimeHelperTestVM(base)
+	frame := machine.currentFrame()
+	frame.cl.Fn.LocalNames = map[int]string{0: "local", 1: "skipNil", 99: "skipRange"}
+	frame.cl.Fn.LocalNames[-1] = "skipNegative"
+	frame.cl.Fn.LocalNames[len(machine.stack)+1] = "skipOutOfRange"
+	machine.stack[0] = &object.String{Value: "local-value"}
+
+	scoped := machine.contextWithFrameLocals()
+	require.NotSame(t, base, scoped)
+	require.Equal(t, "local-value", scoped.Value("local"))
+	require.Equal(t, "value", scoped.Value("outer"))
+	require.False(t, scoped.Has("skipNil"))
+	require.False(t, scoped.Has("skipRange"))
+
+	machine.ctx = nil
+	require.Nil(t, machine.contextWithFrameLocals())
+
+	machine.ctx = base
+	frame.cl.Fn.LocalNames = nil
+	require.Same(t, base, machine.contextWithFrameLocals())
+}
+
+func Test_VM_Optional_Arg_With_Helper_Context_Interface(t *testing.T) {
+	machine := newRuntimeHelperTestVM(plush.NewContext())
+	value, ok := machine.optionalArg(optionalArgHelperContext, reflect.TypeOf((*hctx.HelperContext)(nil)).Elem(), nil)
+	require.True(t, ok)
+	require.Implements(t, (*hctx.HelperContext)(nil), value.Interface())
+
+	value, ok = machine.optionalArg(optionalArgMap, emptyMapType, nil)
+	require.True(t, ok)
+	require.Equal(t, map[string]interface{}{}, value.Interface())
+
+	_, ok = machine.optionalArg(optionalArgNone, stringType, nil)
+	require.False(t, ok)
+}
+
+func Test_VM_Run_Block_Return_Output_And_Error_Branches(t *testing.T) {
+	machine := newRuntimeHelperTestVM(plush.NewContext())
+
+	returnBlock := executeForClosure(executeForInstructions(
+		code.Make(code.OpConstant, 4),
+		code.Make(code.OpReturnValue),
+	), 0)
+	rendered, err := machine.runBlock(returnBlock, nil)
+	require.NoError(t, err)
+	require.Equal(t, "&lt;b&gt;", rendered)
+
+	outputBlock := executeForClosure(executeForInstructions(
+		code.Make(code.OpWriteConstant, 4),
+		code.Make(code.OpReturn),
+	), 0)
+	rendered, err = machine.runBlock(outputBlock, plush.NewContext())
+	require.NoError(t, err)
+	require.Equal(t, "&lt;b&gt;", rendered)
+
+	errorBlock := executeForClosure(executeForInstructions(
+		code.Make(code.OpGetName, 0),
+		code.Make(code.OpReturnValue),
+	), 0)
+	_, err = machine.runBlock(errorBlock, plush.NewContext())
+	require.Error(t, err)
+
+}

--- a/VM/vm/native_property_cache_helpers_test.go
+++ b/VM/vm/native_property_cache_helpers_test.go
@@ -1,0 +1,261 @@
+package vm
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_VM_Property_Value_Branches(t *testing.T) {
+	machine := newRuntimeHelperTestVM(plush.NewContext())
+	user := vmFastPropertyUser{Name: "<mido>", Count: 7}
+	access := object.PropertyAccess{Receiver: "user", Full: "user.Name"}
+	var nameSlot object.InlineCacheSlot
+	var countSlot object.InlineCacheSlot
+	var echoSlot object.InlineCacheSlot
+	var pointerSlot object.InlineCacheSlot
+	var missingSlot object.InlineCacheSlot
+
+	hashKey := (&object.String{Value: "Name"}).HashKey()
+	hash := &object.Hash{Pairs: map[object.HashKey]object.HashPair{
+		hashKey: {Key: &object.String{Value: "Name"}, Value: &object.String{Value: "<hash>"}},
+	}}
+	value, err := machine.propertyValue(hash, "Name", access, &nameSlot)
+	require.NoError(t, err)
+	require.Equal(t, &object.String{Value: "<hash>"}, value)
+
+	value, err = machine.propertyValue(hash, "Missing", access, &missingSlot)
+	require.NoError(t, err)
+	require.Nil(t, value)
+
+	value, err = machine.propertyValue(object.NullObject, "Name", access, &nameSlot)
+	require.NoError(t, err)
+	require.Nil(t, value)
+
+	value, err = machine.propertyValue(nil, "Name", access, &nameSlot)
+	require.NoError(t, err)
+	require.Nil(t, value)
+
+	value, err = machine.propertyValue((*vmFastPropertyUser)(nil), "Name", access, &nameSlot)
+	require.NoError(t, err)
+	require.Nil(t, value)
+
+	value, err = machine.propertyValue(user, "Name", access, &nameSlot)
+	require.NoError(t, err)
+	require.Equal(t, "<mido>", value)
+
+	value, err = machine.propertyValue(&user, "Count", object.PropertyAccess{Receiver: "user", Full: "user.Count"}, &countSlot)
+	require.NoError(t, err)
+	require.Equal(t, int32(7), value)
+
+	value, err = machine.propertyValue(user, "Echo", object.PropertyAccess{Receiver: "user", Full: "user.Echo()", Method: true}, &echoSlot)
+	require.NoError(t, err)
+	require.IsType(t, func() string { return "" }, value)
+
+	value, err = machine.propertyValue(user, "PointerEcho", object.PropertyAccess{Receiver: "user", Full: "user.PointerEcho()", Method: true}, &pointerSlot)
+	require.NoError(t, err)
+	require.IsType(t, func() string { return "" }, value)
+
+	_, err = machine.propertyValue(user, "Name", object.PropertyAccess{Receiver: "user", Full: "user.Name()", Method: true}, &nameSlot)
+	require.ErrorContains(t, err, "does not have a method")
+
+	_, err = machine.propertyValue(user, "Missing", object.PropertyAccess{Receiver: "user", Full: "user.Missing"}, &missingSlot)
+	require.ErrorContains(t, err, "does not have a field or method")
+
+	_, err = machine.propertyValue(3, "Missing", object.PropertyAccess{Receiver: "value", Full: "value.Missing"}, &missingSlot)
+	require.ErrorContains(t, err, "does not have a field or method")
+}
+
+func Test_VM_Get_Property_And_Field_Value_Branches(t *testing.T) {
+	machine := newRuntimeHelperTestVM(plush.NewContext())
+	user := vmFastPropertyUser{Name: "<mido>", Count: 7, hidden: "secret"}
+	access := object.PropertyAccess{Receiver: "user", Full: "user.Name"}
+	var nameSlot object.InlineCacheSlot
+	var countSlot object.InlineCacheSlot
+	var echoSlot object.InlineCacheSlot
+	var pointerSlot object.InlineCacheSlot
+	var missingSlot object.InlineCacheSlot
+
+	hashKey := (&object.String{Value: "Name"}).HashKey()
+	hash := &object.Hash{Pairs: map[object.HashKey]object.HashPair{
+		hashKey: {Key: &object.String{Value: "Name"}, Value: &object.String{Value: "<hash>"}},
+	}}
+	require.NoError(t, machine.getProperty(hash, "Name", access, &nameSlot))
+	require.Equal(t, &object.String{Value: "<hash>"}, machine.pop())
+
+	require.NoError(t, machine.getProperty(hash, "Missing", access, &missingSlot))
+	require.Same(t, Null, machine.pop())
+
+	require.NoError(t, machine.getProperty(object.NullObject, "Name", access, &nameSlot))
+	require.Same(t, Null, machine.pop())
+
+	require.NoError(t, machine.getProperty(&object.Native{Value: (*vmFastPropertyUser)(nil)}, "Name", access, &nameSlot))
+	require.Same(t, Null, machine.pop())
+
+	require.NoError(t, machine.getProperty(&object.Native{Value: user}, "Name", access, &nameSlot))
+	require.Equal(t, &object.String{Value: "<mido>"}, machine.pop())
+
+	require.NoError(t, machine.getProperty(&object.Native{Value: &user}, "Count", object.PropertyAccess{Receiver: "user", Full: "user.Count"}, &countSlot))
+	require.Equal(t, &object.Integer{Value: 7}, machine.pop())
+
+	require.NoError(t, machine.getProperty(&object.Native{Value: user}, "Echo", object.PropertyAccess{Receiver: "user", Full: "user.Echo()", Method: true}, &echoSlot))
+	require.IsType(t, &object.Native{}, machine.pop())
+
+	require.NoError(t, machine.getProperty(&object.Native{Value: user}, "PointerEcho", object.PropertyAccess{Receiver: "user", Full: "user.PointerEcho()", Method: true}, &pointerSlot))
+	require.IsType(t, &object.Native{}, machine.pop())
+
+	err := machine.getProperty(&object.Native{Value: user}, "Name", object.PropertyAccess{Receiver: "user", Full: "user.Name()", Method: true}, &nameSlot)
+	require.ErrorContains(t, err, "does not have a method")
+
+	err = machine.getProperty(&object.Native{Value: user}, "Missing", object.PropertyAccess{}, &missingSlot)
+	require.ErrorContains(t, err, "does not have a field or method")
+
+	budgeted := newRuntimeHelperTestVM(plush.NewContext().WithBudget(plush.NewBudget(0)))
+	err = budgeted.getProperty(&object.Native{Value: user}, "Name", access, &nameSlot)
+	require.ErrorContains(t, err, "render budget exceeded")
+
+	value, err := machine.fieldValue(reflect.ValueOf((*vmFastPropertyUser)(nil)), access, "Name")
+	require.NoError(t, err)
+	require.Nil(t, value)
+
+	hidden := reflect.ValueOf(user).FieldByName("hidden")
+	_, err = machine.fieldValue(hidden, object.PropertyAccess{}, "hidden")
+	require.ErrorContains(t, err, "cannot return value")
+
+	_, err = machine.fieldValue(hidden, object.PropertyAccess{Receiver: "user", Full: "user.hidden"}, "hidden")
+	require.ErrorContains(t, err, "user")
+}
+
+func Test_VM_Write_Fast_Call_Value_With_Entry_Branches(t *testing.T) {
+	ctx := plush.NewContext()
+	var out strings.Builder
+
+	err := writeFastCallValueWithEntry(&out, ctx, "missing", nil, nil, nil)
+	require.ErrorContains(t, err, "invalid function")
+
+	err = writeFastCallValueWithEntry(&out, ctx, "label", func() string { return "<ok>" }, nil, &fastBuilderCallCacheEntry{
+		plan: cachedCallPlan(reflect.TypeOf(func() string { return "" })),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "&lt;ok&gt;", out.String())
+
+	out.Reset()
+	rawStruct := func() vmSegmentUser { return vmSegmentUser{Name: "ignored"} }
+	entry := &fastBuilderCallCacheEntry{plan: cachedCallPlan(reflect.TypeOf(rawStruct))}
+	err = writeFastCallValueWithEntry(&out, ctx, "rawStruct", rawStruct, nil, entry)
+	require.NoError(t, err)
+	require.Empty(t, out.String())
+
+	out.Reset()
+	rawErr := func() (string, error) { return "", errors.New("boom") }
+	err = writeFastCallValueWithEntry(&out, ctx, "rawErr", rawErr, nil, cachedFastCallEntry(reflect.TypeOf(rawErr), rawErr, nil))
+	require.ErrorContains(t, err, "could not call rawErr function")
+}
+
+func Test_VM_Fast_Call_Value_Wrapper_Branches(t *testing.T) {
+	ctx := plush.NewContext()
+	var out strings.Builder
+
+	err := writeFastCallValue(&out, ctx, "nil", nil, nil, nil)
+	require.ErrorContains(t, err, "invalid function")
+
+	err = writeFastCallValue(&out, ctx, "bad", 7, nil, nil)
+	require.ErrorContains(t, err, "invalid function")
+
+	raw := func() string { return "<wrapped>" }
+	err = writeFastCallValue(&out, ctx, "wrapped", &object.Native{Value: raw}, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, "&lt;wrapped&gt;", out.String())
+
+	_, err = fastCallValue("nil", nil, nil, ctx, nil)
+	require.ErrorContains(t, err, "invalid function")
+
+	_, err = fastCallValue("bad", 7, nil, ctx, nil)
+	require.ErrorContains(t, err, "invalid function")
+
+	value, err := fastCallValue("none", func() {}, nil, ctx, nil)
+	require.NoError(t, err)
+	require.Nil(t, value)
+
+	value, err = fastCallValue("nilReturn", func() *string { return nil }, nil, ctx, nil)
+	require.NoError(t, err)
+	require.Nil(t, value)
+
+	_, err = fastCallValue("errReturn", func() (string, error) { return "", errors.New("boom") }, nil, ctx, nil)
+	require.ErrorContains(t, err, "could not call errReturn function")
+
+	value, err = fastCallValue("native", &object.Native{Value: raw}, nil, ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, "<wrapped>", value)
+
+	value, err = fastCallValueWithEntry("fallback", raw, nil, ctx, &fastBuilderCallCacheEntry{
+		plan: cachedCallPlan(reflect.TypeOf(raw)),
+		valueInvoker: func(string, interface{}, *fastCallArgs) (interface{}, error) {
+			return nil, errFastWriteUnsupported
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "<wrapped>", value)
+
+	_, err = fastCallValueWithEntry("badValueInvoker", raw, nil, ctx, &fastBuilderCallCacheEntry{
+		plan: cachedCallPlan(reflect.TypeOf(raw)),
+		valueInvoker: func(string, interface{}, *fastCallArgs) (interface{}, error) {
+			return nil, errors.New("bad fast value")
+		},
+	})
+	require.ErrorContains(t, err, "bad fast value")
+
+	_, err = fastCallValueWithEntry("missingPlan", raw, nil, ctx, &fastBuilderCallCacheEntry{})
+	require.ErrorContains(t, err, "invalid function")
+
+	_, err = fastCallValueWithEntry("badArg", func(value int) string { return "" }, fastArgs("bad"), ctx, &fastBuilderCallCacheEntry{
+		plan: cachedCallPlan(reflect.TypeOf(func(value int) string { return "" })),
+	})
+	require.ErrorContains(t, err, "invalid argument")
+}
+
+func Test_VM_Cached_Call_Entry_For_Slot_Branches(t *testing.T) {
+	raw := func() string { return "ok" }
+	rt := reflect.TypeOf(raw)
+	plan := cachedCallPlan(rt)
+	var slot object.InlineCacheSlot
+
+	require.Same(t, plan, cachedCallPlanForSlot(rt, nil))
+
+	slot.Store(&callCacheEntry{rt: rt, plan: plan})
+	require.Same(t, plan, cachedCallPlanForSlot(rt, &slot))
+
+	var planSlot object.InlineCacheSlot
+	planSlot.Store(plan)
+	require.Same(t, plan, cachedCallPlanForSlot(rt, &planSlot))
+
+	var staleEntrySlot object.InlineCacheSlot
+	staleEntrySlot.Store(&callCacheEntry{rt: reflect.TypeOf(func(int) string { return "" }), plan: cachedCallPlan(reflect.TypeOf(func(int) string { return "" }))})
+	require.Same(t, plan, cachedCallPlanForSlot(rt, &staleEntrySlot))
+
+	var entrySlot object.InlineCacheSlot
+	entrySlot.Store(plan)
+	entry := cachedCallEntryForSlot(rt, raw, &entrySlot)
+	require.NotNil(t, entry)
+	require.Same(t, plan, entry.plan)
+
+	slot = object.InlineCacheSlot{}
+	slot.Store(&callCacheEntry{rt: rt, plan: plan})
+	entry = cachedCallEntryForSlot(rt, raw, &slot)
+	require.NotNil(t, entry)
+	require.NotNil(t, entry.invoker)
+
+	entry = cachedCallEntryForSlot(rt, nil, &slot)
+	require.NotNil(t, entry)
+	require.Equal(t, rt, entry.rt)
+
+	other := func(value string) string { return value }
+	entry = cachedCallEntryForSlot(reflect.TypeOf(other), other, &slot)
+	require.NotNil(t, entry)
+	require.Equal(t, reflect.TypeOf(other), entry.rt)
+}

--- a/VM/vm/numeric.go
+++ b/VM/vm/numeric.go
@@ -1,0 +1,294 @@
+package vm
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+
+	"github.com/gobuffalo/plush/v5/VM/code"
+	"github.com/gobuffalo/plush/v5/VM/object"
+)
+
+type numericKind int
+
+const (
+	numericSigned numericKind = iota
+	numericUnsigned
+	numericFloat
+)
+
+type numericValue struct {
+	kind numericKind
+	i    int64
+	u    uint64
+	f    float64
+}
+
+func numericValueFromObject(obj object.Object) (numericValue, bool) {
+	switch obj := obj.(type) {
+	case *object.Integer:
+		return numericValue{kind: numericSigned, i: obj.Value}, true
+	case *object.Float:
+		return numericValue{kind: numericFloat, f: obj.Value}, true
+	case *object.Native:
+		return numericValueFromGo(obj.Value)
+	default:
+		return numericValue{}, false
+	}
+}
+
+func numericValueFromGo(value interface{}) (numericValue, bool) {
+	if value == nil {
+		return numericValue{}, false
+	}
+
+	rv := reflect.ValueOf(value)
+	switch rv.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return numericValue{kind: numericSigned, i: rv.Int()}, true
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return numericValue{kind: numericUnsigned, u: rv.Uint()}, true
+	case reflect.Float32, reflect.Float64:
+		return numericValue{kind: numericFloat, f: rv.Convert(reflect.TypeOf(float64(0))).Float()}, true
+	default:
+		return numericValue{}, false
+	}
+}
+
+func numericValueFromReflectValue(rv reflect.Value) (numericValue, bool) {
+	if !rv.IsValid() || isNilReflectValue(rv) {
+		return numericValue{}, false
+	}
+	for rv.Kind() == reflect.Interface {
+		rv = rv.Elem()
+		if !rv.IsValid() || isNilReflectValue(rv) {
+			return numericValue{}, false
+		}
+	}
+	switch rv.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return numericValue{kind: numericSigned, i: rv.Int()}, true
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return numericValue{kind: numericUnsigned, u: rv.Uint()}, true
+	case reflect.Float32, reflect.Float64:
+		return numericValue{kind: numericFloat, f: rv.Convert(reflect.TypeOf(float64(0))).Float()}, true
+	default:
+		return numericValue{}, false
+	}
+}
+
+func (n numericValue) float64() float64 {
+	switch n.kind {
+	case numericFloat:
+		return n.f
+	case numericUnsigned:
+		return float64(n.u)
+	default:
+		return float64(n.i)
+	}
+}
+
+func (n numericValue) int64() (int64, bool) {
+	switch n.kind {
+	case numericSigned:
+		return n.i, true
+	case numericUnsigned:
+		if n.u <= uint64(math.MaxInt64) {
+			return int64(n.u), true
+		}
+	}
+	return 0, false
+}
+
+func (n numericValue) uint64() (uint64, bool) {
+	switch n.kind {
+	case numericUnsigned:
+		return n.u, true
+	case numericSigned:
+		if n.i >= 0 {
+			return uint64(n.i), true
+		}
+	}
+	return 0, false
+}
+
+func compareNumericEquality(left, right numericValue) bool {
+	if left.kind == numericFloat || right.kind == numericFloat {
+		return left.float64() == right.float64()
+	}
+
+	if l, ok := left.int64(); ok {
+		if r, ok := right.int64(); ok {
+			return l == r
+		}
+	}
+
+	if left.kind == numericSigned && left.i < 0 {
+		return false
+	}
+	if right.kind == numericSigned && right.i < 0 {
+		return false
+	}
+
+	l, lok := left.uint64()
+	r, rok := right.uint64()
+	return lok && rok && l == r
+}
+
+func compareNumericOrdered(op code.Opcode, left, right numericValue) (bool, error) {
+	if left.kind == numericFloat || right.kind == numericFloat {
+		return compareFloatOrdered(op, left.float64(), right.float64())
+	}
+
+	if left.kind == numericSigned && right.kind == numericSigned {
+		return compareIntOrdered(op, left.i, right.i)
+	}
+	if left.kind == numericUnsigned && right.kind == numericUnsigned {
+		return compareUintOrdered(op, left.u, right.u)
+	}
+	if left.kind == numericSigned {
+		if left.i < 0 {
+			switch op {
+			case code.OpGreaterThan:
+				return false, nil
+			case code.OpGreaterEqual:
+				return false, nil
+			}
+		}
+		return compareUintOrdered(op, uint64(left.i), right.u)
+	}
+
+	if right.i < 0 {
+		switch op {
+		case code.OpGreaterThan:
+			return true, nil
+		case code.OpGreaterEqual:
+			return true, nil
+		}
+	}
+	return compareUintOrdered(op, left.u, uint64(right.i))
+}
+
+func compareFloatOrdered(op code.Opcode, left, right float64) (bool, error) {
+	switch op {
+	case code.OpGreaterThan:
+		return left > right, nil
+	case code.OpGreaterEqual:
+		return left >= right, nil
+	default:
+		return false, fmt.Errorf("unknown ordered comparison: %d", op)
+	}
+}
+
+func compareIntOrdered(op code.Opcode, left, right int64) (bool, error) {
+	switch op {
+	case code.OpGreaterThan:
+		return left > right, nil
+	case code.OpGreaterEqual:
+		return left >= right, nil
+	default:
+		return false, fmt.Errorf("unknown ordered comparison: %d", op)
+	}
+}
+
+func compareUintOrdered(op code.Opcode, left, right uint64) (bool, error) {
+	switch op {
+	case code.OpGreaterThan:
+		return left > right, nil
+	case code.OpGreaterEqual:
+		return left >= right, nil
+	default:
+		return false, fmt.Errorf("unknown ordered comparison: %d", op)
+	}
+}
+
+func numericOperationObject(op code.Opcode, left, right numericValue) (object.Object, error) {
+	if left.kind == numericFloat || right.kind == numericFloat {
+		l := left.float64()
+		r := right.float64()
+		switch op {
+		case code.OpAdd:
+			return &object.Float{Value: l + r}, nil
+		case code.OpSub:
+			return &object.Float{Value: l - r}, nil
+		case code.OpMul:
+			return &object.Float{Value: l * r}, nil
+		case code.OpDiv:
+			if r == 0 {
+				return nil, fmt.Errorf("division by zero %v / %v", l, r)
+			}
+			return &object.Float{Value: l / r}, nil
+		default:
+			return nil, fmt.Errorf("unknown numeric operator: %d", op)
+		}
+	}
+
+	lSigned, lok := left.int64()
+	rSigned, rok := right.int64()
+	if lok && rok {
+		switch op {
+		case code.OpAdd:
+			return &object.Integer{Value: lSigned + rSigned}, nil
+		case code.OpSub:
+			return &object.Integer{Value: lSigned - rSigned}, nil
+		case code.OpMul:
+			return &object.Integer{Value: lSigned * rSigned}, nil
+		case code.OpDiv:
+			if rSigned == 0 {
+				return nil, fmt.Errorf("division by zero %v / %v", lSigned, rSigned)
+			}
+			return &object.Integer{Value: lSigned / rSigned}, nil
+		default:
+			return nil, fmt.Errorf("unknown numeric operator: %d", op)
+		}
+	}
+
+	lUnsigned, lok := left.uint64()
+	rUnsigned, rok := right.uint64()
+	if !lok || !rok {
+		return nil, fmt.Errorf("unsupported mixed signed/unsigned operation")
+	}
+
+	switch op {
+	case code.OpAdd:
+		if math.MaxUint64-lUnsigned < rUnsigned {
+			return nil, fmt.Errorf("integer overflow %v + %v", lUnsigned, rUnsigned)
+		}
+		return unsignedNumericObject(lUnsigned + rUnsigned), nil
+	case code.OpSub:
+		if lUnsigned < rUnsigned {
+			return nil, fmt.Errorf("integer underflow %v - %v", lUnsigned, rUnsigned)
+		}
+		return unsignedNumericObject(lUnsigned - rUnsigned), nil
+	case code.OpMul:
+		if rUnsigned != 0 && lUnsigned > math.MaxUint64/rUnsigned {
+			return nil, fmt.Errorf("integer overflow %v * %v", lUnsigned, rUnsigned)
+		}
+		return unsignedNumericObject(lUnsigned * rUnsigned), nil
+	case code.OpDiv:
+		if rUnsigned == 0 {
+			return nil, fmt.Errorf("division by zero %v / %v", lUnsigned, rUnsigned)
+		}
+		return unsignedNumericObject(lUnsigned / rUnsigned), nil
+	default:
+		return nil, fmt.Errorf("unknown numeric operator: %d", op)
+	}
+}
+
+func unsignedNumericObject(value uint64) object.Object {
+	if value <= uint64(math.MaxInt64) {
+		return &object.Integer{Value: int64(value)}
+	}
+	return &object.Native{Value: value}
+}
+
+func orderedOperatorString(op code.Opcode) string {
+	switch op {
+	case code.OpGreaterThan:
+		return ">"
+	case code.OpGreaterEqual:
+		return ">="
+	default:
+		return fmt.Sprint(op)
+	}
+}

--- a/VM/vm/numeric_reflect_helpers_test.go
+++ b/VM/vm/numeric_reflect_helpers_test.go
@@ -1,0 +1,365 @@
+package vm
+
+import (
+	"errors"
+	"html/template"
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/stretchr/testify/require"
+)
+
+type vmFastArgInt int32
+type vmFastArgInt64 int64
+type vmFastArgUint uint16
+type vmFastArgUint64 uint64
+type vmFastArgFloat float32
+type vmFastArgFloat64 float64
+
+type vmReflectPrivate struct {
+	hidden string
+}
+
+func Test_VM_Numeric_Value_From_Reflect_Value_Branches(t *testing.T) {
+	_, ok := numericValueFromReflectValue(reflect.Value{})
+	require.False(t, ok)
+
+	var nilPtr *int
+	_, ok = numericValueFromReflectValue(reflect.ValueOf(nilPtr))
+	require.False(t, ok)
+
+	var nilIface interface{}
+	_, ok = numericValueFromReflectValue(reflect.ValueOf(&nilIface).Elem())
+	require.False(t, ok)
+
+	value, ok := numericValueFromReflectValue(reflect.ValueOf(int16(-7)))
+	require.True(t, ok)
+	require.Equal(t, numericSigned, value.kind)
+	require.Equal(t, int64(-7), value.i)
+
+	value, ok = numericValueFromReflectValue(reflect.ValueOf(uint16(8)))
+	require.True(t, ok)
+	require.Equal(t, numericUnsigned, value.kind)
+	require.Equal(t, uint64(8), value.u)
+
+	value, ok = numericValueFromReflectValue(reflect.ValueOf(float32(1.25)))
+	require.True(t, ok)
+	require.Equal(t, numericFloat, value.kind)
+	require.InDelta(t, 1.25, value.f, 0.0001)
+
+	var iface interface{} = uint32(9)
+	value, ok = numericValueFromReflectValue(reflect.ValueOf(&iface).Elem())
+	require.True(t, ok)
+	require.Equal(t, numericUnsigned, value.kind)
+	require.Equal(t, uint64(9), value.u)
+
+	_, ok = numericValueFromReflectValue(reflect.ValueOf("nope"))
+	require.False(t, ok)
+}
+
+func Test_VM_Fast_Reflect_Interface_And_Write_Value_Edges(t *testing.T) {
+	require.Nil(t, fastReflectInterface(reflect.Value{}))
+
+	var nilPtr *int
+	require.Nil(t, fastReflectInterface(reflect.ValueOf(nilPtr)))
+
+	var nilIface interface{}
+	require.Nil(t, fastReflectInterface(reflect.ValueOf(&nilIface).Elem()))
+
+	var iface interface{} = "value"
+	require.Equal(t, "value", fastReflectInterface(reflect.ValueOf(&iface).Elem()))
+
+	privateField := reflect.ValueOf(vmReflectPrivate{hidden: "secret"}).FieldByName("hidden")
+	require.Nil(t, fastReflectInterface(privateField))
+
+	ctx := plush.NewContext()
+	var out strings.Builder
+	require.NoError(t, writeFastReflectValue(&out, ctx, reflect.Value{}))
+	require.Empty(t, out.String())
+
+	require.NoError(t, writeFastReflectValue(&out, ctx, reflect.ValueOf(nilPtr)))
+	require.Empty(t, out.String())
+
+	require.NoError(t, writeFastReflectValue(&out, ctx, reflect.ValueOf(&nilIface).Elem()))
+	require.Empty(t, out.String())
+
+	var objectIface interface{} = &object.String{Value: "<obj>"}
+	require.NoError(t, writeFastReflectValue(&out, ctx, reflect.ValueOf(&objectIface).Elem()))
+	require.Equal(t, "&lt;obj&gt;", out.String())
+
+	out.Reset()
+	require.NoError(t, writeFastReflectValue(&out, ctx, privateField))
+	require.Empty(t, out.String())
+}
+
+func Test_VM_Fast_Arg_Numeric_Conversion_Branches(t *testing.T) {
+	valueInt, ok := fastArgInt64(&object.Integer{Value: 7})
+	require.True(t, ok)
+	require.Equal(t, int64(7), valueInt)
+
+	intCases := []struct {
+		name     string
+		value    interface{}
+		expected int64
+	}{
+		{"int", int(-1), -1},
+		{"int8", int8(-2), -2},
+		{"int16", int16(-3), -3},
+		{"int32", int32(-4), -4},
+		{"int64", int64(-5), -5},
+		{"uint", uint(1), 1},
+		{"uint8", uint8(2), 2},
+		{"uint16", uint16(3), 3},
+		{"uint32", uint32(4), 4},
+		{"uint64", uint64(5), 5},
+		{"uintptr", uintptr(6), 6},
+		{"float32", float32(7.5), 7},
+		{"float64", float64(8.5), 8},
+		{"native-int16", &object.Native{Value: int16(9)}, 9},
+	}
+	for _, tt := range intCases {
+		t.Run("int64_"+tt.name, func(t *testing.T) {
+			valueInt, ok := fastArgInt64(tt.value)
+			require.True(t, ok)
+			require.Equal(t, tt.expected, valueInt)
+		})
+	}
+
+	valueInt, ok = fastArgInt64(vmFastArgInt(-3))
+	require.True(t, ok)
+	require.Equal(t, int64(-3), valueInt)
+
+	valueInt, ok = fastArgInt64(vmFastArgUint64(12))
+	require.True(t, ok)
+	require.Equal(t, int64(12), valueInt)
+
+	valueInt, ok = fastArgInt64(vmFastArgFloat(2.75))
+	require.True(t, ok)
+	require.Equal(t, int64(2), valueInt)
+
+	if uint64(^uint(0)) > uint64(math.MaxInt64) {
+		_, ok = fastArgInt64((^uint(0) >> 1) + 1)
+		require.False(t, ok)
+	}
+
+	if uint64(^uintptr(0)) > uint64(math.MaxInt64) {
+		_, ok = fastArgInt64((^uintptr(0) >> 1) + 1)
+		require.False(t, ok)
+	}
+
+	_, ok = fastArgInt64(uint64(math.MaxInt64) + 1)
+	require.False(t, ok)
+
+	_, ok = fastArgInt64(vmFastArgUint64(math.MaxUint64))
+	require.False(t, ok)
+
+	_, ok = fastArgInt64(struct{}{})
+	require.False(t, ok)
+
+	_, ok = fastArgInt64(nil)
+	require.False(t, ok)
+
+	valueUint, ok := fastArgUint64(uint8(4))
+	require.True(t, ok)
+	require.Equal(t, uint64(4), valueUint)
+
+	uintCases := []struct {
+		name     string
+		value    interface{}
+		expected uint64
+	}{
+		{"int", int(1), 1},
+		{"int8", int8(2), 2},
+		{"int16", int16(3), 3},
+		{"int32", int32(4), 4},
+		{"int64", int64(5), 5},
+		{"uint", uint(6), 6},
+		{"uint8", uint8(7), 7},
+		{"uint16", uint16(8), 8},
+		{"uint32", uint32(9), 9},
+		{"uint64", uint64(10), 10},
+		{"uintptr", uintptr(11), 11},
+		{"float32", float32(12.75), 12},
+		{"float64", float64(13.75), 13},
+		{"native-uint16", &object.Native{Value: uint16(14)}, 14},
+	}
+	for _, tt := range uintCases {
+		t.Run("uint64_"+tt.name, func(t *testing.T) {
+			valueUint, ok := fastArgUint64(tt.value)
+			require.True(t, ok)
+			require.Equal(t, tt.expected, valueUint)
+		})
+	}
+
+	valueUint, ok = fastArgUint64(vmFastArgUint(5))
+	require.True(t, ok)
+	require.Equal(t, uint64(5), valueUint)
+
+	valueUint, ok = fastArgUint64(vmFastArgInt64(15))
+	require.True(t, ok)
+	require.Equal(t, uint64(15), valueUint)
+
+	valueUint, ok = fastArgUint64(vmFastArgFloat(6.25))
+	require.True(t, ok)
+	require.Equal(t, uint64(6), valueUint)
+
+	_, ok = fastArgUint64(int32(-1))
+	require.False(t, ok)
+
+	_, ok = fastArgUint64(int8(-1))
+	require.False(t, ok)
+
+	_, ok = fastArgUint64(int16(-1))
+	require.False(t, ok)
+
+	_, ok = fastArgUint64(int64(-1))
+	require.False(t, ok)
+
+	_, ok = fastArgUint64(vmFastArgInt(-1))
+	require.False(t, ok)
+
+	_, ok = fastArgUint64(vmFastArgFloat64(-2.25))
+	require.False(t, ok)
+
+	_, ok = fastArgUint64(float32(-1))
+	require.False(t, ok)
+
+	_, ok = fastArgUint64(float64(-1))
+	require.False(t, ok)
+
+	_, ok = fastArgUint64(struct{}{})
+	require.False(t, ok)
+
+	_, ok = fastArgUint64(nil)
+	require.False(t, ok)
+
+	valueFloat, ok := fastArgFloat64(uint32(9))
+	require.True(t, ok)
+	require.Equal(t, float64(9), valueFloat)
+
+	floatCases := []struct {
+		name     string
+		value    interface{}
+		expected float64
+	}{
+		{"int", int(-1), -1},
+		{"int8", int8(-2), -2},
+		{"int16", int16(-3), -3},
+		{"int32", int32(-4), -4},
+		{"int64", int64(-5), -5},
+		{"uint", uint(1), 1},
+		{"uint8", uint8(2), 2},
+		{"uint16", uint16(3), 3},
+		{"uint32", uint32(4), 4},
+		{"uint64", uint64(5), 5},
+		{"uintptr", uintptr(6), 6},
+		{"float32", float32(7.25), 7.25},
+		{"float64", float64(8.5), 8.5},
+		{"native-float32", &object.Native{Value: float32(9.5)}, 9.5},
+	}
+	for _, tt := range floatCases {
+		t.Run("float64_"+tt.name, func(t *testing.T) {
+			valueFloat, ok := fastArgFloat64(tt.value)
+			require.True(t, ok)
+			require.InDelta(t, tt.expected, valueFloat, 0.0001)
+		})
+	}
+
+	valueFloat, ok = fastArgFloat64(vmFastArgInt(-10))
+	require.True(t, ok)
+	require.Equal(t, float64(-10), valueFloat)
+
+	valueFloat, ok = fastArgFloat64(vmFastArgUint(11))
+	require.True(t, ok)
+	require.Equal(t, float64(11), valueFloat)
+
+	valueFloat, ok = fastArgFloat64(vmFastArgFloat(1.5))
+	require.True(t, ok)
+	require.InDelta(t, 1.5, valueFloat, 0.0001)
+
+	_, ok = fastArgFloat64(struct{}{})
+	require.False(t, ok)
+
+	_, ok = fastArgFloat64(nil)
+	require.False(t, ok)
+
+	_, ok = fastArgInt64(object.NullObject)
+	require.False(t, ok)
+}
+
+func Test_VM_Fast_Reflect_Arg_Value_For_Call_Branches(t *testing.T) {
+	value, err := fastReflectArgValueForCall("helper", 0, reflect.Value{}, stringType)
+	require.NoError(t, err)
+	require.Equal(t, "", value.Interface())
+
+	var nilPtr *vmFastPropertyUser
+	value, err = fastReflectArgValueForCall("helper", 0, reflect.ValueOf(nilPtr), reflect.TypeOf(&vmFastPropertyUser{}))
+	require.NoError(t, err)
+	require.True(t, value.IsNil())
+
+	value, err = fastReflectArgValueForCall("helper", 0, reflect.ValueOf("name"), stringType)
+	require.NoError(t, err)
+	require.Equal(t, "name", value.Interface())
+
+	value, err = fastReflectArgValueForCall("helper", 1, reflect.ValueOf(int32(7)), reflect.TypeOf(int64(0)))
+	require.NoError(t, err)
+	require.Equal(t, int64(7), value.Interface())
+
+	var iface interface{} = int32(8)
+	value, err = fastReflectArgValueForCall("helper", 1, reflect.ValueOf(&iface).Elem(), reflect.TypeOf(int64(0)))
+	require.NoError(t, err)
+	require.Equal(t, int64(8), value.Interface())
+
+	_, err = fastReflectArgValueForCall("helper", 2, reflect.ValueOf(struct{}{}), stringType)
+	require.ErrorContains(t, err, "invalid argument")
+
+	privateField := reflect.ValueOf(vmReflectPrivate{hidden: "secret"}).FieldByName("hidden")
+	_, err = fastReflectArgValueForCall("helper", 3, privateField, reflect.TypeOf(0))
+	require.ErrorContains(t, err, "invalid argument")
+}
+
+func Test_VM_Write_Fast_Reflect_Call_Results_Branches(t *testing.T) {
+	ctx := plush.NewContext()
+	var out strings.Builder
+
+	require.NoError(t, writeFastReflectCallResults(&out, ctx, "helper", nil))
+	require.Empty(t, out.String())
+
+	require.ErrorContains(t, writeFastReflectCallResults(&out, ctx, "helper", []reflect.Value{
+		reflect.ValueOf("ignored"),
+		reflect.ValueOf(errors.New("boom")),
+	}), "could not call helper function")
+
+	require.NoError(t, writeFastReflectCallResults(&out, ctx, "helper", []reflect.Value{reflect.Value{}}))
+	require.Empty(t, out.String())
+
+	var nilString *string
+	require.NoError(t, writeFastReflectCallResults(&out, ctx, "helper", []reflect.Value{reflect.ValueOf(nilString)}))
+	require.Empty(t, out.String())
+
+	tests := []struct {
+		name     string
+		value    reflect.Value
+		expected string
+	}{
+		{"html", reflect.ValueOf(template.HTML("<b>")), "<b>"},
+		{"string", reflect.ValueOf("<x>"), "&lt;x&gt;"},
+		{"object", reflect.ValueOf(&object.String{Value: "<obj>"}), "&lt;obj&gt;"},
+		{"bool", reflect.ValueOf(true), "true"},
+		{"int", reflect.ValueOf(int32(-3)), "-3"},
+		{"uint", reflect.ValueOf(uint32(4)), "4"},
+		{"float", reflect.ValueOf(float32(1.5)), "1.5"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out.Reset()
+			require.NoError(t, writeFastReflectCallResults(&out, ctx, "helper", []reflect.Value{tt.value}))
+			require.Equal(t, tt.expected, out.String())
+		})
+	}
+}

--- a/VM/vm/numeric_truth_field_helpers_test.go
+++ b/VM/vm/numeric_truth_field_helpers_test.go
@@ -1,0 +1,312 @@
+package vm
+
+import (
+	"html/template"
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/code"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/stretchr/testify/require"
+)
+
+type vmFieldStringer string
+
+func (s vmFieldStringer) String() string {
+	return "stringer:" + string(s)
+}
+
+type vmFieldHTMLer struct{}
+
+func (vmFieldHTMLer) HTML() template.HTML {
+	return template.HTML("<b>html</b>")
+}
+
+type vmFieldKinds struct {
+	HTML     template.HTML
+	Stringer vmFieldStringer
+	String   string
+	Bool     bool
+	Int      int32
+	Uint     uint32
+	Float    float32
+	Struct   struct{}
+	hidden   string
+}
+
+func Test_VM_Numeric_Comparison_Helper_Edges(t *testing.T) {
+	_, ok := numericValueFromGo(nil)
+	require.False(t, ok)
+	var nilIface interface{}
+	_, ok = numericValueFromGo(&nilIface)
+	require.False(t, ok)
+	var iface interface{} = int16(-9)
+	value, ok := numericValueFromGo(iface)
+	require.True(t, ok)
+	require.Equal(t, numericSigned, value.kind)
+	require.Equal(t, int64(-9), value.i)
+	value, ok = numericValueFromGo(int32(-3))
+	require.True(t, ok)
+	require.Equal(t, numericSigned, value.kind)
+	value, ok = numericValueFromGo(uint32(4))
+	require.True(t, ok)
+	require.Equal(t, numericUnsigned, value.kind)
+	value, ok = numericValueFromGo(float32(1.5))
+	require.True(t, ok)
+	require.Equal(t, numericFloat, value.kind)
+	_, ok = numericValueFromGo("nope")
+	require.False(t, ok)
+
+	require.True(t, compareNumericEquality(numericValue{kind: numericFloat, f: 1}, numericValue{kind: numericSigned, i: 1}))
+	require.True(t, compareNumericEquality(numericValue{kind: numericUnsigned, u: 9}, numericValue{kind: numericSigned, i: 9}))
+	require.False(t, compareNumericEquality(numericValue{kind: numericSigned, i: -1}, numericValue{kind: numericUnsigned, u: 1}))
+	require.False(t, compareNumericEquality(numericValue{kind: numericSigned, i: -1}, numericValue{kind: numericUnsigned, u: uint64(math.MaxInt64) + 1}))
+	require.False(t, compareNumericEquality(numericValue{kind: numericUnsigned, u: 1}, numericValue{kind: numericSigned, i: -1}))
+	require.False(t, compareNumericEquality(numericValue{kind: numericUnsigned, u: uint64(math.MaxInt64) + 1}, numericValue{kind: numericSigned, i: -1}))
+	require.False(t, compareNumericEquality(numericValue{kind: numericUnsigned, u: uint64(math.MaxInt64) + 1}, numericValue{kind: numericSigned, i: math.MaxInt64}))
+
+	result, err := compareNumericOrdered(code.OpGreaterThan, numericValue{kind: numericFloat, f: 2.5}, numericValue{kind: numericSigned, i: 2})
+	require.NoError(t, err)
+	require.True(t, result)
+
+	result, err = compareNumericOrdered(code.OpGreaterEqual, numericValue{kind: numericSigned, i: 2}, numericValue{kind: numericSigned, i: 2})
+	require.NoError(t, err)
+	require.True(t, result)
+
+	result, err = compareNumericOrdered(code.OpGreaterThan, numericValue{kind: numericUnsigned, u: 4}, numericValue{kind: numericUnsigned, u: 9})
+	require.NoError(t, err)
+	require.False(t, result)
+
+	result, err = compareNumericOrdered(code.OpGreaterThan, numericValue{kind: numericSigned, i: -1}, numericValue{kind: numericUnsigned, u: 0})
+	require.NoError(t, err)
+	require.False(t, result)
+
+	result, err = compareNumericOrdered(code.OpGreaterEqual, numericValue{kind: numericSigned, i: -1}, numericValue{kind: numericUnsigned, u: 0})
+	require.NoError(t, err)
+	require.False(t, result)
+
+	result, err = compareNumericOrdered(code.OpGreaterEqual, numericValue{kind: numericSigned, i: 7}, numericValue{kind: numericUnsigned, u: 7})
+	require.NoError(t, err)
+	require.True(t, result)
+
+	result, err = compareNumericOrdered(code.OpGreaterThan, numericValue{kind: numericUnsigned, u: 0}, numericValue{kind: numericSigned, i: -1})
+	require.NoError(t, err)
+	require.True(t, result)
+
+	result, err = compareNumericOrdered(code.OpGreaterEqual, numericValue{kind: numericUnsigned, u: 0}, numericValue{kind: numericSigned, i: -1})
+	require.NoError(t, err)
+	require.True(t, result)
+
+	result, err = compareNumericOrdered(code.OpGreaterThan, numericValue{kind: numericUnsigned, u: 5}, numericValue{kind: numericSigned, i: 7})
+	require.NoError(t, err)
+	require.False(t, result)
+
+	_, err = compareNumericOrdered(code.OpAdd, numericValue{kind: numericSigned, i: 1}, numericValue{kind: numericUnsigned, u: 1})
+	require.ErrorContains(t, err, "unknown ordered comparison")
+
+	_, err = compareFloatOrdered(code.OpAdd, 1, 2)
+	require.ErrorContains(t, err, "unknown ordered comparison")
+	_, err = compareIntOrdered(code.OpAdd, 1, 2)
+	require.ErrorContains(t, err, "unknown ordered comparison")
+	_, err = compareUintOrdered(code.OpAdd, 1, 2)
+	require.ErrorContains(t, err, "unknown ordered comparison")
+}
+
+func Test_VM_Numeric_Operation_Object_Branches(t *testing.T) {
+	obj, err := numericOperationObject(code.OpAdd, numericValue{kind: numericFloat, f: 1.5}, numericValue{kind: numericSigned, i: 2})
+	require.NoError(t, err)
+	require.Equal(t, &object.Float{Value: 3.5}, obj)
+	obj, err = numericOperationObject(code.OpSub, numericValue{kind: numericFloat, f: 3}, numericValue{kind: numericFloat, f: 1.25})
+	require.NoError(t, err)
+	require.Equal(t, &object.Float{Value: 1.75}, obj)
+	obj, err = numericOperationObject(code.OpMul, numericValue{kind: numericFloat, f: 2}, numericValue{kind: numericFloat, f: 4})
+	require.NoError(t, err)
+	require.Equal(t, &object.Float{Value: 8}, obj)
+	obj, err = numericOperationObject(code.OpDiv, numericValue{kind: numericFloat, f: 5}, numericValue{kind: numericFloat, f: 2})
+	require.NoError(t, err)
+	require.Equal(t, &object.Float{Value: 2.5}, obj)
+	_, err = numericOperationObject(code.OpDiv, numericValue{kind: numericFloat, f: 1}, numericValue{kind: numericFloat, f: 0})
+	require.ErrorContains(t, err, "division by zero")
+	_, err = numericOperationObject(code.OpEqual, numericValue{kind: numericFloat, f: 1}, numericValue{kind: numericFloat, f: 1})
+	require.ErrorContains(t, err, "unknown numeric operator")
+
+	obj, err = numericOperationObject(code.OpAdd, numericValue{kind: numericSigned, i: 2}, numericValue{kind: numericSigned, i: 3})
+	require.NoError(t, err)
+	require.Equal(t, &object.Integer{Value: 5}, obj)
+	obj, err = numericOperationObject(code.OpSub, numericValue{kind: numericSigned, i: 2}, numericValue{kind: numericSigned, i: 3})
+	require.NoError(t, err)
+	require.Equal(t, &object.Integer{Value: -1}, obj)
+	obj, err = numericOperationObject(code.OpMul, numericValue{kind: numericSigned, i: 2}, numericValue{kind: numericSigned, i: 3})
+	require.NoError(t, err)
+	require.Equal(t, &object.Integer{Value: 6}, obj)
+	obj, err = numericOperationObject(code.OpDiv, numericValue{kind: numericSigned, i: 7}, numericValue{kind: numericSigned, i: 2})
+	require.NoError(t, err)
+	require.Equal(t, &object.Integer{Value: 3}, obj)
+	_, err = numericOperationObject(code.OpDiv, numericValue{kind: numericSigned, i: 1}, numericValue{kind: numericSigned, i: 0})
+	require.ErrorContains(t, err, "division by zero")
+	_, err = numericOperationObject(code.OpEqual, numericValue{kind: numericSigned, i: 1}, numericValue{kind: numericSigned, i: 1})
+	require.ErrorContains(t, err, "unknown numeric operator")
+
+	bigUint := uint64(math.MaxInt64) + 2
+	obj, err = numericOperationObject(code.OpAdd, numericValue{kind: numericUnsigned, u: bigUint}, numericValue{kind: numericUnsigned, u: 1})
+	require.NoError(t, err)
+	require.Equal(t, &object.Native{Value: bigUint + 1}, obj)
+	obj, err = numericOperationObject(code.OpSub, numericValue{kind: numericUnsigned, u: bigUint}, numericValue{kind: numericUnsigned, u: 1})
+	require.NoError(t, err)
+	require.Equal(t, &object.Native{Value: bigUint - 1}, obj)
+	obj, err = numericOperationObject(code.OpMul, numericValue{kind: numericUnsigned, u: bigUint}, numericValue{kind: numericUnsigned, u: 1})
+	require.NoError(t, err)
+	require.Equal(t, &object.Native{Value: bigUint}, obj)
+	obj, err = numericOperationObject(code.OpDiv, numericValue{kind: numericUnsigned, u: bigUint}, numericValue{kind: numericUnsigned, u: 2})
+	require.NoError(t, err)
+	require.Equal(t, &object.Integer{Value: int64(bigUint / 2)}, obj)
+	_, err = numericOperationObject(code.OpAdd, numericValue{kind: numericUnsigned, u: math.MaxUint64}, numericValue{kind: numericUnsigned, u: 1})
+	require.ErrorContains(t, err, "integer overflow")
+	_, err = numericOperationObject(code.OpSub, numericValue{kind: numericUnsigned, u: bigUint}, numericValue{kind: numericUnsigned, u: bigUint + 1})
+	require.ErrorContains(t, err, "integer underflow")
+	_, err = numericOperationObject(code.OpMul, numericValue{kind: numericUnsigned, u: math.MaxUint64}, numericValue{kind: numericUnsigned, u: 2})
+	require.ErrorContains(t, err, "integer overflow")
+	_, err = numericOperationObject(code.OpDiv, numericValue{kind: numericUnsigned, u: 1}, numericValue{kind: numericUnsigned, u: 0})
+	require.ErrorContains(t, err, "division by zero")
+	_, err = numericOperationObject(code.OpEqual, numericValue{kind: numericUnsigned, u: 1}, numericValue{kind: numericUnsigned, u: 1})
+	require.ErrorContains(t, err, "unknown numeric operator")
+	_, err = numericOperationObject(code.OpDiv, numericValue{kind: numericUnsigned, u: bigUint}, numericValue{kind: numericUnsigned, u: 0})
+	require.ErrorContains(t, err, "division by zero")
+	_, err = numericOperationObject(code.OpEqual, numericValue{kind: numericUnsigned, u: bigUint}, numericValue{kind: numericUnsigned, u: 1})
+	require.ErrorContains(t, err, "unknown numeric operator")
+	_, err = numericOperationObject(code.OpAdd, numericValue{kind: numericUnsigned, u: math.MaxUint64}, numericValue{kind: numericSigned, i: -1})
+	require.ErrorContains(t, err, "unsupported mixed signed/unsigned")
+}
+
+func Test_VM_Truthy_Fast_Reflect_Value_Branches(t *testing.T) {
+	require.False(t, isTruthyFastReflectValue(reflect.Value{}))
+
+	var nilIface interface{}
+	require.False(t, isTruthyFastReflectValue(reflect.ValueOf(&nilIface).Elem()))
+
+	var objIface interface{} = object.FalseObject
+	require.False(t, isTruthyFastReflectValue(reflect.ValueOf(&objIface).Elem()))
+
+	require.True(t, isTruthyFastReflectValue(reflect.ValueOf(true)))
+	require.False(t, isTruthyFastReflectValue(reflect.ValueOf(false)))
+	require.True(t, isTruthyFastReflectValue(reflect.ValueOf("x")))
+	require.False(t, isTruthyFastReflectValue(reflect.ValueOf("")))
+
+	var nilUser *vmFastPropertyUser
+	require.False(t, isTruthyFastReflectValue(reflect.ValueOf(nilUser)))
+	require.True(t, isTruthyFastReflectValue(reflect.ValueOf(&vmFastPropertyUser{})))
+	require.True(t, isTruthyFastReflectValue(reflect.ValueOf(0)))
+}
+
+func Test_VM_Write_Fast_Field_Branches(t *testing.T) {
+	ctx := plush.NewContext()
+	fields := vmFieldKinds{
+		HTML:     template.HTML("<b>"),
+		Stringer: vmFieldStringer("value"),
+		String:   "<x>",
+		Bool:     true,
+		Int:      -3,
+		Uint:     4,
+		Float:    1.5,
+	}
+	rv := reflect.ValueOf(fields)
+
+	tests := []struct {
+		name     string
+		field    string
+		expected string
+		handled  bool
+	}{
+		{"html", "HTML", "<b>", true},
+		{"stringer", "Stringer", "stringer:value", true},
+		{"string", "String", "&lt;x&gt;", true},
+		{"bool", "Bool", "true", true},
+		{"int", "Int", "-3", true},
+		{"uint", "Uint", "4", true},
+		{"float", "Float", "1.5", true},
+		{"struct", "Struct", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out strings.Builder
+			handled, err := writeFastField(&out, ctx, rv.FieldByName(tt.field), object.PropertyAccess{}, tt.field, rv.FieldByName(tt.field).Type())
+			require.NoError(t, err)
+			require.Equal(t, tt.handled, handled)
+			require.Equal(t, tt.expected, out.String())
+		})
+	}
+
+	var nilString *string
+	handled, err := writeFastField(&strings.Builder{}, ctx, reflect.ValueOf(&nilString).Elem(), object.PropertyAccess{}, "Nil", stringType)
+	require.NoError(t, err)
+	require.True(t, handled)
+
+	value := "ptr"
+	fieldValue, err := fastFieldValue(reflect.ValueOf(&value), object.PropertyAccess{}, "Value")
+	require.NoError(t, err)
+	require.Equal(t, "ptr", fieldValue)
+
+	fieldValue, err = fastFieldValue(rv.FieldByName("String"), object.PropertyAccess{}, "String")
+	require.NoError(t, err)
+	require.Equal(t, "<x>", fieldValue)
+
+	_, err = writeFastField(&strings.Builder{}, ctx, rv.FieldByName("hidden"), object.PropertyAccess{}, "hidden", stringType)
+	require.ErrorContains(t, err, "unexported field")
+
+	require.True(t, canWriteFastGoValue(vmFieldHTMLer{}))
+}
+
+func Test_VM_Eval_Fast_Logical_Infix_Value_Branches(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{"left": true, "right": false})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"left", "right"}}, ctx)
+
+	result, ok, err := evalFastLogicalInfixValue(&compiler.FastValuePlan{
+		Operator: "&&",
+		Left:     &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: false},
+		Right:    &compiler.FastValuePlan{Kind: compiler.FastValueName, Value: "missing", NameIndex: 99},
+	}, ctx, bindings, nil, nil, nil, false)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, false, result)
+
+	result, ok, err = evalFastLogicalInfixValue(&compiler.FastValuePlan{
+		Operator: "||",
+		Left:     &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true},
+		Right:    &compiler.FastValuePlan{Kind: compiler.FastValueName, Value: "missing", NameIndex: 99},
+	}, ctx, bindings, nil, nil, nil, false)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, true, result)
+
+	result, ok, err = evalFastLogicalInfixValue(&compiler.FastValuePlan{
+		Operator: "&&",
+		Left:     &compiler.FastValuePlan{Kind: compiler.FastValueName, Value: "left", NameIndex: 0},
+		Right:    &compiler.FastValuePlan{Kind: compiler.FastValueName, Value: "right", NameIndex: 1},
+	}, ctx, bindings, nil, nil, nil, false)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, false, result)
+
+	result, ok, err = evalFastLogicalInfixValue(&compiler.FastValuePlan{
+		Operator: "??",
+		Left:     &compiler.FastValuePlan{Kind: compiler.FastValueName, Value: "left", NameIndex: 0},
+		Right:    &compiler.FastValuePlan{Kind: compiler.FastValueName, Value: "right", NameIndex: 1},
+	}, ctx, bindings, nil, nil, nil, false)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, result)
+
+	result, ok, err = evalFastLogicalInfixValue(&compiler.FastValuePlan{
+		Operator: "&&",
+		Left:     &compiler.FastValuePlan{Kind: compiler.FastValueLoopKey},
+		Right:    &compiler.FastValuePlan{Kind: compiler.FastValuePath, NameIndex: -1},
+	}, ctx, bindings, "key", "value", nil, true)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, true, result)
+}

--- a/VM/vm/partial_cache.go
+++ b/VM/vm/partial_cache.go
@@ -1,0 +1,155 @@
+package vm
+
+import (
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+	"github.com/gobuffalo/plush/v5/helpers/meta"
+)
+
+func newPartialBytecodeLinkCache() *partialBytecodeLinkCache {
+	return &partialBytecodeLinkCache{entries: map[string]*partialBytecodeLink{}}
+}
+
+type partialMetaIDs struct {
+	templateFileID     int
+	templateBaseFileID int
+	templateExtID      int
+	alreadyPartialID   int
+	contentTypeID      int
+}
+
+func (c *partialBytecodeLinkCache) Get(key string, sourceHash uint64) (*compiler.Bytecode, bool) {
+	link, ok := c.GetLink(key, sourceHash)
+	if !ok {
+		return nil, false
+	}
+	return link.bytecode, true
+}
+
+func (c *partialBytecodeLinkCache) GetLink(key string, sourceHash uint64) (*partialBytecodeLink, bool) {
+	if c == nil || key == "" {
+		return nil, false
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	entry, ok := c.entries[key]
+	if !ok || entry.sourceHash != sourceHash || entry.bytecode == nil {
+		return nil, false
+	}
+	return entry, true
+}
+
+func (c *partialBytecodeLinkCache) Set(key string, sourceHash uint64, bytecode *compiler.Bytecode) *partialBytecodeLink {
+	return c.SetWithSource(key, sourceHash, "", bytecode)
+}
+
+func (c *partialBytecodeLinkCache) SetWithSource(key string, sourceHash uint64, source string, bytecode *compiler.Bytecode) *partialBytecodeLink {
+	if c == nil || key == "" || bytecode == nil {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	link := &partialBytecodeLink{sourceHash: sourceHash, source: source, bytecode: bytecode}
+	c.entries[key] = link
+	return link
+}
+
+func (c *partialBytecodeLinkCache) Len() int {
+	if c == nil {
+		return 0
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.entries)
+}
+
+func (c *partialBytecodeLinkCache) partialFeeder(ctx hctx.Context) (func(string) (string, error), bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	if lookup, ok := ctx.(contextIDLookup); ok && canCacheFastRenderBindingPlan(ctx) {
+		id := c.partialFeederID(lookup)
+		if value, ok := lookup.LookupID(id); ok {
+			feeder, ok := value.(func(string) (string, error))
+			return feeder, ok
+		}
+	}
+	feeder, ok := ctx.Value(vmPartialFeederName).(func(string) (string, error))
+	return feeder, ok
+}
+
+func (c *partialBytecodeLinkCache) partialFeederID(lookup contextIDLookup) int {
+	if c == nil || lookup == nil {
+		return -1
+	}
+	c.mu.RLock()
+	if c.hasFeederID {
+		id := c.feederID
+		c.mu.RUnlock()
+		return id
+	}
+	c.mu.RUnlock()
+
+	id := lookup.InternID(vmPartialFeederName)
+	c.mu.Lock()
+	if !c.hasFeederID {
+		c.feederID = id
+		c.hasFeederID = true
+	}
+	id = c.feederID
+	c.mu.Unlock()
+	return id
+}
+
+func (c *partialBytecodeLinkCache) partialMetaIDs(ctx hctx.Context) (partialMetaIDs, bool) {
+	if c == nil || !canCacheFastRenderBindingPlan(ctx) {
+		return partialMetaIDs{}, false
+	}
+	lookup := ctx.(contextIDLookup)
+	c.mu.RLock()
+	if c.hasMetaIDs {
+		ids := c.metaIDs
+		c.mu.RUnlock()
+		return ids, true
+	}
+	c.mu.RUnlock()
+
+	ids := partialMetaIDs{
+		templateFileID:     lookup.InternID(meta.TemplateFileKey),
+		templateBaseFileID: lookup.InternID(meta.TemplateBaseFileNameKey),
+		templateExtID:      lookup.InternID(meta.TemplateExtensionKey),
+		alreadyPartialID:   lookup.InternID(vmAlreadyInPartial),
+		contentTypeID:      lookup.InternID("contentType"),
+	}
+	c.mu.Lock()
+	if !c.hasMetaIDs {
+		c.metaIDs = ids
+		c.hasMetaIDs = true
+	}
+	ids = c.metaIDs
+	c.mu.Unlock()
+	return ids, true
+}
+
+func (l *partialBytecodeLink) fastBindingPlan(ctx hctx.Context) *fastRenderBindingPlan {
+	if l == nil || l.bytecode == nil || l.bytecode.FastRenderPlan == nil {
+		return nil
+	}
+	l.mu.RLock()
+	plan := l.bindingPlan
+	l.mu.RUnlock()
+	if plan != nil {
+		return plan
+	}
+	plan = newFastRenderBindingPlan(l.bytecode.FastRenderPlan, ctx)
+	if plan == nil {
+		return nil
+	}
+	l.mu.Lock()
+	if l.bindingPlan == nil {
+		l.bindingPlan = plan
+	}
+	plan = l.bindingPlan
+	l.mu.Unlock()
+	return plan
+}

--- a/VM/vm/partial_direct_edges_test.go
+++ b/VM/vm/partial_direct_edges_test.go
@@ -1,0 +1,890 @@
+package vm
+
+import (
+	"fmt"
+	"html/template"
+	"strings"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/helpers/meta"
+	"github.com/gobuffalo/plush/v5/templatecache/inmemory"
+	"github.com/stretchr/testify/require"
+)
+
+func vmPartialDataPlan(name string, key string) (*compiler.FastPartialPlan, *fastPartialDataBindingPlan) {
+	partial := &compiler.FastPartialPlan{
+		Name: name,
+		Data: []compiler.FastPartialDataPair{{
+			Key:   key,
+			Value: compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "Mido"},
+			Line:  3,
+		}},
+		Line: 3,
+	}
+	return partial, buildFastPartialDataBindingPlan(partial)
+}
+
+func Test_VM_Fast_Data_Partial_Direct_Edge_Branches(t *testing.T) {
+	partial, dataPlan := vmPartialDataPlan("edge_data_direct_static.plush", "name")
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"partialFeeder": func(string) (string, error) {
+			return `<span>static</span>`, nil
+		},
+	})
+	var out strings.Builder
+
+	handled, err := renderFastDataPartialInto(nil, partial, ctx, fastRenderBindings{}, dataPlan)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	handled, err = renderFastDataPartialInto(&out, nil, ctx, fastRenderBindings{}, dataPlan)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	handled, err = renderFastDataPartialDirectInto(nil, partial, ctx, fastRenderBindings{}, dataPlan)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	handled, err = renderFastDataPartialDirectInto(&out, nil, ctx, fastRenderBindings{}, dataPlan)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	handled, err = renderFastDataPartialDirectInto(&out, partial, ctx, fastRenderBindings{}, nil)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	handled, err = renderFastDataPartialDirectInto(&out, partial, ctx, fastRenderBindings{}, &fastPartialDataBindingPlan{})
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	layoutPartial, layoutPlan := vmPartialDataPlan("edge_data_direct_layout.plush", "layout")
+	handled, err = renderFastDataPartialDirectInto(&out, layoutPartial, ctx, fastRenderBindings{}, layoutPlan)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	jsCtx := plush.NewContextWith(map[string]interface{}{"contentType": "application/javascript"})
+	handled, err = renderFastDataPartialDirectInto(&out, &compiler.FastPartialPlan{Name: "edge.html", Line: 4}, jsCtx, fastRenderBindings{}, dataPlan)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	handled, err = renderFastDataPartialDirectInto(&out, partial, plush.NewContext(), fastRenderBindings{}, dataPlan)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 3")
+	require.ErrorContains(t, err, "could not find partial feeder")
+
+	errorCtx := plush.NewContextWith(map[string]interface{}{
+		"partialFeeder": func(string) (string, error) {
+			return "", fmt.Errorf("missing partial")
+		},
+	})
+	handled, err = renderFastDataPartialDirectInto(&out, partial, errorCtx, fastRenderBindings{}, dataPlan)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 3: missing partial")
+
+	parseCtx := plush.NewContextWith(map[string]interface{}{
+		"partialFeeder": func(string) (string, error) {
+			return `<%=`, nil
+		},
+	})
+	handled, err = renderFastDataPartialDirectInto(&out, partial, parseCtx, fastRenderBindings{}, dataPlan)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 3")
+
+	filenameCtx := plush.NewContextWith(map[string]interface{}{
+		"partialFeeder": func(string) (string, error) {
+			return `<span>static</span>`, nil
+		},
+	})
+	filenameCtx.Set(meta.TemplateBaseFileNameKey, "index")
+	filenameCtx.Set(meta.TemplateExtensionKey, "plush")
+	filenameCtx.Set(meta.TemplateFileKey, 12)
+	handled, err = renderFastDataPartialDirectInto(&out, partial, filenameCtx, fastRenderBindings{}, dataPlan)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 3")
+	require.ErrorContains(t, err, "expected fileKey to be a string")
+
+	out.Reset()
+	handled, err = renderFastDataPartialDirectInto(&out, partial, ctx, fastRenderBindings{}, dataPlan)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, `<span>static</span>`, out.String())
+}
+
+func Test_VM_Fast_Data_Partial_Direct_Cached_Bytecode_Fallback_Branches(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	plush.PlushCacheSetup(cache)
+	defer func() {
+		plush.ClearTemplateCache()
+		plush.PlushCacheSetup(nil)
+	}()
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"partialFeeder": func(string) (string, error) {
+			return `<span>ignored</span>`, nil
+		},
+	})
+	var out strings.Builder
+
+	partial, dataPlan := vmPartialDataPlan("edge_data_direct_holes.plush", "name")
+	plush.CacheVMBytecodeForCleanFilename(partial.Name, nil, &compiler.Bytecode{HasHoles: true})
+	handled, err := renderFastDataPartialDirectInto(&out, partial, ctx, fastRenderBindings{}, dataPlan)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	partial, dataPlan = vmPartialDataPlan("edge_data_direct_no_fast_plan.plush", "name")
+	plush.CacheVMBytecodeForCleanFilename(partial.Name, nil, &compiler.Bytecode{})
+	handled, err = renderFastDataPartialDirectInto(&out, partial, ctx, fastRenderBindings{}, dataPlan)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	partial, dataPlan = vmPartialDataPlan("edge_data_direct_special_binding.plush", "name")
+	plush.CacheVMBytecodeForCleanFilename(partial.Name, nil, &compiler.Bytecode{
+		FastRenderPlan: &compiler.FastRenderPlan{Bindings: []string{"contentType"}},
+	})
+	handled, err = renderFastDataPartialDirectInto(&out, partial, ctx, fastRenderBindings{}, dataPlan)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	partial, dataPlan = vmPartialDataPlan("edge_data_direct_empty_fast_plan.plush", "name")
+	plush.CacheVMBytecodeForCleanFilename(partial.Name, nil, &compiler.Bytecode{
+		FastRenderPlan: &compiler.FastRenderPlan{Bindings: []string{"name"}},
+	})
+	handled, err = renderFastDataPartialDirectInto(&out, partial, ctx, fastRenderBindings{}, dataPlan)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	errorPartial := &compiler.FastPartialPlan{
+		Name: "edge_data_direct_static_error.plush",
+		Data: []compiler.FastPartialDataPair{{
+			Key: "name",
+			Value: compiler.FastValuePlan{
+				Kind: compiler.FastValueCall,
+				Call: &compiler.FastCallPlan{
+					Name:      "echo",
+					NameIndex: 0,
+					Args:      []compiler.FastValuePlan{{Kind: compiler.FastValueString, Value: "go"}},
+					Line:      33,
+				},
+			},
+			Line: 33,
+		}},
+		Line: 33,
+	}
+	errorPlan := buildFastPartialDataBindingPlan(errorPartial)
+	errorCtx := plush.NewContextWith(map[string]interface{}{
+		"echo": func(string) string { return "go" },
+		"partialFeeder": func(string) (string, error) {
+			return `<span>ignored</span>`, nil
+		},
+	}).WithBudget(plush.NewBudget(0))
+	plush.CacheVMBytecodeForCleanFilename(errorPartial.Name, nil, &compiler.Bytecode{Static: true, StaticOutput: "never"})
+	handled, err = renderFastDataPartialDirectInto(&out, errorPartial, errorCtx, fastRenderBindings{}, errorPlan)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 33")
+}
+
+func Test_VM_Partial_Bytecode_Link_For_Input_Uses_Cached_VM_Bytecode(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	plush.PlushCacheSetup(cache)
+	defer func() {
+		plush.ClearTemplateCache()
+		plush.PlushCacheSetup(nil)
+	}()
+
+	ctx := plush.NewContext()
+	filename := "edge_cached_link.plush"
+	bytecode := &compiler.Bytecode{Static: true, StaticOutput: "cached"}
+	plush.CacheVMBytecodeForCleanFilename(filename, nil, bytecode)
+
+	link, err := partialBytecodeLinkForInput("ignored", filename, ctx)
+	require.NoError(t, err)
+	require.NotNil(t, link)
+	require.Same(t, bytecode, link.bytecode)
+}
+
+func Test_VM_Fast_Data_Partial_Fallback_Error_Branches(t *testing.T) {
+	partial, dataPlan := vmPartialDataPlan("edge_data_fallback.html", "name")
+	var out strings.Builder
+
+	budgetCtx := plush.NewContextWith(map[string]interface{}{
+		"partialFeeder": func(string) (string, error) {
+			return `<span>never</span>`, nil
+		},
+	}).WithBudget(plush.NewBudget(0))
+	handled, err := renderFastDataPartialInto(&out, partial, budgetCtx, fastRenderBindings{}, dataPlan)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 3")
+
+	missingPartial := &compiler.FastPartialPlan{
+		Name: "edge_data_missing.html",
+		Data: []compiler.FastPartialDataPair{{
+			Key:   "name",
+			Value: compiler.FastValuePlan{Kind: compiler.FastValueName, Value: "missing", NameIndex: 99},
+			Line:  15,
+		}},
+		Line: 15,
+	}
+	missingDataPlan := buildFastPartialDataBindingPlan(missingPartial)
+	jsCtx := plush.NewContextWith(map[string]interface{}{
+		"contentType": "application/javascript",
+		"partialFeeder": func(string) (string, error) {
+			return `<span><%= name %></span>`, nil
+		},
+	})
+	handled, err = renderFastDataPartialInto(&out, missingPartial, jsCtx, fastRenderBindings{}, missingDataPlan)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 15")
+
+	out.Reset()
+	handled, err = renderFastDataPartialInto(&out, partial, jsCtx, fastRenderBindings{}, &fastPartialDataBindingPlan{})
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, template.JSEscapeString("<span>Mido</span>"), out.String())
+
+	handled, err = renderFastDataPartialInto(&out, missingPartial, jsCtx, fastRenderBindings{}, nil)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 15")
+
+	filenameCtx := plush.NewContextWith(map[string]interface{}{
+		"contentType": "application/javascript",
+		"partialFeeder": func(string) (string, error) {
+			return `<span><%= name %></span>`, nil
+		},
+	})
+	filenameCtx.Set(meta.TemplateBaseFileNameKey, "index")
+	filenameCtx.Set(meta.TemplateExtensionKey, "plush")
+	filenameCtx.Set(meta.TemplateFileKey, 12)
+	handled, err = renderFastDataPartialInto(&out, partial, filenameCtx, fastRenderBindings{}, dataPlan)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 3")
+	require.ErrorContains(t, err, "expected fileKey to be a string")
+
+	parseCtx := plush.NewContextWith(map[string]interface{}{
+		"contentType": "application/javascript",
+		"partialFeeder": func(string) (string, error) {
+			return `<%=`, nil
+		},
+	})
+	handled, err = renderFastDataPartialInto(&out, partial, parseCtx, fastRenderBindings{}, dataPlan)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 3")
+}
+
+func Test_VM_Fast_Data_Partial_Non_ID_Fallback_Error_Branches(t *testing.T) {
+	var out strings.Builder
+
+	missingPartial := &compiler.FastPartialPlan{
+		Name: "edge_data_slow_apply_missing.plush",
+		Data: []compiler.FastPartialDataPair{{
+			Key:   "name",
+			Value: compiler.FastValuePlan{Kind: compiler.FastValueName, Value: "missing", NameIndex: 99},
+			Line:  51,
+		}},
+		Line: 51,
+	}
+	ctx := newVMFallbackContext(map[string]interface{}{
+		"partialFeeder": func(string) (string, error) {
+			return `<span>never</span>`, nil
+		},
+	})
+	handled, err := renderFastDataPartialInto(&out, missingPartial, ctx, fastRenderBindings{}, &fastPartialDataBindingPlan{})
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 51")
+	require.ErrorContains(t, err, `"missing": unknown identifier`)
+
+	inlineErrPartial := &compiler.FastPartialPlan{
+		Name: "edge_data_slow_inline_parse.plush",
+		Data: []compiler.FastPartialDataPair{{
+			Key:   "layout",
+			Value: compiler.FastValuePlan{Kind: compiler.FastValueString, Value: ""},
+			Line:  52,
+		}},
+		Line: 52,
+	}
+	inlineErrCtx := newVMFallbackContext(map[string]interface{}{
+		"partialFeeder": func(string) (string, error) {
+			return `<%=`, nil
+		},
+	})
+	handled, err = renderFastDataPartialInto(&out, inlineErrPartial, inlineErrCtx, fastRenderBindings{}, buildFastPartialDataBindingPlan(inlineErrPartial))
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 52")
+
+	jsErrPartial := &compiler.FastPartialPlan{
+		Name: "edge_data_slow_js_parse.plush",
+		Data: []compiler.FastPartialDataPair{{
+			Key:   "layout",
+			Value: compiler.FastValuePlan{Kind: compiler.FastValueString, Value: ""},
+			Line:  53,
+		}},
+		Line: 53,
+	}
+	jsErrCtx := newVMFallbackContext(map[string]interface{}{
+		"contentType": "application/javascript",
+		"partialFeeder": func(string) (string, error) {
+			return `<%=`, nil
+		},
+	})
+	handled, err = renderFastDataPartialInto(&out, jsErrPartial, jsErrCtx, fastRenderBindings{}, buildFastPartialDataBindingPlan(jsErrPartial))
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 53")
+}
+
+func Test_VM_Fast_No_Data_Partial_Direct_Edge_Branches(t *testing.T) {
+	var out strings.Builder
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"partialFeeder": func(string) (string, error) {
+			return `<span>static no data</span>`, nil
+		},
+	})
+
+	handled, err := renderFastNoDataPartialDirectInto(nil, "edge_no_data_static.plush", ctx, 5)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	handled, err = renderFastNoDataPartialDirectInto(&out, "edge_no_data_static.plush", nil, 5)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	jsCtx := plush.NewContextWith(map[string]interface{}{"contentType": "application/javascript"})
+	handled, err = renderFastNoDataPartialDirectInto(&out, "edge_no_data.html", jsCtx, 6)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	handled, err = renderFastNoDataPartialDirectInto(&out, "edge_no_data_missing.plush", plush.NewContext(), 7)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 7")
+	require.ErrorContains(t, err, "could not find partial feeder")
+
+	errorCtx := plush.NewContextWith(map[string]interface{}{
+		"partialFeeder": func(string) (string, error) {
+			return "", fmt.Errorf("missing partial")
+		},
+	})
+	handled, err = renderFastNoDataPartialDirectInto(&out, "edge_no_data_error.plush", errorCtx, 8)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 8: missing partial")
+
+	filenameCtx := plush.NewContextWith(map[string]interface{}{
+		"partialFeeder": func(string) (string, error) {
+			return `<span>static no data</span>`, nil
+		},
+	})
+	filenameCtx.Set(meta.TemplateBaseFileNameKey, "index")
+	filenameCtx.Set(meta.TemplateExtensionKey, "plush")
+	filenameCtx.Set(meta.TemplateFileKey, 12)
+	handled, err = renderFastNoDataPartialDirectInto(&out, "edge_no_data_filename.plush", filenameCtx, 9)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 9")
+	require.ErrorContains(t, err, "expected fileKey to be a string")
+
+	parseCtx := plush.NewContextWith(map[string]interface{}{
+		"partialFeeder": func(string) (string, error) {
+			return `<%=`, nil
+		},
+	})
+	handled, err = renderFastNoDataPartialDirectInto(&out, "edge_no_data_parse.plush", parseCtx, 10)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 10")
+
+	out.Reset()
+	handled, err = renderFastNoDataPartialDirectInto(&out, "edge_no_data_static.plush", ctx, 5)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, `<span>static no data</span>`, out.String())
+}
+
+func Test_VM_Fast_No_Data_Partial_Direct_Cached_Bytecode_Fallback_Branches(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	plush.PlushCacheSetup(cache)
+	defer func() {
+		plush.ClearTemplateCache()
+		plush.PlushCacheSetup(nil)
+	}()
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"partialFeeder": func(string) (string, error) {
+			return `<span>ignored</span>`, nil
+		},
+	})
+	var out strings.Builder
+
+	plush.CacheVMBytecodeForCleanFilename("edge_no_data_direct_holes.plush", nil, &compiler.Bytecode{HasHoles: true})
+	handled, err := renderFastNoDataPartialDirectInto(&out, "edge_no_data_direct_holes.plush", ctx, 41)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	plush.CacheVMBytecodeForCleanFilename("edge_no_data_direct_special_binding.plush", nil, &compiler.Bytecode{
+		FastRenderPlan: &compiler.FastRenderPlan{Bindings: []string{"contentType"}},
+	})
+	handled, err = renderFastNoDataPartialDirectInto(&out, "edge_no_data_direct_special_binding.plush", ctx, 42)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	plush.CacheVMBytecodeForCleanFilename("edge_no_data_direct_empty_fast_plan.plush", nil, &compiler.Bytecode{
+		FastRenderPlan: &compiler.FastRenderPlan{Bindings: []string{"name"}},
+	})
+	handled, err = renderFastNoDataPartialDirectInto(&out, "edge_no_data_direct_empty_fast_plan.plush", ctx, 43)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	blockTmpl, err := Compile(`<%= wrap({}) { %>body<% } %>`)
+	require.NoError(t, err)
+	blockFilename := "edge_no_data_cached_block_call.plush"
+	plush.CacheVMBytecodeForCleanFilename(blockFilename, nil, blockTmpl.bytecode)
+	ctx.Set(meta.TemplateFileKey, blockFilename)
+	previousFallback := plush.SetVMGenericFallback(true)
+	handled, err = renderCachedPartialBytecodeInto(&out, ctx, blockFilename, false)
+	plush.SetVMGenericFallback(previousFallback)
+	require.NoError(t, err)
+	require.False(t, handled)
+}
+
+func Test_VM_Direct_Partial_Uses_Cached_Bytecode_Before_Feeder(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	plush.PlushCacheSetup(cache)
+	defer func() {
+		plush.ClearTemplateCache()
+		plush.PlushCacheSetup(nil)
+	}()
+
+	filename := "edge_direct_cached_before_feeder.plush"
+	cachedBytecode := &compiler.Bytecode{Static: true, StaticOutput: "cached"}
+	plush.CacheVMBytecodeForCleanFilename(filename, nil, cachedBytecode)
+
+	feederCalls := 0
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"partialFeeder": func(string) (string, error) {
+			feederCalls++
+			return `<span>from feeder</span>`, nil
+		},
+	})
+
+	link, handled, err := directPartialBytecodeLinkForName(filename, filename, ctx)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.NotNil(t, link)
+	require.Same(t, cachedBytecode, link.bytecode)
+	require.Equal(t, 0, feederCalls)
+}
+
+func Test_VM_Fast_No_Data_Partial_Direct_Uses_Current_Feeder_Source_When_Source_Is_Unknown(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	plush.PlushCacheSetup(cache)
+	defer func() {
+		plush.ClearTemplateCache()
+		plush.PlushCacheSetup(nil)
+	}()
+
+	firstCtx := plush.NewContextWith(map[string]interface{}{
+		"name": "Mido",
+		"partialFeeder": func(string) (string, error) {
+			return `<span><%= name %></span>`, nil
+		},
+	})
+
+	var out strings.Builder
+	handled, err := renderFastNoDataPartialDirectInto(&out, "edge_no_data_cached_before_feeder.html", firstCtx, 44)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, `<span>Mido</span>`, out.String())
+
+	feederCalls := 0
+	secondCtx := plush.NewContextWith(map[string]interface{}{
+		"name": "Fry",
+		"partialFeeder": func(string) (string, error) {
+			feederCalls++
+			return `<span><%= name %></span>`, nil
+		},
+	})
+
+	out.Reset()
+	handled, err = renderFastNoDataPartialDirectInto(&out, "edge_no_data_cached_before_feeder.html", secondCtx, 45)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, `<span>Fry</span>`, out.String())
+	require.Equal(t, 1, feederCalls)
+}
+
+func Test_VM_Fast_No_Data_Partial_Direct_Skips_Contextual_Helper_From_Current_Feeder_Source(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	plush.PlushCacheSetup(cache)
+	defer func() {
+		plush.ClearTemplateCache()
+		plush.PlushCacheSetup(nil)
+	}()
+
+	bytecode := requireCompiledBytecode(t, `<%= filename() %>`)
+	plush.CacheVMBytecodeForCleanFilename("edge_no_data_contextual_helper.plush", nil, bytecode)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"partialFeeder": func(string) (string, error) {
+			return `<%= filename() %>`, nil
+		},
+	})
+	var out strings.Builder
+
+	handled, err := renderFastNoDataPartialDirectInto(&out, "edge_no_data_contextual_helper.plush", ctx, 46)
+	require.NoError(t, err)
+	require.False(t, handled)
+	require.Empty(t, out.String())
+}
+
+func Test_VM_Fast_Data_Partial_Direct_Uses_Current_Feeder_Source_When_Source_Is_Unknown(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	plush.PlushCacheSetup(cache)
+	defer func() {
+		plush.ClearTemplateCache()
+		plush.PlushCacheSetup(nil)
+	}()
+
+	tmpl, err := Compile(`<%= partial("edge_data_cached_before_feeder.html", {name: first}) %>`)
+	require.NoError(t, err)
+	mixed := prepareFastMixedPlan(tmpl.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed)
+	require.Len(t, mixed.ops, 1)
+	require.NotNil(t, mixed.ops[0].partial)
+	require.NotNil(t, mixed.ops[0].partialData)
+
+	firstCtx := plush.NewContextWith(map[string]interface{}{
+		"first": "Mido",
+		"partialFeeder": func(string) (string, error) {
+			return `<span><%= name %></span>`, nil
+		},
+	})
+
+	var out strings.Builder
+	handled, err := renderFastDataPartialDirectInto(&out, mixed.ops[0].partial, firstCtx, newFastRenderBindings(tmpl.bytecode.FastRenderPlan, firstCtx), mixed.ops[0].partialData)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, `<span>Mido</span>`, out.String())
+
+	feederCalls := 0
+	secondCtx := plush.NewContextWith(map[string]interface{}{
+		"first": "Fry",
+		"partialFeeder": func(string) (string, error) {
+			feederCalls++
+			return `<span><%= name %></span>`, nil
+		},
+	})
+
+	out.Reset()
+	handled, err = renderFastDataPartialDirectInto(&out, mixed.ops[0].partial, secondCtx, newFastRenderBindings(tmpl.bytecode.FastRenderPlan, secondCtx), mixed.ops[0].partialData)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, `<span>Fry</span>`, out.String())
+	require.Equal(t, 1, feederCalls)
+}
+
+func Test_VM_Fast_No_Data_Partial_Fallback_Edge_Branches(t *testing.T) {
+	var out strings.Builder
+
+	errCtx := plush.NewContextWith(map[string]interface{}{
+		"contentType": "application/javascript",
+	})
+	handled, err := renderFastNoDataPartialInto(&out, "edge_missing_feeder.html", errCtx, 11)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 11")
+	require.ErrorContains(t, err, "could not find partial feeder")
+
+	feederErrCtx := plush.NewContextWith(map[string]interface{}{
+		"contentType": "application/javascript",
+		"partialFeeder": func(string) (string, error) {
+			return "", fmt.Errorf("fallback missing")
+		},
+	})
+	handled, err = renderFastNoDataPartialInto(&out, "edge_fallback_error.html", feederErrCtx, 12)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 12: fallback missing")
+
+	metadataCtx := plush.NewContextWith(map[string]interface{}{
+		"partialFeeder": func(string) (string, error) {
+			return `<%= ` + meta.TemplateFileKey + ` %>`, nil
+		},
+	})
+	out.Reset()
+	handled, err = renderFastNoDataPartialInto(&out, "edge_fallback_metadata.plush", metadataCtx, 13)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Contains(t, out.String(), "edge_fallback_metadata.plush")
+
+	budgetCtx := plush.NewContextWith(map[string]interface{}{
+		"partialFeeder": func(string) (string, error) {
+			return `<span>never</span>`, nil
+		},
+	}).WithBudget(plush.NewBudget(0))
+	handled, err = renderFastNoDataPartialInto(&out, "edge_budget.plush", budgetCtx, 14)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 14")
+}
+
+func Test_VM_Fast_No_Data_Partial_Fallback_Metadata_And_Parse_Errors(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	plush.PlushCacheSetup(cache)
+	defer func() {
+		plush.ClearTemplateCache()
+		plush.PlushCacheSetup(nil)
+	}()
+
+	var out strings.Builder
+
+	fastMetaErrCtx := plush.NewContextWith(map[string]interface{}{
+		"contentType": "application/javascript",
+		"partialFeeder": func(string) (string, error) {
+			return `<span>never</span>`, nil
+		},
+	})
+	fastMetaErrCtx.Set(meta.TemplateBaseFileNameKey, "index")
+	fastMetaErrCtx.Set(meta.TemplateExtensionKey, "plush")
+	fastMetaErrCtx.Set(meta.TemplateFileKey, 12)
+	handled, err := renderFastNoDataPartialInto(&out, "edge_no_data_fast_meta_error.plush", fastMetaErrCtx, 61)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 61")
+	require.ErrorContains(t, err, "expected fileKey to be a string")
+
+	slowMetaErrCtx := newVMFallbackContext(map[string]interface{}{
+		"contentType":                "application/javascript",
+		"partialFeeder":              func(string) (string, error) { return `<span>never</span>`, nil },
+		meta.TemplateBaseFileNameKey: "index",
+		meta.TemplateExtensionKey:    "plush",
+		meta.TemplateFileKey:         12,
+	})
+	handled, err = renderFastNoDataPartialInto(&out, "edge_no_data_slow_meta_error.plush", slowMetaErrCtx, 62)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 62")
+	require.ErrorContains(t, err, "expected fileKey to be a string")
+
+	jsErrCtx := newVMFallbackContext(map[string]interface{}{
+		"contentType": "application/javascript",
+		"partialFeeder": func(string) (string, error) {
+			return `<%=`, nil
+		},
+	})
+	handled, err = renderFastNoDataPartialInto(&out, "edge_no_data_slow_js_parse.plush", jsErrCtx, 64)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 64")
+}
+
+func Test_VM_Partial_Setup_Template_File_Edges(t *testing.T) {
+	ctx := plush.NewContext()
+	ctx.Set(meta.TemplateBaseFileNameKey, "index")
+	ctx.Set(meta.TemplateExtensionKey, "plush")
+	ctx.Set(meta.TemplateFileKey, 12)
+	require.ErrorContains(t, setupPartialTemplateFile(ctx, "row.plush"), "expected fileKey to be a string")
+
+	ctx = plush.NewContext()
+	ctx.Set(meta.TemplateBaseFileNameKey, "index")
+	ctx.Set(meta.TemplateExtensionKey, "plush")
+	ctx.Set(meta.TemplateFileKey, "templates/index.plush")
+	ctx.Set(vmAlreadyInPartial, "parent.plush")
+	require.NoError(t, setupPartialTemplateFile(ctx, "row.plush"))
+	require.Equal(t, "templates/row.plush", ctx.Value(meta.TemplateFileKey))
+
+	ctx = plush.NewContext()
+	require.NoError(t, setupPartialTemplateFile(ctx, "row.plush"))
+	require.Equal(t, "row.plush", ctx.Value(meta.TemplateFileKey))
+
+	setupPartialNesting(ctx, "row.plush")
+	require.Equal(t, "row.plush", ctx.Value(vmAlreadyInPartial))
+}
+
+func Test_VM_Apply_Fast_Partial_Data_Slow_Error_Edges(t *testing.T) {
+	parent := plush.NewContext()
+	partialCtx := borrowPartialOverlayContext(parent)
+	defer releasePartialOverlayContext(partialCtx)
+
+	require.NoError(t, applyFastPartialDataSlow(nil, nil, parent, fastRenderBindings{}))
+	require.NoError(t, applyFastPartialDataSlow(partialCtx, nil, parent, fastRenderBindings{}))
+
+	partial := &compiler.FastPartialPlan{
+		Data: []compiler.FastPartialDataPair{{
+			Key:   "name",
+			Value: compiler.FastValuePlan{Kind: compiler.FastValueName, Value: "missing", NameIndex: 99},
+			Line:  12,
+		}},
+	}
+	err := applyFastPartialDataSlow(partialCtx, partial, parent, fastRenderBindings{})
+	require.ErrorContains(t, err, "line 12")
+	require.ErrorContains(t, err, `"missing": unknown identifier`)
+}
+
+func Test_VM_Fast_Partial_Data_Binding_Helper_Error_Edges(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"echo": func(string) string { return "go" },
+	}).WithBudget(plush.NewBudget(0))
+	parentBindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"echo"}}, ctx)
+	plan := &fastPartialDataBindingPlan{
+		keys: []string{"name"},
+		pairs: []fastPartialDataBindingPair{{
+			key:  "name",
+			line: 44,
+			value: &fastSimpleValuePlan{
+				value: &compiler.FastValuePlan{
+					Kind: compiler.FastValueCall,
+					Call: &compiler.FastCallPlan{
+						Name:      "echo",
+						NameIndex: 0,
+						Args:      []compiler.FastValuePlan{{Kind: compiler.FastValueString, Value: "go"}},
+						Line:      44,
+					},
+				},
+				args: []*fastSimpleValuePlan{{value: &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "go"}}},
+			},
+		}},
+	}
+
+	_, err := evalFastPartialDataPairValue(&plan.pairs[0], ctx, parentBindings)
+	require.ErrorContains(t, err, "line 44")
+
+	bindings := fastRenderBindings{names: []string{"name"}}
+	err = attachFastPartialDataLocalsFromPlan(&bindings, plan, ctx, parentBindings, &fastPartialLocalStorage{})
+	require.ErrorContains(t, err, "line 44")
+
+	partialCtx := borrowPartialOverlayContext(plush.NewContext())
+	defer releasePartialOverlayContext(partialCtx)
+	handled, err := applyFastPartialDataBindingPlan(partialCtx, plan, ctx, parentBindings)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 44")
+
+	widePlan := &fastPartialDataBindingPlan{
+		keys: []string{"a", "b", "c", "d", "e", "f", "g", "h", "i"},
+		pairs: []fastPartialDataBindingPair{
+			{key: "a", value: &fastSimpleValuePlan{value: &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "wide"}}},
+		},
+	}
+	wideCtx := borrowPartialOverlayContext(plush.NewContext())
+	defer releasePartialOverlayContext(wideCtx)
+	handled, err = applyFastPartialDataBindingPlan(wideCtx, widePlan, plush.NewContext(), fastRenderBindings{})
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "wide", wideCtx.Value("a"))
+}
+
+func Test_VM_Render_Linked_Partial_Cache_And_Inline_Edges(t *testing.T) {
+	var out strings.Builder
+
+	ok, err := renderLinkedPartialInline(nil, `<span>ignored</span>`, nil)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	ok, err = renderLinkedPartialInline(&out, `<span>inline static</span>`, nil)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, `<span>inline static</span>`, out.String())
+
+	ctx := plush.NewContextWith(map[string]interface{}{"name": "Mido"})
+	rendered, err := renderLinkedPartial(`<span><%= name %></span>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, `<span>Mido</span>`, rendered)
+	links := partialBytecodeLinks(ctx)
+	require.Equal(t, 1, links.Len())
+
+	ctx.Set("name", "Leela")
+	rendered, err = renderLinkedPartial(`<span><%= name %></span>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, `<span>Leela</span>`, rendered)
+	require.Equal(t, 1, links.Len())
+
+	blockCtx := plush.NewContextWith(map[string]interface{}{
+		"name": "Mido",
+		"wrap": func(_ map[string]interface{}, help plush.HelperContext) (template.HTML, error) {
+			block, err := help.Block()
+			if err != nil {
+				return "", err
+			}
+			return template.HTML("<b>" + block + "</b>"), nil
+		},
+	})
+	blockPartial := `<%= wrap({}) { %><%= name %><% } %>`
+	blockTmpl, err := Compile(blockPartial)
+	require.NoError(t, err)
+	previousFallback := plush.SetVMGenericFallback(true)
+	defer plush.SetVMGenericFallback(previousFallback)
+	require.True(t, shouldFallbackPartialBytecode(blockTmpl.bytecode))
+	rendered, err = renderLinkedPartial(blockPartial, blockCtx)
+	require.NoError(t, err)
+	require.Equal(t, `<b>Mido</b>`, rendered)
+
+	static, err := renderLinkedPartialBytecode(&partialBytecodeLink{bytecode: &compiler.Bytecode{
+		Static:       true,
+		StaticOutput: "static bytecode",
+	}}, ctx, "", false)
+	require.NoError(t, err)
+	require.Equal(t, "static bytecode", static)
+
+	dynamic, err := Compile(`<%= name %>`)
+	require.NoError(t, err)
+	dynamic.bytecode.FastRenderPlan = nil
+	rendered, err = renderLinkedPartialBytecode(&partialBytecodeLink{bytecode: dynamic.bytecode}, ctx, "", false)
+	require.NoError(t, err)
+	require.Equal(t, "Leela", rendered)
+
+	rendered, err = renderLinkedPartial(`<span>nil ctx</span>`, nil)
+	require.NoError(t, err)
+	require.Equal(t, `<span>nil ctx</span>`, rendered)
+
+	cache := inmemory.NewMemoryCache()
+	plush.PlushCacheSetup(cache)
+	defer func() {
+		plush.ClearTemplateCache()
+		plush.PlushCacheSetup(nil)
+	}()
+
+	cachedBytecode := &compiler.Bytecode{Static: true, StaticOutput: "cached linked"}
+	plush.CacheVMBytecodeForCleanFilename("edge_linked_cached.plush", nil, cachedBytecode)
+	cachedCtx := plush.NewContext()
+	cachedCtx.Set(meta.TemplateFileKey, "edge_linked_cached.plush")
+
+	rendered, err = renderLinkedPartial(`<span>different source</span>`, cachedCtx)
+	require.NoError(t, err)
+	require.Equal(t, "cached linked", rendered)
+
+	out.Reset()
+	ok, err = renderLinkedPartialInline(&out, `<span>different inline source</span>`, cachedCtx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "cached linked", out.String())
+
+	out.Reset()
+	ok, err = renderLinkedPartialInline(&out, `<span><%= name %></span>`, ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, `<span>Leela</span>`, out.String())
+
+	out.Reset()
+	ok, err = renderLinkedPartialInline(&out, `<span><%= name %></span>`, ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, `<span>Leela</span>`, out.String())
+
+	holeCtx := plush.NewContext()
+	holeCtx.Set(meta.TemplateFileKey, "edge_linked_hole.plush")
+	holeCtx.Set("name", "Amy")
+	holes := []plush.HoleMarker{
+		plush.NewHoleMarker(plush.PunchHoleMarkerName(0), `<%= name %>`, 1, 15),
+	}
+	plush.CachePunchHoleSkeleton("edge_linked_hole.plush", holeCtx, "A<PLUSH_HOLE_0>B", holes, true)
+	rendered, err = renderLinkedPartial(`<span>ignored</span>`, holeCtx)
+	require.NoError(t, err)
+	require.Equal(t, "AAmyB", rendered)
+
+	out.Reset()
+	ok, err = renderLinkedPartialInline(&out, `<span>ignored</span>`, holeCtx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "AAmyB", out.String())
+
+	rendered, err = renderLinkedPartialBytecode(nil, ctx, "", false)
+	require.NoError(t, err)
+	require.Empty(t, rendered)
+
+	_, err = renderLinkedPartial(`<%=`, plush.NewContext())
+	require.Error(t, err)
+
+	out.Reset()
+	ok, err = renderLinkedPartialInline(&out, `<%=`, plush.NewContext())
+	require.Error(t, err)
+	require.False(t, ok)
+}

--- a/VM/vm/partial_inline_edges_test.go
+++ b/VM/vm/partial_inline_edges_test.go
@@ -1,0 +1,46 @@
+package vm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_VM_Render_Linked_Partial_Bytecode_Inline_Edges(t *testing.T) {
+	var out strings.Builder
+	ok, err := renderLinkedPartialBytecodeInline(nil, nil, nil)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	ok, err = renderLinkedPartialBytecodeInline(&out, nil, nil)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	ok, err = renderLinkedPartialBytecodeInline(&out, &partialBytecodeLink{}, nil)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	ok, err = renderLinkedPartialBytecodeInline(&out, &partialBytecodeLink{bytecode: &compiler.Bytecode{
+		Static:       true,
+		StaticOutput: "<static>",
+	}}, plush.NewContext())
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "<static>", out.String())
+
+	out.Reset()
+	ok, err = renderLinkedPartialBytecodeInline(&out, &partialBytecodeLink{bytecode: &compiler.Bytecode{
+		HasHoles: true,
+	}}, plush.NewContext())
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Empty(t, out.String())
+
+	ok, err = renderLinkedPartialBytecodeInline(&out, &partialBytecodeLink{bytecode: &compiler.Bytecode{}}, plush.NewContext())
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Empty(t, out.String())
+}

--- a/VM/vm/partials.go
+++ b/VM/vm/partials.go
@@ -1,0 +1,1641 @@
+package vm
+
+import (
+	"fmt"
+	"html/template"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+	"github.com/gobuffalo/plush/v5/helpers/meta"
+)
+
+func installVMPartialHelper(ctx hctx.Context) func() {
+	if ctx == nil || !ctx.Has("partial") {
+		return nil
+	}
+	current := ctx.Value("partial")
+	if !sameFunction(current, plush.PartialHelper) {
+		return nil
+	}
+	ctx.Set("partial", vmPartialHelper)
+	return func() {
+		ctx.Set("partial", current)
+	}
+}
+
+func installVMPartialHelperForBytecode(bytecode *compiler.Bytecode, ctx hctx.Context) func() {
+	if bytecode != nil && !bytecode.HasPartials {
+		return nil
+	}
+	return installVMPartialHelper(ctx)
+}
+
+func useInterpreterPartialHelper(ctx hctx.Context) func() {
+	if ctx == nil || !ctx.Has("partial") {
+		return nil
+	}
+	current := ctx.Value("partial")
+	if !sameFunction(current, vmPartialHelper) {
+		return nil
+	}
+	ctx.Set("partial", plush.PartialHelper)
+	return func() {
+		ctx.Set("partial", current)
+	}
+}
+
+func sameFunction(left, right interface{}) bool {
+	lv := reflect.ValueOf(left)
+	rv := reflect.ValueOf(right)
+	if !lv.IsValid() || !rv.IsValid() || lv.Kind() != reflect.Func || rv.Kind() != reflect.Func {
+		return false
+	}
+	return lv.Pointer() == rv.Pointer()
+}
+
+func (vm *VM) tryWriteLiteralPartialNameCall(name string, raw interface{}, numArgs int) (bool, error) {
+	if name != "partial" || numArgs != 1 || !sameFunction(raw, vmPartialHelper) {
+		return false, nil
+	}
+	if vm.sp < numArgs {
+		return true, fmt.Errorf("stack underflow")
+	}
+	arg, ok := vm.stack[vm.sp-numArgs].(*object.String)
+	if !ok || arg == nil {
+		return false, nil
+	}
+	frame := vm.currentFrame()
+	if frame == nil {
+		return false, nil
+	}
+	if frame.cl != nil && frame.cl.Fn != nil && frame.cl.Fn.NumLocals > 0 {
+		return false, nil
+	}
+
+	oldSP := vm.sp
+	vm.sp -= numArgs
+	handled, err := renderFastNoDataPartialInto(&frame.output, arg.Value, vm.ctx, vm.currentLineNumber())
+	if err != nil {
+		return true, err
+	}
+	if !handled {
+		vm.sp = oldSP
+		return false, nil
+	}
+	frame.hasOutput = true
+	return true, nil
+}
+
+type partialOverlayContext struct {
+	parent     hctx.Context
+	inline     [8]partialOverlayValue
+	count      int
+	extra      map[string]interface{}
+	extraIDs   map[int]interface{}
+	idNames    map[int]string
+	idInterner *plush.InternTable
+}
+
+type partialOverlayValue struct {
+	key   string
+	id    int
+	value interface{}
+}
+
+func newPartialOverlayContext(parent hctx.Context) *partialOverlayContext {
+	return &partialOverlayContext{
+		parent: parent,
+	}
+}
+
+func borrowPartialOverlayContext(parent hctx.Context) *partialOverlayContext {
+	ctx := partialOverlayContextPool.Get().(*partialOverlayContext)
+	ctx.reset(parent)
+	return ctx
+}
+
+func releasePartialOverlayContext(ctx *partialOverlayContext) {
+	if ctx == nil {
+		return
+	}
+	ctx.reset(nil)
+	partialOverlayContextPool.Put(ctx)
+}
+
+func (c *partialOverlayContext) reset(parent hctx.Context) {
+	if c == nil {
+		return
+	}
+	for i := 0; i < c.count; i++ {
+		c.inline[i] = partialOverlayValue{}
+	}
+	c.count = 0
+	if c.extra != nil {
+		clear(c.extra)
+	}
+	if c.extraIDs != nil {
+		clear(c.extraIDs)
+	}
+	if c.idNames != nil {
+		clear(c.idNames)
+	}
+	c.idInterner = nil
+	c.parent = parent
+}
+
+func partialHelperChildContext(parent hctx.Context) (hctx.Context, func()) {
+	switch parent.(type) {
+	case *plush.Context, *partialOverlayContext:
+		child := borrowPartialOverlayContext(parent)
+		return child, func() {
+			releasePartialOverlayContext(child)
+		}
+	default:
+		return parent.New(), nil
+	}
+}
+
+func (c *partialOverlayContext) stableBindingIDs() bool {
+	if c == nil {
+		return false
+	}
+	return canCacheFastRenderBindingPlan(c.parent)
+}
+
+func (c *partialOverlayContext) Deadline() (time.Time, bool) {
+	if c == nil || c.parent == nil {
+		return time.Time{}, false
+	}
+	return c.parent.Deadline()
+}
+
+func (c *partialOverlayContext) Done() <-chan struct{} {
+	if c == nil || c.parent == nil {
+		return nil
+	}
+	return c.parent.Done()
+}
+
+func (c *partialOverlayContext) Err() error {
+	if c == nil || c.parent == nil {
+		return nil
+	}
+	return c.parent.Err()
+}
+
+func (c *partialOverlayContext) Value(key interface{}) interface{} {
+	if c == nil {
+		return nil
+	}
+	if name, ok := key.(string); ok {
+		if value, ok := c.localValue(name); ok {
+			return value
+		}
+	}
+	if c.parent == nil {
+		return nil
+	}
+	return c.parent.Value(key)
+}
+
+func (c *partialOverlayContext) New() hctx.Context {
+	return newPartialOverlayContext(c)
+}
+
+func (c *partialOverlayContext) Has(key string) bool {
+	if c == nil {
+		return false
+	}
+	if _, ok := c.localValue(key); ok {
+		return true
+	}
+	return c.parent != nil && c.parent.Has(key)
+}
+
+func (c *partialOverlayContext) Lookup(key string) (interface{}, bool) {
+	if c == nil {
+		return nil, false
+	}
+	if value, ok := c.localValue(key); ok {
+		return value, true
+	}
+	if lookup, ok := c.parent.(contextLookup); ok {
+		return lookup.Lookup(key)
+	}
+	if c.parent != nil && c.parent.Has(key) {
+		return c.parent.Value(key), true
+	}
+	return nil, false
+}
+
+func (c *partialOverlayContext) InternID(key string) int {
+	if c == nil {
+		return -1
+	}
+	var id int
+	if lookup, ok := c.parent.(contextIDLookup); ok {
+		id = lookup.InternID(key)
+	} else {
+		if c.idInterner == nil {
+			c.idInterner = plush.NewInternTable()
+		}
+		id = c.idInterner.Intern(key)
+	}
+	c.rememberIDName(id, key)
+	return id
+}
+
+func (c *partialOverlayContext) InternIDs(keys []string, ids []int) {
+	if c == nil || len(keys) == 0 || len(ids) < len(keys) {
+		return
+	}
+	if binder, ok := c.parent.(contextIDBinder); ok {
+		binder.InternIDs(keys, ids)
+		for i, key := range keys {
+			c.rememberIDName(ids[i], key)
+		}
+		return
+	}
+	for i, key := range keys {
+		ids[i] = c.InternID(key)
+	}
+}
+
+func (c *partialOverlayContext) LookupID(id int) (interface{}, bool) {
+	if c == nil {
+		return nil, false
+	}
+	if value, ok := c.localValueID(id); ok {
+		return value, true
+	}
+	if lookup, ok := c.parent.(contextIDLookup); ok {
+		if value, ok := lookup.LookupID(id); ok {
+			return value, true
+		}
+	}
+	if name, ok := c.nameForID(id); ok {
+		return c.Lookup(name)
+	}
+	return nil, false
+}
+
+func (c *partialOverlayContext) SetID(id int, value interface{}) {
+	if c == nil || value == nil {
+		return
+	}
+	name, _ := c.nameForID(id)
+	c.setLocalWithID(name, id, value)
+}
+
+func (c *partialOverlayContext) UpdateID(id int, value interface{}) bool {
+	if c == nil || value == nil {
+		return false
+	}
+	if c.setLocalIDExisting(id, value) {
+		return true
+	}
+	if lookup, ok := c.parent.(contextIDLookup); ok {
+		return lookup.UpdateID(id, value)
+	}
+	if name, ok := c.nameForID(id); ok && c.parent != nil {
+		return c.parent.Update(name, value)
+	}
+	return false
+}
+
+func (c *partialOverlayContext) Update(key string, value interface{}) bool {
+	if c == nil || value == nil {
+		return false
+	}
+	if c.setLocalExisting(key, value) {
+		return true
+	}
+	if c.parent != nil {
+		return c.parent.Update(key, value)
+	}
+	return false
+}
+
+func (c *partialOverlayContext) Set(key string, value interface{}) {
+	if c == nil || value == nil {
+		return
+	}
+	c.setLocal(key, value)
+}
+
+func (c *partialOverlayContext) Budget() *plush.Budget {
+	if c == nil || c.parent == nil {
+		return nil
+	}
+	if provider, ok := c.parent.(interface{ Budget() *plush.Budget }); ok {
+		return provider.Budget()
+	}
+	return nil
+}
+
+func (c *partialOverlayContext) localValue(key string) (interface{}, bool) {
+	for i := 0; i < c.count; i++ {
+		if c.inline[i].key == key {
+			return c.inline[i].value, true
+		}
+	}
+	if c.extra != nil {
+		value, ok := c.extra[key]
+		return value, ok
+	}
+	return nil, false
+}
+
+func (c *partialOverlayContext) localValueID(id int) (interface{}, bool) {
+	for i := 0; i < c.count; i++ {
+		if c.inline[i].id == id {
+			return c.inline[i].value, true
+		}
+	}
+	if c.extraIDs != nil {
+		value, ok := c.extraIDs[id]
+		return value, ok
+	}
+	return nil, false
+}
+
+func (c *partialOverlayContext) setLocalExisting(key string, value interface{}) bool {
+	for i := 0; i < c.count; i++ {
+		if c.inline[i].key == key {
+			c.inline[i].value = value
+			return true
+		}
+	}
+	if c.extra != nil {
+		if _, ok := c.extra[key]; ok {
+			c.extra[key] = value
+			return true
+		}
+	}
+	return false
+}
+
+func (c *partialOverlayContext) setLocalIDExisting(id int, value interface{}) bool {
+	for i := 0; i < c.count; i++ {
+		if c.inline[i].id == id {
+			c.inline[i].value = value
+			return true
+		}
+	}
+	if c.extraIDs != nil {
+		if _, ok := c.extraIDs[id]; ok {
+			c.extraIDs[id] = value
+			return true
+		}
+	}
+	return false
+}
+
+func (c *partialOverlayContext) setLocal(key string, value interface{}) {
+	id := c.InternID(key)
+	c.setLocalWithID(key, id, value)
+}
+
+func (c *partialOverlayContext) setLocalWithID(key string, id int, value interface{}) {
+	if key != "" && c.setLocalExisting(key, value) {
+		c.setLocalIDExisting(id, value)
+		return
+	}
+	if c.setLocalIDExisting(id, value) {
+		return
+	}
+	if c.count < len(c.inline) {
+		c.inline[c.count] = partialOverlayValue{key: key, id: id, value: value}
+		c.count++
+		return
+	}
+	if c.extra == nil {
+		c.extra = make(map[string]interface{}, 4)
+	}
+	if key != "" {
+		c.extra[key] = value
+	}
+	if c.extraIDs == nil {
+		c.extraIDs = make(map[int]interface{}, 4)
+	}
+	c.extraIDs[id] = value
+}
+
+func (c *partialOverlayContext) rememberIDName(id int, key string) {
+	if c == nil || id < 0 || key == "" {
+		return
+	}
+	if c.idNames == nil {
+		c.idNames = make(map[int]string, 4)
+	}
+	c.idNames[id] = key
+}
+
+func (c *partialOverlayContext) nameForID(id int) (string, bool) {
+	if c == nil || id < 0 {
+		return "", false
+	}
+	if name, ok := c.idNames[id]; ok {
+		return name, true
+	}
+	if c.idInterner != nil {
+		return c.idInterner.Name(id)
+	}
+	return "", false
+}
+
+func renderFastDataPartialInto(out *strings.Builder, partial *compiler.FastPartialPlan, ctx hctx.Context, bindings fastRenderBindings, dataPlan *fastPartialDataBindingPlan) (bool, error) {
+	if out == nil || partial == nil {
+		return false, nil
+	}
+	if ctx == nil {
+		return true, fastLineError(partial.Line, fmt.Errorf("invalid context. abort"))
+	}
+	if err := spendFastSubRender(ctx, partial.Line); err != nil {
+		return true, err
+	}
+	start := time.Now()
+	defer func() {
+		plush.AddRenderDiagnosticVMPartialTiming(ctx, partial.Name, time.Since(start))
+	}()
+
+	if ok, err := renderFastDataPartialDirectInto(out, partial, ctx, bindings, dataPlan); ok || err != nil {
+		return ok, err
+	}
+
+	links := partialBytecodeLinks(ctx)
+	partialCtx := borrowPartialOverlayContext(ctx)
+	defer releasePartialOverlayContext(partialCtx)
+	metaIDs, useMetaIDs := links.partialMetaIDs(partialCtx)
+
+	if dataPlan != nil {
+		if ok, err := applyFastPartialDataBindingPlan(partialCtx, dataPlan, ctx, bindings); err != nil {
+			return true, err
+		} else if !ok {
+			if err := applyFastPartialDataSlow(partialCtx, partial, ctx, bindings); err != nil {
+				return true, err
+			}
+		}
+	} else if err := applyFastPartialDataSlow(partialCtx, partial, ctx, bindings); err != nil {
+		return true, err
+	}
+
+	if useMetaIDs {
+		if err := setupFastPartialTemplateFile(partialCtx, partial.Name, metaIDs); err != nil {
+			return true, fastLineError(partial.Line, err)
+		}
+	} else {
+		if err := setupPartialTemplateFile(partialCtx, partial.Name); err != nil {
+			return true, fastLineError(partial.Line, err)
+		}
+	}
+
+	if useMetaIDs {
+		setupFastPartialNesting(partialCtx, partial.Name, metaIDs)
+	} else {
+		setupPartialNesting(partialCtx, partial.Name)
+	}
+	needsJSEscape := partialNeedsJSEscape(partialCtx, partial.Name)
+	if useMetaIDs {
+		needsJSEscape = partialNeedsJSEscapeFast(partialCtx, partial.Name, metaIDs)
+	}
+	if renderedCached, err := renderCachedPartialBytecodeInto(out, partialCtx, partial.Name, needsJSEscape); renderedCached || err != nil {
+		if err != nil {
+			return true, fastLineError(partial.Line, err)
+		}
+		return true, nil
+	}
+
+	pf, ok := links.partialFeeder(partialCtx)
+	if !ok {
+		return true, fastLineError(partial.Line, fmt.Errorf("could not find partial feeder from helpers"))
+	}
+
+	part, err := pf(partial.Name)
+	if err != nil {
+		return true, fastLineError(partial.Line, err)
+	}
+
+	if !needsJSEscape {
+		if renderedInline, err := renderLinkedPartialInline(out, part, partialCtx); renderedInline || err != nil {
+			if err != nil {
+				return true, fastLineError(partial.Line, err)
+			}
+			return true, nil
+		}
+	}
+
+	part, err = renderLinkedPartial(part, partialCtx)
+	if err != nil {
+		return true, fastLineError(partial.Line, err)
+	}
+	if needsJSEscape {
+		part = template.JSEscapeString(part)
+	}
+
+	out.WriteString(part)
+	return true, nil
+}
+
+func renderFastDataPartialDirectInto(out *strings.Builder, partial *compiler.FastPartialPlan, ctx hctx.Context, parentBindings fastRenderBindings, dataPlan *fastPartialDataBindingPlan) (bool, error) {
+	if out == nil || partial == nil || dataPlan == nil || len(dataPlan.pairs) == 0 || !fastPartialDataCanDirect(dataPlan) {
+		return false, nil
+	}
+	if partialNeedsJSEscape(ctx, partial.Name) {
+		return false, nil
+	}
+	filename, err := fastPartialTemplateFilename(ctx, partial.Name)
+	if err != nil {
+		return true, fastLineError(partial.Line, err)
+	}
+	link, ok, err := directPartialBytecodeLinkForName(partial.Name, filename, ctx)
+	if err != nil {
+		return true, fastLineError(partial.Line, err)
+	}
+	if !ok {
+		return false, nil
+	}
+	bytecode := link.bytecode
+	var localStorage fastPartialLocalStorage
+	if bytecode.Static {
+		if err := evalFastPartialDataLocalValues(dataPlan, ctx, parentBindings); err != nil {
+			return true, err
+		}
+		out.WriteString(bytecode.StaticOutput)
+		return true, nil
+	}
+	bindings := newFastRenderBindingsWithPlan(bytecode.FastRenderPlan, ctx, link.fastBindingPlan(ctx))
+	if err := attachFastPartialDataLocalsFromPlan(&bindings, dataPlan, ctx, parentBindings, &localStorage); err != nil {
+		return true, err
+	}
+	return renderFastPlanInlineWithBindings(out, bytecode.FastRenderPlan, ctx, bindings)
+}
+
+func fastPartialDataCanDirect(plan *fastPartialDataBindingPlan) bool {
+	if plan == nil {
+		return false
+	}
+	for _, key := range plan.keys {
+		if fastPartialSpecialBindingName(key) {
+			return false
+		}
+	}
+	return true
+}
+
+func fastPartialRenderPlanCanDirect(plan *compiler.FastRenderPlan) bool {
+	if plan == nil {
+		return false
+	}
+	for _, name := range plan.Bindings {
+		if fastPartialSpecialBindingName(name) {
+			return false
+		}
+	}
+	return true
+}
+
+func fastPartialSpecialBindingName(name string) bool {
+	switch name {
+	case "", "layout", vmPartialFeederName, vmAlreadyInPartial,
+		meta.TemplateFileKey, meta.TemplateBaseFileNameKey, meta.TemplateExtensionKey, "contentType":
+		return true
+	default:
+		return false
+	}
+}
+
+func evalFastPartialDataLocalValues(plan *fastPartialDataBindingPlan, ctx hctx.Context, bindings fastRenderBindings) error {
+	for i := range plan.pairs {
+		if _, err := evalFastPartialDataPairValue(&plan.pairs[i], ctx, bindings); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func evalFastPartialDataPairValue(pair *fastPartialDataBindingPair, ctx hctx.Context, bindings fastRenderBindings) (interface{}, error) {
+	if pair == nil {
+		return nil, nil
+	}
+	value, ok, err := evalFastSimpleValue(pair.value, ctx, bindings, nil, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fastLineError(pair.line, fmt.Errorf("%q: unknown identifier", fastSimpleValueMissingName(pair.value)))
+	}
+	return value, nil
+}
+
+func attachFastPartialDataLocalsFromPlan(bindings *fastRenderBindings, plan *fastPartialDataBindingPlan, ctx hctx.Context, parentBindings fastRenderBindings, storage *fastPartialLocalStorage) error {
+	if bindings == nil || plan == nil || len(plan.pairs) == 0 {
+		return nil
+	}
+	if len(bindings.names) > 0 {
+		prepareFastPartialLocalStorage(bindings, storage)
+	}
+	for dataIndex := range plan.pairs {
+		pair := &plan.pairs[dataIndex]
+		value, err := evalFastPartialDataPairValue(pair, ctx, parentBindings)
+		if err != nil {
+			return err
+		}
+		for bindingIndex, name := range bindings.names {
+			if pair.key == name {
+				bindings.localOK[bindingIndex] = true
+				bindings.localVals[bindingIndex] = value
+				break
+			}
+		}
+	}
+	return nil
+}
+
+func prepareFastPartialLocalStorage(bindings *fastRenderBindings, storage *fastPartialLocalStorage) {
+	if bindings == nil || len(bindings.names) == 0 {
+		return
+	}
+	if storage != nil && len(bindings.names) <= len(storage.ok) {
+		bindings.localOK = storage.ok[:len(bindings.names)]
+		bindings.localVals = storage.vals[:len(bindings.names)]
+		return
+	}
+	bindings.localOK = make([]bool, len(bindings.names))
+	bindings.localVals = make([]interface{}, len(bindings.names))
+}
+
+func fastPartialTemplateFilename(ctx hctx.Context, name string) (string, error) {
+	if ctx == nil {
+		return name, nil
+	}
+	base := ctx.Value(meta.TemplateBaseFileNameKey)
+	ext := ctx.Value(meta.TemplateExtensionKey)
+	fileKey := ctx.Value(meta.TemplateFileKey)
+	if base != nil && fileKey != nil && ext != nil {
+		templateFileKey, ok := fileKey.(string)
+		if !ok {
+			return "", fmt.Errorf("expected fileKey to be a string, got %T", fileKey)
+		}
+		if v := ctx.Value(vmAlreadyInPartial); v != nil {
+			if parentPartial, ok := v.(string); ok {
+				templateFileKey = strings.TrimSuffix(templateFileKey, parentPartial)
+			}
+		}
+		baseVal, baseOk := base.(string)
+		extVal, extOk := ext.(string)
+		if baseOk && extOk {
+			templateFileKey = strings.TrimSuffix(templateFileKey, baseVal+"."+extVal)
+		}
+		return strings.ReplaceAll(filepath.Join(templateFileKey, name), "\\", "/"), nil
+	}
+	return name, nil
+}
+
+func partialBytecodeLinkForInput(input, filename string, ctx hctx.Context) (*partialBytecodeLink, error) {
+	input = preprocessTrimTags(input)
+	sourceHash := hashString(input)
+	linkKey := partialBytecodeLinkKey(filename, input, sourceHash)
+	links := partialBytecodeLinks(ctx)
+	if link, ok := links.GetLink(linkKey, sourceHash); ok {
+		return link, nil
+	}
+	if cached, ok := plush.CachedVMBytecodeForCleanFilenameWithSource(filename, input); ok {
+		if bytecode, ok := cached.(*compiler.Bytecode); ok {
+			return links.SetWithSource(linkKey, sourceHash, input, bytecode), nil
+		}
+	}
+	program, cachedProgram, err := parseProgram(input, filename, ctx)
+	if err != nil {
+		return nil, err
+	}
+	comp := compiler.New()
+	if err := comp.Compile(program); err != nil {
+		return nil, err
+	}
+	bytecode := comp.Bytecode()
+	plush.CacheVMBytecodeForCleanFilenameWithSource(filename, cachedProgram, bytecode, input)
+	return links.SetWithSource(linkKey, sourceHash, input, bytecode), nil
+}
+
+func applyFastPartialDataSlow(partialCtx *partialOverlayContext, partial *compiler.FastPartialPlan, ctx hctx.Context, bindings fastRenderBindings) error {
+	if partialCtx == nil || partial == nil {
+		return nil
+	}
+	for i := range partial.Data {
+		pair := &partial.Data[i]
+		value, ok, err := evalFastValue(&pair.Value, ctx, bindings, nil)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fastLineError(pair.Line, fmt.Errorf("%q: unknown identifier", fastValueMissingName(&pair.Value)))
+		}
+		partialCtx.Set(pair.Key, value)
+	}
+	return nil
+}
+
+func applyFastPartialDataBindingPlan(partialCtx *partialOverlayContext, plan *fastPartialDataBindingPlan, ctx hctx.Context, bindings fastRenderBindings) (bool, error) {
+	if partialCtx == nil || plan == nil || len(plan.pairs) == 0 {
+		return false, nil
+	}
+	var inlineIDs [8]int
+	ids := inlineIDs[:]
+	if len(plan.keys) > len(inlineIDs) {
+		ids = make([]int, len(plan.keys))
+	} else {
+		ids = ids[:len(plan.keys)]
+	}
+	partialCtx.InternIDs(plan.keys, ids)
+
+	for i := range plan.pairs {
+		pair := &plan.pairs[i]
+		value, ok, err := evalFastSimpleValue(pair.value, ctx, bindings, nil, nil, nil)
+		if err != nil {
+			return true, err
+		}
+		if !ok {
+			return true, fastLineError(pair.line, fmt.Errorf("%q: unknown identifier", fastSimpleValueMissingName(pair.value)))
+		}
+		id := -1
+		if i < len(ids) {
+			id = ids[i]
+		}
+		partialCtx.setLocalWithID(pair.key, id, value)
+	}
+	return true, nil
+}
+
+func renderFastNoDataPartialInto(out *strings.Builder, name string, ctx hctx.Context, line int) (bool, error) {
+	if out == nil {
+		return false, nil
+	}
+	if ctx == nil {
+		return true, fastLineError(line, fmt.Errorf("invalid context. abort"))
+	}
+	if err := spendFastSubRender(ctx, line); err != nil {
+		return true, err
+	}
+	start := time.Now()
+	defer func() {
+		plush.AddRenderDiagnosticVMPartialTiming(ctx, name, time.Since(start))
+	}()
+
+	if ok, err := renderFastNoDataPartialDirectInto(out, name, ctx, line); ok || err != nil {
+		return ok, err
+	}
+
+	links := partialBytecodeLinks(ctx)
+	partialCtx := borrowPartialOverlayContext(ctx)
+	defer releasePartialOverlayContext(partialCtx)
+	metaIDs, useMetaIDs := links.partialMetaIDs(partialCtx)
+	if useMetaIDs {
+		if err := setupFastPartialTemplateFile(partialCtx, name, metaIDs); err != nil {
+			return true, fastLineError(line, err)
+		}
+	} else {
+		if err := setupPartialTemplateFile(partialCtx, name); err != nil {
+			return true, fastLineError(line, err)
+		}
+	}
+
+	if useMetaIDs {
+		setupFastPartialNesting(partialCtx, name, metaIDs)
+	} else {
+		setupPartialNesting(partialCtx, name)
+	}
+	needsJSEscape := partialNeedsJSEscape(partialCtx, name)
+	if useMetaIDs {
+		needsJSEscape = partialNeedsJSEscapeFast(partialCtx, name, metaIDs)
+	}
+	if renderedCached, err := renderCachedPartialBytecodeInto(out, partialCtx, name, needsJSEscape); renderedCached || err != nil {
+		if err != nil {
+			return true, fastLineError(line, err)
+		}
+		return true, nil
+	}
+
+	pf, ok := links.partialFeeder(partialCtx)
+	if !ok {
+		return true, fastLineError(line, fmt.Errorf("could not find partial feeder from helpers"))
+	}
+
+	part, err := pf(name)
+	if err != nil {
+		return true, fastLineError(line, err)
+	}
+
+	if !needsJSEscape {
+		if renderedInline, err := renderLinkedPartialInline(out, part, partialCtx); renderedInline || err != nil {
+			if err != nil {
+				return true, fastLineError(line, err)
+			}
+			return true, nil
+		}
+	}
+
+	part, err = renderLinkedPartial(part, partialCtx)
+	if err != nil {
+		return true, fastLineError(line, err)
+	}
+	if needsJSEscape {
+		part = template.JSEscapeString(part)
+	}
+
+	out.WriteString(part)
+	return true, nil
+}
+
+func renderCachedPartialBytecodeInto(out *strings.Builder, ctx hctx.Context, name string, needsJSEscape bool) (bool, error) {
+	if out == nil || ctx == nil {
+		return false, nil
+	}
+	filename := plush.PunchHoleTemplateFilename(ctx)
+	if filename == "" {
+		return false, nil
+	}
+	link, ok := cachedPartialBytecodeLinkForFilename(filename, ctx)
+	if !ok || link == nil || link.bytecode == nil || shouldFallbackGenericBytecode(link.bytecode) {
+		return false, nil
+	}
+	if link.source == "" && shouldFallbackPartialBytecode(link.bytecode) {
+		return false, nil
+	}
+	if !needsJSEscape {
+		if renderedInline, err := renderLinkedPartialBytecodeInline(out, link, ctx); renderedInline || err != nil {
+			return renderedInline, err
+		}
+	}
+	rendered, err := renderLinkedPartialBytecode(link, ctx, filename, false)
+	if err != nil {
+		return true, err
+	}
+	if needsJSEscape {
+		rendered = template.JSEscapeString(rendered)
+	}
+	out.WriteString(rendered)
+	return true, nil
+}
+
+func cachedPartialBytecodeLinkForFilename(filename string, ctx hctx.Context) (*partialBytecodeLink, bool) {
+	if filename == "" {
+		return nil, false
+	}
+	links := partialBytecodeLinks(ctx)
+	key := partialBytecodeLinkKey(filename, "", 0)
+	if link, ok := links.GetLink(key, 0); ok {
+		return link, true
+	}
+	return nil, false
+}
+
+func directPartialBytecodeLinkForName(name string, filename string, ctx hctx.Context) (*partialBytecodeLink, bool, error) {
+	if filename == "" {
+		return nil, false, nil
+	}
+	links := partialBytecodeLinks(ctx)
+	linkKey := partialBytecodeLinkKey(filename, "", 0)
+	if link, ok := links.GetLink(linkKey, 0); ok {
+		if directPartialBytecodeLinkCanRender(link.bytecode) {
+			return link, true, nil
+		}
+		return nil, false, nil
+	}
+	if plush.IsPlushTemplateFile(filename) {
+		if cached, ok := plush.CachedVMBytecodeForCleanFilename(filename); ok {
+			if bytecode, ok := cached.(*compiler.Bytecode); ok {
+				link := links.Set(linkKey, 0, bytecode)
+				if directPartialBytecodeLinkCanRender(bytecode) {
+					return link, true, nil
+				}
+				return nil, false, nil
+			}
+		}
+	}
+	return directPartialBytecodeLinkFromFeeder(name, filename, ctx)
+}
+
+func directPartialBytecodeLinkFromFeeder(name string, filename string, ctx hctx.Context) (*partialBytecodeLink, bool, error) {
+	links := partialBytecodeLinks(ctx)
+	pf, ok := links.partialFeeder(ctx)
+	if !ok {
+		return nil, true, fmt.Errorf("could not find partial feeder from helpers")
+	}
+	part, err := pf(name)
+	if err != nil {
+		return nil, true, err
+	}
+	link, err := partialBytecodeLinkForInput(part, filename, ctx)
+	if err != nil {
+		return nil, true, err
+	}
+	if directPartialBytecodeLinkCanRender(link.bytecode) {
+		return link, true, nil
+	}
+	return nil, false, nil
+}
+
+func directPartialBytecodeLinkCanRender(bytecode *compiler.Bytecode) bool {
+	if bytecode == nil || bytecode.HasHoles {
+		return false
+	}
+	if bytecode.Static {
+		return true
+	}
+	if bytecode.FastRenderPlan == nil || !fastPartialRenderPlanCanDirect(bytecode.FastRenderPlan) {
+		return false
+	}
+	if !fastPartialRenderPlanCanRunWithoutPartialContext(bytecode.FastRenderPlan) {
+		return false
+	}
+	mixed := prepareFastMixedPlan(bytecode.FastRenderPlan)
+	return mixed != nil && (mixed.staticName != nil || mixed.simple != nil || len(mixed.ops) > 0)
+}
+
+func fastPartialRenderPlanCanRunWithoutPartialContext(plan *compiler.FastRenderPlan) bool {
+	if plan == nil {
+		return false
+	}
+	return fastRenderSegmentsCanRunWithoutPartialContext(plan.Segments)
+}
+
+func fastRenderSegmentsCanRunWithoutPartialContext(segments []compiler.FastRenderSegment) bool {
+	for i := range segments {
+		segment := &segments[i]
+		switch segment.Kind {
+		case compiler.FastRenderSegmentStatic,
+			compiler.FastRenderSegmentName,
+			compiler.FastRenderSegmentProperty:
+			continue
+		case compiler.FastRenderSegmentValue:
+			if fastValuePlanNeedsPartialContext(&segment.ValuePlan) {
+				return false
+			}
+		case compiler.FastRenderSegmentConditional:
+			if !fastConditionalCanRunWithoutPartialContext(segment.Conditional) {
+				return false
+			}
+		case compiler.FastRenderSegmentLoop:
+			if !fastLoopCanRunWithoutPartialContext(segment.Loop) {
+				return false
+			}
+		case compiler.FastRenderSegmentLet:
+			if fastValuePlanNeedsPartialContext(&segment.ValuePlan) {
+				return false
+			}
+		case compiler.FastRenderSegmentAssign:
+			if fastValuePlanNeedsPartialContext(&segment.ValuePlan) {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func fastConditionalCanRunWithoutPartialContext(conditional *compiler.FastConditionalPlan) bool {
+	if conditional == nil {
+		return false
+	}
+	for i := range conditional.Branches {
+		branch := &conditional.Branches[i]
+		if fastValuePlanNeedsPartialContext(&branch.Condition) {
+			return false
+		}
+		if !fastRenderSegmentsCanRunWithoutPartialContext(branch.Segments) {
+			return false
+		}
+	}
+	return fastRenderSegmentsCanRunWithoutPartialContext(conditional.ElseSegments)
+}
+
+func fastLoopCanRunWithoutPartialContext(loop *compiler.FastLoopPlan) bool {
+	if loop == nil {
+		return false
+	}
+	if fastValuePlanNeedsPartialContext(&loop.Iterable) {
+		return false
+	}
+	return fastLoopPartsCanRunWithoutPartialContext(loop.Parts)
+}
+
+func fastLoopPartsCanRunWithoutPartialContext(parts []compiler.FastLoopPart) bool {
+	for i := range parts {
+		part := &parts[i]
+		switch part.Kind {
+		case compiler.FastLoopPartStatic,
+			compiler.FastLoopPartKey,
+			compiler.FastLoopPartValue,
+			compiler.FastLoopPartValueProperty,
+			compiler.FastLoopPartValuePath,
+			compiler.FastLoopPartBreak,
+			compiler.FastLoopPartContinue:
+			continue
+		case compiler.FastLoopPartLet:
+			if fastValuePlanNeedsPartialContext(&part.ValuePlan) {
+				return false
+			}
+		case compiler.FastLoopPartPartial:
+			return false
+		case compiler.FastLoopPartConditional:
+			if !fastLoopConditionalCanRunWithoutPartialContext(part.Conditional) {
+				return false
+			}
+		case compiler.FastLoopPartLoop:
+			if !fastLoopCanRunWithoutPartialContext(part.Loop) {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func fastLoopConditionalCanRunWithoutPartialContext(conditional *compiler.FastLoopConditionalPlan) bool {
+	if conditional == nil {
+		return false
+	}
+	for i := range conditional.Branches {
+		branch := &conditional.Branches[i]
+		if fastValuePlanNeedsPartialContext(&branch.Condition) {
+			return false
+		}
+		if !fastLoopPartsCanRunWithoutPartialContext(branch.Parts) {
+			return false
+		}
+	}
+	return fastLoopPartsCanRunWithoutPartialContext(conditional.ElseParts)
+}
+
+func fastValuePlanNeedsPartialContext(value *compiler.FastValuePlan) bool {
+	if value == nil {
+		return false
+	}
+	switch value.Kind {
+	case compiler.FastValueCall:
+		return true
+	case compiler.FastValueInfix, compiler.FastValueConcat:
+		return fastValuePlanNeedsPartialContext(value.Left) || fastValuePlanNeedsPartialContext(value.Right)
+	case compiler.FastValuePrefix:
+		return fastValuePlanNeedsPartialContext(value.Right)
+	case compiler.FastValueArray:
+		for i := range value.Elements {
+			if fastValuePlanNeedsPartialContext(&value.Elements[i]) {
+				return true
+			}
+		}
+	case compiler.FastValueHash:
+		for i := range value.Pairs {
+			if fastValuePlanNeedsPartialContext(&value.Pairs[i].Value) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func renderFastNoDataPartialDirectInto(out *strings.Builder, name string, ctx hctx.Context, line int) (bool, error) {
+	if out == nil || ctx == nil {
+		return false, nil
+	}
+	if partialNeedsJSEscape(ctx, name) {
+		return false, nil
+	}
+	filename, err := fastPartialTemplateFilename(ctx, name)
+	if err != nil {
+		return true, fastLineError(line, err)
+	}
+	link, ok, err := directPartialBytecodeLinkForName(name, filename, ctx)
+	if err != nil {
+		return true, fastLineError(line, err)
+	}
+	if !ok {
+		return false, nil
+	}
+	bytecode := link.bytecode
+	if bytecode.Static {
+		out.WriteString(bytecode.StaticOutput)
+		return true, nil
+	}
+	return renderFastPlanInlineSafe(out, bytecode.FastRenderPlan, ctx, link.fastBindingPlan(ctx))
+}
+
+func partialNeedsJSEscape(ctx hctx.Context, name string) bool {
+	if ctx == nil {
+		return false
+	}
+	ct, ok := ctx.Value("contentType").(string)
+	if !ok {
+		return false
+	}
+	ext := filepath.Ext(name)
+	return strings.Contains(ct, "javascript") && ext != ".js" && ext != ""
+}
+
+func partialNeedsJSEscapeFast(ctx *partialOverlayContext, name string, ids partialMetaIDs) bool {
+	if ctx == nil {
+		return false
+	}
+	ct, ok := ctx.LookupID(ids.contentTypeID)
+	if !ok {
+		return false
+	}
+	contentType, ok := ct.(string)
+	if !ok {
+		return false
+	}
+	ext := filepath.Ext(name)
+	return strings.Contains(contentType, "javascript") && ext != ".js" && ext != ""
+}
+
+func setupFastPartialTemplateFile(ctx *partialOverlayContext, name string, ids partialMetaIDs) error {
+	if ctx == nil {
+		return nil
+	}
+	base, baseOK := ctx.LookupID(ids.templateBaseFileID)
+	ext, extOK := ctx.LookupID(ids.templateExtID)
+	fileKey, fileOK := ctx.LookupID(ids.templateFileID)
+	if baseOK && fileOK && extOK {
+		templateFileKey, ok := fileKey.(string)
+		if !ok {
+			return fmt.Errorf("expected fileKey to be a string, got %T", fileKey)
+		}
+		if v, ok := ctx.LookupID(ids.alreadyPartialID); ok {
+			if parentPartial, ok := v.(string); ok {
+				templateFileKey = strings.TrimSuffix(templateFileKey, parentPartial)
+			}
+		}
+		baseVal, baseString := base.(string)
+		extVal, extString := ext.(string)
+		if baseString && extString {
+			templateFileKey = strings.TrimSuffix(templateFileKey, baseVal+"."+extVal)
+		}
+		ctx.setLocalWithID(meta.TemplateFileKey, ids.templateFileID, strings.ReplaceAll(filepath.Join(templateFileKey, name), "\\", "/"))
+		return nil
+	}
+	ctx.setLocalWithID(meta.TemplateFileKey, ids.templateFileID, name)
+	return nil
+}
+
+func setupPartialTemplateFile(ctx hctx.Context, name string) error {
+	base := ctx.Value(meta.TemplateBaseFileNameKey)
+	ext := ctx.Value(meta.TemplateExtensionKey)
+	fileKey := ctx.Value(meta.TemplateFileKey)
+	if base != nil && fileKey != nil && ext != nil {
+		templateFileKey, ok := fileKey.(string)
+		if !ok {
+			return fmt.Errorf("expected fileKey to be a string, got %T", fileKey)
+		}
+		if v := ctx.Value(vmAlreadyInPartial); v != nil {
+			if parentPartial, ok := v.(string); ok {
+				templateFileKey = strings.TrimSuffix(templateFileKey, parentPartial)
+			}
+		}
+		baseVal, baseOk := base.(string)
+		extVal, extOk := ext.(string)
+		if baseOk && extOk {
+			templateFileKey = strings.TrimSuffix(templateFileKey, baseVal+"."+extVal)
+		}
+		ctx.Set(meta.TemplateFileKey, strings.ReplaceAll(filepath.Join(templateFileKey, name), "\\", "/"))
+		return nil
+	}
+	ctx.Set(meta.TemplateFileKey, name)
+	return nil
+}
+
+func setupFastPartialNesting(ctx *partialOverlayContext, name string, ids partialMetaIDs) {
+	if ctx == nil {
+		return
+	}
+	if _, ok := ctx.LookupID(ids.alreadyPartialID); !ok {
+		ctx.setLocalWithID(vmAlreadyInPartial, ids.alreadyPartialID, name)
+		return
+	}
+	extNm := filepath.Ext(name)
+	ctx.setLocalWithID(meta.TemplateBaseFileNameKey, ids.templateBaseFileID, strings.TrimSuffix(name, extNm))
+	ctx.setLocalWithID(meta.TemplateExtensionKey, ids.templateExtID, strings.TrimPrefix(extNm, "."))
+}
+
+func setupPartialNesting(ctx hctx.Context, name string) {
+	if ctx.Value(vmAlreadyInPartial) == nil {
+		ctx.Set(vmAlreadyInPartial, name)
+		return
+	}
+	extNm := filepath.Ext(name)
+	ctx.Set(meta.TemplateBaseFileNameKey, strings.TrimSuffix(name, extNm))
+	ctx.Set(meta.TemplateExtensionKey, strings.TrimPrefix(extNm, "."))
+}
+
+func vmPartialHelper(name string, data map[string]interface{}, help plush.HelperContext) (template.HTML, error) {
+	if plush.InterpreterPartialRenderEnabled(help.Context) {
+		return plush.PartialHelper(name, data, help)
+	}
+	if help.Context == nil {
+		return "", fmt.Errorf("invalid context. abort")
+	}
+
+	if ctx, ok := help.Context.(*plush.Context); ok {
+		if err := ctx.Budget().SpendSubRender(); err != nil {
+			return "", err
+		}
+	}
+
+	links := partialBytecodeLinks(help.Context)
+	child, releaseChild := partialHelperChildContext(help.Context)
+	help.Context = child
+	if releaseChild != nil {
+		defer releaseChild()
+	}
+	for k, v := range data {
+		help.Set(k, v)
+	}
+
+	base := help.Value(meta.TemplateBaseFileNameKey)
+	ext := help.Value(meta.TemplateExtensionKey)
+	fileKey := help.Value(meta.TemplateFileKey)
+	if base != nil && fileKey != nil && ext != nil {
+		templateFileKey, ok := fileKey.(string)
+		if !ok {
+			return "", fmt.Errorf("expected fileKey to be a string, got %T", fileKey)
+		}
+		if v := help.Value(vmAlreadyInPartial); v != nil {
+			if parentPartial, ok := v.(string); ok {
+				templateFileKey = strings.TrimSuffix(templateFileKey, parentPartial)
+			}
+		}
+		baseVal, baseOk := base.(string)
+		extVal, extOk := ext.(string)
+		if baseOk && extOk {
+			templateFileKey = strings.TrimSuffix(templateFileKey, baseVal+"."+extVal)
+		}
+		help.Set(meta.TemplateFileKey, strings.ReplaceAll(filepath.Join(templateFileKey, name), "\\", "/"))
+	} else {
+		help.Set(meta.TemplateFileKey, name)
+	}
+
+	pf, ok := links.partialFeeder(help.Context)
+	if !ok {
+		return "", fmt.Errorf("could not find partial feeder from helpers")
+	}
+
+	part, err := pf(name)
+	if err != nil {
+		return "", err
+	}
+
+	if help.Value(vmAlreadyInPartial) == nil {
+		help.Set(vmAlreadyInPartial, name)
+		defer help.Set(vmAlreadyInPartial, nil)
+	} else {
+		origBase := help.Value(meta.TemplateBaseFileNameKey)
+		origExt := help.Value(meta.TemplateExtensionKey)
+		extNm := filepath.Ext(name)
+		help.Set(meta.TemplateBaseFileNameKey, strings.TrimSuffix(name, extNm))
+		help.Set(meta.TemplateExtensionKey, strings.TrimPrefix(extNm, "."))
+		defer func() {
+			help.Set(meta.TemplateBaseFileNameKey, origBase)
+			help.Set(meta.TemplateExtensionKey, origExt)
+		}()
+	}
+
+	part, err = renderLinkedPartial(part, help.Context)
+	if err != nil {
+		return "", err
+	}
+	if ct, ok := help.Value("contentType").(string); ok {
+		ext := filepath.Ext(name)
+		if strings.Contains(ct, "javascript") && ext != ".js" && ext != "" {
+			part = template.JSEscapeString(part)
+		}
+	}
+
+	if layout, ok := data["layout"].(string); ok {
+		return vmPartialHelper(layout, map[string]interface{}{"yield": template.HTML(part)}, help)
+	}
+
+	return template.HTML(part), nil
+}
+
+func renderLinkedPartial(input string, ctx hctx.Context) (string, error) {
+	if ctx == nil {
+		ctx = plush.NewContext()
+	}
+
+	filename, forceCacheClear, cached, ok := punchHoleCacheState(ctx)
+	if ok {
+		return cached, nil
+	}
+
+	input = preprocessTrimTags(input)
+	sourceHash := hashString(input)
+	linkKey := partialBytecodeLinkKey(filename, input, sourceHash)
+	links := partialBytecodeLinks(ctx)
+	if link, ok := links.GetLink(linkKey, sourceHash); ok {
+		if shouldFallbackPartialBytecode(link.bytecode) {
+			return renderInterpreterFallback(input, ctx, filename)
+		}
+		return renderLinkedPartialBytecode(link, ctx, filename, forceCacheClear)
+	}
+
+	if cached, ok := plush.CachedVMBytecodeForCleanFilenameWithSource(filename, input); ok {
+		if bytecode, ok := cached.(*compiler.Bytecode); ok {
+			link := links.SetWithSource(linkKey, sourceHash, input, bytecode)
+			if shouldFallbackPartialBytecode(bytecode) {
+				return renderInterpreterFallback(input, ctx, filename)
+			}
+			return renderLinkedPartialBytecode(link, ctx, filename, forceCacheClear)
+		}
+	}
+
+	program, cachedProgram, err := parseProgram(input, filename, ctx)
+	if err != nil {
+		return "", err
+	}
+
+	comp := compiler.New()
+	if err := comp.Compile(program); err != nil {
+		return "", err
+	}
+
+	bytecode := comp.Bytecode()
+	plush.CacheVMBytecodeForCleanFilenameWithSource(filename, cachedProgram, bytecode, input)
+	link := links.SetWithSource(linkKey, sourceHash, input, bytecode)
+	if shouldFallbackPartialBytecode(bytecode) {
+		return renderInterpreterFallback(input, ctx, filename)
+	}
+	return renderLinkedPartialBytecode(link, ctx, filename, forceCacheClear)
+}
+
+func shouldFallbackPartialBytecode(bytecode *compiler.Bytecode) bool {
+	if shouldFallbackGenericBytecode(bytecode) {
+		return true
+	}
+	return plush.VMGenericFallbackEnabled() && bytecode != nil && fastRenderPlanHasBlockCalls(bytecode.FastRenderPlan)
+}
+
+func fastRenderPlanHasBlockCalls(plan *compiler.FastRenderPlan) bool {
+	return plan != nil && fastRenderSegmentsHaveBlockCalls(plan.Segments)
+}
+
+func fastRenderSegmentsHaveBlockCalls(segments []compiler.FastRenderSegment) bool {
+	for i := range segments {
+		segment := &segments[i]
+		switch segment.Kind {
+		case compiler.FastRenderSegmentBlockCall:
+			return true
+		case compiler.FastRenderSegmentConditional:
+			if fastConditionalHasBlockCalls(segment.Conditional) {
+				return true
+			}
+		case compiler.FastRenderSegmentLoop:
+			if fastLoopHasBlockCalls(segment.Loop) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func fastConditionalHasBlockCalls(conditional *compiler.FastConditionalPlan) bool {
+	if conditional == nil {
+		return false
+	}
+	for i := range conditional.Branches {
+		if fastRenderSegmentsHaveBlockCalls(conditional.Branches[i].Segments) {
+			return true
+		}
+	}
+	return fastRenderSegmentsHaveBlockCalls(conditional.ElseSegments)
+}
+
+func fastLoopHasBlockCalls(loop *compiler.FastLoopPlan) bool {
+	return loop != nil && fastLoopPartsHaveBlockCalls(loop.Parts)
+}
+
+func fastLoopPartsHaveBlockCalls(parts []compiler.FastLoopPart) bool {
+	for i := range parts {
+		part := &parts[i]
+		switch part.Kind {
+		case compiler.FastLoopPartBlockCall:
+			return true
+		case compiler.FastLoopPartConditional:
+			if fastLoopConditionalHasBlockCalls(part.Conditional) {
+				return true
+			}
+		case compiler.FastLoopPartLoop:
+			if fastLoopHasBlockCalls(part.Loop) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func fastLoopConditionalHasBlockCalls(conditional *compiler.FastLoopConditionalPlan) bool {
+	if conditional == nil {
+		return false
+	}
+	for i := range conditional.Branches {
+		if fastLoopPartsHaveBlockCalls(conditional.Branches[i].Parts) {
+			return true
+		}
+	}
+	return fastLoopPartsHaveBlockCalls(conditional.ElseParts)
+}
+
+func renderLinkedPartialInline(out *strings.Builder, input string, ctx hctx.Context) (bool, error) {
+	if out == nil {
+		return false, nil
+	}
+	if ctx == nil {
+		ctx = plush.NewContext()
+	}
+
+	input = preprocessTrimTags(input)
+	filename := plush.PunchHoleTemplateFilename(ctx)
+	filename, _, cached, ok := punchHoleCacheStateForFilename(filename, ctx, input)
+	if ok {
+		out.WriteString(cached)
+		return true, nil
+	}
+
+	sourceHash := hashString(input)
+	linkKey := partialBytecodeLinkKey(filename, input, sourceHash)
+	links := partialBytecodeLinks(ctx)
+	if link, ok := links.GetLink(linkKey, sourceHash); ok {
+		if rendered, err := renderGenericPartialInline(out, input, ctx, filename, link.bytecode); rendered || err != nil {
+			return rendered, err
+		}
+		return renderLinkedPartialBytecodeInline(out, link, ctx)
+	}
+
+	if cached, ok := plush.CachedVMBytecodeForCleanFilenameWithSource(filename, input); ok {
+		if bytecode, ok := cached.(*compiler.Bytecode); ok {
+			link := links.SetWithSource(linkKey, sourceHash, input, bytecode)
+			if rendered, err := renderGenericPartialInline(out, input, ctx, filename, bytecode); rendered || err != nil {
+				return rendered, err
+			}
+			return renderLinkedPartialBytecodeInline(out, link, ctx)
+		}
+	}
+
+	program, cachedProgram, err := parseProgram(input, filename, ctx)
+	if err != nil {
+		return false, err
+	}
+
+	comp := compiler.New()
+	if err := comp.Compile(program); err != nil {
+		return false, err
+	}
+
+	bytecode := comp.Bytecode()
+	plush.CacheVMBytecodeForCleanFilenameWithSource(filename, cachedProgram, bytecode, input)
+	link := links.SetWithSource(linkKey, sourceHash, input, bytecode)
+	if rendered, err := renderGenericPartialInline(out, input, ctx, filename, bytecode); rendered || err != nil {
+		return rendered, err
+	}
+	return renderLinkedPartialBytecodeInline(out, link, ctx)
+}
+
+func cachedPartialBytecodeCanDirectInline(filename string) (bool, bool) {
+	if filename == "" {
+		return false, false
+	}
+	cached, ok := plush.CachedVMBytecodeForCleanFilename(filename)
+	if !ok {
+		return false, false
+	}
+	bytecode, ok := cached.(*compiler.Bytecode)
+	if !ok {
+		return false, false
+	}
+	return partialBytecodeCanDirectInline(bytecode), true
+}
+
+func partialBytecodeCanDirectInline(bytecode *compiler.Bytecode) bool {
+	return directPartialBytecodeLinkCanRender(bytecode)
+}
+
+func renderGenericPartialInline(out *strings.Builder, input string, ctx hctx.Context, filename string, bytecode *compiler.Bytecode) (bool, error) {
+	if out == nil || !shouldFallbackPartialBytecode(bytecode) {
+		return false, nil
+	}
+	rendered, err := renderInterpreterFallback(input, ctx, filename)
+	if err != nil {
+		return true, err
+	}
+	out.WriteString(rendered)
+	return true, nil
+}
+
+func renderLinkedPartialBytecode(link *partialBytecodeLink, ctx hctx.Context, filename string, forceCacheClear bool) (string, error) {
+	if link == nil || link.bytecode == nil {
+		return "", nil
+	}
+	bytecode := link.bytecode
+	if bytecode.Static {
+		return bytecode.StaticOutput, nil
+	}
+	if link.source != "" && shouldFallbackPartialBytecode(bytecode) {
+		return renderInterpreterFallback(link.source, ctx, filename)
+	}
+	if bytecode.FastRenderPlan != nil {
+		if rendered, ok, err := renderFastPlanWithBindingPlan(bytecode.FastRenderPlan, ctx, link.fastBindingPlan(ctx)); ok || err != nil {
+			return rendered, err
+		}
+	}
+	return renderBytecodeVMWithState(bytecode, ctx, filename, forceCacheClear, link.source)
+}
+
+func renderLinkedPartialBytecodeInline(out *strings.Builder, link *partialBytecodeLink, ctx hctx.Context) (bool, error) {
+	if out == nil || link == nil || link.bytecode == nil {
+		return false, nil
+	}
+	bytecode := link.bytecode
+	if bytecode.Static {
+		out.WriteString(bytecode.StaticOutput)
+		return true, nil
+	}
+	if bytecode.HasHoles {
+		return false, nil
+	}
+	if bytecode.FastRenderPlan != nil {
+		return renderFastPlanInlineSafe(out, bytecode.FastRenderPlan, ctx, link.fastBindingPlan(ctx))
+	}
+	return false, nil
+}
+
+func partialBytecodeLinks(ctx hctx.Context) *partialBytecodeLinkCache {
+	if ctx != nil {
+		if links, ok := ctx.Value(vmPartialBytecodeLinksKey).(*partialBytecodeLinkCache); ok && links != nil {
+			return links
+		}
+	}
+
+	links := newPartialBytecodeLinkCache()
+	if ctx != nil {
+		ctx.Set(vmPartialBytecodeLinksKey, links)
+	}
+	return links
+}
+
+func partialBytecodeLinkKey(filename, input string, sourceHash uint64) string {
+	if filename != "" {
+		return filename
+	}
+	return fmt.Sprintf("source:%x", sourceHash)
+}
+
+func preprocessTrimTags(input string) string {
+	if !strings.Contains(input, "<%-") {
+		return input
+	}
+
+	out := make([]byte, 0, len(input))
+	for i := 0; i < len(input); {
+		if strings.HasPrefix(input[i:], "<%-") {
+			out = trimWhitespaceSuffix(out)
+			out = append(out, "<%="...)
+			i += len("<%-")
+
+			end := strings.Index(input[i:], "%>")
+			if end < 0 {
+				out = append(out, input[i:]...)
+				return string(out)
+			}
+
+			out = append(out, input[i:i+end+len("%>")]...)
+			i += end + len("%>")
+			for i < len(input) && isTrimWhitespace(input[i]) {
+				i++
+			}
+			continue
+		}
+
+		out = append(out, input[i])
+		i++
+	}
+
+	return string(out)
+}
+
+func trimWhitespaceSuffix(input []byte) []byte {
+	for len(input) > 0 && isTrimWhitespace(input[len(input)-1]) {
+		input = input[:len(input)-1]
+	}
+	return input
+}
+
+func isTrimWhitespace(ch byte) bool {
+	return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r'
+}

--- a/VM/vm/render_diagnostics.go
+++ b/VM/vm/render_diagnostics.go
@@ -1,0 +1,264 @@
+package vm
+
+import (
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+)
+
+func updateBytecodeDiagnostics(ctx hctx.Context, bytecode *compiler.Bytecode) {
+	if ctx == nil || bytecode == nil {
+		return
+	}
+	stats := cachedFastRenderPlanDiagnostics(bytecode)
+	filename := plush.PunchHoleTemplateFilename(ctx)
+	plush.UpdateRenderDiagnosticsForTemplate(ctx, filename, func(d *plush.RenderDiagnostics) {
+		d.FastPlan = stats
+		d.FastRejectLine = bytecode.FastRejectLine
+		d.FastReject = bytecode.FastReject
+	})
+}
+
+func cachedFastRenderPlanDiagnostics(bytecode *compiler.Bytecode) plush.RenderFastPlanDiagnostics {
+	if bytecode == nil {
+		return plush.RenderFastPlanDiagnostics{}
+	}
+	if cached := bytecode.FastDiagnostics.Load(); cached != nil {
+		if stats, ok := cached.(*plush.RenderFastPlanDiagnostics); ok && stats != nil {
+			return *stats
+		}
+	}
+	stats := fastRenderPlanDiagnostics(bytecode.FastRenderPlan)
+	bytecode.FastDiagnostics.Store(&stats)
+	return stats
+}
+
+type fastPlanDiagnosticBuilder struct {
+	stats        plush.RenderFastPlanDiagnostics
+	helpersSeen  map[string]struct{}
+	partialsSeen map[string]struct{}
+}
+
+func fastRenderPlanDiagnostics(plan *compiler.FastRenderPlan) plush.RenderFastPlanDiagnostics {
+	if plan == nil {
+		return plush.RenderFastPlanDiagnostics{}
+	}
+	builder := fastPlanDiagnosticBuilder{
+		stats: plush.RenderFastPlanDiagnostics{
+			Bindings: len(plan.Bindings),
+			Segments: len(plan.Segments),
+		},
+		helpersSeen:  map[string]struct{}{},
+		partialsSeen: map[string]struct{}{},
+	}
+	builder.segments(plan.Segments, 1)
+	return builder.stats
+}
+
+func (b *fastPlanDiagnosticBuilder) depth(depth int) {
+	if depth > b.stats.MaxDepth {
+		b.stats.MaxDepth = depth
+	}
+}
+
+func (b *fastPlanDiagnosticBuilder) helper(name string) {
+	if name == "" {
+		return
+	}
+	if _, ok := b.helpersSeen[name]; ok {
+		return
+	}
+	b.helpersSeen[name] = struct{}{}
+	b.stats.HelperNames = append(b.stats.HelperNames, name)
+}
+
+func (b *fastPlanDiagnosticBuilder) partial(name string) {
+	if name == "" {
+		return
+	}
+	if _, ok := b.partialsSeen[name]; ok {
+		return
+	}
+	b.partialsSeen[name] = struct{}{}
+	b.stats.PartialNames = append(b.stats.PartialNames, name)
+}
+
+func (b *fastPlanDiagnosticBuilder) segments(segments []compiler.FastRenderSegment, depth int) {
+	b.depth(depth)
+	for i := range segments {
+		b.segment(&segments[i], depth)
+	}
+}
+
+func (b *fastPlanDiagnosticBuilder) segment(segment *compiler.FastRenderSegment, depth int) {
+	if segment == nil {
+		return
+	}
+	switch segment.Kind {
+	case compiler.FastRenderSegmentStatic:
+		b.stats.StaticSegments++
+	case compiler.FastRenderSegmentName:
+		b.stats.NameSegments++
+	case compiler.FastRenderSegmentProperty:
+		b.stats.PropertyReads++
+	case compiler.FastRenderSegmentValue:
+		b.stats.ValueWrites++
+		b.value(segment.ValuePlan, depth+1)
+	case compiler.FastRenderSegmentCall:
+		b.call(segment.Call, depth+1)
+	case compiler.FastRenderSegmentBlockCall:
+		b.blockCall(segment.BlockCall)
+	case compiler.FastRenderSegmentConditional:
+		b.conditional(segment.Conditional, depth+1)
+	case compiler.FastRenderSegmentLoop:
+		b.loop(segment.Loop, depth+1)
+	case compiler.FastRenderSegmentPartial:
+		b.partialPlan(segment.Partial, depth+1)
+	case compiler.FastRenderSegmentLet:
+		b.value(segment.ValuePlan, depth+1)
+	case compiler.FastRenderSegmentAssign:
+		b.value(segment.ValuePlan, depth+1)
+	}
+}
+
+func (b *fastPlanDiagnosticBuilder) blockCall(call *compiler.FastBlockCallPlan) {
+	if call == nil {
+		return
+	}
+	b.stats.HelperCalls++
+	b.helper(call.Name)
+}
+
+func (b *fastPlanDiagnosticBuilder) conditional(plan *compiler.FastConditionalPlan, depth int) {
+	if plan == nil {
+		return
+	}
+	b.depth(depth)
+	b.stats.Conditionals++
+	for i := range plan.Branches {
+		b.value(plan.Branches[i].Condition, depth+1)
+		b.segments(plan.Branches[i].Segments, depth+1)
+	}
+	b.segments(plan.ElseSegments, depth+1)
+}
+
+func (b *fastPlanDiagnosticBuilder) loop(loop *compiler.FastLoopPlan, depth int) {
+	if loop == nil {
+		return
+	}
+	b.depth(depth)
+	b.stats.Loops++
+	b.stats.LoopParts += len(loop.Parts)
+	for i := range loop.Parts {
+		b.loopPart(&loop.Parts[i], depth+1)
+	}
+}
+
+func (b *fastPlanDiagnosticBuilder) loopPart(part *compiler.FastLoopPart, depth int) {
+	if part == nil {
+		return
+	}
+	b.depth(depth)
+	switch part.Kind {
+	case compiler.FastLoopPartStatic:
+		b.stats.StaticSegments++
+	case compiler.FastLoopPartKey, compiler.FastLoopPartValue:
+		b.stats.ValueWrites++
+	case compiler.FastLoopPartValueProperty:
+		b.stats.ValueWrites++
+		b.stats.PropertyReads++
+	case compiler.FastLoopPartValuePath:
+		b.stats.ValueWrites++
+		b.value(part.ValuePlan, depth+1)
+	case compiler.FastLoopPartCall:
+		b.call(part.Call, depth+1)
+	case compiler.FastLoopPartBlockCall:
+		b.blockCall(part.BlockCall)
+	case compiler.FastLoopPartPartial:
+		b.partialPlan(part.Partial, depth+1)
+	case compiler.FastLoopPartLet:
+		b.value(part.ValuePlan, depth+1)
+	case compiler.FastLoopPartConditional:
+		b.loopConditional(part.Conditional, depth+1)
+	case compiler.FastLoopPartLoop:
+		b.loop(part.Loop, depth+1)
+	}
+}
+
+func (b *fastPlanDiagnosticBuilder) loopConditional(plan *compiler.FastLoopConditionalPlan, depth int) {
+	if plan == nil {
+		return
+	}
+	b.depth(depth)
+	b.stats.Conditionals++
+	for i := range plan.Branches {
+		b.loopCondition(plan.Branches[i].Condition, depth+1)
+		b.stats.LoopParts += len(plan.Branches[i].Parts)
+		for j := range plan.Branches[i].Parts {
+			b.loopPart(&plan.Branches[i].Parts[j], depth+1)
+		}
+	}
+	b.stats.LoopParts += len(plan.ElseParts)
+	for i := range plan.ElseParts {
+		b.loopPart(&plan.ElseParts[i], depth+1)
+	}
+}
+
+func (b *fastPlanDiagnosticBuilder) loopCondition(plan compiler.FastValuePlan, depth int) {
+	b.value(plan, depth)
+}
+
+func (b *fastPlanDiagnosticBuilder) partialPlan(plan *compiler.FastPartialPlan, depth int) {
+	if plan == nil {
+		return
+	}
+	b.depth(depth)
+	b.stats.Partials++
+	b.partial(plan.Name)
+	for i := range plan.Data {
+		b.value(plan.Data[i].Value, depth+1)
+	}
+}
+
+func (b *fastPlanDiagnosticBuilder) call(call *compiler.FastCallPlan, depth int) {
+	if call == nil {
+		return
+	}
+	b.depth(depth)
+	b.stats.HelperCalls++
+	b.helper(call.Name)
+	for i := range call.Args {
+		b.value(call.Args[i], depth+1)
+	}
+}
+
+func (b *fastPlanDiagnosticBuilder) value(plan compiler.FastValuePlan, depth int) {
+	b.depth(depth)
+	switch plan.Kind {
+	case compiler.FastValueName:
+		b.stats.NameSegments++
+	case compiler.FastValuePath:
+		b.stats.PropertyReads += len(plan.Path)
+	case compiler.FastValueInfix, compiler.FastValueConcat:
+		if plan.Left != nil {
+			b.value(*plan.Left, depth+1)
+		}
+		if plan.Right != nil {
+			b.value(*plan.Right, depth+1)
+		}
+	case compiler.FastValuePrefix:
+		if plan.Right != nil {
+			b.value(*plan.Right, depth+1)
+		}
+	case compiler.FastValueCall:
+		b.call(plan.Call, depth+1)
+	case compiler.FastValueArray:
+		for i := range plan.Elements {
+			b.value(plan.Elements[i], depth+1)
+		}
+	case compiler.FastValueHash:
+		for i := range plan.Pairs {
+			b.value(plan.Pairs[i].Value, depth+1)
+		}
+	}
+}

--- a/VM/vm/render_diagnostics_test.go
+++ b/VM/vm/render_diagnostics_test.go
@@ -1,0 +1,173 @@
+package vm
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/helpers/meta"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Render_Diagnostics_Fast_Render_Plan_Stats(t *testing.T) {
+	plan := &compiler.FastRenderPlan{
+		Bindings: []string{"name", "items", "label"},
+		Segments: []compiler.FastRenderSegment{
+			{Kind: compiler.FastRenderSegmentStatic, Value: "<ul>"},
+			{Kind: compiler.FastRenderSegmentName, Value: "name", NameIndex: 0},
+			{Kind: compiler.FastRenderSegmentProperty, Value: "user", Property: "Name"},
+			{Kind: compiler.FastRenderSegmentCall, Call: &compiler.FastCallPlan{
+				Name:      "label",
+				NameIndex: 2,
+				Args:      []compiler.FastValuePlan{{Kind: compiler.FastValueName, Value: "name", NameIndex: 0}},
+			}},
+			{Kind: compiler.FastRenderSegmentConditional, Conditional: &compiler.FastConditionalPlan{
+				Branches: []compiler.FastConditionalBranch{{
+					Condition: compiler.FastValuePlan{
+						Kind:     compiler.FastValueInfix,
+						Operator: "==",
+						Left:     &compiler.FastValuePlan{Kind: compiler.FastValuePath, Value: "product", Path: []compiler.FastPathStep{{Kind: compiler.FastPathStepProperty, Value: "Name"}}},
+						Right:    &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "Pizza"},
+					},
+					Segments: []compiler.FastRenderSegment{{Kind: compiler.FastRenderSegmentStatic, Value: "pizza"}},
+				}},
+			}},
+			{Kind: compiler.FastRenderSegmentLoop, Loop: &compiler.FastLoopPlan{
+				IterableName:      "items",
+				IterableNameIndex: 1,
+				Parts: []compiler.FastLoopPart{
+					{Kind: compiler.FastLoopPartStatic, Value: "<li>"},
+					{Kind: compiler.FastLoopPartValueProperty, PropertyCache: compiler.FastRenderSegment{}.PropertyCache},
+					{Kind: compiler.FastLoopPartCall, Call: &compiler.FastCallPlan{Name: "label", NameIndex: 2}},
+				},
+			}},
+			{Kind: compiler.FastRenderSegmentPartial, Partial: &compiler.FastPartialPlan{
+				Name: "row.plush",
+				Data: []compiler.FastPartialDataPair{
+					{Key: "title", Value: compiler.FastValuePlan{Kind: compiler.FastValuePath, Value: "product", Path: []compiler.FastPathStep{{Kind: compiler.FastPathStepProperty, Value: "Title"}}}},
+				},
+			}},
+		},
+	}
+
+	stats := fastRenderPlanDiagnostics(plan)
+
+	require.Equal(t, 3, stats.Bindings)
+	require.Equal(t, len(plan.Segments), stats.Segments)
+	require.Equal(t, 3, stats.StaticSegments)
+	require.Equal(t, 2, stats.NameSegments)
+	require.Equal(t, 4, stats.PropertyReads)
+	require.Equal(t, 1, stats.ValueWrites)
+	require.Equal(t, 2, stats.HelperCalls)
+	require.Equal(t, 1, stats.Conditionals)
+	require.Equal(t, 1, stats.Loops)
+	require.Equal(t, 3, stats.LoopParts)
+	require.Equal(t, 1, stats.Partials)
+	require.GreaterOrEqual(t, stats.MaxDepth, 3)
+	require.Equal(t, []string{"label"}, stats.HelperNames)
+	require.Equal(t, []string{"row.plush"}, stats.PartialNames)
+}
+
+func Test_Render_Diagnostics_Context_Expose_Fast_Render_Plan_Stats(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name": "Mido",
+	})
+
+	tmpl, err := Compile(`<h1><%= name %></h1>`)
+	require.NoError(t, err)
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "<h1>Mido</h1>", out)
+
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, plush.RenderModeNameVM, diagnostics.Mode)
+	require.Equal(t, plush.VMBytecodeCacheDirect, diagnostics.VMBytecodeCache)
+	require.Greater(t, diagnostics.FastPlan.Segments, 0)
+	require.Greater(t, diagnostics.FastPlan.NameSegments, 0)
+	require.NotZero(t, diagnostics.EngineDuration)
+}
+
+func Test_Render_Diagnostics_Caches_Fast_Render_Plan_Stats_On_Bytecode(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name": "Mido",
+	})
+
+	tmpl, err := Compile(`<h1><%= name %></h1>`)
+	require.NoError(t, err)
+	require.Nil(t, tmpl.bytecode.FastDiagnostics.Load())
+
+	updateBytecodeDiagnostics(ctx, tmpl.bytecode)
+	first := tmpl.bytecode.FastDiagnostics.Load()
+	require.NotNil(t, first)
+
+	updateBytecodeDiagnostics(ctx, tmpl.bytecode)
+	second := tmpl.bytecode.FastDiagnostics.Load()
+	require.Same(t, first, second)
+
+	stats, ok := second.(*plush.RenderFastPlanDiagnostics)
+	require.True(t, ok)
+	require.Greater(t, stats.Segments, 0)
+	require.Greater(t, stats.NameSegments, 0)
+}
+
+func Test_Render_Diagnostics_VM_Hotspots_Record_Fast_Helper_And_Partial(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name": "Mido",
+		"label": func(value string) string {
+			return "slow " + value
+		},
+		"partialFeeder": func(string) (string, error) {
+			return `<%= name %>`, nil
+		},
+	})
+	plush.EnableRenderVMHotspotDiagnostics(ctx)
+	SetFastHelper(ctx, "label", func(w FastWriter, args FastArgs) error {
+		value, ok := args.String(0)
+		require.True(t, ok)
+		w.WriteEscapedString("fast " + value)
+		return nil
+	})
+
+	tmpl, err := Compile(`<%= label(name) %>|<%= partial("row.plush") %>`)
+	require.NoError(t, err)
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "fast Mido|Mido", out)
+
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.GreaterOrEqual(t, diagnostics.VMHotspots.HelperCalls, 1)
+	require.Greater(t, diagnostics.VMHotspots.HelperDuration, time.Duration(0))
+	require.Contains(t, diagnostics.VMHelperHotspotsHeader(), "label:")
+	require.Equal(t, 1, diagnostics.VMHotspots.PartialCalls)
+	require.Greater(t, diagnostics.VMHotspots.PartialDuration, time.Duration(0))
+	require.Contains(t, diagnostics.VMPartialHotspotsHeader(), "row.plush:")
+}
+
+func Test_Render_Diagnostics_Nested_Partial_Does_Not_Overwrite_Top_Template(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name": "Mido",
+		"partialFeeder": func(string) (string, error) {
+			return `<%= name %>`, nil
+		},
+	})
+	plush.EnableRenderVMHotspotDiagnostics(ctx)
+	ctx.Set(meta.TemplateFileKey, "application.plush")
+
+	out, err := Render(`<%= partial("header.html") %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "Mido", out)
+
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, plush.RenderModeNameVM, diagnostics.Mode)
+	require.Equal(t, "application.plush", diagnostics.TemplateFilename)
+	require.Equal(t, plush.VMBytecodeCacheMissStore, diagnostics.VMBytecodeCache)
+	require.Equal(t, []string{"header.html"}, diagnostics.FastPlan.PartialNames)
+	require.Equal(t, 1, diagnostics.VMHotspots.PartialCalls)
+	require.Contains(t, diagnostics.VMPartialHotspotsHeader(), "header.html:")
+}

--- a/VM/vm/render_diagnostics_test.go
+++ b/VM/vm/render_diagnostics_test.go
@@ -72,9 +72,13 @@ func Test_Render_Diagnostics_Fast_Render_Plan_Stats(t *testing.T) {
 func Test_Render_Diagnostics_Context_Expose_Fast_Render_Plan_Stats(t *testing.T) {
 	ctx := plush.NewContextWith(map[string]interface{}{
 		"name": "Mido",
+		"slow": func() string {
+			time.Sleep(20 * time.Millisecond)
+			return ""
+		},
 	})
 
-	tmpl, err := Compile(`<h1><%= name %></h1>`)
+	tmpl, err := Compile(`<%= slow() %><h1><%= name %></h1>`)
 	require.NoError(t, err)
 
 	out, err := tmpl.Render(ctx)
@@ -117,9 +121,11 @@ func Test_Render_Diagnostics_VM_Hotspots_Record_Fast_Helper_And_Partial(t *testi
 	ctx := plush.NewContextWith(map[string]interface{}{
 		"name": "Mido",
 		"label": func(value string) string {
+			time.Sleep(20 * time.Millisecond)
 			return "slow " + value
 		},
 		"partialFeeder": func(string) (string, error) {
+			time.Sleep(20 * time.Millisecond)
 			return `<%= name %>`, nil
 		},
 	})
@@ -127,6 +133,7 @@ func Test_Render_Diagnostics_VM_Hotspots_Record_Fast_Helper_And_Partial(t *testi
 	SetFastHelper(ctx, "label", func(w FastWriter, args FastArgs) error {
 		value, ok := args.String(0)
 		require.True(t, ok)
+		time.Sleep(20 * time.Millisecond)
 		w.WriteEscapedString("fast " + value)
 		return nil
 	})

--- a/VM/vm/render_output.go
+++ b/VM/vm/render_output.go
@@ -1,0 +1,275 @@
+package vm
+
+import (
+	"fmt"
+	"html/template"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/object"
+)
+
+func (vm *VM) stringConstant(index int) string {
+	if index < 0 || index >= len(vm.constants) {
+		return ""
+	}
+	if str, ok := vm.constants[index].(*object.String); ok {
+		return str.Value
+	}
+	return vm.constants[index].Inspect()
+}
+
+func (vm *VM) htmlConstantString(index int) string {
+	if index < 0 || index >= len(vm.constants) {
+		return ""
+	}
+	switch obj := vm.constants[index].(type) {
+	case *object.String:
+		return obj.Value
+	case *object.Native:
+		if html, ok := obj.Value.(template.HTML); ok {
+			return string(html)
+		}
+	}
+	return vm.constants[index].Inspect()
+}
+
+func (vm *VM) renderObject(obj object.Object) string {
+	var out strings.Builder
+	if size := vm.estimatedRenderedObjectSize(obj); size > 0 {
+		out.Grow(size)
+	}
+	vm.writeObject(&out, obj)
+	return out.String()
+}
+
+func (vm *VM) estimatedRenderedObjectsSize(objects []object.Object) int {
+	total := 0
+	for _, obj := range objects {
+		total += vm.estimatedRenderedObjectSize(obj)
+	}
+	return total
+}
+
+func (vm *VM) estimatedRenderedObjectSize(obj object.Object) int {
+	if obj == nil || object.IsNull(obj) {
+		return 0
+	}
+
+	switch obj := obj.(type) {
+	case *object.Array:
+		return vm.estimatedRenderedObjectsSize(obj.Elements)
+	case *object.Integer:
+		return 20
+	case *object.Float:
+		return 24
+	case *object.Boolean:
+		return 5
+	case *object.String:
+		return len(obj.Value)
+	case *object.Native:
+		return vm.estimatedRenderedGoValueSize(obj.Value)
+	default:
+		return len(obj.Inspect())
+	}
+}
+
+func (vm *VM) estimatedRenderedGoValueSize(value interface{}) int {
+	switch value := value.(type) {
+	case nil:
+		return 0
+	case vmHole:
+		return len(plush.PunchHoleMarkerName(0))
+	case time.Time:
+		if vm.ctx != nil {
+			if dtf, ok := vm.ctx.Value("TIME_FORMAT").(string); ok {
+				return len(value.Format(dtf))
+			}
+		}
+		return len(value.Format(plush.DefaultTimeFormat))
+	case *time.Time:
+		if value == nil {
+			return 0
+		}
+		return vm.estimatedRenderedGoValueSize(*value)
+	case template.HTML:
+		return len(value)
+	case string:
+		return len(value)
+	case bool:
+		return 5
+	case uint, uint8, uint16, uint32, uint64, int, int8, int16, int32, int64:
+		return 20
+	case float32, float64:
+		return 24
+	case []string:
+		total := 0
+		for _, el := range value {
+			total += len(el)
+		}
+		return total
+	case []interface{}:
+		total := 0
+		for _, el := range value {
+			total += vm.estimatedRenderedGoValueSize(el)
+		}
+		return total
+	default:
+		rv := reflect.ValueOf(value)
+		if rv.IsValid() && (rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array) {
+			total := 0
+			for i := 0; i < rv.Len(); i++ {
+				total += vm.estimatedRenderedGoValueSize(rv.Index(i).Interface())
+			}
+			return total
+		}
+	}
+	return 0
+}
+
+func (vm *VM) writeObject(out *strings.Builder, obj object.Object) {
+	if obj == nil || object.IsNull(obj) {
+		return
+	}
+
+	switch obj := obj.(type) {
+	case *object.Array:
+		for _, el := range obj.Elements {
+			vm.writeObject(out, el)
+		}
+		return
+	case *object.Integer, *object.Float, *object.Boolean:
+		out.WriteString(template.HTMLEscaper(obj.Inspect()))
+		return
+	case *object.String:
+		out.WriteString(template.HTMLEscapeString(obj.Value))
+		return
+	}
+
+	vm.writeGoValue(out, object.ToGo(obj))
+}
+
+func (vm *VM) writeGoValue(out *strings.Builder, value interface{}) {
+	switch t := value.(type) {
+	case vmHole:
+		if vm.holes == nil {
+			holes := []plush.HoleMarker{}
+			vm.holes = &holes
+		}
+		markerName := plush.PunchHoleMarkerName(len(*vm.holes))
+		start, end := out.Len(), out.Len()+len(markerName)
+		if vm.deferHolePositions {
+			start, end = -1, -1
+		}
+		*vm.holes = append(*vm.holes, plush.NewHoleMarker(markerName, t.input, start, end))
+		out.WriteString(markerName)
+	case nil:
+		return
+	case object.Object:
+		vm.writeObject(out, t)
+	case time.Time:
+		if vm.ctx != nil {
+			if dtf, ok := vm.ctx.Value("TIME_FORMAT").(string); ok {
+				out.WriteString(t.Format(dtf))
+				return
+			}
+		}
+		out.WriteString(t.Format(plush.DefaultTimeFormat))
+	case *time.Time:
+		if t != nil {
+			vm.writeGoValue(out, *t)
+		}
+	case interface{ Interface() interface{} }:
+		vm.writeGoValue(out, t.Interface())
+	case template.HTML:
+		out.WriteString(string(t))
+	case interface{ HTML() template.HTML }:
+		out.WriteString(string(t.HTML()))
+	case string:
+		out.WriteString(template.HTMLEscapeString(t))
+	case bool:
+		out.WriteString(template.HTMLEscaper(t))
+	case uint, uint8, uint16, uint32, uint64, int, int8, int16, int32, int64, float32, float64:
+		out.WriteString(fmt.Sprint(t))
+	case fmt.Stringer:
+		out.WriteString(t.String())
+	case []string:
+		for _, el := range t {
+			vm.writeGoValue(out, el)
+		}
+	case []interface{}:
+		for _, el := range t {
+			vm.writeGoValue(out, el)
+		}
+	default:
+		rv := reflect.ValueOf(value)
+		if rv.IsValid() && (rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array) {
+			for i := 0; i < rv.Len(); i++ {
+				vm.writeGoValue(out, rv.Index(i).Interface())
+			}
+			return
+		}
+	}
+}
+
+func nativeBoolToBooleanObject(input bool) *object.Boolean {
+	if input {
+		return True
+	}
+	return False
+}
+
+func isTruthy(obj object.Object) bool {
+	if obj == nil {
+		return false
+	}
+
+	switch obj := obj.(type) {
+	case *object.Boolean:
+		return obj.Value
+	case *object.Null:
+		return false
+	case *object.String:
+		return obj.Value != ""
+	case *object.Native:
+		if obj.Value == nil {
+			return false
+		}
+		rv := reflect.ValueOf(obj.Value)
+		if rv.Kind() == reflect.Ptr && rv.IsNil() {
+			return false
+		}
+		return true
+	default:
+		return true
+	}
+}
+
+func isTruthyFastValue(value interface{}) bool {
+	switch value := value.(type) {
+	case nil:
+		return false
+	case object.Object:
+		return isTruthy(value)
+	case bool:
+		return value
+	case string:
+		return value != ""
+	default:
+		rv := reflect.ValueOf(value)
+		if rv.IsValid() && rv.Kind() == reflect.Ptr && rv.IsNil() {
+			return false
+		}
+		return true
+	}
+}
+
+func toInt(obj object.Object) (int64, bool) {
+	value, ok := numericValueFromObject(obj)
+	if !ok {
+		return 0, false
+	}
+	return value.int64()
+}

--- a/VM/vm/render_partial_misc_helpers_test.go
+++ b/VM/vm/render_partial_misc_helpers_test.go
@@ -1,0 +1,116 @@
+package vm
+
+import (
+	"html/template"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/gobuffalo/plush/v5/helpers/meta"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_VM_Setup_Fast_Partial_Nesting_Branches(t *testing.T) {
+	setupFastPartialNesting(nil, "row.plush", partialMetaIDs{})
+
+	ctx := borrowPartialOverlayContext(plush.NewContext())
+	defer releasePartialOverlayContext(ctx)
+	ids := partialMetaIDs{
+		alreadyPartialID:   ctx.InternID(vmAlreadyInPartial),
+		templateBaseFileID: ctx.InternID(meta.TemplateBaseFileNameKey),
+		templateExtID:      ctx.InternID(meta.TemplateExtensionKey),
+	}
+
+	setupFastPartialNesting(ctx, "row.plush", ids)
+	value, ok := ctx.LookupID(ids.alreadyPartialID)
+	require.True(t, ok)
+	require.Equal(t, "row.plush", value)
+
+	setupFastPartialNesting(ctx, "nested.html", ids)
+	value, ok = ctx.LookupID(ids.templateBaseFileID)
+	require.True(t, ok)
+	require.Equal(t, "nested", value)
+	value, ok = ctx.LookupID(ids.templateExtID)
+	require.True(t, ok)
+	require.Equal(t, "html", value)
+
+	normal := plush.NewContext()
+	setupPartialNesting(normal, "first.plush")
+	require.Equal(t, "first.plush", normal.Value(vmAlreadyInPartial))
+	setupPartialNesting(normal, "child.html")
+	require.Equal(t, "child", normal.Value(meta.TemplateBaseFileNameKey))
+	require.Equal(t, "html", normal.Value(meta.TemplateExtensionKey))
+}
+
+func Test_VM_Render_Output_Size_Helpers(t *testing.T) {
+	now := time.Date(2026, 7, 7, 1, 2, 3, 0, time.UTC)
+	ctx := plush.NewContextWith(map[string]interface{}{"TIME_FORMAT": "2006"})
+	machine := newRuntimeHelperTestVM(ctx)
+
+	require.Empty(t, machine.stringConstant(-1))
+	machine.constants = []object.Object{&object.String{Value: "name"}, &object.Integer{Value: 7}, &object.Native{Value: template.HTML("<b>")}}
+	require.Equal(t, "name", machine.stringConstant(0))
+	require.Equal(t, "7", machine.stringConstant(1))
+	require.Equal(t, "<b>", machine.htmlConstantString(2))
+	require.Equal(t, "7", machine.htmlConstantString(1))
+	require.Empty(t, machine.htmlConstantString(-1))
+
+	require.Equal(t, 0, machine.estimatedRenderedObjectSize(nil))
+	require.Equal(t, 0, machine.estimatedRenderedObjectSize(object.NullObject))
+	require.Equal(t, len("ab"), machine.estimatedRenderedObjectSize(&object.String{Value: "ab"}))
+	require.Equal(t, 24, machine.estimatedRenderedObjectSize(&object.Float{Value: 1.25}))
+	require.Equal(t, 25, machine.estimatedRenderedObjectSize(&object.Array{Elements: []object.Object{&object.Integer{Value: 1}, object.TrueObject}}))
+	require.Positive(t, machine.estimatedRenderedObjectSize(&object.Builtin{}))
+	require.Equal(t, len(plush.PunchHoleMarkerName(0)), machine.estimatedRenderedGoValueSize(vmHole{}))
+	require.Equal(t, len("2026"), machine.estimatedRenderedGoValueSize(now))
+	require.Equal(t, len(now.Format(plush.DefaultTimeFormat)), newRuntimeHelperTestVM(plush.NewContext()).estimatedRenderedGoValueSize(now))
+	require.Equal(t, 0, machine.estimatedRenderedGoValueSize((*time.Time)(nil)))
+	require.Equal(t, len("2026"), machine.estimatedRenderedGoValueSize(&now))
+	require.Equal(t, len("<b>"), machine.estimatedRenderedGoValueSize(template.HTML("<b>")))
+	require.Equal(t, len("abc"), machine.estimatedRenderedGoValueSize("abc"))
+	require.Equal(t, 5, machine.estimatedRenderedGoValueSize(true))
+	require.Equal(t, 20, machine.estimatedRenderedGoValueSize(uint32(3)))
+	require.Equal(t, 24, machine.estimatedRenderedGoValueSize(float32(1.5)))
+	require.Equal(t, 3, machine.estimatedRenderedGoValueSize([]string{"a", "bc"}))
+	require.Equal(t, 6, machine.estimatedRenderedGoValueSize([]interface{}{"a", true}))
+	require.Equal(t, 4, machine.estimatedRenderedGoValueSize([2]string{"ab", "cd"}))
+	require.Zero(t, machine.estimatedRenderedGoValueSize(struct{}{}))
+
+	holeMachine := &VM{ctx: plush.NewContext(), deferHolePositions: true}
+	var out strings.Builder
+	holeMachine.writeGoValue(&out, vmHole{input: `"hole"`})
+	require.Equal(t, plush.PunchHoleMarkerName(0), out.String())
+	require.Len(t, *holeMachine.holes, 1)
+	require.Equal(t, -1, (*holeMachine.holes)[0].Start())
+	require.Equal(t, -1, (*holeMachine.holes)[0].End())
+}
+
+func Test_VM_Eval_Fast_Infix_Operator_Branches(t *testing.T) {
+	tests := []struct {
+		op       string
+		left     interface{}
+		right    interface{}
+		expected bool
+	}{
+		{"&&", true, "x", true},
+		{"||", false, "x", true},
+		{"==", uint32(1), 1, true},
+		{"!=", uint32(1), 2, true},
+		{">", 3, 2, true},
+		{">=", 3, 3, true},
+		{"<", 2, 3, true},
+		{"<=", 3, 3, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.op, func(t *testing.T) {
+			got, err := evalFastInfixOperator(tt.op, tt.left, tt.right)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+
+	_, err := evalFastInfixOperator("??", 1, 2)
+	require.ErrorContains(t, err, "unknown fast infix operator")
+}

--- a/VM/vm/runtime.go
+++ b/VM/vm/runtime.go
@@ -1,0 +1,586 @@
+package vm
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/gobuffalo/plush/v5/ast"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+	"github.com/gobuffalo/plush/v5/parser"
+)
+
+func New(bytecode *compiler.Bytecode) *VM {
+	return NewWithContext(bytecode, plush.NewContext())
+}
+
+func NewWithContext(bytecode *compiler.Bytecode, ctx hctx.Context) *VM {
+	return newWithContext(bytecode, ctx, false)
+}
+
+func newPooledWithContext(bytecode *compiler.Bytecode, ctx hctx.Context) *VM {
+	return newWithContext(bytecode, ctx, true)
+}
+
+func newWithContext(bytecode *compiler.Bytecode, ctx hctx.Context, pooled bool) *VM {
+	if ctx == nil {
+		ctx = plush.NewContext()
+	}
+
+	mainFn := &object.CompiledFunction{
+		Instructions:   bytecode.Instructions,
+		CallNames:      bytecode.CallNames,
+		LocalNames:     bytecode.LocalNames,
+		LineNumbers:    bytecode.LineNumbers,
+		Properties:     bytecode.Properties,
+		PropertyCaches: bytecode.PropertyCaches,
+		CallCaches:     bytecode.CallCaches,
+		NumLocals:      bytecode.NumLocals,
+	}
+	mainClosure := &object.Closure{Fn: mainFn}
+	mainFrame := newFrame(mainClosure, 0, pooled)
+
+	frames := borrowFrames(pooled)
+	frames[0] = mainFrame
+
+	holes := borrowHoles(pooled)
+	globalSize := globalStoreSize(bytecode)
+
+	machine := &VM{
+		constants:   bytecode.Constants,
+		stack:       borrowStack(pooled),
+		sp:          mainFn.NumLocals,
+		stackMax:    mainFn.NumLocals,
+		globals:     borrowGlobals(globalSize, pooled),
+		globalNames: bytecode.GlobalNames,
+		frames:      frames,
+		framesIndex: 1,
+		ctx:         ctx,
+		holes:       holes,
+		pooled:      pooled,
+		ownGlobals:  pooled,
+		ownHoles:    pooled,
+	}
+	return machine
+}
+
+func NewWithGlobalsStore(bytecode *compiler.Bytecode, globals []object.Object) *VM {
+	vm := New(bytecode)
+	vm.globals = globals
+	return vm
+}
+
+func Compile(input string) (*Template, error) {
+	program, err := parser.Parse(preprocessTrimTags(input))
+	if err != nil {
+		return nil, err
+	}
+
+	return templateFromBytecode(compileProgramBytecode(program))
+}
+
+func compileProgramBytecode(program *ast.Program) (*compiler.Bytecode, error) {
+	comp := compiler.New()
+	if err := comp.Compile(program); err != nil {
+		return nil, err
+	}
+	return comp.Bytecode(), nil
+}
+
+func templateFromBytecode(bytecode *compiler.Bytecode, err error) (*Template, error) {
+	if err != nil {
+		return nil, err
+	}
+	return &Template{bytecode: bytecode}, nil
+}
+
+func (t *Template) Render(ctx hctx.Context) (string, error) {
+	if t == nil || t.bytecode == nil {
+		return "", fmt.Errorf("cannot render nil compiled template")
+	}
+	if ctx == nil {
+		ctx = plush.NewContext()
+	}
+	start := time.Now()
+	plush.UpdateRenderDiagnostics(ctx, func(d *plush.RenderDiagnostics) {
+		d.Mode = plush.RenderModeNameVM
+		d.VMBytecodeCache = plush.VMBytecodeCacheDirect
+		d.FastPath = plush.RenderFastPathGeneric
+		d.PunchHoleCache = plush.PunchHoleCacheDisabled
+	})
+	updateBytecodeDiagnostics(ctx, t.bytecode)
+	defer func() {
+		plush.UpdateRenderDiagnostics(ctx, func(d *plush.RenderDiagnostics) {
+			d.Mode = plush.RenderModeNameVM
+			d.EngineDuration = time.Since(start)
+		})
+	}()
+	return renderBytecode(t.bytecode, ctx)
+}
+
+func globalStoreSize(bytecode *compiler.Bytecode) int {
+	size := bytecode.NumGlobals
+	for index := range bytecode.GlobalNames {
+		if index+1 > size {
+			size = index + 1
+		}
+	}
+	if size < 0 {
+		return 0
+	}
+	return size
+}
+
+func borrowStack(pooled bool) []object.Object {
+	if !pooled {
+		return make([]object.Object, StackSize)
+	}
+	stack := stackPool.Get().(*[]object.Object)
+	return (*stack)[:StackSize]
+}
+
+func releaseStack(stack []object.Object, used int) {
+	if cap(stack) < StackSize {
+		return
+	}
+	stack = stack[:StackSize]
+	if used > len(stack) {
+		used = len(stack)
+	}
+	if used > 0 {
+		clearObjectSlice(stack[:used])
+	}
+	stackPool.Put(&stack)
+}
+
+func borrowFrames(pooled bool) []*Frame {
+	if !pooled {
+		return make([]*Frame, MaxFrames)
+	}
+	frames := framesPool.Get().(*[]*Frame)
+	return (*frames)[:MaxFrames]
+}
+
+func releaseFrames(frames []*Frame) {
+	if cap(frames) < MaxFrames {
+		return
+	}
+	frames = frames[:MaxFrames]
+	clear(frames)
+	framesPool.Put(&frames)
+}
+
+func newFrame(cl *object.Closure, basePointer int, pooled bool) *Frame {
+	if !pooled {
+		return NewFrame(cl, basePointer)
+	}
+	frame := framePool.Get().(*Frame)
+	frame.pooled = true
+	frame.reset(cl, basePointer)
+	return frame
+}
+
+func releaseFrame(frame *Frame) {
+	if frame == nil || !frame.pooled {
+		return
+	}
+	frame.reset(nil, 0)
+	framePool.Put(frame)
+}
+
+func borrowHoles(pooled bool) *[]plush.HoleMarker {
+	if !pooled {
+		holes := []plush.HoleMarker{}
+		return &holes
+	}
+	holes := holesPool.Get().(*[]plush.HoleMarker)
+	clear(*holes)
+	*holes = (*holes)[:0]
+	return holes
+}
+
+func releaseHoles(holes *[]plush.HoleMarker) {
+	if holes == nil {
+		return
+	}
+	clear(*holes)
+	*holes = (*holes)[:0]
+	holesPool.Put(holes)
+}
+
+func borrowGlobals(size int, pooled bool) []object.Object {
+	if size <= 0 {
+		return nil
+	}
+	if !pooled {
+		return make([]object.Object, size)
+	}
+	pool := globalsPool(size)
+	if globalsPtr, ok := pool.Get().(*[]object.Object); ok && cap(*globalsPtr) >= size {
+		globals := (*globalsPtr)[:size]
+		clearObjectSlice(globals)
+		return globals
+	}
+	return make([]object.Object, size)
+}
+
+func releaseGlobals(globals []object.Object) {
+	if cap(globals) == 0 {
+		return
+	}
+	size := cap(globals)
+	globals = globals[:size]
+	clearObjectSlice(globals)
+	globalsPool(size).Put(&globals)
+}
+
+func globalsPool(size int) *sync.Pool {
+	pool, _ := globalsPools.LoadOrStore(size, &sync.Pool{})
+	return pool.(*sync.Pool)
+}
+
+func clearObjectSlice(objects []object.Object) {
+	for i := range objects {
+		objects[i] = nil
+	}
+}
+
+func (vm *VM) Release() {
+	if vm == nil || !vm.pooled {
+		return
+	}
+	if vm.frames != nil {
+		for i := 0; i < vm.framesIndex && i < len(vm.frames); i++ {
+			releaseFrame(vm.frames[i])
+			vm.frames[i] = nil
+		}
+		releaseFrames(vm.frames)
+	}
+	if vm.stack != nil {
+		releaseStack(vm.stack, vm.stackMax)
+	}
+	if vm.ownGlobals {
+		releaseGlobals(vm.globals)
+	}
+	if vm.ownHoles {
+		releaseHoles(vm.holes)
+	}
+	*vm = VM{}
+}
+
+func Render(input string, ctx hctx.Context) (string, error) {
+	if ctx == nil {
+		ctx = plush.NewContext()
+	}
+	start := time.Now()
+	cacheSource := preprocessTrimTags(input)
+	filename := plush.PunchHoleTemplateFilename(ctx)
+	initialCacheState := plush.VMBytecodeCacheMiss
+	if filename == "" || !plush.IsVMBytecodeCacheableTemplateFile(filename) {
+		initialCacheState = plush.VMBytecodeCacheDisabled
+	}
+	plush.UpdateRenderDiagnosticsForTemplate(ctx, filename, func(d *plush.RenderDiagnostics) {
+		d.Mode = plush.RenderModeNameVM
+		d.TemplateFilename = filename
+		d.VMBytecodeCache = initialCacheState
+		d.FastPath = plush.RenderFastPathGeneric
+		d.PunchHoleCache = plush.PunchHoleCacheDisabled
+	})
+	defer func() {
+		if plush.RenderDiagnosticsRootActive(ctx) {
+			return
+		}
+		plush.UpdateRenderDiagnosticsForTemplate(ctx, filename, func(d *plush.RenderDiagnostics) {
+			d.Mode = plush.RenderModeNameVM
+			if d.TemplateFilename == "" {
+				d.TemplateFilename = filename
+			}
+			d.EngineDuration = time.Since(start)
+		})
+	}()
+
+	if filename == "" {
+		if bytecode, ok := cachedSourceBytecode(cacheSource); ok {
+			return renderSourceCachedBytecode(cacheSource, ctx, bytecode)
+		}
+	}
+
+	var cachedBytecode *compiler.Bytecode
+	if cached, ok := plush.CachedVMBytecodeForCleanFilenameWithSource(filename, cacheSource); ok {
+		if bytecode, ok := cached.(*compiler.Bytecode); ok {
+			updateBytecodeDiagnostics(ctx, bytecode)
+			if bytecode.Static {
+				plush.UpdateRenderDiagnosticsForTemplate(ctx, filename, func(d *plush.RenderDiagnostics) {
+					d.VMBytecodeCache = plush.VMBytecodeCacheHitStatic
+					d.FastPath = plush.RenderFastPathStatic
+				})
+				return bytecode.StaticOutput, nil
+			}
+			plush.UpdateRenderDiagnosticsForTemplate(ctx, filename, func(d *plush.RenderDiagnostics) {
+				d.VMBytecodeCache = plush.VMBytecodeCacheHit
+			})
+			cachedBytecode = bytecode
+		}
+	}
+	if shouldFallbackGenericBytecode(cachedBytecode) {
+		return renderInterpreterFallback(input, ctx, filename)
+	}
+	if rendered, ok, err := tryRenderFastBytecode(cachedBytecode, ctx); ok || err != nil {
+		if ok {
+			plush.UpdateRenderDiagnosticsForTemplate(ctx, filename, func(d *plush.RenderDiagnostics) {
+				d.FastPath = plush.RenderFastPathFast
+			})
+		}
+		return rendered, err
+	}
+
+	if cachedBytecode != nil {
+		updateBytecodeDiagnostics(ctx, cachedBytecode)
+		if restorePartial := installVMPartialHelperForBytecode(cachedBytecode, ctx); restorePartial != nil {
+			defer restorePartial()
+		}
+		forceCacheClear := false
+		if cachedBytecode.HasHoles {
+			var cached string
+			var ok bool
+			filename, forceCacheClear, cached, ok = punchHoleCacheStateForFilename(filename, ctx, cacheSource)
+			if ok {
+				plush.UpdateRenderDiagnosticsForTemplate(ctx, filename, func(d *plush.RenderDiagnostics) {
+					d.TemplateFilename = filename
+					d.PunchHoleCache = plush.PunchHoleCacheHit
+				})
+				return cached, nil
+			}
+			plush.UpdateRenderDiagnosticsForTemplate(ctx, filename, func(d *plush.RenderDiagnostics) {
+				d.TemplateFilename = filename
+				d.PunchHoleCache = plush.PunchHoleCacheMiss
+			})
+		}
+
+		return renderBytecodeVMWithState(cachedBytecode, ctx, filename, forceCacheClear, cacheSource)
+	}
+
+	filename, forceCacheClear, cached, ok := punchHoleCacheStateForFilename(filename, ctx, cacheSource)
+	if ok {
+		plush.UpdateRenderDiagnosticsForTemplate(ctx, filename, func(d *plush.RenderDiagnostics) {
+			d.TemplateFilename = filename
+			d.PunchHoleCache = plush.PunchHoleCacheHit
+		})
+		return cached, nil
+	}
+
+	input = cacheSource
+	if cached, ok := plush.CachedVMBytecodeForCleanFilenameWithSource(filename, cacheSource); ok {
+		if bytecode, ok := cached.(*compiler.Bytecode); ok {
+			updateBytecodeDiagnostics(ctx, bytecode)
+			if bytecode.Static {
+				plush.UpdateRenderDiagnosticsForTemplate(ctx, filename, func(d *plush.RenderDiagnostics) {
+					d.VMBytecodeCache = plush.VMBytecodeCacheHitStatic
+					d.FastPath = plush.RenderFastPathStatic
+				})
+				return bytecode.StaticOutput, nil
+			}
+			if rendered, ok, err := tryRenderFastBytecode(bytecode, ctx); ok || err != nil {
+				if ok {
+					plush.UpdateRenderDiagnosticsForTemplate(ctx, filename, func(d *plush.RenderDiagnostics) {
+						d.VMBytecodeCache = plush.VMBytecodeCacheHit
+						d.FastPath = plush.RenderFastPathFast
+					})
+				}
+				return rendered, err
+			}
+			plush.UpdateRenderDiagnosticsForTemplate(ctx, filename, func(d *plush.RenderDiagnostics) {
+				d.VMBytecodeCache = plush.VMBytecodeCacheHit
+			})
+			if shouldFallbackGenericBytecode(bytecode) {
+				return renderInterpreterFallback(input, ctx, filename)
+			}
+			if restorePartial := installVMPartialHelperForBytecode(bytecode, ctx); restorePartial != nil {
+				defer restorePartial()
+			}
+			return renderBytecodeVMWithState(bytecode, ctx, filename, forceCacheClear, cacheSource)
+		}
+	}
+
+	program, cachedProgram, err := parseProgram(input, filename, ctx)
+	if err != nil {
+		return "", err
+	}
+
+	comp := compiler.New()
+	if err := comp.Compile(program); err != nil {
+		return "", err
+	}
+
+	bytecode := comp.Bytecode()
+	if filename == "" {
+		cacheSourceBytecode(cacheSource, bytecode)
+	} else {
+		plush.CacheVMBytecodeForCleanFilenameWithSource(filename, cachedProgram, bytecode, cacheSource)
+	}
+	updateBytecodeDiagnostics(ctx, bytecode)
+	plush.UpdateRenderDiagnosticsForTemplate(ctx, filename, func(d *plush.RenderDiagnostics) {
+		if filename == "" {
+			d.VMBytecodeCache = plush.VMBytecodeCacheMissStoreSource
+		} else if plush.IsPlushTemplateFile(filename) {
+			d.VMBytecodeCache = plush.VMBytecodeCacheMissStore
+		}
+	})
+	if shouldFallbackGenericBytecode(bytecode) {
+		return renderInterpreterFallback(input, ctx, filename)
+	}
+	if restorePartial := installVMPartialHelperForBytecode(bytecode, ctx); restorePartial != nil {
+		defer restorePartial()
+	}
+	return renderBytecodeWithState(bytecode, ctx, filename, forceCacheClear, cacheSource)
+}
+
+func renderSourceCachedBytecode(source string, ctx hctx.Context, bytecode *compiler.Bytecode) (string, error) {
+	updateBytecodeDiagnostics(ctx, bytecode)
+	if bytecode.Static {
+		plush.UpdateRenderDiagnosticsForTemplate(ctx, "", func(d *plush.RenderDiagnostics) {
+			d.VMBytecodeCache = plush.VMBytecodeCacheHitSource
+			d.FastPath = plush.RenderFastPathStatic
+		})
+		return bytecode.StaticOutput, nil
+	}
+	plush.UpdateRenderDiagnosticsForTemplate(ctx, "", func(d *plush.RenderDiagnostics) {
+		d.VMBytecodeCache = plush.VMBytecodeCacheHitSource
+	})
+	if shouldFallbackGenericBytecode(bytecode) {
+		return renderInterpreterFallback(source, ctx, "")
+	}
+	if rendered, ok, err := tryRenderFastBytecode(bytecode, ctx); ok || err != nil {
+		if ok {
+			plush.UpdateRenderDiagnosticsForTemplate(ctx, "", func(d *plush.RenderDiagnostics) {
+				d.FastPath = plush.RenderFastPathFast
+			})
+		}
+		return rendered, err
+	}
+	if restorePartial := installVMPartialHelperForBytecode(bytecode, ctx); restorePartial != nil {
+		defer restorePartial()
+	}
+	return renderBytecodeVMWithState(bytecode, ctx, "", false, source)
+}
+
+func shouldFallbackGenericBytecode(bytecode *compiler.Bytecode) bool {
+	return plush.VMGenericFallbackEnabled() &&
+		bytecode != nil &&
+		!bytecode.Static &&
+		bytecode.FastRenderPlan == nil
+}
+
+func renderInterpreterFallback(input string, ctx hctx.Context, filename string) (string, error) {
+	plush.UpdateRenderDiagnosticsForTemplate(ctx, filename, func(d *plush.RenderDiagnostics) {
+		d.FastPath = plush.RenderFastPathInterpreterFallback
+	})
+	if restorePartial := useInterpreterPartialHelper(ctx); restorePartial != nil {
+		defer restorePartial()
+	}
+	return plush.RenderInterpreter(input, ctx)
+}
+
+func parseProgram(input, filename string, ctx hctx.Context) (*ast.Program, *ast.Program, error) {
+	if filename != "" && plush.IsPlushTemplateFile(filename) {
+		if program, ok := plush.CachedASTProgramWithSource(filename, ctx, input); ok {
+			return program, program, nil
+		}
+	}
+	program, err := parser.Parse(input)
+	return program, nil, err
+}
+
+func renderBytecode(bytecode *compiler.Bytecode, ctx hctx.Context) (string, error) {
+	if ctx == nil {
+		ctx = plush.NewContext()
+	}
+	updateBytecodeDiagnostics(ctx, bytecode)
+	filename := plush.PunchHoleTemplateFilename(ctx)
+	if bytecode != nil && bytecode.Static {
+		plush.UpdateRenderDiagnosticsForTemplate(ctx, filename, func(d *plush.RenderDiagnostics) {
+			d.FastPath = plush.RenderFastPathStatic
+		})
+		return bytecode.StaticOutput, nil
+	}
+	if rendered, ok, err := tryRenderFastBytecode(bytecode, ctx); ok || err != nil {
+		if ok {
+			plush.UpdateRenderDiagnosticsForTemplate(ctx, filename, func(d *plush.RenderDiagnostics) {
+				d.FastPath = plush.RenderFastPathFast
+			})
+		}
+		return rendered, err
+	}
+	if restorePartial := installVMPartialHelperForBytecode(bytecode, ctx); restorePartial != nil {
+		defer restorePartial()
+	}
+
+	forceCacheClear := false
+	if bytecode == nil || bytecode.HasHoles {
+		var cached string
+		var ok bool
+		filename, forceCacheClear, cached, ok = punchHoleCacheState(ctx)
+		if ok {
+			return cached, nil
+		}
+	}
+	return renderBytecodeVMWithState(bytecode, ctx, filename, forceCacheClear, "")
+}
+
+func punchHoleCacheState(ctx hctx.Context) (string, bool, string, bool) {
+	filename := plush.PunchHoleTemplateFilename(ctx)
+	return punchHoleCacheStateForFilename(filename, ctx, "")
+}
+
+func punchHoleCacheStateForFilename(filename string, ctx hctx.Context, source string) (string, bool, string, bool) {
+	if filename == "" {
+		return "", false, "", false
+	}
+
+	cached, err := plush.RenderFromPunchHoleCacheWithSource(filename, source, ctx)
+	if err == nil {
+		return filename, false, cached, true
+	}
+	return filename, plush.IsPunchHoleCacheExpired(err), "", false
+}
+
+func renderBytecodeWithState(bytecode *compiler.Bytecode, ctx hctx.Context, filename string, forceCacheClear bool, source string) (string, error) {
+	if bytecode != nil && bytecode.Static {
+		return bytecode.StaticOutput, nil
+	}
+	if rendered, ok, err := tryRenderFastBytecode(bytecode, ctx); ok || err != nil {
+		return rendered, err
+	}
+	return renderBytecodeVMWithState(bytecode, ctx, filename, forceCacheClear, source)
+}
+
+func renderBytecodeVMWithState(bytecode *compiler.Bytecode, ctx hctx.Context, filename string, forceCacheClear bool, source string) (string, error) {
+	machine := newPooledWithContext(bytecode, ctx)
+	if err := machine.Run(); err != nil {
+		defer machine.Release()
+		return "", machine.wrapRuntimeError(err)
+	}
+
+	rendered := machine.Rendered()
+	if bytecode == nil || !bytecode.HasHoles {
+		machine.Release()
+		return rendered, nil
+	}
+	holes := machine.PunchHoles()
+	machine.Release()
+	if !plush.IsPlushTemplateFile(filename) || len(holes) == 0 {
+		return rendered, nil
+	}
+
+	holes = plush.FinalizePunchHolePositions(rendered, holes)
+	plush.CachePunchHoleSkeletonWithSource(filename, ctx, rendered, holes, forceCacheClear, source)
+	if plush.IsHoleRender(ctx) {
+		return rendered, nil
+	}
+
+	holes = plush.RenderPunchHolesConcurrentlyWith(holes, ctx, Render)
+	return plush.FillPunchHoles(rendered, holes)
+}

--- a/VM/vm/runtime_helpers_test.go
+++ b/VM/vm/runtime_helpers_test.go
@@ -1,0 +1,1257 @@
+package vm
+
+import (
+	"errors"
+	"html/template"
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+	"github.com/gobuffalo/plush/v5/helpers/meta"
+	"github.com/gobuffalo/plush/v5/parser"
+	"github.com/gobuffalo/plush/v5/templatecache/inmemory"
+	"github.com/stretchr/testify/require"
+)
+
+type vmHelperStruct struct {
+	Prop string
+}
+
+type vmHelperNestedStruct struct {
+	Child *vmHelperStruct
+}
+
+type vmHelperInt32 int32
+
+type runtimeSwitchingBytecodeCache struct {
+	astKey   string
+	bytecode *compiler.Bytecode
+	gets     int
+}
+
+func (c *runtimeSwitchingBytecodeCache) Get(key string) (*plush.Template, bool) {
+	if key != c.astKey {
+		return nil, false
+	}
+	c.gets++
+	if c.gets < 3 {
+		return &plush.Template{}, true
+	}
+	return &plush.Template{VMBytecode: c.bytecode}, true
+}
+
+func (c *runtimeSwitchingBytecodeCache) Set(key string, t *plush.Template) {}
+
+func (c *runtimeSwitchingBytecodeCache) Delete(key ...string) {}
+
+func (c *runtimeSwitchingBytecodeCache) Clear() {}
+
+func requireCompiledBytecode(t *testing.T, input string) *compiler.Bytecode {
+	t.Helper()
+	tmpl, err := Compile(input)
+	require.NoError(t, err)
+	return tmpl.bytecode
+}
+
+func newRuntimeHelperTestVM(ctx hctx.Context) *VM {
+	fn := &object.CompiledFunction{
+		LineNumbers:    map[int]int{3: 88},
+		Properties:     map[int]object.PropertyAccess{},
+		PropertyCaches: object.NewInlineCacheSlots(8),
+	}
+	frame := NewFrame(&object.Closure{Fn: fn}, 0)
+	return &VM{
+		constants: []object.Object{
+			&object.String{Value: "name"},
+			&object.String{Value: "global"},
+			&object.String{Value: "Prop"},
+			&object.String{Value: "missing"},
+			&object.String{Value: "<b>"},
+		},
+		stack:       make([]object.Object, StackSize),
+		globals:     make([]object.Object, 2),
+		globalNames: map[int]string{1: "global"},
+		frames:      []*Frame{frame},
+		framesIndex: 1,
+		ctx:         ctx,
+		holes:       &[]plush.HoleMarker{},
+	}
+}
+
+func Test_VM_Runtime_Line_Context_And_Write_Helpers(t *testing.T) {
+	ctx := newIDLookupTestContext(map[string]interface{}{
+		"name":   "old",
+		"global": vmHelperStruct{Prop: "from-context"},
+	})
+	machine := newRuntimeHelperTestVM(ctx)
+	machine.lastIP = 3
+
+	require.EqualError(t, machine.wrapRuntimeError(errors.New("boom")), "line 88: boom")
+	require.EqualError(t, machine.wrapRuntimeError(errors.New("line 7: already wrapped")), "line 7: already wrapped")
+	require.NoError(t, machine.wrapRuntimeError(nil))
+	require.Equal(t, 88, machine.currentLineNumber())
+
+	machine.setName(0, &object.String{Value: "new"})
+	require.Equal(t, "new", ctx.values["name"])
+	require.Positive(t, machine.nameIDCacheLen)
+
+	fallbackSetCtx := newLookupTestContext(map[string]interface{}{"name": "old"})
+	machine.ctx = fallbackSetCtx
+	machine.setName(0, &object.String{Value: "fallback-new"})
+	require.Equal(t, "fallback-new", fallbackSetCtx.values["name"])
+	value, ok := machine.contextValueByNameIndex(0)
+	require.True(t, ok)
+	require.Equal(t, "fallback-new", value)
+	machine.ctx = ctx
+
+	machine.nameIDOverflow = append(machine.nameIDOverflow, nameIDEntry{name: "overflow", id: 99})
+	machine.clearNameIDCache()
+	require.Zero(t, machine.nameIDCacheLen)
+	require.Empty(t, machine.nameIDOverflow)
+
+	require.NoError(t, machine.assignName(0, &object.String{Value: "assigned"}))
+	require.Equal(t, "assigned", ctx.values["name"])
+	require.ErrorContains(t, machine.assignName(3, &object.String{Value: "nope"}), `"missing": unknown identifier`)
+
+	frame := machine.currentFrame()
+	machine.writeConstant(frame, 4)
+	machine.writeConstant(frame, 99)
+	require.Equal(t, "&lt;b&gt;", frame.output.String())
+
+	frame.output.Reset()
+	machine.writeStringConstant(nil, 4)
+	machine.writeStringConstant(frame, 4)
+	require.Equal(t, "&lt;b&gt;", frame.output.String())
+
+	frame.output.Reset()
+	machine.stack[0] = &object.Native{Value: vmHelperStruct{Prop: "from-local"}}
+	require.NoError(t, machine.writeLocalProperty(frame, 0, 2, 0))
+	require.Equal(t, "from-local", frame.output.String())
+	require.NoError(t, machine.writeLocalProperty(nil, 0, 2, 0))
+	require.NoError(t, machine.writeLocalProperty(frame, StackSize+1, 2, 0))
+
+	frame.output.Reset()
+	require.NoError(t, machine.writeGlobalProperty(frame, 1, 2, 0))
+	require.Equal(t, "from-context", frame.output.String())
+	machine.globalNames[0] = "not-present"
+	require.NoError(t, machine.writeGlobalProperty(frame, 0, 2, 0))
+	require.NoError(t, machine.writeGlobalProperty(frame, 99, 2, 0))
+}
+
+func Test_VM_Runtime_State_And_Cache_Edge_Branches(t *testing.T) {
+	machine := &VM{frames: []*Frame{nil}, framesIndex: 1}
+	require.Empty(t, machine.Rendered())
+	require.Nil(t, machine.PunchHoles())
+	require.Nil(t, machine.currentFrameOutputValues())
+	machine.writeFrameOutput(nil, &object.String{Value: "ignored"})
+	require.Zero(t, machine.currentLineNumber())
+	require.Equal(t, anonymousCallName, machine.currentCallName(0))
+	require.Equal(t, object.PropertyAccess{}, machine.currentPropertyAccess(0))
+	require.Nil(t, machine.currentPropertyCacheSlot(0))
+	require.Nil(t, machine.currentCallCacheSlot(0))
+	require.EqualError(t, machine.wrapRuntimeError(errors.New("boom")), "line 1: boom")
+
+	holes := []plush.HoleMarker{plush.NewHoleMarker("hole", `"name"`, 1, 2)}
+	machine.holes = &holes
+	gotHoles := machine.PunchHoles()
+	require.Len(t, gotHoles, 1)
+	gotHoles[0] = plush.NewHoleMarker("changed", `"changed"`, 3, 4)
+	require.Equal(t, "hole", holes[0].MarkerName())
+
+	frame := NewFrame(&object.Closure{Fn: &object.CompiledFunction{
+		CallNames:      map[int]string{2: "named"},
+		LineNumbers:    map[int]int{3: 99},
+		Properties:     map[int]object.PropertyAccess{4: {Receiver: "robot", Full: "robot.Name"}},
+		PropertyCaches: object.NewInlineCacheSlots(1),
+		CallCaches:     object.NewInlineCacheSlots(1),
+	}}, 0)
+	frame.output.WriteString("frame-output")
+	machine = &VM{frames: []*Frame{frame}, framesIndex: 1}
+	require.Equal(t, "frame-output", machine.Rendered())
+	require.Nil(t, machine.currentFrameOutputValues())
+	machine.writeFrameOutput(frame, &object.String{Value: "<extra>"})
+	outputValues := machine.currentFrameOutputValues()
+	require.Len(t, outputValues, 1)
+	require.Equal(t, template.HTML("frame-output&lt;extra&gt;"), object.ToGo(outputValues[0]))
+	require.Equal(t, anonymousCallName, machine.currentCallName(1))
+	require.Equal(t, "named", machine.currentCallName(2))
+	require.Zero(t, machine.currentLineNumber())
+	machine.lastIP = 3
+	require.Equal(t, 99, machine.currentLineNumber())
+	require.Equal(t, object.PropertyAccess{Receiver: "robot", Full: "robot.Name"}, machine.currentPropertyAccess(4))
+	require.NotNil(t, machine.currentPropertyCacheSlot(0))
+	require.Nil(t, machine.currentPropertyCacheSlot(-1))
+	require.Nil(t, machine.currentPropertyCacheSlot(1))
+	require.NotNil(t, machine.currentCallCacheSlot(0))
+	require.Nil(t, machine.currentCallCacheSlot(-1))
+	require.Nil(t, machine.currentCallCacheSlot(1))
+
+	machine.halted = true
+	machine.lastPopped = &object.String{Value: "<done>"}
+	require.Equal(t, "&lt;done&gt;", machine.Rendered())
+	machine.lastPopped = object.NullObject
+	require.Equal(t, "frame-output&lt;extra&gt;", machine.Rendered())
+}
+
+func Test_VM_Runtime_Stack_And_Budget_Edge_Branches(t *testing.T) {
+	machine := &VM{stack: make([]object.Object, StackSize)}
+	require.NoError(t, machine.push(nil))
+	require.Same(t, Null, machine.stack[0])
+	require.Equal(t, 1, machine.sp)
+	require.Equal(t, 1, machine.stackMax)
+
+	machine.sp = StackSize
+	require.EqualError(t, machine.push(&object.Integer{Value: 1}), "stack overflow")
+
+	machine = &VM{}
+	require.Nil(t, machine.budget())
+
+	releaseStack(make([]object.Object, 1), 1)
+	releaseStack(make([]object.Object, StackSize), StackSize+10)
+	releaseFrames(nil)
+	releaseHoles(nil)
+
+	var nilMachine *VM
+	require.NotPanics(t, nilMachine.Release)
+
+	machine = NewWithContext(&compiler.Bytecode{}, nil)
+	require.NotNil(t, machine.ctx)
+	machine.Release()
+
+	require.Same(t, Null, machine.combineFrameOutput(&Frame{}, nil))
+
+	ctx := plush.NewContext().WithBudget(plush.NewBudget(100))
+	machine = &VM{ctx: ctx}
+	require.NoError(t, machine.spendFunctionCall(""))
+	stats := ctx.Budget().Stats()
+	require.Contains(t, stats.ByFunction, anonymousCallName)
+}
+
+func Test_VM_Loop_Context_Property_Assignment_And_Cache_Edges(t *testing.T) {
+	ctx := newIDLookupTestContext(map[string]interface{}{
+		"name": vmHelperStruct{Prop: "<prop>"},
+	})
+	machine := newRuntimeHelperTestVM(ctx)
+	machine.constants = append(machine.constants, &object.String{Value: "nil"})
+	nilIndex := len(machine.constants) - 1
+	frame := machine.currentFrame()
+
+	require.NoError(t, machine.writeNameProperty(frame, nilIndex, 2, 0))
+	require.Empty(t, frame.output.String())
+
+	require.ErrorContains(t, machine.writeNameProperty(frame, 3, 2, 0), `"missing": unknown identifier`)
+	require.NoError(t, machine.writePropertyValue(nil, vmHelperStruct{Prop: "ignored"}, 2, 0))
+
+	budgetMachine := newRuntimeHelperTestVM(plush.NewContext().WithBudget(plush.NewBudget(0)))
+	require.ErrorContains(t, budgetMachine.writePropertyValue(budgetMachine.currentFrame(), vmHelperStruct{Prop: "blocked"}, 2, 0), "budget")
+
+	require.ErrorContains(t, machine.writePropertyValue(frame, vmHelperStruct{Prop: "value"}, 3, 0), "missing")
+
+	fallbackCtx := newLookupTestContext(map[string]interface{}{"name": "old"})
+	machine.ctx = fallbackCtx
+	require.NoError(t, machine.assignName(0, &object.String{Value: "new"}))
+	require.Equal(t, "new", fallbackCtx.values["name"])
+
+	assignmentCosts := plush.ZeroCosts()
+	assignmentCosts.Assignment = 1
+	budgetMachine.ctx = plush.NewContext().WithBudget(plush.NewBudgetWithCosts(0, assignmentCosts))
+	budgetMachine.constants = machine.constants
+	require.ErrorContains(t, budgetMachine.assignName(0, &object.String{Value: "blocked"}), "budget")
+
+	head := &propertyInlineCacheEntry{typ: reflect.TypeOf(vmHelperStruct{})}
+	head.next = &propertyInlineCacheEntry{typ: reflect.TypeOf(vmHelperInt32(0))}
+	require.Nil(t, clonePropertyInlineCache(head, 0))
+	clone := clonePropertyInlineCache(head, 2)
+	require.NotNil(t, clone)
+	require.NotSame(t, head, clone)
+	require.Equal(t, head.typ, clone.typ)
+	require.NotNil(t, clone.next)
+	require.Equal(t, head.next.typ, clone.next.typ)
+	require.Nil(t, clone.next.next)
+
+	slot := object.NewInlineCacheSlots(1)
+	lookup := inlinePropertyLookup(&slot[0], reflect.TypeOf(vmHelperStruct{}), "Prop")
+	require.Equal(t, propertyLookupField, lookup.kind)
+	lookup = inlinePropertyLookup(&slot[0], reflect.TypeOf(vmHelperStruct{}), "Prop")
+	require.Equal(t, propertyLookupField, lookup.kind)
+	lookup = inlinePropertyLookup(&slot[0], reflect.TypeOf(vmHelperNestedStruct{}), "Child")
+	require.Equal(t, propertyLookupField, lookup.kind)
+	lookup = inlinePropertyLookup(nil, reflect.TypeOf(vmHelperStruct{}), "Prop")
+	require.Equal(t, propertyLookupField, lookup.kind)
+	require.Nil(t, buildFastPropertyWriter(reflect.TypeOf(vmHelperStruct{}), propertyLookup{kind: propertyLookupField, fieldIndex: []int{99}}))
+
+	field, ok := fieldByIndex(reflect.TypeOf(vmHelperStruct{}), []int{0})
+	require.True(t, ok)
+	require.Equal(t, "Prop", field.Name)
+	field, ok = fieldByIndex(reflect.TypeOf(vmHelperNestedStruct{}), []int{0, 0})
+	require.True(t, ok)
+	require.Equal(t, "Prop", field.Name)
+	_, ok = fieldByIndex(reflect.TypeOf(1), []int{0})
+	require.False(t, ok)
+	_, ok = fieldByIndex(reflect.TypeOf(vmHelperStruct{}), nil)
+	require.False(t, ok)
+	_, ok = fieldByIndex(reflect.TypeOf(vmHelperStruct{}), []int{2})
+	require.False(t, ok)
+
+	machine = newRuntimeHelperTestVM(plush.NewContext())
+	require.NoError(t, machine.pushField(reflect.ValueOf(vmHelperStruct{Prop: "field"}).FieldByName("Prop"), object.PropertyAccess{}, "Prop"))
+	require.Equal(t, &object.String{Value: "field"}, machine.pop())
+	require.NoError(t, machine.pushField(reflect.ValueOf((*vmHelperStruct)(nil)), object.PropertyAccess{}, "Prop"))
+	require.Same(t, Null, machine.pop())
+	hidden := reflect.ValueOf(vmFastPropertyUser{hidden: "secret"}).FieldByName("hidden")
+	require.ErrorContains(t, machine.pushField(hidden, object.PropertyAccess{Receiver: "user", Full: "user.hidden"}, "hidden"), "user.hidden")
+}
+
+func Test_VM_Name_Global_And_Truthiness_Helpers(t *testing.T) {
+	ctx := newIDLookupTestContext(map[string]interface{}{
+		"name":   "<Mido>",
+		"global": "<Global>",
+	})
+	machine := newRuntimeHelperTestVM(ctx)
+	machine.constants = append(machine.constants, &object.String{Value: "nil"})
+	frame := machine.currentFrame()
+
+	require.NoError(t, machine.writeName(frame, 0, false))
+	require.Equal(t, "&lt;Mido&gt;", frame.output.String())
+
+	require.NoError(t, machine.writeName(nil, 0, false))
+
+	frame.output.Reset()
+	require.NoError(t, machine.writeName(frame, 3, true))
+	require.Empty(t, frame.output.String())
+	require.ErrorContains(t, machine.writeName(frame, 3, false), `"missing": unknown identifier`)
+	require.NoError(t, machine.writeName(frame, 5, false))
+
+	ctx.values["name"] = struct{}{}
+	frame.output.Reset()
+	require.NoError(t, machine.writeName(frame, 0, false))
+	require.Empty(t, frame.output.String())
+	ctx.values["name"] = "<Mido>"
+
+	frame.output.Reset()
+	machine.writeHTMLConstant(frame, 4)
+	require.Equal(t, "<b>", frame.output.String())
+	machine.writeHTMLConstant(nil, 4)
+
+	frame.output.Reset()
+	machine.globals[0] = &object.String{Value: "<local-global>"}
+	machine.writeGlobal(frame, 0)
+	require.Equal(t, "&lt;local-global&gt;", frame.output.String())
+
+	frame.output.Reset()
+	machine.writeGlobal(frame, 1)
+	require.Equal(t, "&lt;Global&gt;", frame.output.String())
+	machine.writeGlobal(nil, 1)
+	machine.writeGlobal(frame, 99)
+
+	machine.updateNamedGlobal(1, &object.String{Value: "updated"})
+	require.Equal(t, "updated", ctx.values["global"])
+	require.Equal(t, &object.String{Value: "updated"}, machine.globalFromContext(1))
+	missingGlobalCtx := newIDLookupTestContext(map[string]interface{}{})
+	machine.ctx = missingGlobalCtx
+	require.Nil(t, machine.globalFromContext(1))
+	machine.ctx = ctx
+	require.Nil(t, machine.globalFromContext(99))
+
+	require.Same(t, True, nativeBoolToBooleanObject(true))
+	require.Same(t, False, nativeBoolToBooleanObject(false))
+	require.False(t, isTruthy(nil))
+	require.False(t, isTruthy(False))
+	require.False(t, isTruthy(Null))
+	require.False(t, isTruthy(&object.String{}))
+	require.False(t, isTruthy(&object.Native{Value: nil}))
+	require.False(t, isTruthy(&object.Native{Value: (*vmHelperStruct)(nil)}))
+	require.True(t, isTruthy(&object.String{Value: "x"}))
+	require.True(t, isTruthy(&object.Integer{Value: 0}))
+
+	require.False(t, isTruthyFastValue(nil))
+	require.False(t, isTruthyFastValue(""))
+	require.False(t, isTruthyFastValue(false))
+	require.False(t, isTruthyFastValue((*vmHelperStruct)(nil)))
+	require.True(t, isTruthyFastValue("x"))
+	require.True(t, isTruthyFastValue(true))
+}
+
+func Test_VM_Loop_Raw_Object_Helpers(t *testing.T) {
+	key, value := loopObjects(3, "value", false)
+	require.IsType(t, &object.Integer{}, key)
+	require.IsType(t, &object.String{}, value)
+
+	nativeKey, nativeValue := loopObjects(3, "value", true)
+	require.IsType(t, &object.Native{}, nativeKey)
+	require.IsType(t, &object.Native{}, nativeValue)
+	require.Equal(t, 3, object.ToGo(nativeKey))
+	require.Equal(t, "value", object.ToGo(nativeValue))
+
+	obj := &object.String{Value: "kept"}
+	require.Same(t, obj, rawLoopObject(obj))
+	require.Same(t, Null, rawLoopObject(nil))
+}
+
+func Test_VM_Set_Index_Helpers(t *testing.T) {
+	machine := newRuntimeHelperTestVM(plush.NewContext())
+
+	array := &object.Array{Elements: []object.Object{&object.String{Value: "a"}}}
+	require.NoError(t, machine.executeSetIndex(array, &object.Integer{Value: 0}, &object.String{Value: "b"}))
+	require.Equal(t, "b", array.Elements[0].(*object.String).Value)
+	require.ErrorContains(t, machine.executeSetIndex(array, &object.String{Value: "bad"}, &object.String{Value: "x"}), "non int")
+	require.ErrorContains(t, machine.executeSetIndex(array, &object.Integer{Value: 2}, &object.String{Value: "x"}), "out of bounds")
+
+	hashKey := &object.String{Value: "key"}
+	hash := &object.Hash{Pairs: map[object.HashKey]object.HashPair{}}
+	require.NoError(t, machine.executeSetIndex(hash, hashKey, &object.Integer{Value: 7}))
+	require.Equal(t, int64(7), hash.Pairs[hashKey.HashKey()].Value.(*object.Integer).Value)
+	require.ErrorContains(t, machine.executeSetIndex(hash, &object.Array{}, &object.Integer{Value: 1}), "unusable as hash key")
+
+	rawMap := map[string]interface{}{}
+	require.NoError(t, machine.executeSetIndex(&object.Native{Value: rawMap}, hashKey, &object.String{Value: "mapped"}))
+	require.Equal(t, "mapped", rawMap["key"])
+
+	rawMapPtr := map[string]interface{}{}
+	require.NoError(t, machine.executeSetIndex(&object.Native{Value: &rawMapPtr}, hashKey, &object.String{Value: "mapped-ptr"}))
+	require.Equal(t, "mapped-ptr", rawMapPtr["key"])
+
+	rawSlice := []string{"zero"}
+	require.NoError(t, machine.executeSetIndex(&object.Native{Value: rawSlice}, &object.Integer{Value: 0}, &object.String{Value: "one"}))
+	require.Equal(t, "one", rawSlice[0])
+	require.ErrorContains(t, machine.executeSetIndex(&object.Native{Value: rawSlice}, &object.String{Value: "bad"}, &object.String{Value: "x"}), "non int")
+	require.ErrorContains(t, machine.executeSetIndex(&object.Native{Value: rawSlice}, &object.Integer{Value: 3}, &object.String{Value: "x"}), "out of bounds")
+	require.ErrorContains(t, machine.executeSetIndex(&object.Native{Value: rawSlice}, &object.Integer{Value: 0}, &object.Integer{Value: 1}), "cannot use")
+
+	var nilRawSlice *[]string
+	require.ErrorContains(t, machine.executeSetIndex(&object.Native{Value: nilRawSlice}, &object.Integer{Value: 0}, &object.String{Value: "x"}), "could not index")
+
+	require.ErrorContains(t, machine.executeSetIndex(&object.Native{Value: vmHelperStruct{}}, hashKey, &object.String{Value: "x"}), "could not index")
+}
+
+func Test_VM_Native_Index_Branches(t *testing.T) {
+	machine := newRuntimeHelperTestVM(plush.NewContext())
+
+	require.NoError(t, machine.executeNativeIndex(object.NullObject, &object.String{Value: "name"}))
+	require.Same(t, Null, machine.pop())
+
+	require.NoError(t, machine.executeNativeIndex(&object.Native{Value: (*vmHelperStruct)(nil)}, &object.String{Value: "Prop"}))
+	require.Same(t, Null, machine.pop())
+
+	require.NoError(t, machine.executeNativeIndex(&object.Native{Value: map[string]int{"count": 3}}, &object.String{Value: "count"}))
+	require.Equal(t, &object.Integer{Value: 3}, machine.pop())
+
+	require.NoError(t, machine.executeNativeIndex(&object.Native{Value: map[interface{}]string{7: "seven"}}, &object.Integer{Value: 7}))
+	require.Equal(t, &object.String{Value: "seven"}, machine.pop())
+
+	rawMapPtr := map[string]int{"count": 4}
+	require.NoError(t, machine.executeNativeIndex(&object.Native{Value: &rawMapPtr}, &object.String{Value: "count"}))
+	require.Equal(t, &object.Integer{Value: 4}, machine.pop())
+
+	require.NoError(t, machine.executeNativeIndex(&object.Native{Value: map[string]int{}}, &object.String{Value: "missing"}))
+	require.Same(t, Null, machine.pop())
+
+	err := machine.executeNativeIndex(&object.Native{Value: map[string]int{}}, &object.Integer{Value: 1})
+	require.ErrorContains(t, err, "cannot use")
+
+	require.NoError(t, machine.executeNativeIndex(&object.Native{Value: []string{"zero", "one"}}, &object.Integer{Value: 1}))
+	require.Equal(t, &object.String{Value: "one"}, machine.pop())
+
+	require.NoError(t, machine.executeNativeIndex(&object.Native{Value: [2]int{4, 5}}, &object.Integer{Value: 0}))
+	require.Equal(t, &object.Integer{Value: 4}, machine.pop())
+
+	err = machine.executeNativeIndex(&object.Native{Value: []string{"zero"}}, &object.String{Value: "bad"})
+	require.ErrorContains(t, err, "non int")
+
+	err = machine.executeNativeIndex(&object.Native{Value: []string{"zero"}}, &object.Integer{Value: 2})
+	require.ErrorContains(t, err, "out of bounds")
+
+	err = machine.executeNativeIndex(&object.Native{Value: vmHelperStruct{}}, &object.String{Value: "Prop"})
+	require.ErrorContains(t, err, "could not index")
+}
+
+func Test_VM_Hash_Index_Branches(t *testing.T) {
+	machine := newRuntimeHelperTestVM(plush.NewContext())
+	key := &object.String{Value: "key"}
+	hash := &object.Hash{Pairs: map[object.HashKey]object.HashPair{
+		key.HashKey(): {Key: key, Value: &object.Integer{Value: 7}},
+	}}
+
+	require.NoError(t, machine.executeHashIndex(hash, key))
+	require.Equal(t, &object.Integer{Value: 7}, machine.pop())
+
+	require.NoError(t, machine.executeHashIndex(hash, &object.String{Value: "missing"}))
+	require.Same(t, Null, machine.pop())
+
+	require.ErrorContains(t, machine.executeHashIndex(hash, &object.Array{}), "unusable as hash key")
+
+	array := &object.Array{Elements: []object.Object{&object.String{Value: "zero"}}}
+	require.NoError(t, machine.executeIndexExpression(array, &object.Integer{Value: 0}))
+	require.Equal(t, &object.String{Value: "zero"}, machine.pop())
+	require.ErrorContains(t, machine.executeIndexExpression(array, &object.Integer{Value: 9}), "array index out of bounds")
+}
+
+func Test_VM_Write_Builtin_And_Native_Calls(t *testing.T) {
+	builtin := &object.Builtin{Fn: func(args ...object.Object) object.Object {
+		return &object.String{Value: strings.Join([]string{args[0].Inspect(), args[1].Inspect()}, ":")}
+	}}
+	machine := newRuntimeHelperTestVM(plush.NewContext())
+	machine.stack[0] = builtin
+	machine.stack[1] = &object.String{Value: "a"}
+	machine.stack[2] = &object.String{Value: "b"}
+	machine.sp = 3
+	require.NoError(t, machine.writeBuiltinCall(builtin, 2, true))
+	require.Equal(t, 0, machine.sp)
+	require.Equal(t, "a:b", machine.currentFrame().output.String())
+
+	nilBuiltin := &object.Builtin{Fn: func(args ...object.Object) object.Object { return nil }}
+	machine.currentFrame().output.Reset()
+	machine.stack[0] = &object.String{Value: "ignored"}
+	machine.sp = 1
+	require.NoError(t, machine.writeBuiltinCall(nilBuiltin, 1, false))
+	require.Equal(t, 0, machine.sp)
+	require.Empty(t, machine.currentFrame().output.String())
+
+	machine.stack[0] = nilBuiltin
+	machine.sp = 1
+	require.NoError(t, machine.callBuiltin(nilBuiltin, 0))
+	require.Same(t, Null, machine.pop())
+
+	fn := func(value string) string { return value + "!" }
+	callee := &object.Native{Value: &fn}
+	machine.currentFrame().output.Reset()
+	machine.stack[0] = callee
+	machine.stack[1] = &object.String{Value: "go"}
+	machine.sp = 2
+	require.NoError(t, machine.writeNativeCall("bang", callee, 1, nil, true))
+	require.Equal(t, 0, machine.sp)
+	require.Equal(t, "go!", machine.currentFrame().output.String())
+}
+
+func Test_VM_Native_Call_Execution_Edge_Branches(t *testing.T) {
+	budgetMachine := newRuntimeHelperTestVM(plush.NewContext().WithBudget(plush.NewBudget(0)))
+	require.ErrorContains(t, budgetMachine.executeCall("blocked", 0, nil, nil), "budget")
+	require.ErrorContains(t, budgetMachine.executeWriteCall("blocked", 0, nil), "budget")
+
+	machine := newRuntimeHelperTestVM(plush.NewContext())
+	var nilFunc *func()
+	require.ErrorContains(t, machine.callNativeValue("nilFunc", nilFunc, 0, nil, nil), "invalid function")
+	require.ErrorContains(t, machine.callNativeValue("bad", 7, 0, nil, nil), "invalid function")
+
+	machine.stack[0] = &object.Native{Value: func() {}}
+	machine.sp = 1
+	require.NoError(t, machine.callNativeValue("noop", func() {}, 0, nil, nil))
+	require.Same(t, Null, machine.pop())
+
+	machine.stack[0] = &object.Native{Value: func() (string, error) { return "", errors.New("boom") }}
+	machine.sp = 1
+	require.ErrorContains(t, machine.callNativeValue("fail", func() (string, error) { return "", errors.New("boom") }, 0, nil, nil), "could not call fail function")
+
+	machine.stack[0] = &object.Native{Value: func(string) string { return "" }}
+	machine.sp = 1
+	require.ErrorContains(t, machine.callNativeValue("needsArg", func(string) string { return "" }, 0, nil, nil), "too few arguments")
+
+	machine.stack[0] = &object.Native{Value: func() {}}
+	machine.sp = 1
+	require.NoError(t, machine.writeNativeValueCall("noop", func() {}, 0, nil, true))
+	require.Equal(t, 0, machine.sp)
+	require.Empty(t, machine.currentFrame().output.String())
+
+	var nilWriteFunc *func()
+	machine.stack[0] = &object.Native{Value: nilWriteFunc}
+	machine.sp = 1
+	require.ErrorContains(t, machine.writeNativeValueCall("nilWrite", nilWriteFunc, 0, nil, true), "invalid function")
+
+	machine.stack[0] = &object.Native{Value: 7}
+	machine.sp = 1
+	require.ErrorContains(t, machine.writeNativeValueCall("badWrite", 7, 0, nil, true), "invalid function")
+
+	machine.stack[0] = &object.Native{Value: func(string) string { return "" }}
+	machine.sp = 1
+	require.ErrorContains(t, machine.writeNativeValueCall("needsArg", func(string) string { return "" }, 0, nil, true), "too few arguments")
+
+	machine.sp = 0
+	handled, err := machine.tryFastWriteNativeValueCall("nilFast", nil, 0, nil, false)
+	require.ErrorContains(t, err, "invalid function")
+	require.False(t, handled)
+
+	machine.sp = 0
+	handled, err = machine.tryFastWriteNativeValueCall("needsArg", func(string) string { return "" }, 0, nil, false)
+	require.NoError(t, err)
+	require.False(t, handled)
+	require.Zero(t, machine.sp)
+
+	machine.stack[0] = &object.Native{Value: func() (string, error) { return "", errors.New("boom") }}
+	machine.sp = 1
+	require.ErrorContains(t, machine.writeNativeValueCall("fail", func() (string, error) { return "", errors.New("boom") }, 0, nil, true), "could not call fail function")
+
+	machine = &VM{stack: make([]object.Object, StackSize), frames: []*Frame{nil}, framesIndex: 1}
+	machine.stack[0] = &object.Native{Value: func() string { return "ignored" }}
+	machine.sp = 1
+	require.NoError(t, machine.writeNativeValueCall("noframe", func() string { return "ignored" }, 0, nil, true))
+	require.Equal(t, 0, machine.sp)
+}
+
+func Test_VM_Fast_Object_And_Optional_Arg_Helpers(t *testing.T) {
+	var out strings.Builder
+	require.True(t, writeFastObject(&out, plush.NewContext(), &object.Array{Elements: []object.Object{
+		&object.String{Value: "<tag>"},
+		&object.Integer{Value: 12},
+		&object.Float{Value: 1.5},
+		True,
+		&object.Native{Value: template.HTML("<safe>")},
+	}}))
+	require.Equal(t, "&lt;tag&gt;121.5true<safe>", out.String())
+	require.True(t, writeFastObject(&out, nil, nil))
+	require.False(t, writeFastObject(&out, nil, &object.Builtin{}))
+	require.True(t, canWriteFastObject(&object.Array{Elements: []object.Object{&object.Integer{Value: 1}}}))
+	require.False(t, canWriteFastObject(&object.Array{Elements: []object.Object{&object.Builtin{}}}))
+
+	value, ok := fastOptionalArg(optionalArgHelperContext, plushHelperContextType, plush.NewContext())
+	require.True(t, ok)
+	require.IsType(t, plush.HelperContext{}, value.Interface())
+
+	value, ok = fastOptionalArg(optionalArgHelperContext, reflect.TypeOf((*hctx.HelperContext)(nil)).Elem(), plush.NewContext())
+	require.True(t, ok)
+	require.Implements(t, (*hctx.HelperContext)(nil), value.Interface())
+
+	value, ok = fastOptionalArg(optionalArgMap, emptyMapType, nil)
+	require.True(t, ok)
+	require.IsType(t, map[string]interface{}{}, value.Interface())
+
+	_, ok = fastOptionalArg(optionalArgNone, stringType, nil)
+	require.False(t, ok)
+}
+
+func Test_VM_Fast_Raw_Numeric_Arg_Helpers(t *testing.T) {
+	i, ok := fastWriteRawInt64Arg(int32(-7))
+	require.True(t, ok)
+	require.Equal(t, int64(-7), i)
+
+	u, ok := fastWriteRawUintArg(uint32(12))
+	require.True(t, ok)
+	require.Equal(t, uint(12), u)
+
+	u64, ok := fastWriteRawUint64Arg(uint64(42))
+	require.True(t, ok)
+	require.Equal(t, uint64(42), u64)
+
+	require.True(t, fastUint64FitsUint(42))
+}
+
+func Test_VM_Fast_Arg_Numeric_Coercions(t *testing.T) {
+	i, ok := fastArgInt64(&object.Integer{Value: 5})
+	require.True(t, ok)
+	require.Equal(t, int64(5), i)
+
+	i, ok = fastArgInt64(vmHelperInt32(-3))
+	require.True(t, ok)
+	require.Equal(t, int64(-3), i)
+
+	_, ok = fastArgInt64(uint64(math.MaxInt64) + 1)
+	require.False(t, ok)
+	_, ok = fastArgInt64("nope")
+	require.False(t, ok)
+
+	u, ok := fastArgUint64(&object.Integer{Value: 6})
+	require.True(t, ok)
+	require.Equal(t, uint64(6), u)
+
+	u, ok = fastArgUint64(float64(7.5))
+	require.True(t, ok)
+	require.Equal(t, uint64(7), u)
+
+	_, ok = fastArgUint64(int(-1))
+	require.False(t, ok)
+	_, ok = fastArgUint64("nope")
+	require.False(t, ok)
+
+	f, ok := fastArgFloat64(&object.Float{Value: 2.25})
+	require.True(t, ok)
+	require.Equal(t, 2.25, f)
+
+	f, ok = fastArgFloat64(uint16(8))
+	require.True(t, ok)
+	require.Equal(t, float64(8), f)
+
+	_, ok = fastArgFloat64("nope")
+	require.False(t, ok)
+}
+
+func Test_VM_Rendered_Go_Value_Size_Branches(t *testing.T) {
+	ctx := plush.NewContext()
+	ctx.Set("TIME_FORMAT", "2006")
+	machine := newRuntimeHelperTestVM(ctx)
+	now := time.Date(2026, time.July, 7, 0, 0, 0, 0, time.UTC)
+
+	require.Zero(t, machine.estimatedRenderedGoValueSize(nil))
+	require.Equal(t, len(plush.PunchHoleMarkerName(0)), machine.estimatedRenderedGoValueSize(vmHole{input: "hole"}))
+	require.Equal(t, 4, machine.estimatedRenderedGoValueSize(now))
+	require.Equal(t, 4, machine.estimatedRenderedGoValueSize(&now))
+	require.Equal(t, len("<b>"), machine.estimatedRenderedGoValueSize(template.HTML("<b>")))
+	require.Equal(t, 3, machine.estimatedRenderedGoValueSize("abc"))
+	require.Equal(t, 5, machine.estimatedRenderedGoValueSize(true))
+	require.Equal(t, 20, machine.estimatedRenderedGoValueSize(uint32(1)))
+	require.Equal(t, 24, machine.estimatedRenderedGoValueSize(float32(1)))
+	require.Equal(t, 3, machine.estimatedRenderedGoValueSize([]string{"a", "bc"}))
+	require.Equal(t, 6, machine.estimatedRenderedGoValueSize([]interface{}{"a", true}))
+	require.Equal(t, 3, machine.estimatedRenderedGoValueSize([2]string{"a", "bc"}))
+	require.Zero(t, machine.estimatedRenderedGoValueSize(struct{}{}))
+}
+
+func Test_VM_Numeric_Unsigned_Helpers(t *testing.T) {
+	value := numericValue{kind: numericUnsigned, u: 9}
+	u, ok := value.uint64()
+	require.True(t, ok)
+	require.Equal(t, uint64(9), u)
+
+	value = numericValue{kind: numericSigned, i: 8}
+	u, ok = value.uint64()
+	require.True(t, ok)
+	require.Equal(t, uint64(8), u)
+
+	_, ok = numericValue{kind: numericSigned, i: -1}.uint64()
+	require.False(t, ok)
+
+	require.IsType(t, &object.Integer{}, unsignedNumericObject(uint64(math.MaxInt64)))
+	require.IsType(t, &object.Native{}, unsignedNumericObject(uint64(math.MaxInt64)+1))
+}
+
+func Test_VM_Fast_Loop_Conditional_And_Call_Helpers(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"items":  []string{"a", "b"},
+		"prefix": "pre:",
+		"label": func(value, prefix string) string {
+			return prefix + value
+		},
+	})
+	plan := &compiler.FastRenderPlan{Bindings: []string{"items", "label", "prefix"}}
+	bindings := newFastRenderBindings(plan, ctx)
+	loop := &compiler.FastLoopPlan{IterableName: "items", IterableNameIndex: 0, Line: 1}
+
+	call := &compiler.FastCallPlan{
+		Name:      "label",
+		NameIndex: 1,
+		Args: []compiler.FastValuePlan{
+			{Kind: compiler.FastValuePath, NameIndex: -1},
+			{Kind: compiler.FastValueName, NameIndex: 2, Value: "prefix"},
+		},
+		Line: 1,
+	}
+	var args fastCallArgs
+	evaluated, err := evalFastLoopCallArgsInto(call.Args, ctx, bindings, 1, "item", &args)
+	require.NoError(t, err)
+	require.Equal(t, 2, evaluated.Len())
+	require.Equal(t, "item", evaluated.Raw(0))
+	require.Equal(t, "pre:", evaluated.Raw(1))
+
+	var out strings.Builder
+	require.NoError(t, writeFastLoopCallPart(&out, ctx, bindings, call, 1, "item"))
+	require.Equal(t, "pre:item", out.String())
+	require.NoError(t, writeFastLoopCallPart(&out, ctx, bindings, nil, 1, "item"))
+
+	out.Reset()
+	conditional := &compiler.FastLoopConditionalPlan{
+		Branches: []compiler.FastLoopConditionalBranch{
+			{
+				Condition: compiler.FastValuePlan{
+					Kind:     compiler.FastValueInfix,
+					Operator: "==",
+					Left:     &compiler.FastValuePlan{Kind: compiler.FastValueLoopKey},
+					Right:    &compiler.FastValuePlan{Kind: compiler.FastValueInteger, IntValue: 1},
+				},
+				Parts: []compiler.FastLoopPart{
+					{Kind: compiler.FastLoopPartStatic, Value: "one:"},
+					{Kind: compiler.FastLoopPartValue},
+				},
+				Line: 1,
+			},
+		},
+		ElseParts: []compiler.FastLoopPart{
+			{Kind: compiler.FastLoopPartStatic, Value: "other:"},
+			{Kind: compiler.FastLoopPartKey},
+		},
+	}
+	require.NoError(t, renderFastLoopConditional(&out, ctx, bindings, loop, conditional, 1, "hit"))
+	require.Equal(t, "one:hit", out.String())
+
+	out.Reset()
+	require.NoError(t, renderFastLoopConditional(&out, ctx, bindings, loop, conditional, 2, "miss"))
+	require.Equal(t, "other:2", out.String())
+	require.NoError(t, renderFastLoopConditional(&out, ctx, bindings, loop, nil, 2, "miss"))
+}
+
+func Test_VM_Fast_Struct_Loop_Value_Helpers(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{"name": "bound"})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"name"}}, ctx)
+	item := reflect.ValueOf(vmHelperStruct{Prop: "field"})
+	path := &compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: -1,
+		Path: []compiler.FastPathStep{
+			{Kind: compiler.FastPathStepProperty, Value: "Prop", Receiver: "item", Full: "item.Prop"},
+		},
+	}
+
+	value, ok, err := evalFastStructLoopValue(path, ctx, bindings, 7, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "field", value)
+
+	truthy, ok, err := isTruthyFastStructLoopValue(path, ctx, bindings, 7, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.True(t, truthy)
+
+	key, ok, err := evalFastStructLoopValue(&compiler.FastValuePlan{Kind: compiler.FastValueLoopKey}, ctx, bindings, 7, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, 7, key)
+
+	bound, ok, err := evalFastStructLoopValue(&compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 0, Value: "name"}, ctx, bindings, 7, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "bound", bound)
+
+	infix := &compiler.FastValuePlan{
+		Kind:     compiler.FastValueInfix,
+		Operator: "==",
+		Left:     path,
+		Right:    &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "field"},
+	}
+	result, ok, err := evalFastStructLoopInfixValue(infix, ctx, bindings, 7, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, true, result)
+
+	logical := &compiler.FastValuePlan{
+		Kind:     compiler.FastValueInfix,
+		Operator: "&&",
+		Left:     infix,
+		Right:    &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true},
+	}
+	result, ok, err = evalFastStructLoopLogicalInfixValue(logical, ctx, bindings, 7, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, true, result)
+
+	whole, ok, err := evalFastStructLoopPathValue(&compiler.FastValuePlan{Kind: compiler.FastValuePath, NameIndex: -1}, ctx, bindings, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, vmHelperStruct{Prop: "field"}, whole)
+
+	require.False(t, isTruthyFastReflectValue(reflect.ValueOf("")))
+	require.True(t, isTruthyFastReflectValue(reflect.ValueOf("x")))
+	require.False(t, isTruthyFastReflectValue(reflect.ValueOf((*vmHelperStruct)(nil))))
+	require.Contains(t, fieldAccessError("item", "item.hidden", "hidden").Error(), "item.hidden")
+	require.Contains(t, fieldAccessError("", "", "hidden").Error(), "hidden")
+}
+
+func Test_VM_Partial_Setup_And_Helper_Rendering(t *testing.T) {
+	ctx := plush.NewContext()
+	ctx.Set(meta.TemplateBaseFileNameKey, "show")
+	ctx.Set(meta.TemplateExtensionKey, "plush")
+	ctx.Set(meta.TemplateFileKey, "templates/users/show.plush")
+
+	require.NoError(t, setupPartialTemplateFile(ctx, "row.plush"))
+	require.Equal(t, "templates/users/row.plush", ctx.Value(meta.TemplateFileKey))
+
+	setupPartialNesting(ctx, "row.plush")
+	require.Equal(t, "row.plush", ctx.Value(vmAlreadyInPartial))
+	setupPartialNesting(ctx, "nested.html")
+	require.Equal(t, "nested", ctx.Value(meta.TemplateBaseFileNameKey))
+	require.Equal(t, "html", ctx.Value(meta.TemplateExtensionKey))
+
+	ctx.Set(vmPartialFeederName, func(name string) (string, error) {
+		switch name {
+		case "row.plush":
+			return `<span><%= name %></span>`, nil
+		case "layout.plush":
+			return `<main><%= yield %></main>`, nil
+		default:
+			return "", errors.New("missing partial")
+		}
+	})
+
+	rendered, err := vmPartialHelper("row.plush", map[string]interface{}{"name": "Mido"}, plush.NewHelperContext(ctx, nil))
+	require.NoError(t, err)
+	require.Equal(t, template.HTML(`<span>Mido</span>`), rendered)
+
+	rendered, err = vmPartialHelper("row.plush", map[string]interface{}{"name": "Mido", "layout": "layout.plush"}, plush.NewHelperContext(ctx, nil))
+	require.NoError(t, err)
+	require.Equal(t, template.HTML(`<main><span>Mido</span></main>`), rendered)
+
+	freshCtx := plush.NewContext()
+	freshCtx.Set(vmPartialFeederName, func(string) (string, error) {
+		return `<span>fresh</span>`, nil
+	})
+	rendered, err = vmPartialHelper("fresh.plush", nil, plush.NewHelperContext(freshCtx, nil))
+	require.NoError(t, err)
+	require.Equal(t, template.HTML(`<span>fresh</span>`), rendered)
+	require.Nil(t, freshCtx.Value(vmAlreadyInPartial))
+
+	_, err = vmPartialHelper("row.plush", nil, plush.NewHelperContext(plush.NewContext(), nil))
+	require.ErrorContains(t, err, "could not find partial feeder")
+
+	badFileKeyCtx := plush.NewContext()
+	badFileKeyCtx.Set(meta.TemplateBaseFileNameKey, "show")
+	badFileKeyCtx.Set(meta.TemplateExtensionKey, "plush")
+	badFileKeyCtx.Set(meta.TemplateFileKey, 12)
+	badFileKeyCtx.Set(vmPartialFeederName, func(string) (string, error) {
+		return `<span>bad</span>`, nil
+	})
+	_, err = vmPartialHelper("row.plush", nil, plush.NewHelperContext(badFileKeyCtx, nil))
+	require.ErrorContains(t, err, "expected fileKey to be a string")
+
+	_, err = vmPartialHelper("missing.plush", nil, plush.NewHelperContext(ctx, nil))
+	require.ErrorContains(t, err, "missing partial")
+
+	parseErrCtx := plush.NewContext()
+	parseErrCtx.Set(vmPartialFeederName, func(string) (string, error) {
+		return `<%=`, nil
+	})
+	_, err = vmPartialHelper("bad.plush", nil, plush.NewHelperContext(parseErrCtx, nil))
+	require.Error(t, err)
+
+	jsCtx := plush.NewContext()
+	jsCtx.Set("contentType", "application/javascript")
+	jsCtx.Set(vmPartialFeederName, func(string) (string, error) {
+		return `<span>"quoted"</span>`, nil
+	})
+	rendered, err = vmPartialHelper("row.plush", nil, plush.NewHelperContext(jsCtx, nil))
+	require.NoError(t, err)
+	require.Equal(t, template.HTML(`\u003Cspan\u003E\"quoted\"\u003C/span\u003E`), rendered)
+
+	_, err = vmPartialHelper("row.plush", nil, plush.HelperContext{})
+	require.ErrorContains(t, err, "invalid context")
+
+	budgetCtx := plush.NewContext().WithBudget(plush.NewBudget(0))
+	budgetCtx.Set(vmPartialFeederName, func(string) (string, error) {
+		return `<span>never</span>`, nil
+	})
+	_, err = vmPartialHelper("row.plush", nil, plush.NewHelperContext(budgetCtx, nil))
+	require.Error(t, err)
+}
+
+func Test_VM_Render_Fast_Partial_Segment(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name": "Mido",
+		"partialFeeder": func(string) (string, error) {
+			return `<span><%= name %></span>`, nil
+		},
+	})
+
+	var out strings.Builder
+	require.NoError(t, renderFastPartialSegment(&out, ctx, fastRenderBindings{}, &compiler.FastPartialPlan{Name: "row.plush", Line: 1}))
+	require.Equal(t, `<span>Mido</span>`, out.String())
+	require.NoError(t, renderFastPartialSegment(&out, ctx, fastRenderBindings{}, nil))
+
+	out.Reset()
+	require.NoError(t, renderFastPartialSegmentWithDataPlan(&out, ctx, fastRenderBindings{}, &compiler.FastPartialPlan{
+		Name: "row.plush",
+		Data: []compiler.FastPartialDataPair{{Key: "name", Value: compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "Leela"}, Line: 2}},
+		Line: 2,
+	}, nil))
+	require.Equal(t, `<span>Leela</span>`, out.String())
+
+	err := renderFastPartialSegmentWithDataPlan(&out, plush.NewContext().WithBudget(plush.NewBudget(0)), fastRenderBindings{}, &compiler.FastPartialPlan{Name: "row.plush", Line: 3}, nil)
+	require.ErrorContains(t, err, "render budget exceeded")
+
+	handled, err := renderFastNoDataPartialInto(nil, "row.plush", ctx, 4)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	handled, err = renderFastNoDataPartialInto(&out, "row.plush", nil, 4)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 4")
+
+	handled, err = renderFastNoDataPartialInto(&out, "row.plush", plush.NewContext(), 5)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 5")
+
+	require.False(t, fastPartialDataCanDirect(nil))
+	require.False(t, fastPartialDataCanDirect(&fastPartialDataBindingPlan{keys: []string{"layout"}}))
+	require.True(t, fastPartialDataCanDirect(&fastPartialDataBindingPlan{keys: []string{"name"}}))
+	require.False(t, fastPartialRenderPlanCanDirect(nil))
+	require.False(t, fastPartialRenderPlanCanDirect(&compiler.FastRenderPlan{Bindings: []string{meta.TemplateFileKey}}))
+	require.True(t, fastPartialRenderPlanCanDirect(&compiler.FastRenderPlan{Bindings: []string{"name"}}))
+}
+
+func Test_VM_Preprocess_Trim_Tags_Branches(t *testing.T) {
+	require.Equal(t, "plain", preprocessTrimTags("plain"))
+	require.Equal(t, "a<%= name %>b", preprocessTrimTags("a \n\t<%- name %> \n\tb"))
+	require.Equal(t, "a<%= name", preprocessTrimTags("a <%- name"))
+}
+
+func Test_VM_New_With_Globals_Store_Uses_Provided_Globals(t *testing.T) {
+	globals := []object.Object{&object.String{Value: "shared"}}
+	bytecode := &compiler.Bytecode{NumGlobals: 1}
+
+	machine := NewWithGlobalsStore(bytecode, globals)
+	require.Same(t, globals[0], machine.globals[0])
+}
+
+func Test_VM_Runtime_Template_Render_Compile_And_Global_Size_Edges(t *testing.T) {
+	var nilTemplate *Template
+	_, err := nilTemplate.Render(nil)
+	require.ErrorContains(t, err, "cannot render nil compiled template")
+
+	_, err = (&Template{}).Render(nil)
+	require.ErrorContains(t, err, "cannot render nil compiled template")
+
+	staticTemplate := &Template{bytecode: &compiler.Bytecode{Static: true, StaticOutput: "static"}}
+	rendered, err := staticTemplate.Render(nil)
+	require.NoError(t, err)
+	require.Equal(t, "static", rendered)
+
+	rendered, err = renderBytecode(&compiler.Bytecode{Static: true, StaticOutput: "bytecode"}, nil)
+	require.NoError(t, err)
+	require.Equal(t, "bytecode", rendered)
+
+	compiled, err := Compile("hello")
+	require.NoError(t, err)
+	rendered, err = compiled.Render(nil)
+	require.NoError(t, err)
+	require.Equal(t, "hello", rendered)
+
+	dynamic, err := Compile(`<%= name %>`)
+	require.NoError(t, err)
+	rendered, err = renderBytecode(dynamic.bytecode, plush.NewContextWith(map[string]interface{}{"name": "Mido"}))
+	require.NoError(t, err)
+	require.Equal(t, "Mido", rendered)
+
+	_, err = renderBytecode(dynamic.bytecode, nil)
+	require.ErrorContains(t, err, "unknown identifier")
+
+	_, err = Compile(`<% if (`)
+	require.Error(t, err)
+
+	require.Equal(t, 0, globalStoreSize(&compiler.Bytecode{NumGlobals: -1}))
+	require.Equal(t, 4, globalStoreSize(&compiler.Bytecode{
+		NumGlobals:  1,
+		GlobalNames: map[int]string{3: "late"},
+	}))
+}
+
+func Test_VM_Runtime_Render_Cache_And_Error_Branches(t *testing.T) {
+	rendered, err := Render("plain", nil)
+	require.NoError(t, err)
+	require.Equal(t, "plain", rendered)
+
+	_, err = Render(`<% if (`, plush.NewContext())
+	require.Error(t, err)
+
+	cache := inmemory.NewMemoryCache()
+	plush.PlushCacheSetup(cache)
+	defer func() {
+		plush.ClearTemplateCache()
+		plush.PlushCacheSetup(nil)
+	}()
+
+	staticCtx := plush.NewContext()
+	staticCtx.Set(meta.TemplateFileKey, "runtime_static.plush")
+	plush.CacheVMBytecodeForCleanFilename("runtime_static.plush", nil, &compiler.Bytecode{Static: true, StaticOutput: "cached static"})
+	rendered, err = Render("ignored", staticCtx)
+	require.NoError(t, err)
+	require.Equal(t, "cached static", rendered)
+
+	cachedProgram, err := parser.Parse("cached ast")
+	require.NoError(t, err)
+	plush.CacheVMBytecodeForCleanFilename("runtime_ast.plush", cachedProgram, &compiler.Bytecode{Static: true, StaticOutput: "cached ast"})
+	parsedProgram, parsedCachedProgram, err := parseProgram("ignored", "runtime_ast.plush", plush.NewContext())
+	require.NoError(t, err)
+	require.Same(t, cachedProgram, parsedProgram)
+	require.Same(t, cachedProgram, parsedCachedProgram)
+
+	fastTemplate, err := Compile(`<%= name %>`)
+	require.NoError(t, err)
+	fastCtx := plush.NewContextWith(map[string]interface{}{"name": "Mido"})
+	fastCtx.Set(meta.TemplateFileKey, "runtime_fast.plush")
+	plush.CacheVMBytecodeForCleanFilename("runtime_fast.plush", nil, fastTemplate.bytecode)
+	rendered, err = Render("ignored", fastCtx)
+	require.NoError(t, err)
+	require.Equal(t, "Mido", rendered)
+
+	dynamicTemplate, err := Compile(`<%= name %>`)
+	require.NoError(t, err)
+	dynamicTemplate.bytecode.FastRenderPlan = nil
+	dynamicTemplate.bytecode.HasPartials = true
+	dynamicCtx := plush.NewContextWith(map[string]interface{}{
+		"name":    "Leela",
+		"partial": plush.PartialHelper,
+	})
+	dynamicCtx.Set(meta.TemplateFileKey, "runtime_dynamic.plush")
+	plush.CacheVMBytecodeForCleanFilename("runtime_dynamic.plush", nil, dynamicTemplate.bytecode)
+	rendered, err = Render("ignored", dynamicCtx)
+	require.NoError(t, err)
+	require.Equal(t, "Leela", rendered)
+	require.True(t, sameFunction(dynamicCtx.Value("partial"), plush.PartialHelper))
+
+	rendered, err = renderBytecode(dynamicTemplate.bytecode, dynamicCtx)
+	require.NoError(t, err)
+	require.Equal(t, "Leela", rendered)
+	require.True(t, sameFunction(dynamicCtx.Value("partial"), plush.PartialHelper))
+}
+
+func Test_VM_Runtime_Render_No_Filename_Uses_Source_Bytecode_Cache(t *testing.T) {
+	clearSourceBytecodeCacheForTest()
+	defer clearSourceBytecodeCacheForTest()
+
+	source := `<%= name %>`
+	firstCtx := plush.NewContextWith(map[string]interface{}{"name": "first"})
+	rendered, err := Render(source, firstCtx)
+	require.NoError(t, err)
+	require.Equal(t, "first", rendered)
+	firstDiagnostics, ok := plush.RenderDiagnosticsFromContext(firstCtx)
+	require.True(t, ok)
+	require.Equal(t, plush.VMBytecodeCacheMissStoreSource, firstDiagnostics.VMBytecodeCache)
+
+	secondCtx := plush.NewContextWith(map[string]interface{}{"name": "second"})
+	rendered, err = Render(source, secondCtx)
+	require.NoError(t, err)
+	require.Equal(t, "second", rendered)
+	secondDiagnostics, ok := plush.RenderDiagnosticsFromContext(secondCtx)
+	require.True(t, ok)
+	require.Equal(t, plush.VMBytecodeCacheHitSource, secondDiagnostics.VMBytecodeCache)
+	require.Equal(t, plush.RenderFastPathFast, secondDiagnostics.FastPath)
+}
+
+func Test_VM_Source_Bytecode_Cache_Is_Bounded(t *testing.T) {
+	cache := newSourceBytecodeCache(2)
+	first := &compiler.Bytecode{Static: true, StaticOutput: "first"}
+	second := &compiler.Bytecode{Static: true, StaticOutput: "second"}
+	third := &compiler.Bytecode{Static: true, StaticOutput: "third"}
+
+	cache.Set("one", first)
+	cache.Set("two", second)
+	cached, ok := cache.Get("one")
+	require.True(t, ok)
+	require.Same(t, first, cached)
+
+	cache.Set("three", third)
+	_, ok = cache.Get("one")
+	require.False(t, ok)
+	cached, ok = cache.Get("two")
+	require.True(t, ok)
+	require.Same(t, second, cached)
+	cached, ok = cache.Get("three")
+	require.True(t, ok)
+	require.Same(t, third, cached)
+}
+
+func Test_VM_Runtime_Render_Returns_Cached_Punch_Hole_Skeleton_Before_Compile(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	plush.PlushCacheSetup(cache)
+	defer func() {
+		plush.ClearTemplateCache()
+		plush.PlushCacheSetup(nil)
+	}()
+
+	ctx := plush.NewContextWith(map[string]interface{}{"name": "cached"})
+	ctx.Set(meta.TemplateFileKey, "runtime_cached_hole.plush")
+	holes := []plush.HoleMarker{
+		plush.NewHoleMarker(plush.PunchHoleMarkerName(0), `<%= name %>`, 1, 15),
+	}
+	plush.CachePunchHoleSkeleton("runtime_cached_hole.plush", ctx, "A<PLUSH_HOLE_0>B", holes, true)
+
+	rendered, err := Render("ignored", ctx)
+	require.NoError(t, err)
+	require.Equal(t, "AcachedB", rendered)
+}
+
+func Test_VM_Runtime_Render_Uses_Post_Preprocess_Bytecode_Cache(t *testing.T) {
+	tests := []struct {
+		name     string
+		bytecode *compiler.Bytecode
+		ctx      hctx.Context
+		expected string
+	}{
+		{
+			name:     "Static_Bytecode",
+			bytecode: &compiler.Bytecode{Static: true, StaticOutput: "static cache"},
+			ctx:      plush.NewContext(),
+			expected: "static cache",
+		},
+		{
+			name:     "Fast_Bytecode",
+			bytecode: requireCompiledBytecode(t, `<%= name %>`),
+			ctx:      plush.NewContextWith(map[string]interface{}{"name": "fast cache"}),
+			expected: "fast cache",
+		},
+		{
+			name: "VM_Bytecode_With_Partial_Helper_Restore",
+			bytecode: func() *compiler.Bytecode {
+				bytecode := requireCompiledBytecode(t, `<%= name %>`)
+				bytecode.FastRenderPlan = nil
+				bytecode.HasPartials = true
+				return bytecode
+			}(),
+			ctx: plush.NewContextWith(map[string]interface{}{
+				"name":    "vm cache",
+				"partial": plush.PartialHelper,
+			}),
+			expected: "vm cache",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filename := "runtime_post_preprocess_" + tt.name + ".plush"
+			cache := &runtimeSwitchingBytecodeCache{
+				astKey:   plush.GenerateASTKey(filename),
+				bytecode: tt.bytecode,
+			}
+			plush.PlushCacheSetup(cache)
+			defer plush.PlushCacheSetup(nil)
+
+			if setter, ok := tt.ctx.(interface{ Set(string, interface{}) }); ok {
+				setter.Set(meta.TemplateFileKey, filename)
+			}
+			rendered, err := Render("ignored", tt.ctx)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, rendered)
+			require.GreaterOrEqual(t, cache.gets, 3)
+		})
+	}
+}
+
+func Test_VM_Runtime_Render_Bytecode_Uses_Cached_Punch_Hole_Skeleton(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	plush.PlushCacheSetup(cache)
+	defer func() {
+		plush.ClearTemplateCache()
+		plush.PlushCacheSetup(nil)
+	}()
+
+	ctx := plush.NewContextWith(map[string]interface{}{"name": "bytecode cache"})
+	ctx.Set(meta.TemplateFileKey, "runtime_render_bytecode_hole.plush")
+	holes := []plush.HoleMarker{
+		plush.NewHoleMarker(plush.PunchHoleMarkerName(0), `<%= name %>`, 1, 15),
+	}
+	plush.CachePunchHoleSkeleton("runtime_render_bytecode_hole.plush", ctx, "A<PLUSH_HOLE_0>B", holes, true)
+
+	rendered, err := renderBytecode(&compiler.Bytecode{HasHoles: true}, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "Abytecode cacheB", rendered)
+}
+
+func Test_VM_Runtime_Hole_Render_Returns_Nested_Hole_Skeleton(t *testing.T) {
+	nested := requireCompiledBytecode(t, `<%H "inner" %>`)
+	parent := plush.NewContext()
+	parent.Set(meta.TemplateFileKey, "runtime_nested_hole.plush")
+	outer := []plush.HoleMarker{
+		plush.NewHoleMarker(plush.PunchHoleMarkerName(0), `<%= "outer" %>`, 0, len(plush.PunchHoleMarkerName(0))),
+	}
+
+	rendered := plush.RenderPunchHolesConcurrentlyWith(outer, parent, func(input string, ctx hctx.Context) (string, error) {
+		if !plush.IsHoleRender(ctx) {
+			return "", errors.New("expected hole render context")
+		}
+		return renderBytecodeVMWithState(nested, ctx, "runtime_nested_hole.plush", false, "")
+	})
+
+	require.Len(t, rendered, 1)
+	require.Equal(t, plush.PunchHoleMarkerName(0), rendered[0].Content())
+	require.NoError(t, rendered[0].Err())
+}

--- a/VM/vm/runtime_run_dispatch_test.go
+++ b/VM/vm/runtime_run_dispatch_test.go
@@ -1,0 +1,683 @@
+package vm
+
+import (
+	"html/template"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/code"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_VM_Run_Dispatch_Core_Opcodes(t *testing.T) {
+	array := &object.Array{Elements: []object.Object{&object.Integer{Value: 1}}}
+	constants := []object.Object{
+		&object.Integer{Value: 1},
+		&object.Integer{Value: 2},
+		&object.Integer{Value: 5},
+		&object.Integer{Value: 3},
+		&object.Integer{Value: 4},
+		&object.String{Value: "abc"},
+		&object.String{Value: "a.c"},
+		&object.String{Value: "k"},
+		&object.Integer{Value: 7},
+		array,
+		&object.Integer{Value: 0},
+		&object.Integer{Value: 42},
+	}
+
+	instructions := code.Instructions{}
+	instructions = append(instructions, code.Make(code.OpConstant, 0)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 1)...)
+	instructions = append(instructions, code.Make(code.OpAdd)...)
+	instructions = append(instructions, code.Make(code.OpPop)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 2)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 3)...)
+	instructions = append(instructions, code.Make(code.OpSub)...)
+	instructions = append(instructions, code.Make(code.OpPop)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 1)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 4)...)
+	instructions = append(instructions, code.Make(code.OpMul)...)
+	instructions = append(instructions, code.Make(code.OpPop)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 4)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 1)...)
+	instructions = append(instructions, code.Make(code.OpDiv)...)
+	instructions = append(instructions, code.Make(code.OpPop)...)
+	instructions = append(instructions, code.Make(code.OpTrue)...)
+	instructions = append(instructions, code.Make(code.OpFalse)...)
+	instructions = append(instructions, code.Make(code.OpEqual)...)
+	instructions = append(instructions, code.Make(code.OpPop)...)
+	instructions = append(instructions, code.Make(code.OpTrue)...)
+	instructions = append(instructions, code.Make(code.OpFalse)...)
+	instructions = append(instructions, code.Make(code.OpNotEqual)...)
+	instructions = append(instructions, code.Make(code.OpPop)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 1)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 0)...)
+	instructions = append(instructions, code.Make(code.OpGreaterThan)...)
+	instructions = append(instructions, code.Make(code.OpPop)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 0)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 0)...)
+	instructions = append(instructions, code.Make(code.OpGreaterEqual)...)
+	instructions = append(instructions, code.Make(code.OpPop)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 5)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 6)...)
+	instructions = append(instructions, code.Make(code.OpMatches)...)
+	instructions = append(instructions, code.Make(code.OpPop)...)
+	instructions = append(instructions, code.Make(code.OpTrue)...)
+	instructions = append(instructions, code.Make(code.OpFalse)...)
+	instructions = append(instructions, code.Make(code.OpAnd)...)
+	instructions = append(instructions, code.Make(code.OpPop)...)
+	instructions = append(instructions, code.Make(code.OpFalse)...)
+	instructions = append(instructions, code.Make(code.OpTrue)...)
+	instructions = append(instructions, code.Make(code.OpOr)...)
+	instructions = append(instructions, code.Make(code.OpPop)...)
+	instructions = append(instructions, code.Make(code.OpTrue)...)
+	instructions = append(instructions, code.Make(code.OpBang)...)
+	instructions = append(instructions, code.Make(code.OpPop)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 0)...)
+	instructions = append(instructions, code.Make(code.OpMinus)...)
+	instructions = append(instructions, code.Make(code.OpPop)...)
+	instructions = append(instructions, code.Make(code.OpNull)...)
+	instructions = append(instructions, code.Make(code.OpPop)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 0)...)
+	instructions = append(instructions, code.Make(code.OpSetGlobal, 0)...)
+	instructions = append(instructions, code.Make(code.OpGetGlobal, 0)...)
+	instructions = append(instructions, code.Make(code.OpPop)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 0)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 1)...)
+	instructions = append(instructions, code.Make(code.OpArray, 2)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 0)...)
+	instructions = append(instructions, code.Make(code.OpIndex)...)
+	instructions = append(instructions, code.Make(code.OpPop)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 7)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 8)...)
+	instructions = append(instructions, code.Make(code.OpHash, 2)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 7)...)
+	instructions = append(instructions, code.Make(code.OpIndex)...)
+	instructions = append(instructions, code.Make(code.OpPop)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 9)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 10)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 11)...)
+	instructions = append(instructions, code.Make(code.OpSetIndex)...)
+	instructions = append(instructions, code.Make(code.OpPop)...)
+
+	machine := NewWithContext(&compiler.Bytecode{
+		Instructions: instructions,
+		Constants:    constants,
+		NumGlobals:   1,
+	}, plush.NewContext())
+
+	require.NoError(t, machine.Run())
+	require.Equal(t, &object.Integer{Value: 42}, array.Elements[0])
+	require.Zero(t, machine.sp)
+}
+
+func Test_VM_Compile_Compiler_Error_Branch(t *testing.T) {
+	_, err := templateFromBytecode(compileProgramBytecode(vmCoverageBadProgram()))
+	require.ErrorContains(t, err, "unknown operator ??")
+}
+
+func Test_VM_Run_Dispatch_Jump_Write_And_Name_Opcodes(t *testing.T) {
+	constants := []object.Object{
+		&object.String{Value: "<skip>"},
+		&object.String{Value: "name"},
+		&object.String{Value: "missing"},
+		&object.String{Value: "<text>"},
+		&object.Native{Value: template.HTML("<raw>")},
+		&object.String{Value: "user"},
+		&object.String{Value: "Prop"},
+		&object.String{Value: "updated"},
+		&object.String{Value: "assigned"},
+		&object.String{Value: "local"},
+		&object.Native{Value: vmHelperStruct{Prop: "local-prop"}},
+		&object.String{Value: "global"},
+		&object.Native{Value: vmHelperStruct{Prop: "global-prop"}},
+		&object.String{Value: `<%= name %>`},
+		&object.String{Value: "<constant>"},
+	}
+	instructions := code.Instructions{}
+	instructions = append(instructions, code.Make(code.OpJump, 6)...)
+	instructions = append(instructions, code.Make(code.OpWriteString, 0)...)
+	instructions = append(instructions, code.Make(code.OpFalse)...)
+	instructions = append(instructions, code.Make(code.OpJumpNotTruthy, 13)...)
+	instructions = append(instructions, code.Make(code.OpWriteString, 0)...)
+	instructions = append(instructions, code.Make(code.OpWriteName, 1)...)
+	instructions = append(instructions, code.Make(code.OpWriteNameOrNull, 2)...)
+	instructions = append(instructions, code.Make(code.OpWriteString, 3)...)
+	instructions = append(instructions, code.Make(code.OpWriteHTML, 4)...)
+	instructions = append(instructions, code.Make(code.OpWriteConstant, 14)...)
+	instructions = append(instructions, code.Make(code.OpGetName, 1)...)
+	instructions = append(instructions, code.Make(code.OpWrite)...)
+	instructions = append(instructions, code.Make(code.OpGetNameOrNull, 2)...)
+	instructions = append(instructions, code.Make(code.OpWrite)...)
+	instructions = append(instructions, code.Make(code.OpGetName, 5)...)
+	instructions = append(instructions, code.Make(code.OpGetProperty, 6)...)
+	instructions = append(instructions, code.Make(code.OpWrite)...)
+	instructions = append(instructions, code.Make(code.OpWriteNameProperty, 5, 6)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 7)...)
+	instructions = append(instructions, code.Make(code.OpSetName, 1)...)
+	instructions = append(instructions, code.Make(code.OpWriteName, 1)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 8)...)
+	instructions = append(instructions, code.Make(code.OpAssignName, 1)...)
+	instructions = append(instructions, code.Make(code.OpPop)...)
+	instructions = append(instructions, code.Make(code.OpWriteName, 1)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 9)...)
+	instructions = append(instructions, code.Make(code.OpSetLocal, 0)...)
+	instructions = append(instructions, code.Make(code.OpWriteLocal, 0)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 10)...)
+	instructions = append(instructions, code.Make(code.OpSetLocal, 1)...)
+	instructions = append(instructions, code.Make(code.OpWriteLocalProperty, 1, 6)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 11)...)
+	instructions = append(instructions, code.Make(code.OpSetGlobal, 0)...)
+	instructions = append(instructions, code.Make(code.OpWriteGlobal, 0)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 12)...)
+	instructions = append(instructions, code.Make(code.OpSetGlobal, 1)...)
+	instructions = append(instructions, code.Make(code.OpWriteGlobalProperty, 1, 6)...)
+	instructions = append(instructions, code.Make(code.OpConstant, 13)...)
+	instructions = append(instructions, code.Make(code.OpRenderTemplate)...)
+	instructions = append(instructions, code.Make(code.OpWrite)...)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name": "Mido",
+		"user": vmHelperStruct{Prop: "user-prop"},
+	})
+	machine := NewWithContext(&compiler.Bytecode{
+		Instructions: instructions,
+		Constants:    constants,
+		NumLocals:    2,
+		NumGlobals:   2,
+	}, ctx)
+
+	require.NoError(t, machine.Run())
+	require.Equal(t, "Mido&lt;text&gt;<raw>&lt;constant&gt;Midouser-propuser-propupdatedassignedlocallocal-propglobalglobal-propassigned", machine.Rendered())
+}
+
+func Test_VM_Run_Dispatch_Builtin_Context_Override(t *testing.T) {
+	lenIndex := -1
+	for i, definition := range object.Builtins {
+		if definition.Name == "len" {
+			lenIndex = i
+			break
+		}
+	}
+	require.GreaterOrEqual(t, lenIndex, 0)
+
+	overrideInstructions := code.Instructions{}
+	overrideInstructions = append(overrideInstructions, code.Make(code.OpGetBuiltin, lenIndex)...)
+	overrideInstructions = append(overrideInstructions, code.Make(code.OpPop)...)
+
+	defaultInstructions := code.Instructions{}
+	defaultInstructions = append(defaultInstructions, code.Make(code.OpGetBuiltin, lenIndex)...)
+	defaultInstructions = append(defaultInstructions, code.Make(code.OpArray, 0)...)
+	defaultInstructions = append(defaultInstructions, code.Make(code.OpCall, 1)...)
+	defaultInstructions = append(defaultInstructions, code.Make(code.OpPop)...)
+
+	overrideMachine := NewWithContext(&compiler.Bytecode{Instructions: overrideInstructions}, plush.NewContextWith(map[string]interface{}{
+		"len": "override",
+	}))
+	require.NoError(t, overrideMachine.Run())
+	require.Equal(t, &object.String{Value: "override"}, overrideMachine.LastPoppedStackElem())
+
+	defaultMachine := NewWithContext(&compiler.Bytecode{Instructions: defaultInstructions}, plush.NewContext())
+	require.NoError(t, defaultMachine.Run())
+	require.Equal(t, &object.Integer{Value: 0}, defaultMachine.LastPoppedStackElem())
+}
+
+func newVMDispatchAssignmentBudgetContext() *plush.Context {
+	costs := plush.ZeroCosts()
+	costs.Assignment = 1
+	return plush.NewContext().WithBudget(plush.NewBudgetWithCosts(0, costs))
+}
+
+func Test_VM_Run_Dispatch_Error_Branches(t *testing.T) {
+	tests := []struct {
+		name         string
+		constants    []object.Object
+		instructions code.Instructions
+		ctx          *plush.Context
+		numLocals    int
+		numGlobals   int
+		expected     string
+	}{
+		{
+			name:         "binary_operation",
+			instructions: append(append(code.Make(code.OpNull), code.Make(code.OpNull)...), code.Make(code.OpAdd)...),
+			expected:     "unsupported types",
+		},
+		{
+			name: "comparison",
+			constants: []object.Object{
+				&object.Integer{Value: 1},
+				&object.String{Value: "one"},
+			},
+			instructions: append(append(
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1)...,
+			), code.Make(code.OpEqual)...),
+			expected: "unable to operate",
+		},
+		{
+			name: "minus",
+			constants: []object.Object{
+				&object.String{Value: "bad"},
+			},
+			instructions: append(
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpMinus)...,
+			),
+			expected: "unsupported type for negation",
+		},
+		{
+			name: "condition_budget",
+			ctx:  plush.NewContext().WithBudget(plush.NewBudget(0)),
+			instructions: append(append(
+				code.Make(code.OpFalse),
+				code.Make(code.OpJumpNotTruthy, 4)...,
+			), code.Make(code.OpNull)...),
+			expected: "budget",
+		},
+		{
+			name: "assignment_budget",
+			ctx:  newVMDispatchAssignmentBudgetContext(),
+			constants: []object.Object{
+				&object.Integer{Value: 1},
+			},
+			instructions: append(
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpSetGlobal, 0)...,
+			),
+			numGlobals: 1,
+			expected:   "budget",
+		},
+		{
+			name: "hash_key",
+			constants: []object.Object{
+				&object.Array{},
+				&object.Integer{Value: 1},
+			},
+			instructions: append(append(
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1)...,
+			), code.Make(code.OpHash, 2)...),
+			expected: "unusable as hash key",
+		},
+		{
+			name: "index",
+			constants: []object.Object{
+				&object.Integer{Value: 1},
+				&object.Integer{Value: 0},
+			},
+			instructions: append(append(
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1)...,
+			), code.Make(code.OpIndex)...),
+			expected: "could not index",
+		},
+		{
+			name: "set_index",
+			constants: []object.Object{
+				&object.Integer{Value: 1},
+				&object.Integer{Value: 0},
+				&object.Integer{Value: 9},
+			},
+			instructions: append(append(append(
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1)...,
+			), code.Make(code.OpConstant, 2)...), code.Make(code.OpSetIndex)...),
+			expected: "could not index",
+		},
+		{
+			name: "call",
+			constants: []object.Object{
+				&object.Integer{Value: 1},
+			},
+			instructions: append(
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpCall, 0)...,
+			),
+			expected: "invalid function",
+		},
+		{
+			name: "write_call",
+			constants: []object.Object{
+				&object.Integer{Value: 1},
+			},
+			instructions: append(
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpWriteCall, 0)...,
+			),
+			expected: "invalid function",
+		},
+		{
+			name: "write_name_call",
+			constants: []object.Object{
+				&object.String{Value: "missing"},
+			},
+			instructions: code.Make(code.OpWriteNameCall, 0, 0),
+			expected:     `"missing": unknown identifier`,
+		},
+		{
+			name: "call_block",
+			constants: []object.Object{
+				&object.Integer{Value: 1},
+			},
+			instructions: code.Make(code.OpCallBlock, 0, 0, 0),
+			expected:     "not a function",
+		},
+		{
+			name: "closure",
+			constants: []object.Object{
+				&object.Integer{Value: 1},
+			},
+			instructions: code.Make(code.OpClosure, 0, 0),
+			expected:     "not a function",
+		},
+		{
+			name: "get_name",
+			constants: []object.Object{
+				&object.String{Value: "missing"},
+			},
+			instructions: code.Make(code.OpGetName, 0),
+			expected:     `"missing": unknown identifier`,
+		},
+		{
+			name: "assign_name",
+			constants: []object.Object{
+				&object.String{Value: "missing"},
+				&object.Integer{Value: 1},
+			},
+			instructions: append(
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpAssignName, 0)...,
+			),
+			expected: `"missing": unknown identifier`,
+		},
+		{
+			name: "get_property",
+			constants: []object.Object{
+				&object.Integer{Value: 1},
+				&object.String{Value: "Prop"},
+			},
+			instructions: append(
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpGetProperty, 1)...,
+			),
+			expected: "Prop",
+		},
+		{
+			name: "write_name",
+			constants: []object.Object{
+				&object.String{Value: "missing"},
+			},
+			instructions: code.Make(code.OpWriteName, 0),
+			expected:     `"missing": unknown identifier`,
+		},
+		{
+			name: "write_local_property",
+			constants: []object.Object{
+				&object.Integer{Value: 1},
+				&object.String{Value: "Prop"},
+			},
+			instructions: append(append(
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpSetLocal, 0)...,
+			), code.Make(code.OpWriteLocalProperty, 0, 1)...),
+			numLocals: 1,
+			expected:  "Prop",
+		},
+		{
+			name: "write_global_property",
+			constants: []object.Object{
+				&object.Integer{Value: 1},
+				&object.String{Value: "Prop"},
+			},
+			instructions: append(append(
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpSetGlobal, 0)...,
+			), code.Make(code.OpWriteGlobalProperty, 0, 1)...),
+			numGlobals: 1,
+			expected:   "Prop",
+		},
+		{
+			name: "write_name_property",
+			ctx: plush.NewContextWith(map[string]interface{}{
+				"user": 1,
+			}),
+			constants: []object.Object{
+				&object.String{Value: "user"},
+				&object.String{Value: "Prop"},
+			},
+			instructions: code.Make(code.OpWriteNameProperty, 0, 1),
+			expected:     "Prop",
+		},
+		{
+			name: "render_template",
+			constants: []object.Object{
+				&object.String{Value: `<%= missing %>`},
+			},
+			instructions: append(
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpRenderTemplate)...,
+			),
+			expected: "missing",
+		},
+		{
+			name: "for_block",
+			constants: []object.Object{
+				&object.Integer{Value: 1},
+				&object.String{Value: "k"},
+				&object.String{Value: "v"},
+			},
+			instructions: code.Make(code.OpFor, 0, 1, 2, 0),
+			expected:     "not a function",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := tt.ctx
+			if ctx == nil {
+				ctx = plush.NewContext()
+			}
+			machine := NewWithContext(&compiler.Bytecode{
+				Instructions: tt.instructions,
+				Constants:    tt.constants,
+				NumLocals:    tt.numLocals,
+				NumGlobals:   tt.numGlobals,
+			}, ctx)
+			require.ErrorContains(t, machine.Run(), tt.expected)
+		})
+	}
+}
+
+func Test_VM_Run_Dispatch_Stack_Overflow_Error_Branches(t *testing.T) {
+	tests := []struct {
+		name         string
+		constants    []object.Object
+		instructions code.Instructions
+		numGlobals   int
+	}{
+		{
+			name: "constant",
+			constants: []object.Object{
+				&object.Integer{Value: 1},
+			},
+			instructions: code.Make(code.OpConstant, 0),
+		},
+		{
+			name:         "true",
+			instructions: code.Make(code.OpTrue),
+		},
+		{
+			name:         "false",
+			instructions: code.Make(code.OpFalse),
+		},
+		{
+			name:         "null",
+			instructions: code.Make(code.OpNull),
+		},
+		{
+			name:         "global",
+			instructions: code.Make(code.OpGetGlobal, 0),
+			numGlobals:   1,
+		},
+		{
+			name:         "name_or_null",
+			constants:    []object.Object{&object.String{Value: "missing"}},
+			instructions: code.Make(code.OpGetNameOrNull, 0),
+		},
+		{
+			name:         "array",
+			instructions: code.Make(code.OpArray, 0),
+		},
+		{
+			name:         "hash",
+			instructions: code.Make(code.OpHash, 0),
+		},
+		{
+			name: "closure",
+			constants: []object.Object{
+				&object.CompiledFunction{},
+			},
+			instructions: code.Make(code.OpClosure, 0, 0),
+		},
+		{
+			name:         "current_closure",
+			instructions: code.Make(code.OpCurrentClosure),
+		},
+		{
+			name: "builtin",
+			instructions: code.Make(code.OpGetBuiltin, func() int {
+				for i, definition := range object.Builtins {
+					if definition.Name == "len" {
+						return i
+					}
+				}
+				return 0
+			}()),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			machine := NewWithContext(&compiler.Bytecode{
+				Instructions: tt.instructions,
+				Constants:    tt.constants,
+				NumGlobals:   tt.numGlobals,
+			}, plush.NewContext())
+			machine.sp = StackSize
+			require.EqualError(t, machine.Run(), "stack overflow")
+		})
+	}
+}
+
+func Test_VM_Run_Dispatch_Builtin_Default_Stack_Overflow_Branch(t *testing.T) {
+	lenIndex := -1
+	for i, definition := range object.Builtins {
+		if definition.Name == "len" {
+			lenIndex = i
+			break
+		}
+	}
+	require.GreaterOrEqual(t, lenIndex, 0)
+
+	machine := New(&compiler.Bytecode{
+		Instructions: code.Make(code.OpGetBuiltin, lenIndex),
+	})
+	machine.ctx = nil
+	machine.sp = StackSize
+	require.EqualError(t, machine.Run(), "stack overflow")
+}
+
+func Test_VM_Run_Dispatch_Get_Free_Stack_Overflow_Branch(t *testing.T) {
+	machine := NewWithContext(&compiler.Bytecode{
+		Instructions: code.Make(code.OpGetFree, 0),
+	}, plush.NewContext())
+	machine.currentFrame().cl.Free = []object.Object{&object.String{Value: "free"}}
+	machine.sp = StackSize
+	require.EqualError(t, machine.Run(), "stack overflow")
+}
+
+func Test_VM_Run_Dispatch_Call_Block_Execute_Error_Branch(t *testing.T) {
+	instructions := append(
+		code.Make(code.OpConstant, 0),
+		code.Make(code.OpCallBlock, 0, 1, 0)...,
+	)
+	machine := NewWithContext(&compiler.Bytecode{
+		Instructions: instructions,
+		Constants: []object.Object{
+			&object.Integer{Value: 1},
+			&object.CompiledFunction{Instructions: code.Make(code.OpReturn)},
+		},
+	}, plush.NewContext())
+	require.ErrorContains(t, machine.Run(), "invalid function")
+}
+
+func Test_VM_Run_Dispatch_Child_Frame_Return_Overflow_Branches(t *testing.T) {
+	tests := []struct {
+		name         string
+		instructions code.Instructions
+	}{
+		{name: "return_value", instructions: code.Make(code.OpReturnValue)},
+		{name: "return", instructions: code.Make(code.OpReturn)},
+		{name: "break", instructions: code.Make(code.OpBreak)},
+		{name: "continue", instructions: code.Make(code.OpContinue)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parent := NewFrame(&object.Closure{Fn: &object.CompiledFunction{Instructions: code.Make(code.OpNull)}}, 0)
+			child := NewFrame(&object.Closure{Fn: &object.CompiledFunction{Instructions: tt.instructions}}, StackSize)
+			machine := &VM{
+				stack:       make([]object.Object, StackSize),
+				sp:          StackSize,
+				frames:      make([]*Frame, MaxFrames),
+				framesIndex: 2,
+				ctx:         plush.NewContext(),
+			}
+			machine.stack[StackSize-1] = &object.String{Value: "return"}
+			machine.frames[0] = parent
+			machine.frames[1] = child
+			require.EqualError(t, machine.Run(), "stack overflow")
+		})
+	}
+}
+
+func Test_VM_Run_Dispatch_Set_And_Get_Local_Error_Branches(t *testing.T) {
+	setMachine := NewWithContext(&compiler.Bytecode{
+		Instructions: append(
+			code.Make(code.OpConstant, 0),
+			code.Make(code.OpSetLocal, 0)...,
+		),
+		Constants: []object.Object{&object.String{Value: "value"}},
+		NumLocals: 1,
+	}, newVMDispatchAssignmentBudgetContext())
+	require.ErrorContains(t, setMachine.Run(), "budget")
+
+	getMachine := NewWithContext(&compiler.Bytecode{
+		Instructions: code.Make(code.OpGetLocal, 0),
+		NumLocals:    1,
+	}, plush.NewContext())
+	getMachine.stack[0] = &object.String{Value: "value"}
+	getMachine.sp = StackSize
+	require.EqualError(t, getMachine.Run(), "stack overflow")
+}
+
+func Test_VM_Run_Dispatch_For_Execute_Error_Branch(t *testing.T) {
+	instructions := append(
+		code.Make(code.OpConstant, 0),
+		code.Make(code.OpFor, 1, 2, 3, 0)...,
+	)
+	machine := NewWithContext(&compiler.Bytecode{
+		Instructions: instructions,
+		Constants: []object.Object{
+			&object.Integer{Value: 7},
+			&object.CompiledFunction{Instructions: code.Make(code.OpReturn)},
+			&object.String{Value: "i"},
+			&object.String{Value: "item"},
+		},
+	}, plush.NewContext())
+	require.ErrorContains(t, machine.Run(), "could not iterate")
+}

--- a/VM/vm/source_cache.go
+++ b/VM/vm/source_cache.go
@@ -1,0 +1,101 @@
+package vm
+
+import (
+	"hash/maphash"
+	"sync"
+
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+)
+
+const sourceBytecodeCacheLimit = 1024
+
+var (
+	vmSourceHashSeed  = maphash.MakeSeed()
+	sourceBytecodeMap = newSourceBytecodeCache(sourceBytecodeCacheLimit)
+)
+
+type sourceBytecodeCacheEntry struct {
+	source   string
+	bytecode *compiler.Bytecode
+}
+
+type sourceBytecodeCache struct {
+	mu      sync.RWMutex
+	limit   int
+	entries map[uint64]sourceBytecodeCacheEntry
+	order   []uint64
+}
+
+func newSourceBytecodeCache(limit int) *sourceBytecodeCache {
+	return &sourceBytecodeCache{
+		limit:   limit,
+		entries: map[uint64]sourceBytecodeCacheEntry{},
+		order:   make([]uint64, 0, limit),
+	}
+}
+
+func hashString(input string) uint64 {
+	return maphash.String(vmSourceHashSeed, input)
+}
+
+func cachedSourceBytecode(source string) (*compiler.Bytecode, bool) {
+	if source == "" {
+		return nil, false
+	}
+	return sourceBytecodeMap.Get(source)
+}
+
+func cacheSourceBytecode(source string, bytecode *compiler.Bytecode) {
+	if source == "" || bytecode == nil {
+		return
+	}
+	sourceBytecodeMap.Set(source, bytecode)
+}
+
+func clearSourceBytecodeCacheForTest() {
+	sourceBytecodeMap.Clear()
+}
+
+func (c *sourceBytecodeCache) Get(source string) (*compiler.Bytecode, bool) {
+	if c == nil || source == "" {
+		return nil, false
+	}
+	hash := hashString(source)
+	c.mu.RLock()
+	entry, ok := c.entries[hash]
+	c.mu.RUnlock()
+	if !ok || entry.source != source || entry.bytecode == nil {
+		return nil, false
+	}
+	return entry.bytecode, true
+}
+
+func (c *sourceBytecodeCache) Set(source string, bytecode *compiler.Bytecode) {
+	if c == nil || c.limit <= 0 || source == "" || bytecode == nil {
+		return
+	}
+	hash := hashString(source)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ok := c.entries[hash]; !ok {
+		c.order = append(c.order, hash)
+	}
+	c.entries[hash] = sourceBytecodeCacheEntry{source: source, bytecode: bytecode}
+	for len(c.entries) > c.limit && len(c.order) > 0 {
+		oldest := c.order[0]
+		copy(c.order, c.order[1:])
+		c.order = c.order[:len(c.order)-1]
+		delete(c.entries, oldest)
+	}
+}
+
+func (c *sourceBytecodeCache) Clear() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	clear(c.entries)
+	clear(c.order)
+	c.order = c.order[:0]
+}

--- a/VM/vm/vm.go
+++ b/VM/vm/vm.go
@@ -1,0 +1,178 @@
+package vm
+
+import (
+	"fmt"
+	"html/template"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+)
+
+const StackSize = 2048
+const MaxFrames = 1024
+const anonymousCallName = "<anonymous>"
+
+var vmAlreadyInPartial = "__plush_vm_internal_already_in_partial_" + fmt.Sprintf("%d", time.Now().UnixNano()) + "__"
+var vmPartialBytecodeLinksKey = "__plush_vm_internal_partial_bytecode_links_" + fmt.Sprintf("%d", time.Now().UnixNano()) + "__"
+var vmFastHelpersKey = "__plush_vm_internal_fast_helpers_" + fmt.Sprintf("%d", time.Now().UnixNano()) + "__"
+
+const vmPartialFeederName = "partialFeeder"
+
+var fastStructLoopWriterPlanCache sync.Map
+var fastFieldChainPlanCache sync.Map
+var fastAccessChainPlanCache sync.Map
+
+var True = object.TrueObject
+var False = object.FalseObject
+var Null = object.NullObject
+
+type VM struct {
+	constants []object.Object
+
+	stack    []object.Object
+	sp       int
+	stackMax int
+
+	globals     []object.Object
+	globalNames map[int]string
+
+	frames      []*Frame
+	framesIndex int
+
+	ctx hctx.Context
+
+	holes              *[]plush.HoleMarker
+	deferHolePositions bool
+	nameIDCache        [8]nameIDEntry
+	nameIDCacheLen     int
+	nameIDOverflow     []nameIDEntry
+
+	lastPopped object.Object
+	lastIP     int
+	halted     bool
+
+	pooled     bool
+	ownGlobals bool
+	ownHoles   bool
+}
+
+type vmHole struct {
+	input string
+}
+
+type nameIDEntry struct {
+	name string
+	id   int
+}
+
+type contextLookup interface {
+	Lookup(string) (interface{}, bool)
+}
+
+type contextIDLookup interface {
+	InternID(string) int
+	LookupID(int) (interface{}, bool)
+	SetID(int, interface{})
+	UpdateID(int, interface{}) bool
+}
+
+type contextIDBinder interface {
+	InternIDs([]string, []int)
+}
+
+type Template struct {
+	bytecode *compiler.Bytecode
+}
+
+var stackPool = sync.Pool{
+	New: func() interface{} {
+		stack := make([]object.Object, StackSize)
+		return &stack
+	},
+}
+
+var framesPool = sync.Pool{
+	New: func() interface{} {
+		frames := make([]*Frame, MaxFrames)
+		return &frames
+	},
+}
+
+var framePool = sync.Pool{
+	New: func() interface{} {
+		frame := NewFrame(nil, 0)
+		frame.pooled = true
+		return frame
+	},
+}
+
+var holesPool = sync.Pool{
+	New: func() interface{} {
+		holes := make([]plush.HoleMarker, 0, 8)
+		return &holes
+	},
+}
+
+var partialOverlayContextPool = sync.Pool{
+	New: func() interface{} {
+		return &partialOverlayContext{}
+	},
+}
+
+var globalsPools sync.Map
+
+var (
+	errorType                  = reflect.TypeOf((*error)(nil)).Elem()
+	stringType                 = reflect.TypeOf("")
+	templateHTMLType           = reflect.TypeOf(template.HTML(""))
+	boolType                   = reflect.TypeOf(false)
+	emptyInterfaceType         = reflect.TypeOf((*interface{})(nil)).Elem()
+	objectInterfaceType        = reflect.TypeOf((*object.Object)(nil)).Elem()
+	plushHelperContextType     = reflect.TypeOf(plush.HelperContext{})
+	hctxHelperContextInterface = reflect.TypeOf((*hctx.HelperContext)(nil)).Elem()
+	emptyMapType               = reflect.TypeOf(map[string]interface{}{})
+	callPlanCache              sync.Map
+	propertyLookupCache        sync.Map
+	regexCache                 sync.Map
+)
+
+type optionalArgKind uint8
+
+const (
+	optionalArgNone optionalArgKind = iota
+	optionalArgHelperContext
+	optionalArgMap
+)
+
+type callReturnKind uint8
+
+const (
+	callReturnGeneric callReturnKind = iota
+	callReturnNone
+	callReturnString
+	callReturnHTML
+	callReturnBool
+	callReturnInt
+	callReturnUint
+	callReturnFloat
+	callReturnObject
+)
+
+type callPlan struct {
+	rt           reflect.Type
+	numIn        int
+	isVariadic   bool
+	minArgs      int
+	argTypes     []reflect.Type
+	optionalArgs []optionalArgKind
+	variadicElem reflect.Type
+	returnKind   callReturnKind
+}
+
+// ErrFastUnsupported lets a custom fast helper decline a call and fall back to
+// the normal VM helper path.

--- a/VM/vm/vm_package_coverage_edges_test.go
+++ b/VM/vm/vm_package_coverage_edges_test.go
@@ -1,0 +1,919 @@
+package vm
+
+import (
+	"errors"
+	"html/template"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/code"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/gobuffalo/plush/v5/ast"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+	"github.com/gobuffalo/plush/v5/helpers/meta"
+	"github.com/gobuffalo/plush/v5/templatecache/inmemory"
+	"github.com/stretchr/testify/require"
+)
+
+type vmCoveragePointerMethod struct {
+	Name string
+}
+
+func (v *vmCoveragePointerMethod) Echo() string {
+	return v.Name
+}
+
+type vmCoveragePointerField struct {
+	Value *string
+}
+
+func vmCoverageBadProgram() *ast.Program {
+	return &ast.Program{Statements: []ast.Statement{
+		&ast.ExpressionStatement{Expression: &ast.PrefixExpression{
+			Operator: "??",
+			Right:    &ast.Boolean{Value: true},
+		}},
+	}}
+}
+
+func Test_VM_Runtime_And_Property_Remaining_Edge_Branches(t *testing.T) {
+	machine := newRuntimeHelperTestVM(plush.NewContext())
+	machine.halted = true
+	machine.lastPopped = &object.String{Value: "<done>"}
+	require.Equal(t, "&lt;done&gt;", machine.Rendered())
+
+	values := []string{"a"}
+	handled, err := machine.executeNativeSliceAppend(&object.Native{Value: &values}, &object.String{Value: "b"})
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, []string{"a", "b"}, object.ToGo(machine.pop()))
+
+	ordered, err := compareOrdered(code.OpGreaterEqual, &object.String{Value: "b"}, &object.String{Value: "b"})
+	require.NoError(t, err)
+	require.True(t, ordered)
+
+	ctx := plush.NewContextWith(map[string]interface{}{"name": struct{ Value string }{Value: "slow"}})
+	machine = newRuntimeHelperTestVM(ctx)
+	var frame Frame
+	require.NoError(t, machine.writeName(&frame, 0, false))
+	require.True(t, frame.hasOutput)
+
+	raw := &vmCoveragePointerMethod{Name: "method"}
+	value, err := machine.propertyValue(raw, "Echo", object.PropertyAccess{Method: true, Receiver: "raw", Full: "raw.Echo()"}, nil)
+	require.NoError(t, err)
+	method, ok := value.(func() string)
+	require.True(t, ok)
+	require.Equal(t, "method", method())
+
+	rv, rawValue, ok, err := fastPropertyReflectValue(raw)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Same(t, raw, rawValue)
+	require.Equal(t, reflect.Struct, rv.Kind())
+
+	rv, rawValue, ok, err = fastPropertyReflectValue(nil)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.False(t, rv.IsValid())
+	require.Nil(t, rawValue)
+
+	pointerLookup := cachedPropertyLookup(reflect.TypeOf(vmCoveragePointerMethod{}), "Echo")
+	pointerEntry := &propertyInlineCacheEntry{lookup: pointerLookup}
+	addressable := reflect.ValueOf(raw).Elem()
+	value, err = fastPropertyValueFromReflect(addressable, raw, "Echo", object.PropertyAccess{Method: true}, pointerEntry)
+	require.NoError(t, err)
+	method, ok = value.(func() string)
+	require.True(t, ok)
+	require.Equal(t, "method", method())
+
+	reader := buildFastPropertyReader(pointerLookup)
+	value, err = reader(addressable, object.PropertyAccess{Method: true}, "Echo")
+	require.NoError(t, err)
+	method, ok = value.(func() string)
+	require.True(t, ok)
+	require.Equal(t, "method", method())
+
+	fieldValue := "field"
+	field := reflect.ValueOf(vmCoveragePointerField{Value: &fieldValue}).FieldByName("Value")
+	var out strings.Builder
+	written, err := writeFastField(&out, plush.NewContext(), field, object.PropertyAccess{}, "Value", field.Type())
+	require.NoError(t, err)
+	require.True(t, written)
+	require.Equal(t, "field", out.String())
+}
+
+func Test_VM_Execute_For_Remaining_Output_And_Stop_Branches(t *testing.T) {
+	outputOnlyBlock := executeForClosure(code.Make(code.OpWriteLocal, 1), 2)
+	result, err := newExecuteForTestVM().executeFor(&object.Native{Value: []string{"out"}}, outputOnlyBlock, "i", "item")
+	require.NoError(t, err)
+	outputArray := result.(*object.Array)
+	require.Len(t, outputArray.Elements, 1)
+	require.Equal(t, template.HTML("out"), object.ToGo(outputArray.Elements[0]))
+
+	breakBlock := executeForClosure(executeForInstructions(
+		code.Make(code.OpWriteLocal, 1),
+		code.Make(code.OpBreak),
+	), 2)
+
+	result, err = newExecuteForTestVM().executeFor(
+		&object.Native{Value: []object.Object{&object.String{Value: "obj"}, &object.String{Value: "skip"}}},
+		breakBlock,
+		"i",
+		"item",
+	)
+	require.NoError(t, err)
+	objectArray := result.(*object.Array)
+	require.Len(t, objectArray.Elements, 1)
+	require.Equal(t, template.HTML("obj"), object.ToGo(objectArray.Elements[0]))
+
+	result, err = newExecuteForTestVM().executeFor(&object.Native{Value: []int{7, 8}}, breakBlock, "i", "item")
+	require.NoError(t, err)
+	reflectArray := result.(*object.Array)
+	require.Len(t, reflectArray.Elements, 1)
+	require.Equal(t, template.HTML("7"), object.ToGo(reflectArray.Elements[0]))
+
+	result, err = newExecuteForTestVM().executeFor(
+		&object.Native{Value: &vmForIterator{values: []interface{}{"first", "second"}}},
+		breakBlock,
+		"i",
+		"item",
+	)
+	require.NoError(t, err)
+	iteratorArray := result.(*object.Array)
+	require.Len(t, iteratorArray.Elements, 1)
+	require.Equal(t, template.HTML("first"), object.ToGo(iteratorArray.Elements[0]))
+}
+
+func Test_VM_Partial_Remaining_Error_Branches(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	plush.PlushCacheSetup(cache)
+	defer func() {
+		plush.ClearTemplateCache()
+		plush.PlushCacheSetup(nil)
+	}()
+
+	fallbackCtx := newVMFallbackContext(map[string]interface{}{
+		vmPartialFeederName:          func(string) (string, error) { return "never", nil },
+		meta.TemplateBaseFileNameKey: "index",
+		meta.TemplateExtensionKey:    "plush",
+		meta.TemplateFileKey:         12,
+	})
+	handled, err := renderFastDataPartialInto(&strings.Builder{}, &compiler.FastPartialPlan{
+		Name: "edge_fallback_meta_error_no_data.plush",
+		Line: 3,
+	}, fallbackCtx, fastRenderBindings{}, nil)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "expected fileKey to be a string")
+
+	partial, dataPlan := vmPartialDataPlan("edge_fallback_meta_error.plush", "name")
+	handled, err = renderFastDataPartialInto(&strings.Builder{}, partial, fallbackCtx, fastRenderBindings{}, dataPlan)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "expected fileKey to be a string")
+
+	badLinkFile := "edge_partial_compile_error.plush"
+	plush.CacheVMBytecodeForCleanFilename(badLinkFile, vmCoverageBadProgram(), "not-bytecode")
+	_, err = partialBytecodeLinkForInput("ignored", badLinkFile, plush.NewContext())
+	require.ErrorContains(t, err, "unknown operator ??")
+
+	_, err = renderLinkedPartial("ignored", partialCompileErrorContext("edge_render_linked_compile_error.plush"))
+	require.ErrorContains(t, err, "unknown operator ??")
+
+	var out strings.Builder
+	handled, err = renderLinkedPartialInline(&out, "ignored", partialCompileErrorContext("edge_render_linked_inline_compile_error.plush"))
+	require.False(t, handled)
+	require.ErrorContains(t, err, "unknown operator ??")
+
+	errorDataPartial := &compiler.FastPartialPlan{
+		Name: "edge_slow_data_error.plush",
+		Data: []compiler.FastPartialDataPair{{
+			Key: "name",
+			Value: compiler.FastValuePlan{
+				Kind: compiler.FastValueCall,
+				Call: &compiler.FastCallPlan{Name: "echo", NameIndex: 0, Line: 44},
+			},
+			Line: 44,
+		}},
+		Line: 44,
+	}
+	errorCtx := plush.NewContextWith(map[string]interface{}{"echo": func() string { return "never" }}).WithBudget(plush.NewBudget(0))
+	errorBindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"echo"}}, errorCtx)
+	overlay := borrowPartialOverlayContext(errorCtx)
+	err = applyFastPartialDataSlow(overlay, errorDataPartial, errorCtx, errorBindings)
+	releasePartialOverlayContext(overlay)
+	require.ErrorContains(t, err, "line 44")
+
+	inlineErrorName := "edge_no_data_inline_compile_error.plush"
+	plush.CacheVMBytecodeForCleanFilename(inlineErrorName, vmCoverageBadProgram(), "not-bytecode")
+	noDataCtx := plush.NewContextWith(map[string]interface{}{
+		vmPartialFeederName: func(string) (string, error) { return "ignored", nil },
+	})
+	handled, err = renderFastNoDataPartialInto(&strings.Builder{}, inlineErrorName, noDataCtx, 55)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 55")
+	require.ErrorContains(t, err, "unknown operator ??")
+
+	parseErrorCtx := plush.NewContextWith(map[string]interface{}{
+		vmPartialFeederName: func(string) (string, error) { return `<%=`, nil },
+	})
+	handled, err = renderFastNoDataPartialInto(&strings.Builder{}, "edge_no_data_inline_parse_error.plush", parseErrorCtx, 56)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 56")
+
+	slowInlineErrorName := "edge_no_data_slow_inline_error.plush"
+	plush.CacheVMBytecodeForCleanFilename(slowInlineErrorName, nil, &compiler.Bytecode{
+		FastRenderPlan: &compiler.FastRenderPlan{
+			Bindings: []string{meta.TemplateFileKey, "missing"},
+			Segments: []compiler.FastRenderSegment{{
+				Kind:      compiler.FastRenderSegmentName,
+				NameIndex: 1,
+				Value:     "missing",
+				Line:      58,
+			}},
+		},
+	})
+	slowInlineCtx := plush.NewContextWith(map[string]interface{}{
+		vmPartialFeederName: func(string) (string, error) { return "ignored", nil },
+	})
+	handled, err = renderFastNoDataPartialInto(&strings.Builder{}, slowInlineErrorName, slowInlineCtx, 58)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 58")
+	require.ErrorContains(t, err, `"missing": unknown identifier`)
+
+	attachErrorPartial := &compiler.FastPartialPlan{
+		Name: "edge_direct_attach_error.plush",
+		Data: []compiler.FastPartialDataPair{{
+			Key: "name",
+			Value: compiler.FastValuePlan{
+				Kind: compiler.FastValueCall,
+				Call: &compiler.FastCallPlan{Name: "echo", NameIndex: 0, Line: 57},
+			},
+			Line: 57,
+		}},
+		Line: 57,
+	}
+	attachDataPlan := buildFastPartialDataBindingPlan(attachErrorPartial)
+	attachBytecode := requireCompiledBytecode(t, `<%= name %>`)
+	plush.CacheVMBytecodeForCleanFilename(attachErrorPartial.Name, nil, attachBytecode)
+	attachCtx := plush.NewContextWith(map[string]interface{}{
+		"echo": func() string { return "never" },
+		vmPartialFeederName: func(string) (string, error) {
+			return `<%= name %>`, nil
+		},
+	}).WithBudget(plush.NewBudget(0))
+	attachBindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"echo"}}, attachCtx)
+	handled, err = renderFastDataPartialDirectInto(&strings.Builder{}, attachErrorPartial, attachCtx, attachBindings, attachDataPlan)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 57")
+}
+
+func partialCompileErrorContext(filename string) hctx.Context {
+	plush.CacheVMBytecodeForCleanFilename(filename, vmCoverageBadProgram(), "not-bytecode")
+	ctx := plush.NewContext()
+	ctx.Set(meta.TemplateFileKey, filename)
+	return ctx
+}
+
+func Test_VM_Native_Call_Remaining_Edge_Branches(t *testing.T) {
+	machine := newRuntimeHelperTestVM(plush.NewContext())
+	require.ErrorContains(t, machine.writeNativeValueCall("bad", 7, 0, nil, false), "invalid function")
+
+	require.NoError(t, machine.push(&object.Native{Value: func() (string, error) {
+		return "", errors.New("boom")
+	}}))
+	require.ErrorContains(t, machine.writeNativeValueCall("boom", machine.stack[0].(*object.Native).Value, 0, nil, true), "boom")
+
+	var frame Frame
+	machine.writeNativeReturnValue(&frame, reflect.ValueOf("raw-object-fallback"), &callPlan{returnKind: callReturnObject})
+	require.Equal(t, "raw-object-fallback", frame.output.String())
+
+	_, ok := fastOptionalArg(optionalArgMap, reflect.TypeOf(namedVMCoverageMap{}), plush.NewContext())
+	require.True(t, ok)
+
+	_, ok = machine.optionalArg(optionalArgMap, reflect.TypeOf(namedVMCoverageMap{}), nil)
+	require.True(t, ok)
+
+	arg, err := fastReflectArgForCall("nilarg", 0, nil, stringType)
+	require.NoError(t, err)
+	require.Equal(t, "", arg.String())
+
+	arg, err = machine.reflectArg("nilnative", 0, &object.Native{Value: nil}, stringType)
+	require.NoError(t, err)
+	require.Equal(t, "", arg.String())
+
+	rawArgs := fastCallArgs{}
+	rawArgs.Append("extra")
+	_, err = fastReflectArgsInto("tooMany", &callPlan{numIn: 0}, &rawArgs, plush.NewContext(), nil)
+	require.ErrorContains(t, err, "too many arguments")
+
+	machine = newRuntimeHelperTestVM(plush.NewContext())
+	require.NoError(t, machine.push(&object.String{Value: "extra"}))
+	_, err = machine.reflectArgs("tooMany", &callPlan{numIn: 0}, 1, nil, nil)
+	require.ErrorContains(t, err, "too many arguments")
+
+	badValue := 7
+	require.ErrorContains(t, machine.writeNativeValueCall("badPointer", &badValue, 0, nil, false), "invalid function")
+
+	machine = newRuntimeHelperTestVM(plush.NewContext())
+	require.NoError(t, machine.push(&object.Native{Value: &badValue}))
+	require.ErrorContains(t, machine.executeWriteCall("badPointer", 0, nil), "invalid function")
+
+	errorFunc := func() (string, error) {
+		return "", errors.New("slow boom")
+	}
+	require.ErrorContains(t, machine.writeNativeValueCall("slowBoom", &errorFunc, 0, nil, false), "slow boom")
+
+	entry := &fastOutputCacheEntry{kind: fastOutputKind(255)}
+	require.False(t, entry.matches("anything"))
+}
+
+type namedVMCoverageMap map[string]interface{}
+
+func Test_VM_Fast_Render_And_Value_Remaining_Edge_Branches(t *testing.T) {
+	handled, err := renderFastSimplePlanInlineSafe(nil, plush.NewContext(), fastRenderBindings{}, nil)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"label": func(value string) string { return value },
+		"user":  struct{}{},
+	})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label", "user"}}, ctx)
+	_, ok, err := evalFastCallValuePlan(&compiler.FastCallPlan{
+		Name:      "label",
+		NameIndex: 0,
+		Args: []compiler.FastValuePlan{{
+			Kind:      compiler.FastValuePath,
+			NameIndex: 1,
+			Value:     "user",
+			Path: []compiler.FastPathStep{{
+				Kind:     compiler.FastPathStepProperty,
+				Value:    "Missing",
+				Receiver: "user",
+				Full:     "user.Missing",
+				Line:     66,
+			}},
+			Line: 66,
+		}},
+		Line: 66,
+	}, nil, ctx, bindings, nil, nil, nil)
+	require.True(t, ok)
+	require.ErrorContains(t, err, "line 66")
+
+	var nilProduct *vmStructLoopProduct
+	value, ok, err := evalFastFieldChainValue(&compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: -1,
+		Path: []compiler.FastPathStep{{
+			Kind:  compiler.FastPathStepProperty,
+			Value: "Name",
+			Line:  67,
+		}},
+	}, nilProduct, plush.NewContext())
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Nil(t, value)
+
+	emptyChainPlan := &compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: -1,
+		Path: []compiler.FastPathStep{{
+			Kind:  compiler.FastPathStepProperty,
+			Value: "Name",
+			Line:  69,
+		}},
+	}
+	emptyChainKey := fastFieldChainPlanKey{plan: emptyChainPlan, typ: reflect.TypeOf(vmStructLoopProduct{})}
+	fastFieldChainPlanCache.Store(emptyChainKey, &fastFieldChainPlan{})
+	defer fastFieldChainPlanCache.Delete(emptyChainKey)
+	rawProduct := vmStructLoopProduct{Name: "cached"}
+	value, ok, err = evalFastFieldChainValue(emptyChainPlan, rawProduct, plush.NewContext())
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, rawProduct, value)
+
+	indexed, found, handled := fastAccessDirectMapIndex(reflect.ValueOf(map[string]int{"name": 1}), &fastAccessChainStep{
+		mapDirect: fastMapDirectStringString,
+		mapString: "name",
+	})
+	require.False(t, indexed.IsValid())
+	require.False(t, found)
+	require.False(t, handled)
+
+	var nilPointer *int
+	var iface interface{} = nilPointer
+	_, numericOK := numericValueFromReflectValue(reflect.ValueOf(&iface).Elem())
+	require.False(t, numericOK)
+
+	boolValue, boolOK := fastConditionOperandValue{hasReflect: true, reflect: reflect.ValueOf(&iface).Elem()}.boolValue()
+	require.False(t, boolValue)
+	require.False(t, boolOK)
+	_, stringOK := fastConditionOperandValue{hasReflect: true, reflect: reflect.ValueOf(&iface).Elem()}.stringValue()
+	require.False(t, stringOK)
+}
+
+func Test_VM_Fast_Call_Segment_General_Argument_Error_Branch(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"format": func() string { return "never" },
+	})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"format"}}, ctx)
+	err := writeFastCallSegment(&strings.Builder{}, ctx, bindings, &compiler.FastCallPlan{
+		Name:      "format",
+		NameIndex: 0,
+		Args: []compiler.FastValuePlan{
+			{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing", Line: 68},
+			{Kind: compiler.FastValueString, Value: "suffix", Line: 68},
+		},
+		Line: 68,
+	})
+	require.ErrorContains(t, err, `line 68`)
+	require.ErrorContains(t, err, `"missing": unknown identifier`)
+}
+
+func Test_VM_Fast_Mixed_Render_Remaining_Error_Branches(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"user": vmFastValueHiddenChild{child: vmFastPropertyChild{Name: "hidden"}},
+	})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"user"}}, ctx)
+
+	handled, err := renderFastMixedPlan(&strings.Builder{}, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{{
+		kind:      fastMixedOpAccessChain,
+		nameIndex: 0,
+		line:      81,
+		valuePlan: compiler.FastValuePlan{
+			Kind:      compiler.FastValuePath,
+			NameIndex: 0,
+			Value:     "user",
+			Path: []compiler.FastPathStep{{
+				Kind:     compiler.FastPathStepProperty,
+				Value:    "child",
+				Receiver: "user",
+				Full:     "user.child",
+				Line:     81,
+			}},
+			Line: 81,
+		},
+	}}})
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 81")
+
+	handled, err = renderFastMixedPlan(&strings.Builder{}, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{{
+		kind: fastMixedOpAccessChain,
+		line: 82,
+		valuePlan: compiler.FastValuePlan{
+			Kind:     compiler.FastValueInfix,
+			Operator: "??",
+			Left:     &compiler.FastValuePlan{Kind: compiler.FastValueInteger, IntValue: 1},
+			Right:    &compiler.FastValuePlan{Kind: compiler.FastValueInteger, IntValue: 2},
+			Line:     82,
+		},
+	}}})
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 82")
+
+	handled, err = renderFastMixedPlan(&strings.Builder{}, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, &fastMixedPlan{ops: []fastMixedOp{{
+		kind: fastMixedOpConditional,
+		conditional: &compiler.FastConditionalPlan{Branches: []compiler.FastConditionalBranch{{
+			Condition: compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true, Line: 83},
+			Segments:  []compiler.FastRenderSegment{{Kind: compiler.FastRenderSegmentStatic, Value: "never"}},
+			Line:      83,
+		}}},
+	}}})
+	require.True(t, handled)
+	require.ErrorContains(t, err, "line 83")
+}
+
+func Test_VM_Fast_Call_And_Loop_Call_Remaining_Error_Branches(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"label": func(int) string { return "never" },
+		"user":  struct{}{},
+	})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label", "user"}}, ctx)
+	call := &compiler.FastCallPlan{
+		Name:      "label",
+		NameIndex: 0,
+		Args: []compiler.FastValuePlan{{
+			Kind:      compiler.FastValuePath,
+			NameIndex: 1,
+			Value:     "user",
+			Path: []compiler.FastPathStep{{
+				Kind:     compiler.FastPathStepProperty,
+				Value:    "Missing",
+				Receiver: "user",
+				Full:     "user.Missing",
+				Line:     84,
+			}},
+			Line: 84,
+		}},
+		Line: 84,
+	}
+	err := writeFastCallSegment(&strings.Builder{}, ctx, bindings, call)
+	require.ErrorContains(t, err, `line 84`)
+
+	badCtx := plush.NewContextWith(map[string]interface{}{"label": 12})
+	badBindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label"}}, badCtx)
+	err = writeFastLoopCallPart(&strings.Builder{}, badCtx, badBindings, &compiler.FastCallPlan{
+		Name:      "label",
+		NameIndex: 0,
+		Line:      85,
+	}, 0, "value")
+	require.ErrorContains(t, err, "line 85")
+	require.ErrorContains(t, err, "invalid function")
+}
+
+func Test_VM_Fast_Struct_Loop_Call_Remaining_State_Branches(t *testing.T) {
+	item := reflect.ValueOf(vmStructLoopProduct{Name: "bot"})
+
+	floatArg := buildFastStructLoopCallArgPlan(&compiler.FastValuePlan{Kind: compiler.FastValueFloat, FloatValue: 1.25, Line: 70}, reflect.TypeOf(vmStructLoopProduct{}))
+	require.Equal(t, fastStructLoopCallArgFloat, floatArg.kind)
+	require.Equal(t, 1.25, floatArg.floatVal)
+
+	helperCtx := plush.NewContextWith(map[string]interface{}{
+		"label": func(string) string { return "slow" },
+		vmFastHelpersKey: &fastHelperRegistry{helpers: map[string]FastHelperFunc{
+			"label": func(FastWriter, FastArgs) error {
+				return nil
+			},
+		}},
+	})
+	_, helperOK := fastHelperForContext(helperCtx, "label")
+	require.True(t, helperOK)
+	helperBindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label"}}, helperCtx)
+	_, helperBindingOK := helperBindings.value(0)
+	require.True(t, helperBindingOK)
+	helperPlan := structLoopCallPlan(t, compiler.FastValuePlan{
+		Kind:      compiler.FastValueName,
+		NameIndex: 99,
+		Value:     "missing",
+		Line:      71,
+	})
+	require.Equal(t, "label", helperPlan.call.Name)
+	require.Len(t, helperPlan.args, 1)
+	err := writeFastStructLoopCallPart(&strings.Builder{}, helperCtx, helperBindings, &fastStructLoopRenderState{}, helperPlan, 0, item)
+	require.ErrorContains(t, err, `line 71`)
+
+	validHelperPlan := structLoopCallPlan(t, structLoopNameArg())
+	var helperOut strings.Builder
+	require.NoError(t, writeFastStructLoopCallPart(&helperOut, helperCtx, helperBindings, &fastStructLoopRenderState{}, validHelperPlan, 0, item))
+
+	entryArgPlan := structLoopCallPlan(t, compiler.FastValuePlan{
+		Kind:      compiler.FastValueName,
+		NameIndex: 99,
+		Value:     "missing",
+		Line:      75,
+	})
+	entryArgState := &fastStructLoopRenderState{
+		singleCall: entryArgPlan,
+		singleResolvedCall: &fastStructLoopResolvedCall{
+			raw: func(int) string { return "never" },
+			entry: &fastBuilderCallCacheEntry{
+				invoker: func(*strings.Builder, hctx.Context, string, interface{}, *fastCallArgs) error {
+					return nil
+				},
+			},
+		},
+	}
+	err = writeFastStructLoopCallPart(&strings.Builder{}, plush.NewContext(), fastRenderBindings{}, entryArgState, entryArgPlan, 0, item)
+	require.ErrorContains(t, err, `line 75`)
+
+	entryErrorPlan := &fastStructLoopCallPlan{
+		call: &compiler.FastCallPlan{Name: "label", NameIndex: 0, Line: 76},
+	}
+	entryErrorState := &fastStructLoopRenderState{
+		singleCall: entryErrorPlan,
+		singleResolvedCall: &fastStructLoopResolvedCall{
+			raw: func() string { return "never" },
+			entry: &fastBuilderCallCacheEntry{
+				invoker: func(*strings.Builder, hctx.Context, string, interface{}, *fastCallArgs) error {
+					return errors.New("entry direct boom")
+				},
+			},
+		},
+	}
+	err = writeFastStructLoopCallPart(&strings.Builder{}, plush.NewContext(), fastRenderBindings{}, entryErrorState, entryErrorPlan, 0, item)
+	require.ErrorContains(t, err, `line 76`)
+	require.ErrorContains(t, err, "entry direct boom")
+
+	finalErrorPlan := &fastStructLoopCallPlan{
+		call: &compiler.FastCallPlan{Name: "label", NameIndex: 0, Line: 77},
+	}
+	finalErrorState := &fastStructLoopRenderState{
+		singleCall: finalErrorPlan,
+		singleResolvedCall: &fastStructLoopResolvedCall{
+			raw: func() string { return "never" },
+		},
+	}
+	err = writeFastStructLoopCallPart(&strings.Builder{}, plush.NewContext(), fastRenderBindings{}, finalErrorState, finalErrorPlan, 0, item)
+	require.ErrorContains(t, err, `line 77`)
+	require.ErrorContains(t, err, "invalid function")
+
+	hiddenPlan, ok := fastAccessChainPlanFor(&compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: -1,
+		Path: []compiler.FastPathStep{{
+			Kind:     compiler.FastPathStepProperty,
+			Value:    "child",
+			Receiver: "user",
+			Full:     "user.child",
+			Line:     78,
+		}},
+	}, reflect.TypeOf(vmFastValueHiddenChild{}))
+	require.True(t, ok)
+	err = evalFastStructLoopCallPlanArgs(&fastStructLoopCallPlan{
+		args: []fastStructLoopCallArgPlan{{
+			kind:       fastStructLoopCallArgAccessChain,
+			accessPlan: hiddenPlan,
+			line:       78,
+		}},
+	}, plush.NewContext(), fastRenderBindings{}, 0, reflect.ValueOf(vmFastValueHiddenChild{child: vmFastPropertyChild{Name: "hidden"}}), &fastCallArgs{})
+	require.ErrorContains(t, err, `line 78`)
+
+	hiddenHelperCtx := plush.NewContextWith(map[string]interface{}{
+		"label": func(interface{}) string { return "never" },
+		vmFastHelpersKey: &fastHelperRegistry{helpers: map[string]FastHelperFunc{
+			"label": func(FastWriter, FastArgs) error {
+				return nil
+			},
+		}},
+	})
+	hiddenHelperBindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label"}}, hiddenHelperCtx)
+	hiddenHelperPlan := &fastStructLoopCallPlan{
+		call: &compiler.FastCallPlan{Name: "label", NameIndex: 0, Line: 79},
+		args: []fastStructLoopCallArgPlan{{
+			kind:       fastStructLoopCallArgAccessChain,
+			accessPlan: hiddenPlan,
+			line:       79,
+		}},
+	}
+	err = writeFastStructLoopCallPart(&strings.Builder{}, hiddenHelperCtx, hiddenHelperBindings, &fastStructLoopRenderState{}, hiddenHelperPlan, 0, reflect.ValueOf(vmFastValueHiddenChild{child: vmFastPropertyChild{Name: "hidden"}}))
+	require.ErrorContains(t, err, `line 78`)
+
+	unsupportedPlan := &fastStructLoopCallPlan{
+		call: &compiler.FastCallPlan{Name: "label", NameIndex: 0, Line: 72},
+	}
+	unsupportedState := &fastStructLoopRenderState{
+		singleCall: unsupportedPlan,
+		singleResolvedCall: &fastStructLoopResolvedCall{
+			raw: func() string { return "fallback" },
+			entry: &fastBuilderCallCacheEntry{
+				rt:   reflect.TypeOf(func() string { return "" }),
+				plan: cachedCallPlan(reflect.TypeOf(func() string { return "" })),
+				invoker: func(*strings.Builder, hctx.Context, string, interface{}, *fastCallArgs) error {
+					return errFastWriteUnsupported
+				},
+			},
+		},
+	}
+	var out strings.Builder
+	err = writeFastStructLoopCallPart(&out, plush.NewContext(), fastRenderBindings{}, unsupportedState, unsupportedPlan, 0, item)
+	require.NoError(t, err)
+	require.Equal(t, "fallback", out.String())
+
+	finalArgPlan := structLoopCallPlan(t, compiler.FastValuePlan{
+		Kind:      compiler.FastValueName,
+		NameIndex: 99,
+		Value:     "missing",
+		Line:      73,
+	})
+	finalArgState := &fastStructLoopRenderState{
+		singleCall: finalArgPlan,
+		singleResolvedCall: &fastStructLoopResolvedCall{
+			raw: func(string) string { return "never" },
+		},
+	}
+	err = writeFastStructLoopCallPart(&strings.Builder{}, plush.NewContext(), fastRenderBindings{}, finalArgState, finalArgPlan, 0, item)
+	require.ErrorContains(t, err, `line 73`)
+
+	require.ErrorIs(t, writeFastStructLoopReflectCall(&strings.Builder{}, plush.NewContext(), fastRenderBindings{}, nil, nil, 0, item), errFastWriteUnsupported)
+
+	reflectPlan := structLoopCallPlan(t, structLoopNameArg())
+	reflectResolved := &fastStructLoopResolvedCall{
+		fn: reflect.ValueOf(func(string) string { return "never" }),
+		entry: &fastBuilderCallCacheEntry{plan: &callPlan{
+			numIn:    1,
+			argTypes: []reflect.Type{stringType},
+		}},
+	}
+	err = writeFastStructLoopReflectCall(&strings.Builder{}, plush.NewContext().WithBudget(plush.NewBudget(0)), fastRenderBindings{}, reflectPlan, reflectResolved, 0, item)
+	require.ErrorContains(t, err, "line 1")
+
+	staticResolved := &fastStructLoopResolvedCall{
+		entry: &fastBuilderCallCacheEntry{plan: &callPlan{
+			numIn:    1,
+			argTypes: []reflect.Type{stringType},
+		}},
+	}
+	err = staticResolved.prepareStaticReflectArgs(&fastStructLoopCallPlan{
+		call: &compiler.FastCallPlan{Name: "label"},
+		args: []fastStructLoopCallArgPlan{{
+			kind:      fastStructLoopCallArgBinding,
+			nameIndex: 99,
+			line:      74,
+			value:     compiler.FastValuePlan{Value: "missing"},
+		}},
+	}, fastRenderBindings{})
+	require.ErrorContains(t, err, `line 74`)
+}
+
+func Test_VM_Fast_Struct_Loop_Direct_Writer_And_String_Arg_Remaining_Branches(t *testing.T) {
+	ctx := plush.NewContext()
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{}, ctx)
+	item := reflect.ValueOf(vmStructLoopProduct{Name: "bot"})
+	firstMissingPlan := structLoopCallPlan(t,
+		compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing", Line: 86},
+		structLoopNameArg(),
+	)
+
+	for _, tt := range []struct {
+		name string
+		raw  interface{}
+	}{
+		{"string_string", func(value, prefix string) string { return prefix + value }},
+		{"string_string_error", func(value, prefix string) (string, error) { return prefix + value, nil }},
+		{"html_string", func(value, prefix string) template.HTML { return template.HTML(prefix + value) }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			writer := fastStructLoopDirectCallWriterForRaw(tt.raw, firstMissingPlan)
+			require.NotNil(t, writer)
+			handled, err := writer(&strings.Builder{}, ctx, bindings, firstMissingPlan, 0, item)
+			require.NoError(t, err)
+			require.False(t, handled)
+		})
+	}
+
+	errorPlan := structLoopCallPlan(t, structLoopNameArg(), compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "suffix"})
+	writer := fastStructLoopDirectCallWriterForRaw(func(string, string) (string, error) {
+		return "", errors.New("two arg boom")
+	}, errorPlan)
+	require.NotNil(t, writer)
+	handled, err := writer(&strings.Builder{}, ctx, bindings, errorPlan, 0, item)
+	require.True(t, handled)
+	require.ErrorContains(t, err, "two arg boom")
+
+	childOnlyPlan, ok := fastAccessChainPlanFor(&compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: -1,
+		Path: []compiler.FastPathStep{{
+			Kind:     compiler.FastPathStepProperty,
+			Value:    "Child",
+			Receiver: "user",
+			Full:     "user.Child",
+			Line:     87,
+		}},
+	}, reflect.TypeOf(vmFastPropertyUser{}))
+	require.True(t, ok)
+
+	arg, ok, err := evalFastStructLoopCallArgString(
+		&fastStructLoopCallArgPlan{kind: fastStructLoopCallArgAccessChain, accessPlan: childOnlyPlan},
+		ctx,
+		bindings,
+		0,
+		reflect.ValueOf(vmFastPropertyUser{}),
+	)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Empty(t, arg)
+
+	nameOnlyPlan, ok := fastAccessChainPlanFor(&compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: -1,
+		Path: []compiler.FastPathStep{{
+			Kind:     compiler.FastPathStepProperty,
+			Value:    "Name",
+			Receiver: "user",
+			Full:     "user.Name",
+			Line:     88,
+		}},
+	}, reflect.TypeOf(vmFastPropertyChild{}))
+	require.True(t, ok)
+	arg, ok, err = evalFastStructLoopCallArgString(
+		&fastStructLoopCallArgPlan{kind: fastStructLoopCallArgAccessChain, accessPlan: nameOnlyPlan},
+		ctx,
+		bindings,
+		0,
+		reflect.ValueOf(vmFastPropertyChild{Name: "kid"}),
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "kid", arg)
+
+	hiddenPlan, ok := fastAccessChainPlanFor(&compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: -1,
+		Path: []compiler.FastPathStep{{
+			Kind:     compiler.FastPathStepProperty,
+			Value:    "child",
+			Receiver: "user",
+			Full:     "user.child",
+			Line:     89,
+		}},
+	}, reflect.TypeOf(vmFastValueHiddenChild{}))
+	require.True(t, ok)
+	arg, ok, err = evalFastStructLoopCallArgString(
+		&fastStructLoopCallArgPlan{kind: fastStructLoopCallArgAccessChain, accessPlan: hiddenPlan},
+		ctx,
+		bindings,
+		0,
+		reflect.ValueOf(vmFastValueHiddenChild{child: vmFastPropertyChild{Name: "hidden"}}),
+	)
+	require.ErrorContains(t, err, "line 89")
+	require.Empty(t, arg)
+
+	arg, ok, err = evalFastStructLoopCallArgString(
+		&fastStructLoopCallArgPlan{kind: fastStructLoopCallArgAccessChain, accessPlan: &fastAccessChainPlan{}},
+		ctx,
+		bindings,
+		0,
+		reflect.ValueOf([]string(nil)),
+	)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Empty(t, arg)
+
+	hiddenField := reflect.ValueOf(vmFastValueHiddenChild{child: vmFastPropertyChild{Name: "hidden"}}).FieldByName("child")
+	arg, ok, err = evalFastStructLoopCallArgString(
+		&fastStructLoopCallArgPlan{kind: fastStructLoopCallArgAccessChain, accessPlan: &fastAccessChainPlan{}},
+		ctx,
+		bindings,
+		0,
+		hiddenField,
+	)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Empty(t, arg)
+}
+
+func Test_VM_Fast_Struct_Loop_Value_Remaining_Branches(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{"fail": func() string { return "never" }})
+	bindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"fail"}}, ctx)
+	item := reflect.ValueOf(vmStructLoopProduct{Name: "bot"})
+
+	truthy, ok, err := isTruthyFastStructLoopValue(&compiler.FastValuePlan{
+		Kind:      compiler.FastValueName,
+		NameIndex: 99,
+		Value:     "missing",
+	}, ctx, bindings, 0, item)
+	require.NoError(t, err)
+	require.False(t, truthy)
+	require.False(t, ok)
+
+	var objectIface interface{} = object.TrueObject
+	require.True(t, isTruthyFastReflectValue(reflect.ValueOf(&objectIface).Elem()))
+	var stringIface interface{} = "hello"
+	require.True(t, isTruthyFastReflectValue(reflect.ValueOf(&stringIface).Elem()))
+
+	value, ok, err := evalFastStructLoopPathValue(&compiler.FastValuePlan{
+		Kind:      compiler.FastValuePath,
+		NameIndex: -1,
+		Path: []compiler.FastPathStep{{
+			Kind:   compiler.FastPathStepProperty,
+			Value:  "Echo",
+			Method: true,
+			Line:   90,
+		}},
+	}, ctx, bindings, item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NotNil(t, value)
+
+	_, ok, err = evalFastStructLoopLogicalInfixValue(&compiler.FastValuePlan{
+		Operator: "&&",
+		Left: &compiler.FastValuePlan{
+			Kind: compiler.FastValueCall,
+			Call: &compiler.FastCallPlan{Name: "fail", NameIndex: 0, Line: 91},
+		},
+		Right: &compiler.FastValuePlan{Kind: compiler.FastValueBool, BoolValue: true},
+	}, plush.NewContextWith(map[string]interface{}{"fail": func() string { return "never" }}).WithBudget(plush.NewBudget(0)), bindings, 0, item)
+	require.ErrorContains(t, err, "line 91")
+	require.True(t, ok)
+
+	var nilIface interface{}
+	conditionValue := reflect.ValueOf(&nilIface).Elem()
+	boolValue, boolOK := fastConditionOperandValue{hasReflect: true, reflect: conditionValue}.boolValue()
+	require.False(t, boolValue)
+	require.False(t, boolOK)
+	stringValue, stringOK := fastConditionOperandValue{hasReflect: true, reflect: conditionValue}.stringValue()
+	require.Empty(t, stringValue)
+	require.False(t, stringOK)
+}
+
+func Test_VM_Fast_Access_Chain_Nil_Intermediate_Remaining_Branches(t *testing.T) {
+	ctx := plush.NewContext()
+	chain := &fastAccessChainPlan{steps: []fastAccessChainStep{
+		{kind: fastAccessStepIndex, index: 0, line: 92},
+		{kind: fastAccessStepField, line: 92},
+	}}
+
+	value, ok, err := evalFastAccessChainPlanValue(chain, reflect.ValueOf([]*vmFastPropertyChild{nil}), ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Nil(t, value)
+
+	var out strings.Builder
+	handled, err := writeFastAccessChainPlanOutput(&out, ctx, chain, reflect.ValueOf([]*vmFastPropertyChild{nil}))
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Empty(t, out.String())
+}

--- a/VM/vm/vm_test.go
+++ b/VM/vm/vm_test.go
@@ -1,0 +1,4290 @@
+package vm
+
+import (
+	"context"
+	"fmt"
+	"html/template"
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/code"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/gobuffalo/plush/v5/ast"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+	"github.com/gobuffalo/plush/v5/helpers/meta"
+	"github.com/gobuffalo/plush/v5/parser"
+	"github.com/gobuffalo/plush/v5/templatecache/inmemory"
+	"github.com/stretchr/testify/require"
+)
+
+type vmTestCase struct {
+	input    string
+	expected interface{}
+}
+
+type vmInlineCacheUser struct {
+	Name string
+}
+
+type vmInlineCacheOtherUser struct {
+	Name string
+}
+
+type lookupTestContext struct {
+	context.Context
+	values map[string]interface{}
+	lookup int
+	has    int
+	value  int
+}
+
+func newFastRenderBindings(plan *compiler.FastRenderPlan, ctx hctx.Context) fastRenderBindings {
+	return newFastRenderBindingsWithPlan(plan, ctx, nil)
+}
+
+func fastStructFieldLoopParts(loop *compiler.FastLoopPlan, elemType reflect.Type) bool {
+	_, ok := fastStructLoopWriterPlanFor(loop, elemType)
+	return ok
+}
+
+func newLookupTestContext(values map[string]interface{}) *lookupTestContext {
+	return &lookupTestContext{Context: context.Background(), values: values}
+}
+
+func (c *lookupTestContext) New() hctx.Context {
+	return newLookupTestContext(c.values)
+}
+
+func (c *lookupTestContext) Lookup(key string) (interface{}, bool) {
+	c.lookup++
+	value, ok := c.values[key]
+	return value, ok
+}
+
+func (c *lookupTestContext) Has(key string) bool {
+	c.has++
+	_, ok := c.values[key]
+	return ok
+}
+
+func (c *lookupTestContext) Value(key interface{}) interface{} {
+	c.value++
+	if key, ok := key.(string); ok {
+		return c.values[key]
+	}
+	return nil
+}
+
+func (c *lookupTestContext) Set(key string, value interface{}) {
+	c.values[key] = value
+}
+
+func (c *lookupTestContext) Update(key string, value interface{}) bool {
+	if _, ok := c.values[key]; !ok {
+		return false
+	}
+	c.values[key] = value
+	return true
+}
+
+type idLookupTestContext struct {
+	context.Context
+	values     map[string]interface{}
+	stringToID map[string]int
+	idToString []string
+	internID   int
+	lookupID   int
+	setID      int
+	updateID   int
+	lookup     int
+	has        int
+	value      int
+}
+
+func newIDLookupTestContext(values map[string]interface{}) *idLookupTestContext {
+	ctx := &idLookupTestContext{
+		Context:    context.Background(),
+		values:     values,
+		stringToID: map[string]int{},
+	}
+	for key := range values {
+		ctx.InternID(key)
+	}
+	ctx.internID = 0
+	return ctx
+}
+
+func (c *idLookupTestContext) New() hctx.Context {
+	return c
+}
+
+func (c *idLookupTestContext) InternID(key string) int {
+	c.internID++
+	if id, ok := c.stringToID[key]; ok {
+		return id
+	}
+	id := len(c.idToString)
+	c.stringToID[key] = id
+	c.idToString = append(c.idToString, key)
+	return id
+}
+
+func (c *idLookupTestContext) LookupID(id int) (interface{}, bool) {
+	c.lookupID++
+	if id < 0 || id >= len(c.idToString) {
+		return nil, false
+	}
+	value, ok := c.values[c.idToString[id]]
+	return value, ok
+}
+
+func (c *idLookupTestContext) SetID(id int, value interface{}) {
+	c.setID++
+	if id >= 0 && id < len(c.idToString) {
+		c.values[c.idToString[id]] = value
+	}
+}
+
+func (c *idLookupTestContext) UpdateID(id int, value interface{}) bool {
+	c.updateID++
+	if id < 0 || id >= len(c.idToString) {
+		return false
+	}
+	key := c.idToString[id]
+	if _, ok := c.values[key]; !ok {
+		return false
+	}
+	c.values[key] = value
+	return true
+}
+
+func (c *idLookupTestContext) Lookup(key string) (interface{}, bool) {
+	c.lookup++
+	value, ok := c.values[key]
+	return value, ok
+}
+
+func (c *idLookupTestContext) Has(key string) bool {
+	c.has++
+	_, ok := c.values[key]
+	return ok
+}
+
+func (c *idLookupTestContext) Value(key interface{}) interface{} {
+	c.value++
+	if key, ok := key.(string); ok {
+		return c.values[key]
+	}
+	return nil
+}
+
+func (c *idLookupTestContext) Set(key string, value interface{}) {
+	c.values[key] = value
+}
+
+func (c *idLookupTestContext) Update(key string, value interface{}) bool {
+	if _, ok := c.values[key]; !ok {
+		return false
+	}
+	c.values[key] = value
+	return true
+}
+
+func Test_Integer_Arithmetic(t *testing.T) {
+	tests := []vmTestCase{
+		{"1", 1},
+		{"1 + 2", 3},
+		{"5 * (2 + 10)", 60},
+		{"-50 + 100 + -50", 0},
+	}
+
+	runVMTests(t, tests)
+}
+
+func Test_Booleans_And_Conditionals(t *testing.T) {
+	tests := []vmTestCase{
+		{"true", true},
+		{"false", false},
+		{"1 < 2", true},
+		{"1 > 2", false},
+		{"!true", false},
+		{"if (true) { 10 } else { 20 }", 10},
+		{"if (false) { 10 }", Null},
+	}
+
+	runVMTests(t, tests)
+}
+
+func Test_Functions_And_Closures(t *testing.T) {
+	tests := []vmTestCase{
+		{`let identity = fn(a) { a; }; identity(4);`, 4},
+		{`let sum = fn(a, b) { a + b; }; sum(1, 2);`, 3},
+		{`let newAdder = fn(a, b) { fn(c) { a + b + c }; }; let add = newAdder(1, 2); add(8);`, 11},
+	}
+
+	runVMTests(t, tests)
+}
+
+func Test_VM_Runtime_Coverage(t *testing.T) {
+	tests := []vmTestCase{
+		{`"plu" + "sh"`, "plush"},
+		{`[1, 2, 3]`, []int{1, 2, 3}},
+		{`[1 + 2, 3 * 4, 5 + 6]`, []int{3, 12, 11}},
+		{`[1, 2, 3][1]`, 2},
+		{
+			`{1: 2, 2: 3}`,
+			map[object.HashKey]int{
+				(&object.Integer{Value: 1}).HashKey(): 2,
+				(&object.Integer{Value: 2}).HashKey(): 3,
+			},
+		},
+		{
+			`{true: 1, false: 2, "three": 3}`,
+			map[object.HashKey]int{
+				(&object.Boolean{Value: true}).HashKey():   1,
+				(&object.Boolean{Value: false}).HashKey():  2,
+				(&object.String{Value: "three"}).HashKey(): 3,
+			},
+		},
+		{`{1: 1, 2: 2}[2]`, 2},
+		{`{"foo": 5}["foo"]`, 5},
+		{`{"foo": 5}["bar"]`, Null},
+		{`let globalSeed = 50; let minusOne = fn(num) { globalSeed - num; }; minusOne(1);`, 49},
+		{`let returnsOneReturner = fn() { fn() { 1; }; }; returnsOneReturner()();`, 1},
+		{`let newAdder = fn(a, b) { fn(c) { a + b + c }; }; let add = newAdder(1, 2); add(8);`, 11},
+		{`let countDown = fn(x) { if (x == 0) { 0 } else { countDown(x - 1) } }; countDown(3);`, 0},
+		{`len("")`, 0},
+		{`len("hello world")`, 11},
+		{`len([1, 2, 3])`, 3},
+		{`first([1, 2, 3])`, 1},
+		{`last([1, 2, 3])`, 3},
+		{`rest([1, 2, 3])`, []int{2, 3}},
+		{`push([], 1)`, []int{1}},
+	}
+
+	runVMTests(t, tests)
+
+	program, err := compiler.ParseScript(`[][0]`)
+	require.NoError(t, err)
+	comp := compiler.New()
+	require.NoError(t, comp.Compile(program))
+	machine := New(comp.Bytecode())
+	require.ErrorContains(t, machine.Run(), "array index out of bounds")
+}
+
+func Test_Phase_14_Wrong_Function_Argument_Counts(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{`fn() { 1; }(1);`, `wrong number of arguments: want=0, got=1`},
+		{`fn(a) { a; }();`, `wrong number of arguments: want=1, got=0`},
+		{`fn(a, b) { a + b; }(1);`, `wrong number of arguments: want=2, got=1`},
+	}
+
+	for _, tt := range tests {
+		program, err := compiler.ParseScript(tt.input)
+		require.NoError(t, err)
+
+		comp := compiler.New()
+		require.NoError(t, comp.Compile(program))
+
+		machine := New(comp.Bytecode())
+		err = machine.Run()
+		require.Error(t, err)
+		require.EqualError(t, err, tt.expected)
+	}
+}
+
+func Test_Render_Plush_Features(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name": "mark",
+		"hi": func(name string) string {
+			return "hi " + name
+		},
+	})
+
+	out, err := Render(`<p><%= hi(name) %></p>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "<p>hi mark</p>", out)
+
+	out, err = Render(`<% let total = "" %><%= for (i,v) in ["a", "b", "c"] { return v } %>`, plush.NewContext())
+	require.NoError(t, err)
+	require.Equal(t, "abc", out)
+
+	out, err = Render(`<% if (true) { %>hidden<% } %>`, plush.NewContext())
+	require.NoError(t, err)
+	require.Empty(t, out)
+
+	out, err = Render(`<% if (true) { %><%= "hidden" %><% } %>`, plush.NewContext())
+	require.NoError(t, err)
+	require.Empty(t, out)
+
+	out, err = Render(`<%= if (true) { %>shown<% } %>`, plush.NewContext())
+	require.NoError(t, err)
+	require.Equal(t, "shown", out)
+
+	_, err = Render(`<% let a = [] %><%= a[0] %>`, plush.NewContext())
+	require.ErrorContains(t, err, "array index out of bounds")
+}
+
+func Test_VM_Allocates_Globals_From_Bytecode(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expectedCount int
+	}{
+		{
+			name:          "no globals",
+			input:         `1 + 2;`,
+			expectedCount: 0,
+		},
+		{
+			name:          "two globals",
+			input:         `let one = 1; let two = 2; one + two;`,
+			expectedCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			program, err := compiler.ParseScript(tt.input)
+			require.NoError(t, err)
+
+			comp := compiler.New()
+			require.NoError(t, comp.Compile(program))
+
+			machine := New(comp.Bytecode())
+			require.Len(t, machine.globals, tt.expectedCount)
+		})
+	}
+}
+
+func Test_VM_Grows_Undersized_Globals_Store(t *testing.T) {
+	instructions := append(code.Make(code.OpConstant, 0), code.Make(code.OpSetGlobal, 3)...)
+	bytecode := &compiler.Bytecode{
+		Instructions: instructions,
+		Constants:    []object.Object{&object.Integer{Value: 7}},
+	}
+
+	machine := NewWithContext(bytecode, plush.NewContext())
+	require.Empty(t, machine.globals)
+
+	require.NoError(t, machine.Run())
+	require.Len(t, machine.globals, 4)
+	testIntegerObject(t, 7, machine.globals[3])
+}
+
+func Test_VM_Get_Global_Outside_Store_Falls_Back_To_Null(t *testing.T) {
+	instructions := append(code.Make(code.OpGetGlobal, 7), code.Make(code.OpPop)...)
+	bytecode := &compiler.Bytecode{Instructions: instructions}
+
+	machine := NewWithContext(bytecode, plush.NewContext())
+	require.Empty(t, machine.globals)
+
+	require.NoError(t, machine.Run())
+	require.Same(t, Null, machine.LastPoppedStackElem())
+}
+
+func Test_VM_Name_Lookup_Uses_Context_Lookup_Fast_Path(t *testing.T) {
+	program, err := compiler.ParseScript(`name`)
+	require.NoError(t, err)
+
+	comp := compiler.New()
+	require.NoError(t, comp.Compile(program))
+
+	ctx := newLookupTestContext(map[string]interface{}{"name": "mido"})
+	machine := NewWithContext(comp.Bytecode(), ctx)
+	require.NoError(t, machine.Run())
+
+	require.Equal(t, 1, ctx.lookup)
+	require.Zero(t, ctx.has)
+	require.Zero(t, ctx.value)
+}
+
+func Test_VM_Write_Name_Uses_Context_ID_Lookup_Fast_Path(t *testing.T) {
+	program, err := parser.Parse(`<%= name %><%= name %>`)
+	require.NoError(t, err)
+
+	comp := compiler.New()
+	require.NoError(t, comp.Compile(program))
+	require.Contains(t, comp.Bytecode().Instructions.String(), "OpWriteName")
+
+	ctx := newIDLookupTestContext(map[string]interface{}{"name": "mido"})
+	machine := NewWithContext(comp.Bytecode(), ctx)
+	require.NoError(t, machine.Run())
+
+	require.Equal(t, "midomido", machine.Rendered())
+	require.Equal(t, 2, ctx.lookupID)
+	require.Equal(t, 1, ctx.internID)
+	require.Zero(t, ctx.lookup)
+	require.Zero(t, ctx.has)
+	require.Zero(t, ctx.value)
+}
+
+func Test_VM_Property_Inline_Cache_Reuses_Instruction_Slot(t *testing.T) {
+	program, err := parser.Parse(`<%= user.Name %><%= user.Name %>`)
+	require.NoError(t, err)
+
+	comp := compiler.New()
+	require.NoError(t, comp.Compile(program))
+	bytecode := comp.Bytecode()
+	positions := opcodePositions(bytecode.Instructions, code.OpWriteNameProperty)
+	require.Len(t, positions, 2)
+	for _, pos := range positions {
+		require.Nil(t, bytecode.PropertyCaches[pos].Load())
+	}
+
+	machine := NewWithContext(bytecode, plush.NewContextWith(map[string]interface{}{
+		"user": vmInlineCacheUser{Name: "Ada"},
+	}))
+	require.NoError(t, machine.Run())
+	require.Equal(t, "AdaAda", machine.Rendered())
+
+	firstEntries := make([]*propertyInlineCacheEntry, 0, len(positions))
+	for _, pos := range positions {
+		entry, ok := bytecode.PropertyCaches[pos].Load().(*propertyInlineCacheEntry)
+		require.True(t, ok)
+		require.Equal(t, reflect.TypeOf(vmInlineCacheUser{}), entry.typ)
+		require.Equal(t, propertyLookupField, entry.lookup.kind)
+		firstEntries = append(firstEntries, entry)
+	}
+
+	machine = NewWithContext(bytecode, plush.NewContextWith(map[string]interface{}{
+		"user": vmInlineCacheUser{Name: "Grace"},
+	}))
+	require.NoError(t, machine.Run())
+	require.Equal(t, "GraceGrace", machine.Rendered())
+
+	for i, pos := range positions {
+		entry, ok := bytecode.PropertyCaches[pos].Load().(*propertyInlineCacheEntry)
+		require.True(t, ok)
+		require.Same(t, firstEntries[i], entry)
+	}
+}
+
+func Test_VM_Property_Inline_Cache_Keeps_Polymorphic_Receivers(t *testing.T) {
+	program, err := parser.Parse(`<%= user.Name %>`)
+	require.NoError(t, err)
+
+	comp := compiler.New()
+	require.NoError(t, comp.Compile(program))
+	bytecode := comp.Bytecode()
+	positions := opcodePositions(bytecode.Instructions, code.OpWriteNameProperty)
+	require.Len(t, positions, 1)
+	slot := &bytecode.PropertyCaches[positions[0]]
+
+	machine := NewWithContext(bytecode, plush.NewContextWith(map[string]interface{}{
+		"user": vmInlineCacheUser{Name: "Ada"},
+	}))
+	require.NoError(t, machine.Run())
+	require.Equal(t, "Ada", machine.Rendered())
+
+	machine = NewWithContext(bytecode, plush.NewContextWith(map[string]interface{}{
+		"user": vmInlineCacheOtherUser{Name: "Grace"},
+	}))
+	require.NoError(t, machine.Run())
+	require.Equal(t, "Grace", machine.Rendered())
+
+	head, ok := slot.Load().(*propertyInlineCacheEntry)
+	require.True(t, ok)
+	require.Equal(t, reflect.TypeOf(vmInlineCacheOtherUser{}), head.typ)
+	require.NotNil(t, head.next)
+	require.Equal(t, reflect.TypeOf(vmInlineCacheUser{}), head.next.typ)
+}
+
+func Test_VM_Regex_Cache_Reuses_Compiled_Pattern(t *testing.T) {
+	regexCache.Delete(`^mido$`)
+
+	first, err := cachedRegex(`^mido$`)
+	require.NoError(t, err)
+	second, err := cachedRegex(`^mido$`)
+	require.NoError(t, err)
+	require.Same(t, first, second)
+}
+
+func Test_VM_Render_Size_Estimation(t *testing.T) {
+	machine := New(&compiler.Bytecode{})
+	objects := []object.Object{
+		&object.String{Value: "hello"},
+		&object.Array{Elements: []object.Object{
+			&object.String{Value: "world"},
+			&object.Integer{Value: 10},
+		}},
+		&object.Native{Value: template.HTML("<strong>x</strong>")},
+	}
+
+	require.GreaterOrEqual(t, machine.estimatedRenderedObjectsSize(objects), len("helloworld10<strong>x</strong>"))
+	var out strings.Builder
+	for _, obj := range objects {
+		machine.writeObject(&out, obj)
+	}
+	require.Equal(t, "helloworld10<strong>x</strong>", out.String())
+}
+
+func Test_VM_Fast_Helper_Registry_Writer_And_Args(t *testing.T) {
+	ctx := plush.NewContext()
+	args := &fastCallArgs{}
+	obj := &object.String{Value: "obj"}
+	args.Append("<tag>")
+	args.Append(int32(-7))
+	args.Append(uint32(9))
+	args.Append(float32(2.5))
+	args.Append(true)
+	args.Append(obj)
+
+	SetFastHelper(nil, "ignored", func(FastWriter, FastArgs) error { return nil })
+	SetFastHelper(ctx, "", func(FastWriter, FastArgs) error { return nil })
+	require.Nil(t, fastHelperRegistryForContext(nil, false))
+	_, ok := fastHelperForContext(ctx, "")
+	require.False(t, ok)
+
+	SetFastHelper(ctx, "custom", func(w FastWriter, got FastArgs) error {
+		require.Same(t, ctx, w.Context())
+		require.Equal(t, 6, got.Len())
+		raw, ok := got.Raw(1)
+		require.True(t, ok)
+		require.Equal(t, int32(-7), raw)
+		text, ok := got.String(0)
+		require.True(t, ok)
+		require.Equal(t, "<tag>", text)
+		i, ok := got.Int64(1)
+		require.True(t, ok)
+		require.Equal(t, int64(-7), i)
+		u, ok := got.Uint64(2)
+		require.True(t, ok)
+		require.Equal(t, uint64(9), u)
+		f, ok := got.Float64(3)
+		require.True(t, ok)
+		require.InDelta(t, 2.5, f, 0.001)
+		b, ok := got.Bool(4)
+		require.True(t, ok)
+		require.True(t, b)
+		gotObj, ok := got.Object(5)
+		require.True(t, ok)
+		require.Same(t, obj, gotObj)
+		_, ok = got.Raw(99)
+		require.False(t, ok)
+
+		w.WriteEscapedString("<x>")
+		w.WriteHTML(template.HTML("<b>raw</b>"))
+		w.WriteHTMLString("<i>raw</i>")
+		require.True(t, w.WriteGoValue("<go>"))
+		return nil
+	})
+
+	helper, ok := fastHelperForContext(ctx, "custom")
+	require.True(t, ok)
+	var out strings.Builder
+	handled, err := writeRegisteredFastHelper(&out, ctx, helper, args)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "&lt;x&gt;<b>raw</b><i>raw</i>&lt;go&gt;", out.String())
+
+	handled, err = writeRegisteredFastHelper(&out, ctx, func(FastWriter, FastArgs) error {
+		return ErrFastUnsupported
+	}, nil)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	handled, err = writeRegisteredFastHelper(nil, ctx, helper, args)
+	require.NoError(t, err)
+	require.False(t, handled)
+	handled, err = writeRegisteredFastHelper(&out, ctx, nil, args)
+	require.NoError(t, err)
+	require.False(t, handled)
+
+	require.False(t, FastArgs{}.Len() != 0)
+	_, ok = FastArgs{}.String(0)
+	require.False(t, ok)
+	_, ok = FastArgs{}.Bool(0)
+	require.False(t, ok)
+	_, ok = FastArgs{}.Int64(0)
+	require.False(t, ok)
+	_, ok = FastArgs{}.Uint64(0)
+	require.False(t, ok)
+	_, ok = FastArgs{}.Float64(0)
+	require.False(t, ok)
+	_, ok = FastArgs{}.Object(0)
+	require.False(t, ok)
+
+	ClearFastHelper(ctx, "custom")
+	_, ok = fastHelperForContext(ctx, "custom")
+	require.False(t, ok)
+}
+
+func Test_VM_Fast_Call_Args_Objects_And_Frame_Writers(t *testing.T) {
+	args := &fastCallArgs{}
+	args.Append("name")
+	args.Append(3)
+
+	objects := args.Objects()
+	require.Len(t, objects, 2)
+	require.Equal(t, objects, args.Objects())
+	require.Equal(t, "name", objects[0].(*object.String).Value)
+	require.Equal(t, int64(3), objects[1].(*object.Integer).Value)
+
+	var nilArgs *fastCallArgs
+	require.Nil(t, nilArgs.Objects())
+	require.Nil(t, args.Raw(99))
+
+	frame := &Frame{}
+	writeFastString(frame, "<name>")
+	writeFastHTML(frame, template.HTML("<b>html</b>"))
+	writeFastBool(frame, true)
+	writeFastInt(frame, -12)
+	writeFastUint(frame, 42)
+	writeFastFloat(frame, 2.5, 64)
+
+	require.True(t, frame.hasOutput)
+	require.Equal(t, "&lt;name&gt;<b>html</b>true-12422.5", frame.output.String())
+
+	writeFastString(nil, "ignored")
+	writeFastHTML(nil, template.HTML("ignored"))
+	writeFastBool(nil, false)
+	writeFastInt(nil, 0)
+	writeFastUint(nil, 0)
+	writeFastFloat(nil, 0, 64)
+}
+
+func Test_VM_Partial_Overlay_Context_Methods(t *testing.T) {
+	parent := plush.NewContextWith(map[string]interface{}{
+		"parent": "value",
+	})
+	budget := plush.NewBudget(100)
+	parent.WithBudget(budget)
+
+	ctx := borrowPartialOverlayContext(parent)
+	defer releasePartialOverlayContext(ctx)
+
+	require.False(t, (*partialOverlayContext)(nil).stableBindingIDs())
+	require.True(t, ctx.stableBindingIDs())
+	deadline, ok := ctx.Deadline()
+	require.False(t, ok)
+	require.True(t, deadline.IsZero())
+	require.Nil(t, ctx.Done())
+	require.NoError(t, ctx.Err())
+	require.Same(t, budget, ctx.Budget())
+
+	ctx.Set("local", "first")
+	require.True(t, ctx.Has("local"))
+	require.True(t, ctx.Has("parent"))
+	require.Equal(t, "first", ctx.Value("local"))
+	value, ok := ctx.Lookup("parent")
+	require.True(t, ok)
+	require.Equal(t, "value", value)
+	require.True(t, ctx.Update("local", "second"))
+	value, ok = ctx.Lookup("local")
+	require.True(t, ok)
+	require.Equal(t, "second", value)
+
+	id := ctx.InternID("local")
+	value, ok = ctx.LookupID(id)
+	require.True(t, ok)
+	require.Equal(t, "second", value)
+	ctx.SetID(id, "third")
+	value, ok = ctx.LookupID(id)
+	require.True(t, ok)
+	require.Equal(t, "third", value)
+	require.True(t, ctx.UpdateID(id, "fourth"))
+	value, ok = ctx.LookupID(id)
+	require.True(t, ok)
+	require.Equal(t, "fourth", value)
+
+	ids := make([]int, 2)
+	ctx.InternIDs([]string{"local", "another"}, ids)
+	require.NotEqual(t, ids[0], ids[1])
+	ctx.SetID(ids[1], "extra")
+	value, ok = ctx.Lookup("another")
+	require.True(t, ok)
+	require.Equal(t, "extra", value)
+
+	child := ctx.New()
+	require.NotNil(t, child)
+	child.Set("child", "value")
+	require.True(t, child.Has("child"))
+	releasePartialOverlayContext(child.(*partialOverlayContext))
+
+	partialChild, cleanup := partialHelperChildContext(parent)
+	require.NotNil(t, partialChild)
+	require.NotNil(t, cleanup)
+	cleanup()
+}
+
+func Test_VM_Partial_Cache_Trim_And_Data_Application_Helpers(t *testing.T) {
+	cache := newPartialBytecodeLinkCache()
+	bytecode := &compiler.Bytecode{}
+	link := cache.Set("row", 7, bytecode)
+	require.NotNil(t, link)
+	require.Equal(t, 1, cache.Len())
+	got, ok := cache.Get("row", 7)
+	require.True(t, ok)
+	require.Same(t, bytecode, got)
+	_, ok = cache.Get("row", 8)
+	require.False(t, ok)
+
+	require.Equal(t, "hello", string(trimWhitespaceSuffix([]byte("hello \n\t"))))
+	require.True(t, isTrimWhitespace(' '))
+	require.True(t, isTrimWhitespace('\n'))
+	require.False(t, isTrimWhitespace('x'))
+
+	parent := plush.NewContextWith(map[string]interface{}{
+		"title": "Engineer",
+	})
+	partialCtx := borrowPartialOverlayContext(parent)
+	defer releasePartialOverlayContext(partialCtx)
+
+	partial := &compiler.FastPartialPlan{
+		Data: []compiler.FastPartialDataPair{
+			{
+				Key:   "name",
+				Value: compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "Mido", Line: 1},
+				Line:  1,
+			},
+			{
+				Key:   "title",
+				Value: compiler.FastValuePlan{Kind: compiler.FastValueName, Value: "title", NameIndex: 0, Line: 1},
+				Line:  1,
+			},
+		},
+	}
+	bindings := fastRenderBindings{ctx: parent, names: []string{"title"}}
+	require.NoError(t, applyFastPartialDataSlow(partialCtx, partial, parent, bindings))
+	value, ok := partialCtx.Lookup("name")
+	require.True(t, ok)
+	require.Equal(t, "Mido", value)
+	value, ok = partialCtx.Lookup("title")
+	require.True(t, ok)
+	require.Equal(t, "Engineer", value)
+
+	dataPlan := buildFastPartialDataBindingPlan(partial)
+	require.NotNil(t, dataPlan)
+	applied, err := applyFastPartialDataBindingPlan(partialCtx, dataPlan, parent, bindings)
+	require.NoError(t, err)
+	require.True(t, applied)
+}
+
+func Test_VM_Render_Linked_Partial_Inline(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{"name": "<Mido>"})
+	var out strings.Builder
+
+	ok, err := renderLinkedPartialInline(&out, `<span><%= name %></span>`, ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, `<span>&lt;Mido&gt;</span>`, out.String())
+}
+
+func Test_VM_Fast_Value_Evaluation_Helpers(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"left":  true,
+		"right": false,
+		"name":  "Mido",
+	})
+	plan := &compiler.FastRenderPlan{Bindings: []string{"left", "right", "name"}}
+	bindings := newFastRenderBindings(plan, ctx)
+
+	value, ok, err := evalFastValue(&compiler.FastValuePlan{Kind: compiler.FastValueName, Value: "name", NameIndex: 2}, ctx, bindings, nil)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "Mido", value)
+
+	value, ok, err = evalFastLoopValue(&compiler.FastValuePlan{Kind: compiler.FastValueLoopKey}, ctx, bindings, "key", "value")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "key", value)
+
+	value, ok, err = evalFastInfixValue(&compiler.FastValuePlan{
+		Kind:     compiler.FastValueInfix,
+		Operator: "||",
+		Left:     &compiler.FastValuePlan{Kind: compiler.FastValueName, Value: "left", NameIndex: 0},
+		Right:    &compiler.FastValuePlan{Kind: compiler.FastValueName, Value: "right", NameIndex: 1},
+	}, ctx, bindings, nil, nil, nil, false)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, true, value)
+
+	value, ok, err = evalFastInfixValue(&compiler.FastValuePlan{
+		Kind:     compiler.FastValueInfix,
+		Operator: "==",
+		Left:     &compiler.FastValuePlan{Kind: compiler.FastValueInteger, IntValue: 3},
+		Right:    &compiler.FastValuePlan{Kind: compiler.FastValueFloat, FloatValue: 3.0},
+	}, ctx, bindings, nil, nil, nil, false)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, true, value)
+}
+
+func Test_VM_Op_Write_Streams_Frame_Output(t *testing.T) {
+	program, err := parser.Parse(`<p><%= name %></p>`)
+	require.NoError(t, err)
+
+	comp := compiler.New()
+	require.NoError(t, comp.Compile(program))
+
+	machine := NewWithContext(comp.Bytecode(), plush.NewContextWith(map[string]interface{}{"name": "<Mido>"}))
+	require.NoError(t, machine.Run())
+
+	require.Equal(t, "<p>&lt;Mido&gt;</p>", machine.frames[0].output.String())
+	require.True(t, machine.frames[0].hasOutput)
+	require.Equal(t, machine.frames[0].output.String(), machine.Rendered())
+}
+
+func Test_VM_Raw_Write_Opcodes_Preserve_Escaping(t *testing.T) {
+	program, err := parser.Parse(`<%= "<x>" %><%= name %><strong></strong>`)
+	require.NoError(t, err)
+
+	comp := compiler.New()
+	require.NoError(t, comp.Compile(program))
+	require.NotEmptyf(t, opcodePositions(comp.Bytecode().Instructions, code.OpWriteHTML), "expected OpWriteHTML:\n%s", comp.Bytecode().Instructions.String())
+	require.NotEmptyf(t, opcodePositions(comp.Bytecode().Instructions, code.OpWriteString), "expected OpWriteString:\n%s", comp.Bytecode().Instructions.String())
+
+	machine := NewWithContext(comp.Bytecode(), plush.NewContextWith(map[string]interface{}{"name": "<Mido>"}))
+	require.NoError(t, machine.Run())
+	require.Equal(t, "&lt;x&gt;&lt;Mido&gt;<strong></strong>", machine.Rendered())
+}
+
+func Test_VM_Direct_Write_Call_Opcodes(t *testing.T) {
+	input := `<%= greet(name) %>|<%= robot.Name.Echo() %>|<% let make = fn() { return "closure" } %><%= make() %>|<%= noop() %>done`
+	program, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	comp := compiler.New()
+	require.NoError(t, comp.Compile(program))
+	bytecode := comp.Bytecode()
+	require.Equalf(t, 2, len(opcodePositions(bytecode.Instructions, code.OpWriteNameCall)), "expected OpWriteNameCall:\n%s", bytecode.Instructions.String())
+	require.Equalf(t, 2, len(opcodePositions(bytecode.Instructions, code.OpWriteCall)), "expected OpWriteCall:\n%s", bytecode.Instructions.String())
+	require.Emptyf(t, callWritePairs(bytecode.Instructions), "expected call/write pairs to be fused:\n%s", bytecode.Instructions.String())
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name": "Mido",
+		"greet": func(name string) string {
+			return "hi " + name
+		},
+		"robot": struct {
+			Name vmEchoName
+		}{Name: "bender"},
+		"noop": func() {},
+	})
+	out, err := Render(input, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "hi Mido|bender|closure|done", out)
+}
+
+func Test_VM_Static_Only_Template_Render_Fast_Path(t *testing.T) {
+	tmpl, err := Compile(`<strong><%= "<x>" %></strong>`)
+	require.NoError(t, err)
+	require.True(t, tmpl.bytecode.Static)
+	require.Equal(t, `<strong>&lt;x&gt;</strong>`, tmpl.bytecode.StaticOutput)
+
+	out, err := tmpl.Render(nil)
+	require.NoError(t, err)
+	require.Equal(t, `<strong>&lt;x&gt;</strong>`, out)
+
+	tmpl, err = Compile(`<%= 10 %><span>items</span>`)
+	require.NoError(t, err)
+	require.True(t, tmpl.bytecode.Static)
+	require.Equal(t, `10<span>items</span>`, tmpl.bytecode.StaticOutput)
+
+	out, err = tmpl.Render(nil)
+	require.NoError(t, err)
+	require.Equal(t, `10<span>items</span>`, out)
+}
+
+func Test_VM_Compile_And_Render_Error_Branches(t *testing.T) {
+	_, err := Compile(`<%= "bad".Name %>`)
+	require.ErrorContains(t, err, "no prefix parse function")
+
+	cache := inmemory.NewMemoryCache()
+	plush.PlushCacheSetup(cache)
+	defer func() {
+		plush.ClearTemplateCache()
+		plush.PlushCacheSetup(nil)
+	}()
+
+	filename := "edge_compile_error.plush"
+	badProgram := &ast.Program{Statements: []ast.Statement{
+		&ast.ExpressionStatement{Expression: &ast.PrefixExpression{
+			Operator: "??",
+			Right:    &ast.Boolean{Value: true},
+		}},
+	}}
+	plush.CacheVMBytecodeForCleanFilename(filename, badProgram, "not-bytecode")
+	ctx := plush.NewContext()
+	ctx.Set(meta.TemplateFileKey, filename)
+
+	_, err = Render(`<%= true %>`, ctx)
+	require.ErrorContains(t, err, "unknown operator ??")
+}
+
+func Test_VM_Mixed_Static_Name_Render_Fast_Path(t *testing.T) {
+	tmpl, err := Compile(`<p>Hello <%= name %></p><p><%= title %></p>`)
+	require.NoError(t, err)
+	require.False(t, tmpl.bytecode.Static)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	require.Equal(t, 2, tmpl.bytecode.FastRenderPlan.NameCount)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"name":  "<Mido>",
+		"title": template.HTML("<strong>Engineer</strong>"),
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `<p>Hello &lt;Mido&gt;</p><p><strong>Engineer</strong></p>`, out)
+}
+
+func Test_VM_Fast_Static_Name_Plan_Renders_Simple_Template(t *testing.T) {
+	tmpl, err := Compile(`<p><%= name %></p><%= title %>!`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+
+	mixed := prepareFastMixedPlan(tmpl.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed)
+	require.NotNil(t, mixed.staticName)
+	require.Len(t, mixed.staticName.ops, 3)
+	require.Equal(t, []int{0, 1}, mixed.staticName.nameIndexes)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"name":  "<Mido>",
+		"title": template.HTML("<strong>Engineer</strong>"),
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `<p>&lt;Mido&gt;</p><strong>Engineer</strong>!`, out)
+	require.NotNil(t, mixed.staticName.ops[0].outputCache.Load())
+	require.NotNil(t, mixed.staticName.ops[1].outputCache.Load())
+}
+
+func Test_VM_Fast_Static_Name_Plan_Looks_Up_Repeated_Name_Once(t *testing.T) {
+	tmpl, err := Compile(`<%= name %>|<%= name %>|<%= name %>`)
+	require.NoError(t, err)
+	mixed := prepareFastMixedPlan(tmpl.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed.staticName)
+	require.Equal(t, []int{0}, mixed.staticName.nameIndexes)
+
+	ctx := newIDLookupTestContext(map[string]interface{}{"name": "Mido"})
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `Mido|Mido|Mido`, out)
+	require.Equal(t, 1, ctx.lookupID)
+}
+
+func Test_VM_Fast_Static_Name_Plan_Rejects_Non_Name_Segments(t *testing.T) {
+	type user struct {
+		Name string
+	}
+
+	tmpl, err := Compile(`<p><%= user.Name %></p>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+
+	mixed := prepareFastMixedPlan(tmpl.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed)
+	require.Nil(t, mixed.staticName)
+	require.NotNil(t, mixed.simple)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"user": user{Name: "<Mido>"},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `<p>&lt;Mido&gt;</p>`, out)
+}
+
+func Test_VM_Fast_Static_Name_Plan_Unknown_Identifier_Falls_Back_To_Error(t *testing.T) {
+	tmpl, err := Compile(`<p><%= missing %></p>`)
+	require.NoError(t, err)
+	require.NotNil(t, prepareFastMixedPlan(tmpl.bytecode.FastRenderPlan).staticName)
+
+	_, err = tmpl.Render(plush.NewContext())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `"missing": unknown identifier`)
+}
+
+func Test_VM_Fast_Simple_Plan_Renders_Static_Property_Access_And_Infix(t *testing.T) {
+	type profile struct {
+		Name string
+	}
+	type user struct {
+		Profile profile
+	}
+
+	tmpl, err := Compile(`<p><%= name %>|<%= user.Profile.Name %>|<%= labels["status"] %>|<%= count == 1 %></p>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+
+	mixed := prepareFastMixedPlan(tmpl.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed)
+	require.Nil(t, mixed.staticName)
+	require.NotNil(t, mixed.simple)
+	require.Equal(t, []int{0, 1, 2, 3}, mixed.simple.nameIndexes)
+	require.Len(t, mixed.simple.ops, 5)
+	require.Equal(t, fastMixedOpName, mixed.simple.ops[0].op.kind)
+	require.Equal(t, fastMixedOpAccessChain, mixed.simple.ops[1].op.kind)
+	require.Equal(t, fastMixedOpAccessChain, mixed.simple.ops[2].op.kind)
+	require.Equal(t, fastMixedOpValue, mixed.simple.ops[3].op.kind)
+	require.Equal(t, compiler.FastValueInfix, mixed.simple.ops[3].op.valuePlan.Kind)
+	require.NotNil(t, mixed.simple.ops[3].value)
+	require.Equal(t, 3, mixed.simple.ops[3].value.left.lookupIndex)
+	require.Equal(t, -1, mixed.simple.ops[3].value.right.lookupIndex)
+	require.Equal(t, fastMixedOpStatic, mixed.simple.ops[4].op.kind)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"name":   "<Mido>",
+		"user":   user{Profile: profile{Name: "<Bender>"}},
+		"labels": map[string]string{"status": "<ok>"},
+		"count":  uint32(1),
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `<p>&lt;Mido&gt;|&lt;Bender&gt;|&lt;ok&gt;|true</p>`, out)
+}
+
+func Test_VM_Fast_Simple_Plan_Looks_Up_Repeated_Root_Once(t *testing.T) {
+	type user struct {
+		Name string
+	}
+
+	tmpl, err := Compile(`<%= user.Name %>|<%= user.Name %>|<%= user.Name == "Mido" %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+
+	mixed := prepareFastMixedPlan(tmpl.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed)
+	require.Nil(t, mixed.staticName)
+	require.NotNil(t, mixed.simple)
+	require.Equal(t, []int{0}, mixed.simple.nameIndexes)
+	require.NotNil(t, mixed.simple.ops[2].value)
+	require.Equal(t, 0, mixed.simple.ops[2].value.left.lookupIndex)
+
+	ctx := newIDLookupTestContext(map[string]interface{}{"user": user{Name: "Mido"}})
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `Mido|Mido|true`, out)
+	require.Equal(t, 1, ctx.lookupID)
+}
+
+func Test_VM_Mixed_Static_Property_Render_Fast_Path(t *testing.T) {
+	type user struct {
+		Name string
+	}
+
+	costs := plush.ZeroCosts()
+	costs.ObjectTraversal = 3
+	budget := plush.NewBudgetWithCosts(20, costs)
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"user": user{Name: "<Mido>"},
+	})
+	ctx.WithBudget(budget)
+
+	tmpl, err := Compile(`<p><%= user.Name %></p>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `<p>&lt;Mido&gt;</p>`, out)
+	require.Equal(t, int64(3), budget.Stats().ObjectTraversals)
+}
+
+func Test_VM_Simple_Loop_Render_Fast_Path(t *testing.T) {
+	type product struct {
+		Name string
+	}
+
+	costs := plush.ZeroCosts()
+	costs.LoopIteration = 2
+	costs.ObjectTraversal = 3
+	budget := plush.NewBudgetWithCosts(100, costs)
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"items":    []string{"a", "b"},
+		"products": []product{{Name: "Bender"}, {Name: "<Fry>"}},
+	})
+	ctx.WithBudget(budget)
+
+	tmpl, err := Compile(`<%= for (i, item) in items { %><%= i %>:<%= item %>;<% } %>|<%= for (i, product) in products { %><%= product.Name %>;<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `0:a;1:b;|Bender;&lt;Fry&gt;;`, out)
+
+	stats := budget.Stats()
+	require.Equal(t, int64(8), stats.LoopIterations)
+	require.Equal(t, int64(6), stats.ObjectTraversals)
+}
+
+func Test_VM_Fast_Render_Loop_Break_And_Continue(t *testing.T) {
+	type variant struct {
+		OnSale bool
+		Price  int
+	}
+	type product struct {
+		Name     string
+		Skip     bool
+		Variants []variant
+	}
+
+	tmpl, err := Compile(`<%= for (_, product) in products { %><%= if product.Skip { %><%= continue %><% } %><%= product.Name %>:<%= for (_, variant) in product.Variants { %><%= if variant.OnSale { %><span><%= variant.Price %></span><%= break %><% } %><% } %>;<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"products": []product{
+			{Name: "A", Variants: []variant{{OnSale: false, Price: 1}, {OnSale: true, Price: 2}, {OnSale: true, Price: 3}}},
+			{Name: "B", Skip: true, Variants: []variant{{OnSale: true, Price: 4}}},
+			{Name: "C", Variants: []variant{{OnSale: true, Price: 5}}},
+		},
+	})
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `A:<span>2</span>;C:<span>5</span>;`, out)
+
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, plush.RenderFastPathFast, diagnostics.FastPath)
+	require.Empty(t, diagnostics.FastReject)
+}
+
+func Test_VM_Fast_Render_Script_Loop_Control(t *testing.T) {
+	tmpl, err := Compile(`<%= for (i, v) in [1, 2, 3] { %><%= i %><% break %><% } %>|<%= for (i, v) in [1, 2, 3] { %><% continue %><%= v %><% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	ctx := plush.NewContext()
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `0|`, out)
+
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, plush.RenderFastPathFast, diagnostics.FastPath)
+}
+
+func Test_VM_Fast_Render_Loop_Block_Helper_Sees_Current_Value(t *testing.T) {
+	type product struct {
+		ID   int
+		Name string
+	}
+
+	tmpl, err := Compile(`<%= for (_, product) in products { %><%= form({id: product.ID, path: cartPath()}) { %><span><%= product.Name %></span><% } %><% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"products": []product{{ID: 1, Name: "<A>"}, {ID: 2, Name: "B"}},
+		"cartPath": func() string {
+			return "/cart"
+		},
+		"form": func(data map[string]interface{}, help plush.HelperContext) (template.HTML, error) {
+			body, err := help.Block()
+			if err != nil {
+				return "", err
+			}
+			return template.HTML(fmt.Sprintf(`<form action="%s" id="%v">%s</form>`, data["path"], data["id"], body)), nil
+		},
+	})
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `<form action="/cart" id="1"><span>&lt;A&gt;</span></form><form action="/cart" id="2"><span>B</span></form>`, out)
+
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, plush.RenderFastPathFast, diagnostics.FastPath)
+	require.Empty(t, diagnostics.FastReject)
+	require.GreaterOrEqual(t, diagnostics.FastPlan.HelperCalls, 1)
+}
+
+func Test_VM_Helper_Call_Render_Fast_Plan(t *testing.T) {
+	tmpl, err := Compile(`<%= greet(name) %><%= greet(title) %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	require.Len(t, tmpl.bytecode.FastRenderPlan.Segments, 2)
+	require.Equal(t, compiler.FastRenderSegmentCall, tmpl.bytecode.FastRenderPlan.Segments[0].Kind)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"name":  "<Mido>",
+		"title": "Engineer",
+		"greet": func(value string) string {
+			return "hi " + value
+		},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `hi &lt;Mido&gt;hi Engineer`, out)
+
+	if entry, ok := tmpl.bytecode.FastRenderPlan.Segments[0].Call.Cache.Load().(*fastBuilderCallCacheEntry); ok {
+		require.NotNil(t, entry.invoker)
+	}
+}
+
+func Test_VM_Helper_Call_Value_Argument_Can_Satisfy_Pointer_Parameter(t *testing.T) {
+	tmpl, err := Compile(`<%= render_section(section) %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"section": vmPointerArgSection{Name: "hero"},
+		"render_section": func(section *vmPointerArgSection) string {
+			return section.Name
+		},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "hero", out)
+}
+
+func Test_VM_Block_Helper_Call_And_Array_Arguments_Render_Fast_Plan(t *testing.T) {
+	tmpl, err := Compile(`<%= multiple_menu_items([menu_nav, menu_categories_string]) %>|<%= form({content_for: "head", class: klass}) { %><span><%= name %></span><% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"menu_nav":               "main",
+		"menu_categories_string": "categories",
+		"klass":                  "hero",
+		"name":                   "<Mido>",
+		"multiple_menu_items": func(values []interface{}) string {
+			return fmt.Sprintf("%s,%s", values[0], values[1])
+		},
+		"form": func(data map[string]interface{}, help plush.HelperContext) (template.HTML, error) {
+			body, err := help.Block()
+			if err != nil {
+				return "", err
+			}
+			return template.HTML(fmt.Sprintf(`<div data-for="%s" class="%s">%s</div>`, data["content_for"], data["class"], body)), nil
+		},
+	})
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `main,categories|<div data-for="head" class="hero"><span>&lt;Mido&gt;</span></div>`, out)
+
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, plush.RenderFastPathFast, diagnostics.FastPath)
+	require.Empty(t, diagnostics.FastReject)
+	require.GreaterOrEqual(t, diagnostics.FastPlan.HelperCalls, 2)
+}
+
+func Test_VM_Block_Helper_Call_Renders_Block_With_Script_Let(t *testing.T) {
+	tmpl, err := Compile(`<%= wrap() { %><% let label = name %><span><%= label %></span><% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name": "<Mido>",
+		"wrap": func(help plush.HelperContext) (template.HTML, error) {
+			body, err := help.Block()
+			return template.HTML("<div>" + body + "</div>"), err
+		},
+	})
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `<div><span>&lt;Mido&gt;</span></div>`, out)
+}
+
+func Test_VM_Fast_Helper_Call_Uses_Direct_String_Path(t *testing.T) {
+	calls := 0
+	tmpl, err := Compile(`<%= greet(name) %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"name": "<Mido>",
+		"greet": func(value string) string {
+			calls++
+			return "hi " + value
+		},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `hi &lt;Mido&gt;`, out)
+	require.Equal(t, 1, calls)
+	require.Nil(t, tmpl.bytecode.FastRenderPlan.Segments[0].Call.Cache.Load())
+}
+
+func Test_VM_Fast_Helper_Args_Stay_Raw_For_Direct_Invoker(t *testing.T) {
+	args := &fastCallArgs{}
+	args.Append("<Mido>")
+	var out strings.Builder
+
+	err := writeFastCallValue(&out, plush.NewContext(), "greet", func(value string) string {
+		return "hi " + value
+	}, args, &object.InlineCacheSlot{})
+
+	require.NoError(t, err)
+	require.Equal(t, "hi &lt;Mido&gt;", out.String())
+	require.Nil(t, args.objects)
+}
+
+func Test_VM_Fast_Helper_Call_Uses_Direct_Scalar_Paths(t *testing.T) {
+	type name string
+
+	tests := []struct {
+		name     string
+		args     []interface{}
+		helper   interface{}
+		expected string
+	}{
+		{
+			name: "named string to base string",
+			args: []interface{}{name("<Mido>")},
+			helper: func(value string) string {
+				return "hi " + value
+			},
+			expected: "hi &lt;Mido&gt;",
+		},
+		{
+			name: "int and string",
+			args: []interface{}{int32(7), "items"},
+			helper: func(count int, suffix string) string {
+				return fmt.Sprintf("%d %s", count, suffix)
+			},
+			expected: "7 items",
+		},
+		{
+			name: "uint32 and string",
+			args: []interface{}{uint32(3), "left"},
+			helper: func(count uint32, suffix string) string {
+				return fmt.Sprintf("%d %s", count, suffix)
+			},
+			expected: "3 left",
+		},
+		{
+			name: "bool and string",
+			args: []interface{}{true, "enabled"},
+			helper: func(enabled bool, suffix string) string {
+				return fmt.Sprintf("%t %s", enabled, suffix)
+			},
+			expected: "true enabled",
+		},
+		{
+			name: "float64 and string",
+			args: []interface{}{float32(1.5), "rate"},
+			helper: func(rate float64, suffix string) string {
+				return fmt.Sprintf("%.1f %s", rate, suffix)
+			},
+			expected: "1.5 rate",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var args fastCallArgs
+			for _, arg := range tt.args {
+				args.Append(arg)
+			}
+			var out strings.Builder
+			slot := &object.InlineCacheSlot{}
+
+			err := writeFastCallValue(&out, plush.NewContext(), "helper", tt.helper, &args, slot)
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, out.String())
+			require.Nil(t, args.objects)
+			entry, ok := slot.Load().(*fastBuilderCallCacheEntry)
+			require.Truef(t, ok, "expected fast builder cache entry, got %T", slot.Load())
+			require.NotNil(t, entry.invoker)
+		})
+	}
+}
+
+func Test_VM_Write_Fast_Invoker_Uses_Direct_Scalar_Paths(t *testing.T) {
+	invoker := writeFastInvokerForRaw(func(count int, suffix string) string {
+		return fmt.Sprintf("%d %s", count, suffix)
+	})
+	require.NotNil(t, invoker)
+
+	frame := &Frame{}
+	err := invoker(nil, frame, "label", func(count int, suffix string) string {
+		return fmt.Sprintf("%d %s", count, suffix)
+	}, []object.Object{
+		object.Wrap(int32(9)),
+		object.Wrap("<items>"),
+	})
+
+	require.NoError(t, err)
+	require.True(t, frame.hasOutput)
+	require.Equal(t, "9 &lt;items&gt;", frame.output.String())
+}
+
+func Test_VM_Indexed_Property_Chain_Render_Fast_Plan(t *testing.T) {
+	tmpl, err := Compile(`<%= robots[0].Name.Echo() %>|<%= robots[1].Name.Echo() %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	require.Equal(t, compiler.FastRenderSegmentValue, tmpl.bytecode.FastRenderPlan.Segments[0].Kind)
+	mixed := prepareFastMixedPlan(tmpl.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed)
+	require.Equal(t, fastMixedOpAccessChain, mixed.ops[0].kind)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"robots": []vmAccessRobot{
+			{Name: "bender"},
+			{Name: "<fry>"},
+		},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `bender|&lt;fry&gt;`, out)
+
+	entry, ok := mixed.ops[0].accessCache.Load().(*fastTopLevelAccessCacheEntry)
+	require.True(t, ok)
+	require.Equal(t, fastTopLevelAccessMethodCall, entry.kind)
+	require.Equal(t, reflect.TypeOf([]vmAccessRobot{}), entry.typ)
+	require.NotNil(t, entry.method)
+}
+
+func Test_VM_Conditional_Render_Fast_Plan(t *testing.T) {
+	costs := plush.ZeroCosts()
+	costs.ConditionCheck = 5
+	budget := plush.NewBudgetWithCosts(100, costs)
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"enabled":  false,
+		"fallback": true,
+		"name":     "<fallback>",
+	})
+	ctx.WithBudget(budget)
+
+	tmpl, err := Compile(`<%= if enabled { %>yes<% } else if fallback { %><%= name %><% } else { %>no<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	require.Equal(t, compiler.FastRenderSegmentConditional, tmpl.bytecode.FastRenderPlan.Segments[0].Kind)
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `&lt;fallback&gt;`, out)
+	require.Equal(t, int64(10), budget.Stats().ConditionChecks)
+}
+
+func Test_VM_Fast_Simple_Conditional_Plan_Renders_Simple_Branches(t *testing.T) {
+	type robot struct {
+		Name  string
+		Stock uint32
+	}
+
+	costs := plush.ZeroCosts()
+	costs.ConditionCheck = 5
+	costs.ObjectTraversal = 2
+	budget := plush.NewBudgetWithCosts(100, costs)
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"robot":    robot{Name: "<Bender>", Stock: 0},
+		"fallback": true,
+		"labels":   map[string]string{"status": "<ready>"},
+		"count":    uint32(1),
+	})
+	ctx.WithBudget(budget)
+
+	tmpl, err := Compile(`<%= if robot.Stock > 0 { %><%= robot.Name %><% } else if fallback { %><%= labels["status"] %>:<%= count == 1 %><% } else { %>no<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+
+	mixed := prepareFastMixedPlan(tmpl.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed)
+	require.Len(t, mixed.ops, 1)
+	require.Equal(t, fastMixedOpConditional, mixed.ops[0].kind)
+	require.NotNil(t, mixed.ops[0].simpleCond)
+	require.Len(t, mixed.ops[0].simpleCond.branches, 2)
+	require.NotNil(t, mixed.ops[0].simpleCond.branches[0].condition)
+	require.NotNil(t, mixed.ops[0].simpleCond.branches[0].segments)
+	require.NotNil(t, mixed.ops[0].simpleCond.branches[1].segments)
+	require.NotNil(t, mixed.ops[0].simpleCond.elseSegments)
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `&lt;ready&gt;:true`, out)
+	require.Equal(t, int64(10), budget.Stats().ConditionChecks)
+	require.Equal(t, int64(2), budget.Stats().ObjectTraversals)
+}
+
+func Test_VM_Fast_Simple_Conditional_Plan_Rejects_Complex_Branches(t *testing.T) {
+	tmpl, err := Compile(`<%= if enabled { %><%= greet(name) %><% } else { %>no<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+
+	mixed := prepareFastMixedPlan(tmpl.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed)
+	require.Len(t, mixed.ops, 1)
+	require.Equal(t, fastMixedOpConditional, mixed.ops[0].kind)
+	require.Nil(t, mixed.ops[0].simpleCond)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"enabled": true,
+		"name":    "<Mido>",
+		"greet": func(name string) string {
+			return "hi " + name
+		},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `hi &lt;Mido&gt;`, out)
+}
+
+func Test_VM_Partial_Render_Fast_Plan_Reuses_Linked_Bytecode(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name": "Mido",
+		"partialFeeder": func(string) (string, error) {
+			return `<span><%= name %></span>`, nil
+		},
+	})
+
+	tmpl, err := Compile(`<%= partial("row.plush") %><%= partial("row.plush") %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	require.Equal(t, compiler.FastRenderSegmentPartial, tmpl.bytecode.FastRenderPlan.Segments[0].Kind)
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `<span>Mido</span><span>Mido</span>`, out)
+
+	links, ok := ctx.Value(vmPartialBytecodeLinksKey).(*partialBytecodeLinkCache)
+	require.True(t, ok)
+	require.Equal(t, 1, links.Len())
+	require.True(t, links.hasFeederID)
+}
+
+func Test_VM_Partial_Render_Binding_Plan_Reuses_Linked_Binding_I_Ds(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name": "Mido",
+		"partialFeeder": func(string) (string, error) {
+			return `<span><%= name %></span>`, nil
+		},
+	})
+
+	tmpl, err := Compile(`<%= partial("row.plush") %><%= partial("row.plush") %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `<span>Mido</span><span>Mido</span>`, out)
+
+	link := onlyPartialBytecodeLink(t, ctx)
+	require.NotNil(t, link.bindingPlan)
+	require.Equal(t, []string{"name"}, link.bindingPlan.names)
+}
+
+func Test_VM_Fast_Loop_Partial_Sees_Current_Loop_Value(t *testing.T) {
+	type product struct {
+		Name string
+	}
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"products": []product{{Name: "Pizza"}, {Name: "Pasta"}},
+		"partialFeeder": func(name string) (string, error) {
+			require.Equal(t, "partials/product-card.plush.html", name)
+			return `<span><%= product.Name %></span>`, nil
+		},
+	})
+
+	tmpl, err := Compile(`<%= for (_, product) in products { %><%= partial("partials/product-card.plush.html") %><% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	require.Len(t, tmpl.bytecode.FastRenderPlan.Segments, 1)
+	segment := tmpl.bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, compiler.FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+	require.Len(t, segment.Loop.Parts, 1)
+	require.Equal(t, compiler.FastLoopPartPartial, segment.Loop.Parts[0].Kind)
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `<span>Pizza</span><span>Pasta</span>`, out)
+	require.False(t, ctx.Has("product"))
+}
+
+func Test_VM_Partial_Render_Binding_Plan_Keeps_Data_Values_Live(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"partialFeeder": func(string) (string, error) {
+			return `<span><%= name %></span>`, nil
+		},
+	})
+
+	out, err := Render(`<%= partial("row.plush", {name: "Mido"}) %><%= partial("row.plush", {name: "Fry"}) %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, `<span>Mido</span><span>Fry</span>`, out)
+
+	link := onlyPartialBytecodeLink(t, ctx)
+	require.NotNil(t, link.bindingPlan)
+	require.Equal(t, []string{"name"}, link.bindingPlan.names)
+}
+
+func Test_VM_Fast_Data_Partial_Uses_Overlay_And_Keeps_Values_Live(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name":   "Outer",
+		"first":  "Mido",
+		"second": "Fry",
+		"robot":  vmAccessRobot{Name: "Bender"},
+		"partialFeeder": func(string) (string, error) {
+			return `<span><%= name %>:<%= title %></span>`, nil
+		},
+	})
+
+	tmpl, err := Compile(`<%= partial("row.plush", {name: first, title: robot.Name}) %>|<%= partial("row.plush", {name: second, title: "literal"}) %>|<%= name %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	require.NotEmpty(t, tmpl.bytecode.FastRenderPlan.Segments)
+	require.Equal(t, compiler.FastRenderSegmentPartial, tmpl.bytecode.FastRenderPlan.Segments[0].Kind)
+	require.Len(t, tmpl.bytecode.FastRenderPlan.Segments[0].Partial.Data, 2)
+
+	mixed := prepareFastMixedPlan(tmpl.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed)
+	require.Len(t, mixed.ops, 3)
+	require.Equal(t, fastMixedOpPartial, mixed.ops[0].kind)
+	require.NotNil(t, mixed.ops[0].partialData)
+	require.Equal(t, []string{"name", "title"}, mixed.ops[0].partialData.keys)
+	require.Equal(t, []int{0, 1}, mixed.ops[0].partialData.nameIndexes)
+	require.Equal(t, 0, mixed.ops[0].partialData.pairs[0].value.lookupIndex)
+	require.Equal(t, 1, mixed.ops[0].partialData.pairs[1].value.lookupIndex)
+	require.Equal(t, fastMixedOpPartial, mixed.ops[1].kind)
+	require.NotNil(t, mixed.ops[1].partialData)
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `<span>Mido:Bender</span>|<span>Fry:literal</span>|Outer`, out)
+
+	link := onlyPartialBytecodeLink(t, ctx)
+	require.NotNil(t, link.bindingPlan)
+	require.Equal(t, []string{"name", "title"}, link.bindingPlan.names)
+}
+
+func Test_VM_Fast_Data_Partial_Helper_Call_Value(t *testing.T) {
+	type product struct {
+		Name string
+	}
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"product": product{Name: "<Bender>"},
+		"prefix":  "robot",
+		"label": func(name string, prefix string) string {
+			return prefix + ":" + name
+		},
+		"partialFeeder": func(string) (string, error) {
+			return `<span><%= label %></span>`, nil
+		},
+	})
+
+	tmpl, err := Compile(`<%= partial("row.plush", {label: label(product.Name, prefix)}) %>|<%= product.Name %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	require.NotEmpty(t, tmpl.bytecode.FastRenderPlan.Segments)
+	segment := tmpl.bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, compiler.FastRenderSegmentPartial, segment.Kind)
+	require.NotNil(t, segment.Partial)
+	require.Len(t, segment.Partial.Data, 1)
+	require.Equal(t, compiler.FastValueCall, segment.Partial.Data[0].Value.Kind)
+	require.NotNil(t, segment.Partial.Data[0].Value.Call)
+
+	mixed := prepareFastMixedPlan(tmpl.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed)
+	require.Len(t, mixed.ops, 2)
+	require.Equal(t, fastMixedOpPartial, mixed.ops[0].kind)
+	require.NotNil(t, mixed.ops[0].partialData)
+	require.Equal(t, []string{"label"}, mixed.ops[0].partialData.keys)
+	require.Equal(t, []int{0, 1, 2}, mixed.ops[0].partialData.nameIndexes)
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `<span>robot:&lt;Bender&gt;</span>|&lt;Bender&gt;`, out)
+
+	entry, ok := segment.Partial.Data[0].Value.Call.Cache.Load().(*fastBuilderCallCacheEntry)
+	require.Truef(t, ok, "expected fast value call cache entry, got %T", segment.Partial.Data[0].Value.Call.Cache.Load())
+	require.NotNil(t, entry)
+	require.NotNil(t, entry.plan)
+	require.NotNil(t, entry.valueInvoker)
+}
+
+func Test_VM_Fast_Data_Partial_Helper_Call_Value_Missing_Helper_Names_Error(t *testing.T) {
+	type product struct {
+		Name string
+	}
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"product": product{Name: "Bender"},
+		"prefix":  "robot",
+		"partialFeeder": func(string) (string, error) {
+			return `<span>static</span>`, nil
+		},
+	})
+
+	tmpl, err := Compile(`<%= partial("row.plush", {label: label(product.Name, prefix)}) %>`)
+	require.NoError(t, err)
+
+	_, err = tmpl.Render(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `"label": unknown identifier`)
+}
+
+func Test_VM_Fast_Data_Partial_Direct_Binding_Renders_Simple_Linked_Partial(t *testing.T) {
+	type robot struct {
+		Name string
+	}
+
+	tmpl, err := Compile(`<%= partial("row.plush", {name: first, title: robot.Name}) %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	mixed := prepareFastMixedPlan(tmpl.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed)
+	require.Len(t, mixed.ops, 1)
+	require.Equal(t, fastMixedOpPartial, mixed.ops[0].kind)
+	require.NotNil(t, mixed.ops[0].partialData)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"first": "Mido",
+		"robot": robot{Name: "<Bender>"},
+		"partialFeeder": func(string) (string, error) {
+			return `<span><%= name %>|<%= title %></span>`, nil
+		},
+	})
+	bindings := newFastRenderBindings(tmpl.bytecode.FastRenderPlan, ctx)
+	var out strings.Builder
+	ok, err := renderFastDataPartialDirectInto(&out, mixed.ops[0].partial, ctx, bindings, mixed.ops[0].partialData)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, `<span>Mido|&lt;Bender&gt;</span>`, out.String())
+
+	links, ok := ctx.Value(vmPartialBytecodeLinksKey).(*partialBytecodeLinkCache)
+	require.True(t, ok)
+	require.Equal(t, 1, links.Len())
+	link := onlyPartialBytecodeLink(t, ctx)
+	require.NotNil(t, link.bytecode.FastRenderPlan)
+}
+
+func Test_VM_Fast_Data_Partial_Direct_Binding_Evaluates_Unused_Data(t *testing.T) {
+	tmpl, err := Compile(`<%= partial("row.plush", {name: missing}) %>`)
+	require.NoError(t, err)
+	mixed := prepareFastMixedPlan(tmpl.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed)
+	require.Len(t, mixed.ops, 1)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"partialFeeder": func(string) (string, error) {
+			return `<span>static</span>`, nil
+		},
+	})
+	var out strings.Builder
+	ok, err := renderFastDataPartialDirectInto(&out, mixed.ops[0].partial, ctx, newFastRenderBindings(tmpl.bytecode.FastRenderPlan, ctx), mixed.ops[0].partialData)
+	require.True(t, ok)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `"missing": unknown identifier`)
+	require.Empty(t, out.String())
+}
+
+func Test_VM_Inline_Partial_Fast_Path_Writes_Linked_Static_Name_Bytecode(t *testing.T) {
+	partial, err := Compile(`<span><%= name %></span>`)
+	require.NoError(t, err)
+	require.NotNil(t, partial.bytecode.FastRenderPlan)
+	require.NotNil(t, prepareFastMixedPlan(partial.bytecode.FastRenderPlan).staticName)
+
+	ctx := plush.NewContextWith(map[string]interface{}{"name": "Mido"})
+	link := &partialBytecodeLink{bytecode: partial.bytecode}
+	var out strings.Builder
+
+	ok, err := renderLinkedPartialBytecodeInline(&out, link, ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, `<span>Mido</span>`, out.String())
+	require.NotNil(t, link.bindingPlan)
+}
+
+func Test_VM_Inline_Partial_Fast_Path_Writes_Linked_Simple_Bytecode(t *testing.T) {
+	type profile struct {
+		Name string
+	}
+	type user struct {
+		Profile profile
+	}
+
+	partial, err := Compile(`<span><%= user.Profile.Name %>|<%= labels["status"] %>|<%= count == 1 %></span>`)
+	require.NoError(t, err)
+	require.NotNil(t, partial.bytecode.FastRenderPlan)
+	mixed := prepareFastMixedPlan(partial.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed)
+	require.Nil(t, mixed.staticName)
+	require.NotNil(t, mixed.simple)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"user":   user{Profile: profile{Name: "<Mido>"}},
+		"labels": map[string]string{"status": "<ready>"},
+		"count":  uint32(1),
+	})
+	link := &partialBytecodeLink{bytecode: partial.bytecode}
+	var out strings.Builder
+
+	ok, err := renderLinkedPartialBytecodeInline(&out, link, ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, `<span>&lt;Mido&gt;|&lt;ready&gt;|true</span>`, out.String())
+	require.NotNil(t, link.bindingPlan)
+	require.Equal(t, []string{"user", "labels", "count"}, link.bindingPlan.names)
+}
+
+func Test_VM_Inline_Partial_Fast_Path_Writes_Linked_Mixed_Bytecode(t *testing.T) {
+	partial, err := Compile(`<%= for (item) in items { %><%= item %>|<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, partial.bytecode.FastRenderPlan)
+	mixed := prepareFastMixedPlan(partial.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed)
+	require.Nil(t, mixed.staticName)
+	require.Nil(t, mixed.simple)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"items": []string{"a", "b"},
+	})
+	link := &partialBytecodeLink{bytecode: partial.bytecode}
+	var out strings.Builder
+
+	ok, err := renderLinkedPartialBytecodeInline(&out, link, ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, `a|b|`, out.String())
+	require.NotNil(t, link.bindingPlan)
+	require.Equal(t, []string{"items"}, link.bindingPlan.names)
+}
+
+func Test_VM_Inline_Partial_Fast_Path_Rejects_Unsupported_Block_Helper_Before_Writing(t *testing.T) {
+	partial, err := Compile(`<%= form({}) { %>body<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, partial.bytecode.FastRenderPlan)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"form": func(interface{}, plush.HelperContext, map[string]interface{}, string) template.HTML {
+			return template.HTML("unsupported")
+		},
+	})
+	link := &partialBytecodeLink{bytecode: partial.bytecode}
+	var out strings.Builder
+
+	ok, err := renderLinkedPartialBytecodeInline(&out, link, ctx)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Empty(t, out.String())
+}
+
+func Test_VM_Inline_Partial_Fast_Path_Rejects_Unsupported_Simple_Before_Writing(t *testing.T) {
+	partial, err := Compile(`<span><%= labels["status"] %></span>`)
+	require.NoError(t, err)
+	require.NotNil(t, partial.bytecode.FastRenderPlan)
+	mixed := prepareFastMixedPlan(partial.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed)
+	require.Nil(t, mixed.staticName)
+	require.NotNil(t, mixed.simple)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"labels": 12,
+	})
+	link := &partialBytecodeLink{bytecode: partial.bytecode}
+	var out strings.Builder
+
+	ok, err := renderLinkedPartialBytecodeInline(&out, link, ctx)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Empty(t, out.String())
+}
+
+func Test_VM_Inline_Partial_Fast_Path_Rejects_Unsupported_Output_Before_Writing(t *testing.T) {
+	partial, err := Compile(`<span><%= name %></span>`)
+	require.NoError(t, err)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name": &object.Builtin{},
+	})
+	link := &partialBytecodeLink{bytecode: partial.bytecode}
+	var out strings.Builder
+
+	ok, err := renderLinkedPartialBytecodeInline(&out, link, ctx)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Empty(t, out.String())
+}
+
+func Test_VM_Inline_Partial_Fast_Path_Skips_When_JS_Escape_Is_Needed(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"contentType": "application/javascript",
+		"partialFeeder": func(string) (string, error) {
+			return `<%= "<tag>" %>`, nil
+		},
+	})
+	var out strings.Builder
+
+	ok, err := renderFastNoDataPartialInto(&out, "row.html", ctx, 1)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, template.JSEscapeString("&lt;tag&gt;"), out.String())
+}
+
+func Test_VM_Fast_No_Data_Partial_Direct_Renders_Simple_Linked_Partial(t *testing.T) {
+	type robot struct {
+		Name string
+	}
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name":  "<Mido>",
+		"robot": robot{Name: "<Bender>"},
+		"partialFeeder": func(string) (string, error) {
+			return `<span><%= name %>|<%= robot.Name %></span>`, nil
+		},
+	})
+	var out strings.Builder
+
+	ok, err := renderFastNoDataPartialDirectInto(&out, "row.plush", ctx, 1)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, `<span>&lt;Mido&gt;|&lt;Bender&gt;</span>`, out.String())
+
+	links, ok := ctx.Value(vmPartialBytecodeLinksKey).(*partialBytecodeLinkCache)
+	require.True(t, ok)
+	require.Equal(t, 1, links.Len())
+	link := onlyPartialBytecodeLink(t, ctx)
+	require.NotNil(t, link.bytecode.FastRenderPlan)
+}
+
+func Test_VM_Fast_No_Data_Partial_Direct_Rejects_Metadata_Bindings(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"partialFeeder": func(string) (string, error) {
+			return `<%= ` + meta.TemplateFileKey + ` %>`, nil
+		},
+	})
+	var out strings.Builder
+
+	ok, err := renderFastNoDataPartialDirectInto(&out, "row.plush", ctx, 1)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Empty(t, out.String())
+}
+
+func Test_VM_Partial_Overlay_Pool_Clears_Values(t *testing.T) {
+	parent := plush.NewContextWith(map[string]interface{}{"name": "parent"})
+
+	ctx := borrowPartialOverlayContext(parent)
+	ctx.Set("name", "child")
+	for i := 0; i < 10; i++ {
+		ctx.Set(fmt.Sprintf("extra%d", i), i)
+	}
+	value, ok := ctx.Lookup("name")
+	require.True(t, ok)
+	require.Equal(t, "child", value)
+	releasePartialOverlayContext(ctx)
+
+	reused := borrowPartialOverlayContext(parent)
+	defer releasePartialOverlayContext(reused)
+
+	value, ok = reused.Lookup("name")
+	require.True(t, ok)
+	require.Equal(t, "parent", value)
+	for i := 0; i < 10; i++ {
+		_, ok := reused.localValue(fmt.Sprintf("extra%d", i))
+		require.False(t, ok)
+	}
+}
+
+func Test_VM_Partial_Feeder_ID_Cache_Uses_Current_Feeder(t *testing.T) {
+	ctx := plush.NewContext()
+	tmpl, err := Compile(`<%= partial("row") %>`)
+	require.NoError(t, err)
+
+	ctx.Set("partialFeeder", func(string) (string, error) {
+		return `<%= "a" %>`, nil
+	})
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "a", out)
+
+	links, ok := ctx.Value(vmPartialBytecodeLinksKey).(*partialBytecodeLinkCache)
+	require.True(t, ok)
+	require.True(t, links.hasFeederID)
+
+	ctx.Set("partialFeeder", func(string) (string, error) {
+		return `<%= "b" %>`, nil
+	})
+	out, err = tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "b", out)
+	require.True(t, links.hasFeederID)
+}
+
+func onlyPartialBytecodeLink(t *testing.T, ctx hctx.Context) *partialBytecodeLink {
+	t.Helper()
+	links, ok := ctx.Value(vmPartialBytecodeLinksKey).(*partialBytecodeLinkCache)
+	require.True(t, ok)
+	require.Equal(t, 1, links.Len())
+
+	links.mu.RLock()
+	defer links.mu.RUnlock()
+	for _, link := range links.entries {
+		return link
+	}
+	require.FailNow(t, "expected partial bytecode link")
+	return nil
+}
+
+type trackingNewContext struct {
+	hctx.Context
+	newCalls int
+}
+
+func (c *trackingNewContext) New() hctx.Context {
+	c.newCalls++
+	return c.Context.New()
+}
+
+func Test_VM_Fast_No_Data_Partial_Avoids_Parent_Context_New(t *testing.T) {
+	base := plush.NewContextWith(map[string]interface{}{
+		"name": "Mido",
+		"partialFeeder": func(string) (string, error) {
+			return `<span><%= name %></span>`, nil
+		},
+	})
+	ctx := &trackingNewContext{Context: base}
+
+	tmpl, err := Compile(`<%= partial("row.plush") %><%= partial("row.plush") %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `<span>Mido</span><span>Mido</span>`, out)
+	require.Zero(t, ctx.newCalls)
+
+	links, ok := base.Value(vmPartialBytecodeLinksKey).(*partialBytecodeLinkCache)
+	require.True(t, ok)
+	require.Equal(t, 1, links.Len())
+}
+
+func Test_VM_Fast_Mixed_Plan_Fuses_Static_Prefixes(t *testing.T) {
+	type user struct {
+		Name string
+	}
+
+	tmpl, err := Compile(`<p>Hello <%= name %>, <%= user.Name %></p>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+
+	mixed := prepareFastMixedPlan(tmpl.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed)
+	require.Len(t, mixed.ops, 3)
+	require.Equal(t, fastMixedOpName, mixed.ops[0].kind)
+	require.Equal(t, "<p>Hello ", mixed.ops[0].prefix)
+	require.Equal(t, fastMixedOpProperty, mixed.ops[1].kind)
+	require.Equal(t, ", ", mixed.ops[1].prefix)
+	require.Equal(t, fastMixedOpStatic, mixed.ops[2].kind)
+	require.Equal(t, "</p>", mixed.ops[2].prefix)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"name": "Mido",
+		"user": user{Name: "<Bender>"},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `<p>Hello Mido, &lt;Bender&gt;</p>`, out)
+}
+
+func Test_VM_Fast_Output_Grow_Size_Includes_Loop_Estimate(t *testing.T) {
+	tmpl, err := Compile(`<ul><%= for (i, item) in items { %><li><%= i %>:<%= item %></li><% } %></ul>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	mixed := prepareFastMixedPlan(tmpl.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"items": []string{"one", "two", "three"},
+	})
+	bindings := newFastRenderBindings(tmpl.bytecode.FastRenderPlan, ctx)
+
+	base := mixed.staticSize + mixed.nameCount*16
+	require.Greater(t, fastOutputGrowSize(mixed, bindings), base)
+}
+
+func Test_VM_Fast_Struct_Field_Chain_Plan_Writes_Output(t *testing.T) {
+	type profile struct {
+		Name string
+	}
+	type user struct {
+		Profile profile
+	}
+
+	costs := plush.ZeroCosts()
+	costs.ObjectTraversal = 2
+	budget := plush.NewBudgetWithCosts(10, costs)
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"user": user{Profile: profile{Name: "<Mido>"}},
+	})
+	ctx.WithBudget(budget)
+
+	tmpl, err := Compile(`<p><%= user.Profile.Name %></p>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	mixed := prepareFastMixedPlan(tmpl.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed)
+	require.Len(t, mixed.ops, 2)
+	require.Equal(t, fastMixedOpAccessChain, mixed.ops[0].kind)
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `<p>&lt;Mido&gt;</p>`, out)
+	require.Equal(t, int64(4), budget.Stats().ObjectTraversals)
+
+	entry, ok := mixed.ops[0].accessCache.Load().(*fastTopLevelAccessCacheEntry)
+	require.True(t, ok)
+	require.Equal(t, fastTopLevelAccessFieldChain, entry.kind)
+	require.Equal(t, reflect.TypeOf(user{}), entry.typ)
+	require.Len(t, entry.fieldChain.steps, 2)
+}
+
+func Test_VM_Fast_Struct_Field_Chain_Plan_Handles_Nil_Pointers(t *testing.T) {
+	type profile struct {
+		Name string
+	}
+	type user struct {
+		Profile *profile
+	}
+
+	tmpl, err := Compile(`<%= user.Profile.Name %>|<%= user.Profile.Name %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"user": user{},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `|`, out)
+}
+
+func Test_VM_Fast_Indexed_Access_Chain_Plan_Writes_Slice_Output(t *testing.T) {
+	type robot struct {
+		Name string
+	}
+
+	tmpl, err := Compile(`<%= robots[0].Name %>|<%= robots[1].Name %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	mixed := prepareFastMixedPlan(tmpl.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed)
+	require.Len(t, mixed.ops, 2)
+	require.Equal(t, fastMixedOpAccessChain, mixed.ops[0].kind)
+
+	chain, ok := fastAccessChainPlanFor(&mixed.ops[0].valuePlan, reflect.TypeOf([]robot{}))
+	require.True(t, ok)
+	require.Len(t, chain.steps, 2)
+	require.Equal(t, fastAccessStepIndex, chain.steps[0].kind)
+	require.Equal(t, fastAccessStepField, chain.steps[1].kind)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"robots": []robot{
+			{Name: "Bender"},
+			{Name: "<Fry>"},
+		},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `Bender|&lt;Fry&gt;`, out)
+
+	entry, ok := mixed.ops[0].accessCache.Load().(*fastTopLevelAccessCacheEntry)
+	require.True(t, ok)
+	require.Equal(t, fastTopLevelAccessChain, entry.kind)
+	require.Equal(t, reflect.TypeOf([]robot{}), entry.typ)
+}
+
+func Test_VM_Fast_Indexed_Access_Chain_Plan_Writes_Map_Output(t *testing.T) {
+	type robot struct {
+		Name string
+	}
+
+	tmpl, err := Compile(`<%= robots[0].Name %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	mixed := prepareFastMixedPlan(tmpl.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed)
+	require.Len(t, mixed.ops, 1)
+
+	chain, ok := fastAccessChainPlanFor(&mixed.ops[0].valuePlan, reflect.TypeOf(map[int]robot{}))
+	require.True(t, ok)
+	require.Len(t, chain.steps, 2)
+	require.Equal(t, fastAccessStepIndex, chain.steps[0].kind)
+	require.Equal(t, fastAccessStepField, chain.steps[1].kind)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"robots": map[int]robot{
+			0: {Name: "<Bender>"},
+		},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `&lt;Bender&gt;`, out)
+}
+
+func Test_VM_Fast_String_Indexed_Access_Chain_Plan_Writes_Map_Output(t *testing.T) {
+	tmpl, err := Compile(`<%= labels["status"] %>|<%= counts["active"] %>|<%= ints["count"] %>|<%= any["label"] %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	mixed := prepareFastMixedPlan(tmpl.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed)
+	require.Len(t, mixed.ops, 4)
+	for i := range mixed.ops {
+		require.Equal(t, fastMixedOpAccessChain, mixed.ops[i].kind)
+	}
+
+	labelChain, ok := fastAccessChainPlanFor(&mixed.ops[0].valuePlan, reflect.TypeOf(map[string]string{}))
+	require.True(t, ok)
+	require.Len(t, labelChain.steps, 1)
+	require.Equal(t, fastAccessStepIndex, labelChain.steps[0].kind)
+	require.True(t, labelChain.steps[0].mapKey.IsValid())
+	require.Equal(t, "status", labelChain.steps[0].mapKey.Interface())
+	require.Equal(t, fastMapDirectStringString, labelChain.steps[0].mapDirect)
+	var directOut strings.Builder
+	handled, err := writeFastDirectMapIndexOutput(&directOut, plush.NewContext(), reflect.ValueOf(map[string]string{"status": "<ok>"}), &labelChain.steps[0])
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "&lt;ok&gt;", directOut.String())
+
+	countChain, ok := fastAccessChainPlanFor(&mixed.ops[1].valuePlan, reflect.TypeOf(map[string]uint32{}))
+	require.True(t, ok)
+	require.Len(t, countChain.steps, 1)
+	require.Equal(t, fastAccessStepIndex, countChain.steps[0].kind)
+	require.True(t, countChain.steps[0].mapKey.IsValid())
+	require.Equal(t, "active", countChain.steps[0].mapKey.Interface())
+	require.Equal(t, fastMapDirectStringUint32, countChain.steps[0].mapDirect)
+	directOut.Reset()
+	handled, err = writeFastDirectMapIndexOutput(&directOut, plush.NewContext(), reflect.ValueOf(map[string]uint32{"active": 7}), &countChain.steps[0])
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "7", directOut.String())
+
+	intChain, ok := fastAccessChainPlanFor(&mixed.ops[2].valuePlan, reflect.TypeOf(map[string]int{}))
+	require.True(t, ok)
+	require.Len(t, intChain.steps, 1)
+	require.Equal(t, fastMapDirectStringInt, intChain.steps[0].mapDirect)
+	directOut.Reset()
+	handled, err = writeFastDirectMapIndexOutput(&directOut, plush.NewContext(), reflect.ValueOf(map[string]int{"count": 3}), &intChain.steps[0])
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "3", directOut.String())
+
+	interfaceChain, ok := fastAccessChainPlanFor(&mixed.ops[3].valuePlan, reflect.TypeOf(map[string]interface{}{}))
+	require.True(t, ok)
+	require.Len(t, interfaceChain.steps, 1)
+	require.Equal(t, fastMapDirectStringInterface, interfaceChain.steps[0].mapDirect)
+	directOut.Reset()
+	handled, err = writeFastDirectMapIndexOutput(&directOut, plush.NewContext(), reflect.ValueOf(map[string]interface{}{"label": "<any>"}), &interfaceChain.steps[0])
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "&lt;any&gt;", directOut.String())
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"labels": map[string]string{"status": "<ok>"},
+		"counts": map[string]uint32{"active": 7},
+		"ints":   map[string]int{"count": 3},
+		"any":    map[string]interface{}{"label": "<any>"},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `&lt;ok&gt;|7|3|&lt;any&gt;`, out)
+}
+
+func Test_VM_Fast_String_Indexed_Access_Chain_Plan_Writes_Nested_Map_Struct_Output(t *testing.T) {
+	type robot struct {
+		Name string
+	}
+
+	tmpl, err := Compile(`<%= robots["bender"].Name %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	mixed := prepareFastMixedPlan(tmpl.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed)
+	require.Len(t, mixed.ops, 1)
+	require.Equal(t, fastMixedOpAccessChain, mixed.ops[0].kind)
+
+	chain, ok := fastAccessChainPlanFor(&mixed.ops[0].valuePlan, reflect.TypeOf(map[string]robot{}))
+	require.True(t, ok)
+	require.Len(t, chain.steps, 2)
+	require.Equal(t, fastAccessStepIndex, chain.steps[0].kind)
+	require.Equal(t, "bender", chain.steps[0].mapKey.Interface())
+	require.Equal(t, fastAccessStepField, chain.steps[1].kind)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"robots": map[string]robot{
+			"bender": {Name: "<Bender>"},
+		},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `&lt;Bender&gt;`, out)
+}
+
+func Test_VM_Fast_String_Indexed_Access_Chain_Plan_Handles_Interface_Map_Keys(t *testing.T) {
+	tmpl, err := Compile(`<%= labels["status"] %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	mixed := prepareFastMixedPlan(tmpl.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed)
+	require.Len(t, mixed.ops, 1)
+	require.Equal(t, fastMixedOpAccessChain, mixed.ops[0].kind)
+
+	chain, ok := fastAccessChainPlanFor(&mixed.ops[0].valuePlan, reflect.TypeOf(map[interface{}]string{}))
+	require.True(t, ok)
+	require.Len(t, chain.steps, 1)
+	require.Equal(t, fastAccessStepIndex, chain.steps[0].kind)
+	require.True(t, chain.steps[0].mapKey.IsValid())
+	require.Equal(t, "status", chain.steps[0].mapKey.Interface())
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"labels": map[interface{}]string{"status": "<ok>"},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `&lt;ok&gt;`, out)
+}
+
+func Test_VM_Fast_String_Indexed_Access_Chain_Preserves_Bad_Key_Error(t *testing.T) {
+	_, err := Render(`<%= lookup["bad"] %>`, plush.NewContextWith(map[string]interface{}{
+		"lookup": map[int]string{1: "one"},
+	}))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `cannot use bad (string constant) as int value in map index`)
+}
+
+func Test_VM_Fast_Top_Level_Access_Chain_Plan_Handles_Method_Chain(t *testing.T) {
+	tmpl, err := Compile(`<%= robot.Name.Echo() %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	mixed := prepareFastMixedPlan(tmpl.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed)
+	require.Len(t, mixed.ops, 1)
+	require.Equal(t, fastMixedOpAccessChain, mixed.ops[0].kind)
+
+	_, ok := fastFieldChainPlanFor(&mixed.ops[0].valuePlan, reflect.TypeOf(vmAccessRobot{}))
+	require.False(t, ok)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"robot": vmAccessRobot{Name: "Bender"},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `Bender`, out)
+
+	entry, ok := mixed.ops[0].accessCache.Load().(*fastTopLevelAccessCacheEntry)
+	require.True(t, ok)
+	require.Equal(t, fastTopLevelAccessMethodCall, entry.kind)
+	require.Equal(t, reflect.TypeOf(vmAccessRobot{}), entry.typ)
+	require.NotNil(t, entry.method)
+}
+
+func Test_VM_Fast_Top_Level_Access_Chain_Skips_Method_In_Middle(t *testing.T) {
+	tmpl, err := Compile(`<%= robot.GetFriends()[0].Name.Echo() %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	mixed := prepareFastMixedPlan(tmpl.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed)
+	require.Len(t, mixed.ops, 1)
+	require.Equal(t, fastMixedOpValue, mixed.ops[0].kind)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"robot": vmAccessRobot{Friends: []vmAccessRobot{{Name: "Fry"}}},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `Fry`, out)
+}
+
+func Test_VM_Loop_Fast_Plan_Uses_Typed_Field_Cache(t *testing.T) {
+	type product struct {
+		Name string
+	}
+
+	tmpl, err := Compile(`<%= for (i, product) in products { %><%= product.Name %>;<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	segment := &tmpl.bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, compiler.FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+	require.Len(t, segment.Loop.Parts, 2)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"products": []product{{Name: "Bender"}, {Name: "Fry"}},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `Bender;Fry;`, out)
+
+	cache := segment.Loop.Parts[0].PropertyCache.Load()
+	require.NotNil(t, cache)
+	entry, ok := cache.(*propertyInlineCacheEntry)
+	require.True(t, ok)
+	require.NotNil(t, entry.reader)
+}
+
+func Test_VM_Fast_Loop_Helper_Call_Part(t *testing.T) {
+	type product struct {
+		Name string
+	}
+
+	tmpl, err := Compile(`<%= for (i, product) in products { %><%= label(product.Name, prefix) %>;<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	segment := &tmpl.bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, compiler.FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+	require.Len(t, segment.Loop.Parts, 2)
+	require.Equal(t, compiler.FastLoopPartCall, segment.Loop.Parts[0].Kind)
+	require.NotNil(t, segment.Loop.Parts[0].Call)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"prefix":   "robot",
+		"products": []product{{Name: "Bender"}, {Name: "<Fry>"}},
+		"label": func(name string, prefix string) string {
+			return prefix + ":" + name
+		},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `robot:Bender;robot:&lt;Fry&gt;;`, out)
+
+	entry, ok := segment.Loop.Parts[0].Call.Cache.Load().(*fastBuilderCallCacheEntry)
+	require.Truef(t, ok, "expected fast loop call cache entry, got %T", segment.Loop.Parts[0].Call.Cache.Load())
+	require.NotNil(t, entry)
+	require.NotNil(t, entry.plan)
+	require.NotNil(t, entry.invoker)
+
+	argPlan := &segment.Loop.Parts[0].Call.Args[0]
+	chain, ok := fastFieldChainPlanFor(argPlan, reflect.TypeOf(product{}))
+	require.True(t, ok)
+	require.Len(t, chain.steps, 1)
+	require.Equal(t, "Name", chain.steps[0].name)
+}
+
+func Test_VM_Fast_Struct_Loop_Specializes_Helper_Call_Part_Automatically(t *testing.T) {
+	type product struct {
+		Name string
+	}
+
+	tmpl, err := Compile(`<%= for (i, product) in products { %><%= label(product.Name, prefix) %>;<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	segment := &tmpl.bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, compiler.FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+
+	elemType, ok := fastStructLoopElementType(reflect.TypeOf([]product{}))
+	require.True(t, ok)
+	writerPlan, ok := fastStructLoopWriterPlanFor(segment.Loop, elemType)
+	require.True(t, ok)
+	require.Len(t, writerPlan.ops, 2)
+	require.Equal(t, fastStructLoopWriterCall, writerPlan.ops[0].kind)
+	require.NotNil(t, writerPlan.ops[0].call)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"prefix":   "robot",
+		"products": []product{{Name: "Bender"}, {Name: "<Fry>"}},
+		"label": func(name string, prefix string) string {
+			return prefix + ":" + name
+		},
+	})
+	bindings := newFastRenderBindings(tmpl.bytecode.FastRenderPlan, ctx)
+	state := &fastStructLoopRenderState{}
+	resolved, err := state.resolvedCall(writerPlan.ops[0].call, bindings)
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+	require.NotNil(t, resolved.directWriter)
+
+	var out strings.Builder
+	handled, err := renderFastStructFieldLoop(&out, ctx, bindings, segment.Loop, reflect.ValueOf([]product{{Name: "Bender"}, {Name: "<Fry>"}}))
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, `robot:Bender;robot:&lt;Fry&gt;;`, out.String())
+
+	rendered, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `robot:Bender;robot:&lt;Fry&gt;;`, rendered)
+}
+
+func Test_VM_Fast_Struct_Loop_Helper_Call_Learns_Reflect_Arg_Plan(t *testing.T) {
+	type productName string
+	type product struct {
+		Name productName
+	}
+
+	tmpl, err := Compile(`<%= for (i, product) in products { %><%= label(product.Name, prefix) %>;<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	segment := &tmpl.bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, compiler.FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+
+	elemType, ok := fastStructLoopElementType(reflect.TypeOf([]product{}))
+	require.True(t, ok)
+	writerPlan, ok := fastStructLoopWriterPlanFor(segment.Loop, elemType)
+	require.True(t, ok)
+	require.Len(t, writerPlan.ops, 2)
+	require.Equal(t, fastStructLoopWriterCall, writerPlan.ops[0].kind)
+	require.NotNil(t, writerPlan.ops[0].call)
+	require.Len(t, writerPlan.ops[0].call.args, 2)
+	require.Equal(t, fastStructLoopCallArgAccessChain, writerPlan.ops[0].call.args[0].kind)
+	require.Equal(t, fastStructLoopCallArgBinding, writerPlan.ops[0].call.args[1].kind)
+
+	label := func(name productName, prefix string) string {
+		return prefix + ":" + string(name)
+	}
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"prefix":   "robot",
+		"products": []product{{Name: "Bender"}, {Name: "<Fry>"}},
+		"label":    label,
+	})
+	bindings := newFastRenderBindings(tmpl.bytecode.FastRenderPlan, ctx)
+	state := &fastStructLoopRenderState{}
+	resolved, err := state.resolvedCall(writerPlan.ops[0].call, bindings)
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+	require.True(t, resolved.canReflect)
+	require.Equal(t, reflect.TypeOf(label), resolved.entry.rt)
+
+	var out strings.Builder
+	handled, err := renderFastStructFieldLoop(&out, ctx, bindings, segment.Loop, reflect.ValueOf([]product{{Name: "Bender"}, {Name: "<Fry>"}}))
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, `robot:Bender;robot:&lt;Fry&gt;;`, out.String())
+
+	rendered, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `robot:Bender;robot:&lt;Fry&gt;;`, rendered)
+}
+
+func Test_VM_Fast_Loop_Key_Values_For_Helper_Calls(t *testing.T) {
+	type product struct {
+		Name string
+	}
+
+	tmpl, err := Compile(`<%= for (i, product) in products { %><%= label(i) %>:<%= product.Name %>;<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	segment := &tmpl.bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, compiler.FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+	require.Equal(t, compiler.FastLoopPartCall, segment.Loop.Parts[0].Kind)
+	require.Equal(t, compiler.FastValueLoopKey, segment.Loop.Parts[0].Call.Args[0].Kind)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"products": []product{{Name: "Bender"}, {Name: "Fry"}},
+		"label": func(index int) string {
+			return fmt.Sprintf("idx-%d", index)
+		},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `idx-0:Bender;idx-1:Fry;`, out)
+
+	entry, ok := segment.Loop.Parts[0].Call.Cache.Load().(*fastBuilderCallCacheEntry)
+	require.Truef(t, ok, "expected fast loop call cache entry, got %T", segment.Loop.Parts[0].Call.Cache.Load())
+	require.NotNil(t, entry.invoker)
+}
+
+func Test_VM_Fast_Loop_Conditional_Part(t *testing.T) {
+	type product struct {
+		Name    string
+		Enabled bool
+	}
+
+	tmpl, err := Compile(`<%= for (i, product) in products { %><%= if product.Enabled { %><%= product.Name %><% } else if fallback { %>fallback<% } else { %>hidden<% } %>;<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	segment := &tmpl.bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, compiler.FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+	require.Len(t, segment.Loop.Parts, 2)
+	require.Equal(t, compiler.FastLoopPartConditional, segment.Loop.Parts[0].Kind)
+	require.NotNil(t, segment.Loop.Parts[0].Conditional)
+
+	products := []product{
+		{Name: "<Bender>", Enabled: true},
+		{Name: "Fry", Enabled: false},
+	}
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"products": products,
+		"fallback": false,
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `&lt;Bender&gt;;hidden;`, out)
+
+	out, err = tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"products": products,
+		"fallback": true,
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `&lt;Bender&gt;;fallback;`, out)
+}
+
+func Test_VM_Fast_Loop_Infix_Conditional_Part(t *testing.T) {
+	type product struct {
+		Name  string
+		Stock uint32
+	}
+
+	tmpl, err := Compile(`<%= for (i, product) in products { %><%= if product.Stock > min { %><%= product.Name %><% } else if i == 0 { %>first<% } else { %>low<% } %>;<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	segment := &tmpl.bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, compiler.FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+	require.Equal(t, compiler.FastLoopPartConditional, segment.Loop.Parts[0].Kind)
+	require.Equal(t, compiler.FastValueInfix, segment.Loop.Parts[0].Conditional.Branches[0].Condition.Kind)
+	require.Equal(t, compiler.FastValueInfix, segment.Loop.Parts[0].Conditional.Branches[1].Condition.Kind)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"min": uint64(2),
+		"products": []product{
+			{Name: "Bender", Stock: 0},
+			{Name: "<Fry>", Stock: 3},
+			{Name: "Leela", Stock: 1},
+		},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `first;&lt;Fry&gt;;low;`, out)
+}
+
+func Test_VM_Fast_Top_Level_Infix_Output(t *testing.T) {
+	type robot struct {
+		Stock uint32
+	}
+
+	tmpl, err := Compile(`<%= i32 == 0 %>|<%= u32 == 0 %>|<%= u64one == 1.0 %>|<%= f32i == 3 %>|<%= f64i == i32v %>|<%= robot.Stock == 3.0 %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	mixed := prepareFastMixedPlan(tmpl.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed)
+	require.Len(t, mixed.ops, 6)
+	for i := range mixed.ops {
+		require.Equal(t, fastMixedOpValue, mixed.ops[i].kind)
+		require.Equal(t, compiler.FastValueInfix, mixed.ops[i].valuePlan.Kind)
+	}
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"i32":    int32(0),
+		"i32v":   int32(3),
+		"u32":    uint32(0),
+		"u64one": uint64(1),
+		"f32i":   float32(3),
+		"f64i":   float64(3),
+		"robot":  robot{Stock: uint32(3)},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `true|true|true|true|true|true`, out)
+}
+
+func Test_VM_Fast_Top_Level_Logical_Infix_Output_Short_Circuits(t *testing.T) {
+	tmpl, err := Compile(`<%= enabled && missing.Value %>|<%= enabled || missing.Value %>|<%= count == 1 && enabled %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"enabled": false,
+		"count":   uint32(1),
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `false|false|false`, out)
+
+	out, err = tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"enabled": true,
+		"count":   uint32(1),
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `false|true|true`, out)
+}
+
+func Test_VM_Fast_Top_Level_Infix_Output_Preserves_Missing_Ordered_Error(t *testing.T) {
+	_, err := Render(`<%= undefined > 3 %>`, plush.NewContext())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `unable to operate (>)`)
+}
+
+func Test_VM_Fast_Struct_Loop_Specializes_Conditional_Part_Automatically(t *testing.T) {
+	type product struct {
+		Name  string
+		Stock uint32
+	}
+
+	tmpl, err := Compile(`<%= for (i, product) in products { %><%= if product.Stock > min { %><%= product.Name %><% } else if i == 0 { %>first<% } else { %>low<% } %>;<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	segment := &tmpl.bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, compiler.FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+
+	elemType, ok := fastStructLoopElementType(reflect.TypeOf([]product{}))
+	require.True(t, ok)
+	writerPlan, ok := fastStructLoopWriterPlanFor(segment.Loop, elemType)
+	require.True(t, ok)
+	require.Len(t, writerPlan.ops, 2)
+	require.Equal(t, fastStructLoopWriterConditional, writerPlan.ops[0].kind)
+	require.NotNil(t, writerPlan.ops[0].conditional)
+	require.Len(t, writerPlan.ops[0].conditional.branches, 2)
+	firstCondition := writerPlan.ops[0].conditional.branches[0].conditionPlan
+	require.NotNil(t, firstCondition)
+	require.Equal(t, fastStructLoopConditionInfix, firstCondition.kind)
+	require.Equal(t, ">", firstCondition.operator)
+	require.Equal(t, fastStructLoopCallArgAccessChain, firstCondition.leftValue.kind)
+	require.Equal(t, fastStructLoopCallArgBinding, firstCondition.rightValue.kind)
+	secondCondition := writerPlan.ops[0].conditional.branches[1].conditionPlan
+	require.NotNil(t, secondCondition)
+	require.Equal(t, fastStructLoopConditionInfix, secondCondition.kind)
+	require.Equal(t, "==", secondCondition.operator)
+	require.Equal(t, fastStructLoopCallArgKey, secondCondition.leftValue.kind)
+	require.Equal(t, fastStructLoopCallArgInt, secondCondition.rightValue.kind)
+
+	products := []product{
+		{Name: "Bender", Stock: 0},
+		{Name: "<Fry>", Stock: 3},
+		{Name: "Leela", Stock: 1},
+	}
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"min":      uint64(2),
+		"products": products,
+	})
+	var out strings.Builder
+	handled, err := renderFastStructFieldLoop(&out, ctx, newFastRenderBindings(tmpl.bytecode.FastRenderPlan, ctx), segment.Loop, reflect.ValueOf(products))
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, `first;&lt;Fry&gt;;low;`, out.String())
+
+	rendered, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `first;&lt;Fry&gt;;low;`, rendered)
+}
+
+func Test_VM_Fast_Struct_Loop_Specializes_Logical_Infix_Conditional_Part(t *testing.T) {
+	type product struct {
+		Name  string
+		Stock uint32
+	}
+
+	tmpl, err := Compile(`<%= for (i, product) in products { %><%= if product.Stock > min && i != 0 { %><%= product.Name %><% } else { %>skip<% } %>;<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	segment := &tmpl.bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, compiler.FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+
+	elemType, ok := fastStructLoopElementType(reflect.TypeOf([]product{}))
+	require.True(t, ok)
+	writerPlan, ok := fastStructLoopWriterPlanFor(segment.Loop, elemType)
+	require.True(t, ok)
+	require.Len(t, writerPlan.ops, 2)
+	require.Equal(t, fastStructLoopWriterConditional, writerPlan.ops[0].kind)
+	require.NotNil(t, writerPlan.ops[0].conditional)
+	require.Len(t, writerPlan.ops[0].conditional.branches, 1)
+
+	condition := writerPlan.ops[0].conditional.branches[0].conditionPlan
+	require.NotNil(t, condition)
+	require.Equal(t, fastStructLoopConditionLogical, condition.kind)
+	require.Equal(t, "&&", condition.operator)
+	require.NotNil(t, condition.left)
+	require.NotNil(t, condition.right)
+	require.Equal(t, fastStructLoopConditionInfix, condition.left.kind)
+	require.Equal(t, fastStructLoopConditionInfix, condition.right.kind)
+
+	products := []product{
+		{Name: "Bender", Stock: 5},
+		{Name: "<Fry>", Stock: 3},
+		{Name: "Leela", Stock: 1},
+	}
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"min":      uint64(2),
+		"products": products,
+	})
+	var out strings.Builder
+	handled, err := renderFastStructFieldLoop(&out, ctx, newFastRenderBindings(tmpl.bytecode.FastRenderPlan, ctx), segment.Loop, reflect.ValueOf(products))
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, `skip;&lt;Fry&gt;;skip;`, out.String())
+
+	rendered, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `skip;&lt;Fry&gt;;skip;`, rendered)
+}
+
+func Test_VM_Fast_Binding_Output_Inline_Cache(t *testing.T) {
+	tmpl, err := Compile(`<%= name %>|<%= count %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"name":  "<Mido>",
+		"count": uint32(7),
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `&lt;Mido&gt;|7`, out)
+
+	mixed := prepareFastMixedPlan(tmpl.bytecode.FastRenderPlan)
+	require.NotNil(t, mixed)
+	require.Len(t, mixed.ops, 2)
+	require.NotNil(t, mixed.ops[0].outputCache.Load())
+	require.NotNil(t, mixed.ops[1].outputCache.Load())
+
+	out, err = tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"name":  template.HTML("<b>Mido</b>"),
+		"count": uint64(9),
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `<b>Mido</b>|9`, out)
+}
+
+func Test_VM_Top_Level_Fast_Binding_Plan_Caches_Root_Context_I_Ds(t *testing.T) {
+	tmpl, err := Compile(`<%= name %>|<%= title %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"z":     true,
+		"name":  "Mido",
+		"title": "Engineer",
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `Mido|Engineer`, out)
+
+	cached, ok := tmpl.bytecode.FastRenderPlan.BindingPrepared.Load().(*fastRenderBindingPlan)
+	require.True(t, ok)
+	require.NotNil(t, cached)
+	require.True(t, cached.matches(tmpl.bytecode.FastRenderPlan.Bindings))
+
+	out, err = tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"a":     true,
+		"title": "Pilot",
+		"name":  "Fry",
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `Fry|Pilot`, out)
+
+	reused, ok := tmpl.bytecode.FastRenderPlan.BindingPrepared.Load().(*fastRenderBindingPlan)
+	require.True(t, ok)
+	require.Same(t, cached, reused)
+}
+
+func Test_VM_Top_Level_Fast_Binding_Plan_Skips_Custom_ID_Context(t *testing.T) {
+	tmpl, err := Compile(`<%= name %>|<%= title %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+
+	ctx := newIDLookupTestContext(map[string]interface{}{
+		"name":  "Mido",
+		"title": "Engineer",
+	})
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `Mido|Engineer`, out)
+	require.Nil(t, tmpl.bytecode.FastRenderPlan.BindingPrepared.Load())
+	require.Equal(t, 2, ctx.lookupID)
+}
+
+func Test_VM_Fast_Binding_Output_Inline_Cache_Scalar_Types(t *testing.T) {
+	cases := []struct {
+		name     string
+		value    interface{}
+		expected string
+	}{
+		{name: "string", value: "<x>", expected: "&lt;x&gt;"},
+		{name: "html", value: template.HTML("<b>x</b>"), expected: "<b>x</b>"},
+		{name: "bool", value: true, expected: "true"},
+		{name: "int", value: int(-1), expected: "-1"},
+		{name: "int8", value: int8(-2), expected: "-2"},
+		{name: "int16", value: int16(-3), expected: "-3"},
+		{name: "int32", value: int32(-4), expected: "-4"},
+		{name: "int64", value: int64(-5), expected: "-5"},
+		{name: "uint", value: uint(1), expected: "1"},
+		{name: "uint8", value: uint8(2), expected: "2"},
+		{name: "uint16", value: uint16(3), expected: "3"},
+		{name: "uint32", value: uint32(4), expected: "4"},
+		{name: "uint64", value: uint64(5), expected: "5"},
+		{name: "uintptr", value: uintptr(6), expected: "6"},
+		{name: "float32", value: float32(1.25), expected: "1.25"},
+		{name: "float64", value: float64(2.5), expected: "2.5"},
+	}
+
+	ctx := plush.NewContext()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var slot object.InlineCacheSlot
+			var out strings.Builder
+			handled := writeFastBindingOutput(&out, ctx, tc.value, &slot)
+			require.True(t, handled)
+			require.Equal(t, tc.expected, out.String())
+
+			entry, ok := slot.Load().(*fastOutputCacheEntry)
+			require.True(t, ok)
+			require.True(t, entry.matches(tc.value))
+
+			out.Reset()
+			handled = writeFastBindingOutput(&out, ctx, tc.value, &slot)
+			require.True(t, handled)
+			require.Equal(t, tc.expected, out.String())
+		})
+	}
+}
+
+func Test_VM_Fast_Struct_Slice_Loop_Specialization(t *testing.T) {
+	type product struct {
+		Name  string
+		Price int
+	}
+
+	tmpl, err := Compile(`<%= for (i, product) in products { %><%= i %>:<%= product.Name %>=<%= product.Price %>;<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	segment := &tmpl.bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, compiler.FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+
+	elemType, ok := fastStructLoopElementType(reflect.TypeOf([]product{}))
+	require.True(t, ok)
+	require.Equal(t, reflect.TypeOf(product{}), elemType)
+	require.True(t, fastStructFieldLoopParts(segment.Loop, elemType))
+	writerPlan, ok := fastStructLoopWriterPlanFor(segment.Loop, elemType)
+	require.True(t, ok)
+	require.Len(t, writerPlan.ops, 6)
+	require.Equal(t, fastStructLoopWriterKey, writerPlan.ops[0].kind)
+	require.Equal(t, fastStructLoopWriterField, writerPlan.ops[2].kind)
+	require.Equal(t, "Name", writerPlan.ops[2].name)
+	require.Equal(t, fastStructLoopWriterField, writerPlan.ops[4].kind)
+	require.Equal(t, "Price", writerPlan.ops[4].name)
+
+	products := []product{
+		{Name: "Bender", Price: 10},
+		{Name: "<Fry>", Price: 20},
+	}
+	var out strings.Builder
+	ctx := plush.NewContext()
+	handled, err := renderFastStructFieldLoop(&out, ctx, newFastRenderBindings(tmpl.bytecode.FastRenderPlan, ctx), segment.Loop, reflect.ValueOf(products))
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, `0:Bender=10;1:&lt;Fry&gt;=20;`, out.String())
+
+	rendered, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"products": products,
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `0:Bender=10;1:&lt;Fry&gt;=20;`, rendered)
+}
+
+func Test_VM_Fast_Struct_Pointer_Slice_Loop_Specialization(t *testing.T) {
+	type product struct {
+		Name string
+	}
+
+	tmpl, err := Compile(`<%= for (i, product) in products { %><%= product.Name %>;<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	segment := &tmpl.bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, compiler.FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+
+	elemType, ok := fastStructLoopElementType(reflect.TypeOf([]*product{}))
+	require.True(t, ok)
+	require.Equal(t, reflect.TypeOf(product{}), elemType)
+	require.True(t, fastStructFieldLoopParts(segment.Loop, elemType))
+
+	products := []*product{{Name: "Bender"}, nil, {Name: "<Fry>"}}
+	var out strings.Builder
+	ctx := plush.NewContext()
+	handled, err := renderFastStructFieldLoop(&out, ctx, newFastRenderBindings(tmpl.bytecode.FastRenderPlan, ctx), segment.Loop, reflect.ValueOf(products))
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, `Bender;;&lt;Fry&gt;;`, out.String())
+
+	rendered, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"products": products,
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `Bender;;&lt;Fry&gt;;`, rendered)
+}
+
+func Test_VM_Fast_Struct_Slice_Loop_Specializes_Nested_Value_Path(t *testing.T) {
+	type category struct {
+		Name string
+	}
+	type product struct {
+		Category category
+	}
+
+	tmpl, err := Compile(`<%= for (i, product) in products { %><%= product.Category.Name %>;<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	segment := &tmpl.bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, compiler.FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+
+	elemType, ok := fastStructLoopElementType(reflect.TypeOf([]product{}))
+	require.True(t, ok)
+	require.True(t, fastStructFieldLoopParts(segment.Loop, elemType))
+	writerPlan, ok := fastStructLoopWriterPlanFor(segment.Loop, elemType)
+	require.True(t, ok)
+	require.Len(t, writerPlan.ops, 2)
+	require.Equal(t, fastStructLoopWriterAccessChain, writerPlan.ops[0].kind)
+	require.NotNil(t, writerPlan.ops[0].accessPlan)
+	require.Len(t, writerPlan.ops[0].accessPlan.steps, 2)
+
+	products := []product{
+		{Category: category{Name: "Drinks"}},
+		{Category: category{Name: "<Snacks>"}},
+	}
+	var out strings.Builder
+	ctx := plush.NewContext()
+	handled, err := renderFastStructFieldLoop(&out, ctx, newFastRenderBindings(tmpl.bytecode.FastRenderPlan, ctx), segment.Loop, reflect.ValueOf(products))
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, `Drinks;&lt;Snacks&gt;;`, out.String())
+
+	rendered, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"products": products,
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `Drinks;&lt;Snacks&gt;;`, rendered)
+}
+
+func Test_VM_Fast_Struct_Slice_Loop_Specializes_Indexed_Value_Path(t *testing.T) {
+	type friend struct {
+		Name string
+	}
+	type product struct {
+		Friends []friend
+	}
+
+	tmpl, err := Compile(`<%= for (i, product) in products { %><%= product.Friends[0].Name %>;<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	segment := &tmpl.bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, compiler.FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+
+	elemType, ok := fastStructLoopElementType(reflect.TypeOf([]product{}))
+	require.True(t, ok)
+	require.True(t, fastStructFieldLoopParts(segment.Loop, elemType))
+	writerPlan, ok := fastStructLoopWriterPlanFor(segment.Loop, elemType)
+	require.True(t, ok)
+	require.Len(t, writerPlan.ops, 2)
+	require.Equal(t, fastStructLoopWriterAccessChain, writerPlan.ops[0].kind)
+	require.NotNil(t, writerPlan.ops[0].accessPlan)
+	require.Len(t, writerPlan.ops[0].accessPlan.steps, 3)
+	require.Equal(t, fastAccessStepField, writerPlan.ops[0].accessPlan.steps[0].kind)
+	require.Equal(t, fastAccessStepIndex, writerPlan.ops[0].accessPlan.steps[1].kind)
+	require.Equal(t, fastAccessStepField, writerPlan.ops[0].accessPlan.steps[2].kind)
+
+	products := []product{
+		{Friends: []friend{{Name: "Bender"}}},
+		{Friends: []friend{{Name: "<Fry>"}}},
+	}
+	var out strings.Builder
+	ctx := plush.NewContext()
+	handled, err := renderFastStructFieldLoop(&out, ctx, newFastRenderBindings(tmpl.bytecode.FastRenderPlan, ctx), segment.Loop, reflect.ValueOf(products))
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, `Bender;&lt;Fry&gt;;`, out.String())
+
+	rendered, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"products": products,
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `Bender;&lt;Fry&gt;;`, rendered)
+}
+
+func Test_VM_Fast_Struct_Slice_Loop_Specializes_Method_Value_Path(t *testing.T) {
+	tmpl, err := Compile(`<%= for (i, product) in products { %><%= product.Name.Echo() %>;<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	segment := &tmpl.bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, compiler.FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+
+	elemType, ok := fastStructLoopElementType(reflect.TypeOf([]vmAccessRobot{}))
+	require.True(t, ok)
+	require.True(t, fastStructFieldLoopParts(segment.Loop, elemType))
+	writerPlan, ok := fastStructLoopWriterPlanFor(segment.Loop, elemType)
+	require.True(t, ok)
+	require.Len(t, writerPlan.ops, 2)
+	require.Equal(t, fastStructLoopWriterMethodCall, writerPlan.ops[0].kind)
+	require.NotNil(t, writerPlan.ops[0].methodPlan)
+
+	var out strings.Builder
+	ctx := plush.NewContext()
+	handled, err := renderFastStructFieldLoop(&out, ctx, newFastRenderBindings(tmpl.bytecode.FastRenderPlan, ctx), segment.Loop, reflect.ValueOf([]vmAccessRobot{{Name: "Bender"}, {Name: "<Fry>"}}))
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, `Bender;&lt;Fry&gt;;`, out.String())
+
+	rendered, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"products": []vmAccessRobot{{Name: "Bender"}, {Name: "<Fry>"}},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `Bender;&lt;Fry&gt;;`, rendered)
+}
+
+func Test_VM_Fast_String_Key_Value_Loop_Specialization(t *testing.T) {
+	tmpl, err := Compile(`<%= for (i, item) in items { %><%= i %>:<%= item %>;<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	segment := &tmpl.bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, compiler.FastRenderSegmentLoop, segment.Kind)
+	require.NotNil(t, segment.Loop)
+
+	separator, suffix, ok := fastStringKeyValueLoopParts(segment.Loop)
+	require.True(t, ok)
+	require.Equal(t, ":", separator)
+	require.Equal(t, ";", suffix)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"items": []string{"a", "<b>"},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, `0:a;1:&lt;b&gt;;`, out)
+}
+
+func Test_VM_Mixed_Static_Name_Fast_Path_Falls_Back_For_Unsupported_Values(t *testing.T) {
+	tmpl, err := Compile(`<%= values %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"values": []int{1, 2, 3},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "123", out)
+}
+
+func Test_VM_Static_Only_Render_Uses_Cached_Static_Bytecode(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	plush.PlushCacheSetup(cache)
+	defer plush.ClearTemplateCache()
+
+	filename := "vm-static-fast-path.plush"
+	ctx := plush.NewContext()
+	ctx.Set(meta.TemplateFileKey, filename)
+
+	out, err := Render(`<%= 10 %><span>items</span>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, `10<span>items</span>`, out)
+
+	entry, ok := cache.Get(plush.GenerateASTKey(filename))
+	require.True(t, ok)
+	bytecode, ok := entry.VMBytecode.(*compiler.Bytecode)
+	require.True(t, ok)
+	require.True(t, bytecode.Static)
+
+	ctx = plush.NewContext()
+	ctx.Set(meta.TemplateFileKey, filename)
+	out, err = Render(`<%= 10 %><span>items</span>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, bytecode.StaticOutput, out)
+}
+
+func Test_VM_Cached_Bytecode_Entry_Renders_VM_Only_Bytecode(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	plush.PlushCacheSetup(cache)
+	defer plush.ClearTemplateCache()
+
+	filename := "vm-bytecode-entry.plush"
+	input := `<% let forceBytecode = fn() { return "x" } %><% let name = "cached" %><%= name %>`
+	ctx := plush.NewContext()
+	ctx.Set(meta.TemplateFileKey, filename)
+
+	out, err := Render(input, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "cached", out)
+
+	entry, ok := cache.Get(plush.GenerateASTKey(filename))
+	require.True(t, ok)
+	bytecode, ok := entry.VMBytecode.(*compiler.Bytecode)
+	require.True(t, ok)
+	require.False(t, bytecode.Static)
+	require.Nil(t, bytecode.FastRenderPlan)
+
+	ctx = plush.NewContext()
+	ctx.Set(meta.TemplateFileKey, filename)
+	out, err = Render(input, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "cached", out)
+}
+
+func Test_VM_Direct_Write_Call_Renders_Helpers_Methods_And_Closures(t *testing.T) {
+	input := `<%= greet(name) %>|<%= robot.Name() %>|<% let local = fn(value) { return "local " + value } %><%= local(name) %>|<%= echo.Echo() %>`
+	program, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	comp := compiler.New()
+	require.NoError(t, comp.Compile(program))
+	bytecode := comp.Bytecode()
+	require.Equal(t, 1, len(opcodePositions(bytecode.Instructions, code.OpWriteNameCall)))
+	require.Equal(t, 3, len(opcodePositions(bytecode.Instructions, code.OpWriteCall)))
+	require.Falsef(t, instructionContainsSequenceForVM(bytecode.Instructions, code.OpCall, code.OpWrite), "expected call/write pair to be fused:\n%s", bytecode.Instructions.String())
+
+	out, err := Render(input, plush.NewContextWith(map[string]interface{}{
+		"name":  "Mido",
+		"greet": func(name string) string { return "hi " + name },
+		"robot": &vmRobot{name: "Bender"},
+		"echo":  vmEchoName("echoed"),
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "hi Mido|Bender|local Mido|echoed", out)
+}
+
+func Test_VM_Direct_Write_Call_Renders_Fast_Return_Kinds(t *testing.T) {
+	input := `<%= unsafe() %>|<%= safe() %>|<%= yes() %>|<%= count() %>|<%= ratio() %>`
+	out, err := Render(input, plush.NewContextWith(map[string]interface{}{
+		"unsafe": func() string { return "<x>" },
+		"safe":   func() template.HTML { return template.HTML("<b>x</b>") },
+		"yes":    func() bool { return true },
+		"count":  func() int { return 7 },
+		"ratio":  func() float64 { return 1.5 },
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "&lt;x&gt;|<b>x</b>|true|7|1.5", out)
+}
+
+func Test_VM_Callsite_Cache_For_Named_Helpers(t *testing.T) {
+	input := `<% let forceBytecode = fn() { return "x" } %><%= greet(name) %><%= greet(name) %>`
+	tmpl, err := Compile(input)
+	require.NoError(t, err)
+
+	positions := opcodePositions(tmpl.bytecode.Instructions, code.OpWriteNameCall)
+	require.Len(t, positions, 2)
+	for _, pos := range positions {
+		require.Nil(t, tmpl.bytecode.CallCaches[pos].Load())
+	}
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name":  "Mido",
+		"greet": func(name string) string { return "hi " + name },
+	})
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "hi Midohi Mido", out)
+
+	for _, pos := range positions {
+		entry := requireCallCacheEntry(t, tmpl.bytecode.CallCaches[pos].Load())
+		require.NotNil(t, entry.plan)
+		require.NotNil(t, entry.invoker)
+		require.False(t, entry.noFast)
+	}
+}
+
+func Test_VM_Callsite_Cache_For_Method_Write_Calls(t *testing.T) {
+	input := `<% let forceBytecode = fn() { return "x" } %><%= echo.Echo() %><%= echo.Echo() %>`
+	tmpl, err := Compile(input)
+	require.NoError(t, err)
+
+	positions := opcodePositions(tmpl.bytecode.Instructions, code.OpWriteCall)
+	require.Len(t, positions, 2)
+	for _, pos := range positions {
+		require.Nil(t, tmpl.bytecode.CallCaches[pos].Load())
+	}
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"echo": vmEchoName("<echo>"),
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "&lt;echo&gt;&lt;echo&gt;", out)
+
+	for _, pos := range positions {
+		entry := requireCallCacheEntry(t, tmpl.bytecode.CallCaches[pos].Load())
+		require.NotNil(t, entry.plan)
+		require.NotNil(t, entry.invoker)
+		require.False(t, entry.noFast)
+	}
+}
+
+func Test_VM_Write_Call_Falls_Back_When_Fast_Invoker_Is_Unavailable(t *testing.T) {
+	input := `<% let forceBytecode = fn() { return "x" } %><%= robot.Generic() %>`
+	tmpl, err := Compile(input)
+	require.NoError(t, err)
+
+	positions := opcodePositions(tmpl.bytecode.Instructions, code.OpWriteCall)
+	require.Len(t, positions, 1)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"robot": vmGenericMethodRobot{},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "generic", out)
+
+	entry := requireCallCacheEntry(t, tmpl.bytecode.CallCaches[positions[0]].Load())
+	require.NotNil(t, entry.plan)
+	require.Nil(t, entry.invoker)
+	require.True(t, entry.noFast)
+}
+
+func Test_VM_Direct_Property_Write_Fusion_And_Raw_Loop_Values(t *testing.T) {
+	type product struct {
+		Name string
+	}
+	input := `<%= user.Name %>|<%= for (i, product) in products { %><%= product.Name %>;<% } %>`
+	program, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	comp := compiler.New()
+	require.NoError(t, comp.Compile(program))
+	require.NotEmptyf(t, opcodePositions(comp.Bytecode().Instructions, code.OpWriteNameProperty), "expected OpWriteNameProperty:\n%s", comp.Bytecode().Instructions.String())
+
+	loopFn := firstCompiledFunction(t, comp.Bytecode().Constants)
+	require.NotEmptyf(t, opcodePositions(loopFn.Instructions, code.OpWriteLocalProperty), "expected OpWriteLocalProperty:\n%s", loopFn.Instructions.String())
+	require.True(t, loopCanUseRawValues(&object.Closure{Fn: loopFn}))
+
+	out, err := Render(input, plush.NewContextWith(map[string]interface{}{
+		"user":     product{Name: "<Ada>"},
+		"products": []product{{Name: "Bender"}, {Name: "<Fry>"}},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "&lt;Ada&gt;|Bender;&lt;Fry&gt;;", out)
+}
+
+func Test_VM_Loop_Raw_Value_Detection_Rejects_Computed_Locals(t *testing.T) {
+	program, err := compiler.ParseScript(`for (i, item) in items { item + "!" }`)
+	require.NoError(t, err)
+
+	comp := compiler.New()
+	require.NoError(t, comp.Compile(program))
+
+	loopFn := firstCompiledFunction(t, comp.Bytecode().Constants)
+	require.False(t, loopCanUseRawValues(&object.Closure{Fn: loopFn}))
+}
+
+func Test_VM_Partial_Bytecode_Links_Reuse_Within_Render(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name": "Mido",
+		"partialFeeder": func(string) (string, error) {
+			return `<span><%= name %></span>`, nil
+		},
+	})
+
+	out, err := Render(`<%= partial("row") %><%= partial("row") %><%= partial("row") %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "<span>Mido</span><span>Mido</span><span>Mido</span>", out)
+
+	links, ok := ctx.Value(vmPartialBytecodeLinksKey).(*partialBytecodeLinkCache)
+	require.True(t, ok)
+	require.Equal(t, 1, links.Len())
+}
+
+func Test_VM_Partial_Bytecode_Links_Do_Not_Stale_Dynamic_Feeder_Source(t *testing.T) {
+	parts := []string{`<%= "a" %>`, `<%= "b" %>`}
+	calls := 0
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"partialFeeder": func(string) (string, error) {
+			part := parts[calls]
+			calls++
+			return part, nil
+		},
+	})
+
+	out, err := Render(`<%= partial("dynamic") %><%= partial("dynamic") %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "ab", out)
+	require.Equal(t, 2, calls)
+
+	links, ok := ctx.Value(vmPartialBytecodeLinksKey).(*partialBytecodeLinkCache)
+	require.True(t, ok)
+	require.Equal(t, 1, links.Len())
+}
+
+func Test_VM_Loop_Context_Write_Detection(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		template bool
+		expected bool
+	}{
+		{
+			name:     "pure stack locals",
+			input:    `for (i, item) in items { item }`,
+			expected: false,
+		},
+		{
+			name:     "helper call",
+			input:    `for (i, item) in items { helper(item) }`,
+			expected: true,
+		},
+		{
+			name:     "hole",
+			input:    `<%= for (i, item) in items { %><%H item %><% } %>`,
+			template: true,
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				program interface{}
+				err     error
+			)
+			if tt.template {
+				program, err = parser.Parse(tt.input)
+			} else {
+				program, err = compiler.ParseScript(tt.input)
+			}
+			require.NoError(t, err)
+
+			comp := compiler.New()
+			require.NoError(t, comp.Compile(program))
+
+			fn := firstCompiledFunction(t, comp.Bytecode().Constants)
+			require.Equal(t, tt.expected, loopNeedsContextWrites(&object.Closure{Fn: fn}))
+		})
+	}
+}
+
+func Test_Render_Helper_Block_And_Assignment(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"wrap": func(help plush.HelperContext) (template.HTML, error) {
+			body, err := help.Block()
+			return template.HTML("<div>" + body + "</div>"), err
+		},
+	})
+
+	out, err := Render(`<% let message = "hello" %><%= wrap() { message = "bye" } %><%= message %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "<div></div>bye", out)
+}
+
+func Test_Render_Phase_6_Helper_Interop_Matrix(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name": "mark",
+		"count": func(values ...int) int {
+			return len(values)
+		},
+		"touch": func(value string) {},
+		"pair": func() (string, error) {
+			return "pair", nil
+		},
+		"wrap": func(data map[string]interface{}, help plush.HelperContext) (template.HTML, error) {
+			child := help.New()
+			for k, v := range data {
+				child.Set(k, v)
+			}
+			body, err := help.BlockWith(child)
+			return template.HTML(body), err
+		},
+		"iface": func(help hctx.HelperContext) string {
+			if !help.HasBlock() {
+				return "no block"
+			}
+			body, _ := help.Block()
+			return body
+		},
+		"renderSnippet": func(help hctx.HelperContext) (template.HTML, error) {
+			body, err := help.Render(`<%= name %>`)
+			return template.HTML(body), err
+		},
+	})
+
+	out, err := Render(`<%= count() %>|<%= count(1, 2) %>|<%= touch("x") %>|<%= pair() %>|<%= wrap({name: "child"}) { return name } %>|<%= name %>|<%= iface() { return "block" } %>|<%= renderSnippet() %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "0|2||pair|child|mark|block|mark", out)
+}
+
+func Test_Render_Struct_Traversal(t *testing.T) {
+	ctx := plush.NewContext()
+	ctx.Set("user", struct {
+		Name string
+	}{Name: "Mark"})
+
+	out, err := Render(`<%= user.Name %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "Mark", out)
+}
+
+type vmRobot struct {
+	name string
+}
+
+func (r *vmRobot) Name() string {
+	return r.name
+}
+
+type vmHTMLer struct {
+	value string
+}
+
+func (h vmHTMLer) HTML() template.HTML {
+	return template.HTML(h.value)
+}
+
+type vmInterfaceValue struct {
+	value interface{}
+}
+
+func (v vmInterfaceValue) Interface() interface{} {
+	return v.value
+}
+
+type vmStringer string
+
+func (s vmStringer) String() string {
+	return string(s)
+}
+
+type vmGenericStringer string
+
+func (s vmGenericStringer) String() string {
+	return string(s)
+}
+
+type vmGenericMethodRobot struct{}
+
+func (vmGenericMethodRobot) Generic() vmGenericStringer {
+	return "generic"
+}
+
+type vmPhase9Robot struct {
+	Name string
+}
+
+type vmBudgetGreeter struct{}
+
+func (vmBudgetGreeter) Greet() string {
+	return "hi"
+}
+
+type vmBudgetRobot struct {
+	Name vmEchoName
+}
+
+func Test_Render_Pointer_Method_On_Struct_Value(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"robot": vmRobot{name: "Bender"},
+	})
+
+	out, err := Render(`<%= robot.Name() %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "Bender", out)
+}
+
+func Test_Render_Phase_7_Output_Safety_Matrix(t *testing.T) {
+	tm := time.Date(2013, time.February, 3, 0, 0, 0, 0, time.UTC)
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"unsafe":        `<strong>"x"</strong>`,
+		"safeHTML":      template.HTML(`<strong>"x"</strong>`),
+		"htmler":        vmHTMLer{value: `<em>x</em>`},
+		"interfaceHTML": vmInterfaceValue{value: template.HTML(`<i>x</i>`)},
+		"rawStringer":   vmStringer(`<b>stringer</b>`),
+		"tm":            tm,
+		"strings":       []string{"a", "<b>"},
+		"mixed":         []interface{}{"x", template.HTML("<y>"), 7, false, nil},
+	})
+
+	out, err := Render(`<%= "<script>" %>|<%= unsafe %>|<%= safeHTML %>|<%= htmler %>|<%= interfaceHTML %>|<%= rawStringer %>|<%= tm %>|<%= strings %>|<%= mixed %>|<%= nil %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, `&lt;script&gt;|&lt;strong&gt;&#34;x&#34;&lt;/strong&gt;|<strong>"x"</strong>|<em>x</em>|<i>x</i>|<b>stringer</b>|February 03, 2013 00:00:00 +0000|a&lt;b&gt;|x<y>7false|`, out)
+
+	ctx.Set("TIME_FORMAT", "2006-02-Jan")
+	out, err = Render(`<%= tm %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "2013-03-Feb", out)
+}
+
+func Test_Render_Phase_9_Optional_If_Parentheses(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name":   "mark",
+		"admin":  false,
+		"robots": []vmPhase9Robot{{Name: "mark"}},
+		"lookup": map[string]string{"TESTING": "mark"},
+	})
+
+	out, err := Render(`<%= if true { %>a<% } %>|<%= if name == "mark" || admin { %>b<% } %>|<%= if (name == "ringo") || admin { %>x<% } else if robots[0].Name == "mark" { %>c<% } %>|<%= if lookup["TESTING"] == "mark" { %>d<% } %>|<%= if (true) { %>old<% } %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "a|b|c|d|old", out)
+}
+
+func Test_Render_If_Block_Output(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"show": true,
+	})
+
+	out, err := Render(`<%= if (show) { %>yes<% } %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "yes", out)
+}
+
+func Test_Render_If_Branch_Let_Does_Not_Overwrite_Outer(t *testing.T) {
+	out, err := Render(`<p><% let username = "Hello World" %><%= if (username) {
+		let username = "hi"
+		username = "bye"
+	} %><%= username %></p>`, plush.NewContext())
+	require.NoError(t, err)
+	require.Equal(t, "<p>Hello World</p>", out)
+}
+
+func Test_Render_If_Branch_Assignment_Updates_Outer(t *testing.T) {
+	out, err := Render(`<p><% let username = "Hello World" %><%= if (username) {
+		username = "hi"
+		if (username == "hi") {
+			username = "hi2"
+		}
+	} %><%= username %></p>`, plush.NewContext())
+	require.NoError(t, err)
+	require.Equal(t, "<p>hi2</p>", out)
+}
+
+func Test_VM_Fast_Render_Silent_If_Assignment_Updates_Outer(t *testing.T) {
+	type listing struct {
+		DisplayResult int
+		TotalResult   int
+	}
+
+	tmpl, err := Compile(`<% let displayResult = listing.DisplayResult
+if (listing.TotalResult < listing.DisplayResult) {
+	displayResult = listing.TotalResult
+}
+%><%= displayResult %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+	require.Len(t, tmpl.bytecode.FastRenderPlan.Segments, 3)
+	require.Equal(t, compiler.FastRenderSegmentLet, tmpl.bytecode.FastRenderPlan.Segments[0].Kind)
+	require.Equal(t, compiler.FastRenderSegmentConditional, tmpl.bytecode.FastRenderPlan.Segments[1].Kind)
+	require.Equal(t, compiler.FastRenderSegmentAssign, tmpl.bytecode.FastRenderPlan.Segments[1].Conditional.Branches[0].Segments[0].Kind)
+	require.Equal(t, compiler.FastRenderSegmentName, tmpl.bytecode.FastRenderPlan.Segments[2].Kind)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"listing": listing{DisplayResult: 10, TotalResult: 3},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "3", out)
+}
+
+type vmProductListing struct {
+	Products []vmProduct
+}
+
+type vmProduct struct {
+	Name []string
+}
+
+type vmEchoName string
+
+func (n vmEchoName) Echo() string {
+	return string(n)
+}
+
+func (n vmEchoName) String() string {
+	return string(n)
+}
+
+type vmAccessNode struct {
+	N    string
+	Next *vmAccessNode
+}
+
+type vmAccessRobot struct {
+	Name    vmEchoName
+	Next    *vmAccessNode
+	Friends []vmAccessRobot
+	Map     map[string]vmAccessRobot
+	Buckets map[string]vmAccessBucket
+}
+
+func (r vmAccessRobot) GetFriends() []vmAccessRobot {
+	return r.Friends
+}
+
+type vmAccessBucket struct {
+	Items []vmAccessRobot
+}
+
+type vmRobotFactory struct {
+	values []vmAccessRobot
+}
+
+func (f vmRobotFactory) Robots() []vmAccessRobot {
+	return f.values
+}
+
+type vmFunctionReturnFactory struct {
+	robot vmFunctionReturnRobot
+}
+
+func (f vmFunctionReturnFactory) Robots() vmFunctionReturnRobot {
+	return f.robot
+}
+
+type vmFunctionReturnRobot struct {
+	name vmEchoName
+}
+
+func (r vmFunctionReturnRobot) Name() vmEchoName {
+	return r.name
+}
+
+type vmArrayHolder struct {
+	Items [2]vmAccessRobot
+}
+
+type vmAccessPerson struct {
+	born time.Time
+}
+
+func (p vmAccessPerson) GetBorn() time.Time {
+	return p.born
+}
+
+type vmNumericStats struct {
+	Count uint64
+}
+
+type vmNumericRobot struct {
+	Count uint32
+	Stats vmNumericStats
+}
+
+func (r vmNumericRobot) MethodCount() uint32 {
+	return r.Count
+}
+
+func Test_Render_Indexed_Receiver_Callee_Chain(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"product_listing": vmProductListing{
+			Products: []vmProduct{{Name: []string{"Buffalo"}}},
+		},
+	})
+
+	out, err := Render(`<% let a = product_listing.Products[0].Name[0] %><%= a %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "Buffalo", out)
+}
+
+func Test_Render_Struct_Access_Phase_5_Chains(t *testing.T) {
+	robot := vmAccessRobot{
+		Name: "bender",
+		Next: &vmAccessNode{N: "one", Next: &vmAccessNode{N: "two"}},
+		Friends: []vmAccessRobot{
+			{Name: "fry"},
+			{Name: "leela"},
+		},
+	}
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"robot":  robot,
+		"robots": []vmAccessRobot{robot},
+		"getRobots": func() []vmAccessRobot {
+			return []vmAccessRobot{{Name: "scruffy"}}
+		},
+		"factory": func() vmRobotFactory {
+			return vmRobotFactory{values: []vmAccessRobot{{Name: "factory"}}}
+		},
+	})
+
+	out, err := Render(`<%= robot.Next.Next.N %>|<%= robots[0].Friends[1].Name.Echo() %>|<%= getRobots()[0].Name %>|<%= factory().Robots()[0].Name.Echo() %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "two|leela|scruffy|factory", out)
+}
+
+func Test_Render_Struct_Access_Phase_5_Map_And_Typed_Collection_Chains(t *testing.T) {
+	robot := vmAccessRobot{
+		Name: "bender",
+		Map: map[string]vmAccessRobot{
+			"owner": {Name: "fry"},
+		},
+		Buckets: map[string]vmAccessBucket{
+			"team": {Items: []vmAccessRobot{{Name: "amy"}}},
+		},
+	}
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"robot":     robot,
+		"key":       "owner",
+		"bucketKey": "team",
+		"holder": vmArrayHolder{
+			Items: [2]vmAccessRobot{{Name: "zero"}, {Name: "one"}},
+		},
+		"nour": vmAccessPerson{
+			born: time.Date(1993, time.January, 11, 0, 0, 0, 0, time.UTC),
+		},
+	})
+
+	out, err := Render(`<%= robot.Map[key].Name.Echo() %>|<%= robot.Buckets[bucketKey].Items[0].Name %>|<%= holder.Items[1].Name %>|<%= nour.GetBorn().Format("Jan 2, 2006") %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "fry|amy|one|Jan 11, 1993", out)
+
+	out, err = Render(`<%= robot.Map["missing"].Name %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "", out)
+}
+
+func Test_Render_Struct_Access_Phase_5_Nested_Function_Returns(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"factory": func() vmFunctionReturnFactory {
+			return vmFunctionReturnFactory{
+				robot: vmFunctionReturnRobot{name: "nested"},
+			}
+		},
+	})
+
+	out, err := Render(`<%= factory().Robots().Name().Echo() %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "nested", out)
+}
+
+func Test_Render_Struct_Access_Phase_5_Errors(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"robot": vmAccessRobot{
+			Name:    "bender",
+			Friends: []vmAccessRobot{{Name: "fry"}},
+		},
+		"items":  []vmAccessRobot{{Name: "zero"}},
+		"lookup": map[int]string{1: "one"},
+	})
+
+	tests := []struct {
+		name     string
+		input    string
+		contains string
+	}{
+		{
+			name:     "slice index type",
+			input:    `<%= items["bad"].Name %>`,
+			contains: `can't access Slice/Array with a non int Index`,
+		},
+		{
+			name:     "slice out of bounds after method return",
+			input:    `<%= robot.GetFriends()[9].Name %>`,
+			contains: `array index out of bounds`,
+		},
+		{
+			name:     "map key type",
+			input:    `<%= lookup["bad"] %>`,
+			contains: `cannot use bad (string constant) as int value in map index`,
+		},
+		{
+			name:     "call non function field",
+			input:    `<%= robot.Name() %>`,
+			contains: `does not have a method named 'Name'`,
+		},
+		{
+			name:     "invalid chained call",
+			input:    `<%= robot.Name.Missing() %>`,
+			contains: `does not have a method named 'Missing'`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Render(tt.input, ctx)
+			require.Error(t, err)
+			require.ErrorContains(t, err, tt.contains)
+		})
+	}
+}
+
+func Test_Render_Loop_Break_Stops_After_Output(t *testing.T) {
+	out, err := Render(`<%= for (i,v) in [1, 2, 3, 4] {
+		%>Start<%
+		if (v == 3) {
+			%>Stop<%
+			break
+		}
+		return v
+	} %>`, plush.NewContext())
+	require.NoError(t, err)
+	require.Equal(t, "Start1Start2StartStop", out)
+}
+
+func Test_Render_Loop_Continue_Keeps_Output_And_Skips_Value(t *testing.T) {
+	out, err := Render(`<%= for (i,v) in [1, 2, 3, 4] {
+		%>Start<%
+		if (v == 1 || v == 3) {
+			%>Odd<%
+			continue
+		}
+		return v
+	} %>`, plush.NewContext())
+	require.NoError(t, err)
+	require.Equal(t, "StartOddStart2StartOddStart4", out)
+}
+
+func Test_Render_Native_Slice_Append(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"ints": []int{1, 2},
+	})
+
+	out, err := Render(`<% let a = ints %><% a = a + 3 %><%= a[2] %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "3", out)
+}
+
+func Test_Render_Safe_Mixed_Numeric_Comparisons(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"i32":     int32(0),
+		"neg":     int32(-1),
+		"u32":     uint32(0),
+		"u32v":    uint32(3),
+		"u64":     uint64(0),
+		"u64one":  uint64(1),
+		"u64max":  uint64(math.MaxUint64),
+		"f32":     float32(3.5),
+		"f64":     float64(3.5),
+		"counts":  map[string]uint32{"active": 0},
+		"values":  []uint32{0},
+		"robot":   vmNumericRobot{Count: 0, Stats: vmNumericStats{Count: 0}},
+		"robots":  []vmNumericRobot{{Count: 1, Stats: vmNumericStats{Count: 0}}},
+		"counter": func() uint32 { return 0 },
+	})
+
+	out, err := Render(`<%= i32 == 0 %>|<%= u32 == 0 %>|<%= u64 == 0 %>|<%= u64one > 0 %>|<%= u64max > 0 %>|<%= neg < 0 %>|<%= neg < u64 %>|<%= neg == u64 %>|<%= u32v == 3 %>|<%= f32 == 3.5 %>|<%= f64 > 3 %>|<%= robot.Count == 0 %>|<%= robots[0].Stats.Count == 0 %>|<%= counts["active"] == 0 %>|<%= values[0] == 0 %>|<%= counter() == 0 %>|<%= robot.MethodCount() == 0 %>|<%= robot.Count + 1 %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "true|true|true|true|true|true|true|false|true|true|true|true|true|true|true|true|true|1", out)
+}
+
+func Test_Render_Top_Level_Return(t *testing.T) {
+	out, err := Render(`<% return "x" %>`, plush.NewContext())
+	require.NoError(t, err)
+	require.Equal(t, "x", out)
+}
+
+func Test_Render_Context_Value_Shadows_Builtin_Identifier(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"len": "shadow",
+	})
+
+	out, err := Render(`<%= len %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "shadow", out)
+}
+
+func Test_Render_Context_Function_Shadows_Builtin_Call(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"len": func() string {
+			return "ctx"
+		},
+	})
+
+	out, err := Render(`<%= len() %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "ctx", out)
+}
+
+func Test_Logical_Short_Circuit(t *testing.T) {
+	out, err := Render(`<%= false && missing %>|<%= true || missing %>`, plush.NewContext())
+	require.NoError(t, err)
+	require.Equal(t, "false|true", out)
+}
+
+func Test_Render_Undefined_Equality_Does_Not_Error(t *testing.T) {
+	out, err := Render(`<%= undefined == 3 %>|<%= 3 != unknown %>`, plush.NewContext())
+	require.NoError(t, err)
+	require.Equal(t, "false|true", out)
+}
+
+func Test_Render_Phase_11_Named_Function_Budget_Stats(t *testing.T) {
+	costs := plush.ZeroCosts()
+	costs.HelperCall = 1
+	costs.FunctionCosts = map[string]int64{
+		"expensive": 7,
+		"Greet":     5,
+		"Echo":      3,
+	}
+	costs.ObjectTraversal = 2
+
+	budget := plush.NewBudgetWithCosts(100, costs)
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"expensive": func() string { return "x" },
+		"greeter":   vmBudgetGreeter{},
+		"robot":     vmBudgetRobot{Name: vmEchoName("Bender")},
+		"robots":    []vmBudgetRobot{{Name: vmEchoName("Fry")}},
+	})
+	ctx.WithBudget(budget)
+
+	out, err := Render(`<%= expensive() %>|<%= greeter.Greet() %>|<%= robot.Name.Echo() %>|<%= robots[0].Name.Echo() %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "x|hi|Bender|Fry", out)
+
+	stats := budget.Stats()
+	require.Equal(t, int64(18), stats.FunctionCalls)
+	require.Equal(t, int64(7), stats.ByFunction["expensive"])
+	require.Equal(t, int64(5), stats.ByFunction["Greet"])
+	require.Equal(t, int64(6), stats.ByFunction["Echo"])
+	require.Equal(t, int64(10), stats.ObjectTraversals)
+	require.Equal(t, stats.TotalUsed, stats.FunctionCalls+stats.ObjectTraversals)
+}
+
+func Test_Render_Phase_11_Named_Function_Budget_Exceeded(t *testing.T) {
+	costs := plush.ZeroCosts()
+	costs.FunctionCosts = map[string]int64{"expensive": 7}
+
+	budget := plush.NewBudgetWithCosts(6, costs)
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"expensive": func() string { return "x" },
+	})
+	ctx.WithBudget(budget)
+
+	out, err := Render(`<%= expensive() %>`, ctx)
+	require.ErrorIs(t, err, plush.ErrBudgetExceeded)
+	require.Empty(t, out)
+
+	stats := budget.Stats()
+	require.Equal(t, int64(7), stats.FunctionCalls)
+	require.Equal(t, int64(7), stats.ByFunction["expensive"])
+	require.Equal(t, int64(7), stats.TotalUsed)
+}
+
+func Test_Render_Phase_11_User_Function_Budget_Name(t *testing.T) {
+	costs := plush.ZeroCosts()
+	costs.Assignment = 1
+	costs.FunctionCosts = map[string]int64{"add": 9}
+
+	budget := plush.NewBudgetWithCosts(100, costs)
+	ctx := plush.NewContext()
+	ctx.WithBudget(budget)
+
+	out, err := Render(`<% let add = fn(x) { return x + 1 } %><%= add(2) %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "3", out)
+
+	stats := budget.Stats()
+	require.Equal(t, int64(9), stats.FunctionCalls)
+	require.Equal(t, int64(9), stats.ByFunction["add"])
+	require.Equal(t, int64(1), stats.Assignments)
+	require.Equal(t, int64(10), stats.TotalUsed)
+}
+
+func Test_Render_Phase_11_Nested_Function_Budget_Names(t *testing.T) {
+	costs := plush.ZeroCosts()
+	costs.FunctionCosts = map[string]int64{
+		"make":  2,
+		"inner": 3,
+		"greet": 5,
+	}
+
+	budget := plush.NewBudgetWithCosts(100, costs)
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"greet": func() string { return "hi" },
+	})
+	ctx.WithBudget(budget)
+
+	out, err := Render(`<% let make = fn() { let inner = fn() { return greet() }; return inner() } %><%= make() %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "hi", out)
+
+	stats := budget.Stats()
+	require.Equal(t, int64(10), stats.FunctionCalls)
+	require.Equal(t, int64(2), stats.ByFunction["make"])
+	require.Equal(t, int64(3), stats.ByFunction["inner"])
+	require.Equal(t, int64(5), stats.ByFunction["greet"])
+	require.Equal(t, int64(10), stats.TotalUsed)
+}
+
+func Test_Render_Hole_Statements(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"items": []string{"a", "b", "c"},
+	})
+
+	out, err := Render(`<%H "start" %><%H for (i,v) in items { %><%= v %><% } %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "<PLUSH_HOLE_0><PLUSH_HOLE_1>", out)
+
+	ctx.Set(meta.TemplateFileKey, "holes.plush")
+	out, err = Render(`<%H "start" %><%H for (i,v) in items { %><%= v %><% } %>`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "startabc", out)
+}
+
+func Test_Render_Phase_10_Hole_Skeleton_Records_Markers(t *testing.T) {
+	program, err := parser.Parse(`<% let a = ["a", "b"] %><% a = a + "1" %><%= a %><%H "testing" %><%= a %><%H "sssss" %>`)
+	require.NoError(t, err)
+
+	comp := compiler.New()
+	require.NoError(t, comp.Compile(program))
+
+	machine := NewWithContext(comp.Bytecode(), plush.NewContext())
+	require.NoError(t, machine.Run())
+
+	skeleton := machine.Rendered()
+	holes := machine.PunchHoles()
+	require.Equal(t, `ab1<PLUSH_HOLE_0>ab1<PLUSH_HOLE_1>`, skeleton)
+	require.Len(t, holes, 2)
+	require.Equal(t, "<PLUSH_HOLE_0>", holes[0].MarkerName())
+	require.Equal(t, `<%= "testing" %>`, holes[0].Input())
+	require.Equal(t, 3, holes[0].Start())
+	require.Equal(t, 17, holes[0].End())
+	require.Empty(t, holes[0].Content())
+	require.NoError(t, holes[0].Err())
+	require.Equal(t, "<PLUSH_HOLE_1>", holes[1].MarkerName())
+	require.Equal(t, `<%= "sssss" %>`, holes[1].Input())
+	require.Equal(t, 20, holes[1].Start())
+	require.Equal(t, 34, holes[1].End())
+}
+
+func Test_Render_Phase_10_Hole_Cache_Behavior(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	plush.PlushCacheSetup(cache)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"myArray": []string{"a", "b"},
+	})
+	ctx.Set(meta.TemplateFileKey, "vm-cache-hole.plush")
+
+	input := `<% let a = myArray %><% a = a + "1" %><%= a %><%H "testing" %><%= a %><%H "sssss" %>`
+	out, err := Render(input, ctx)
+	require.NoError(t, err)
+	require.Equal(t, `ab1testingab1sssss`, out)
+
+	cachedInput := `<% let a = myArray %><% a = a + "2" %><%= a %><%H "testing" %><%= a %><%H "sssss" %>`
+	out, err = Render(cachedInput, ctx)
+	require.NoError(t, err)
+	require.Equal(t, `ab2testingab2sssss`, out)
+
+	cache.Delete(plush.GenerateASTKey("vm-cache-hole.plush"))
+	out, err = Render(cachedInput, ctx)
+	require.NoError(t, err)
+	require.Equal(t, `ab2testingab2sssss`, out)
+}
+
+func runVMTests(t *testing.T, tests []vmTestCase) {
+	t.Helper()
+
+	for _, tt := range tests {
+		program, err := compiler.ParseScript(tt.input)
+		require.NoError(t, err)
+
+		comp := compiler.New()
+		require.NoError(t, comp.Compile(program))
+
+		machine := New(comp.Bytecode())
+		require.NoError(t, machine.Run())
+
+		testExpectedObject(t, tt.expected, machine.LastPoppedStackElem())
+	}
+}
+
+func testExpectedObject(t *testing.T, expected interface{}, actual object.Object) {
+	t.Helper()
+
+	switch expected := expected.(type) {
+	case int:
+		testIntegerObject(t, int64(expected), actual)
+	case string:
+		testStringObject(t, expected, actual)
+	case bool:
+		testBooleanObject(t, expected, actual)
+	case []int:
+		testArrayObject(t, expected, actual)
+	case map[object.HashKey]int:
+		testHashObject(t, expected, actual)
+	case *object.Null:
+		require.Same(t, Null, actual)
+	case *object.Error:
+		result, ok := actual.(*object.Error)
+		require.Truef(t, ok, "object is not Error. got=%T (%+v)", actual, actual)
+		require.Equal(t, expected.Message, result.Message)
+	default:
+		require.Failf(t, "unsupported expected type", "unsupported expected type %T", expected)
+	}
+}
+
+func testIntegerObject(t *testing.T, expected int64, actual object.Object) {
+	t.Helper()
+
+	result, ok := actual.(*object.Integer)
+	require.Truef(t, ok, "object is not Integer. got=%T (%+v)", actual, actual)
+	require.Equal(t, expected, result.Value)
+}
+
+func testBooleanObject(t *testing.T, expected bool, actual object.Object) {
+	t.Helper()
+
+	result, ok := actual.(*object.Boolean)
+	require.Truef(t, ok, "object is not Boolean. got=%T (%+v)", actual, actual)
+	require.Equal(t, expected, result.Value)
+}
+
+func testStringObject(t *testing.T, expected string, actual object.Object) {
+	t.Helper()
+
+	result, ok := actual.(*object.String)
+	require.Truef(t, ok, "object is not String. got=%T (%+v)", actual, actual)
+	require.Equal(t, expected, result.Value)
+}
+
+func testArrayObject(t *testing.T, expected []int, actual object.Object) {
+	t.Helper()
+
+	result, ok := actual.(*object.Array)
+	require.Truef(t, ok, "object is not Array. got=%T (%+v)", actual, actual)
+	require.Len(t, result.Elements, len(expected))
+	for i, expectedElem := range expected {
+		testIntegerObject(t, int64(expectedElem), result.Elements[i])
+	}
+}
+
+func testHashObject(t *testing.T, expected map[object.HashKey]int, actual object.Object) {
+	t.Helper()
+
+	result, ok := actual.(*object.Hash)
+	require.Truef(t, ok, "object is not Hash. got=%T (%+v)", actual, actual)
+	require.Len(t, result.Pairs, len(expected))
+	for expectedKey, expectedValue := range expected {
+		pair, ok := result.Pairs[expectedKey]
+		require.Truef(t, ok, "missing hash key %+v", expectedKey)
+		testIntegerObject(t, int64(expectedValue), pair.Value)
+	}
+}
+
+func firstCompiledFunction(t *testing.T, constants []object.Object) *object.CompiledFunction {
+	t.Helper()
+
+	for _, constant := range constants {
+		if fn, ok := constant.(*object.CompiledFunction); ok {
+			return fn
+		}
+	}
+	require.Fail(t, "expected compiled function constant")
+	return nil
+}
+
+func requireCallCacheEntry(t *testing.T, value interface{}) *callCacheEntry {
+	t.Helper()
+
+	entry, ok := value.(*callCacheEntry)
+	require.Truef(t, ok, "expected call cache entry, got %T", value)
+	require.NotNil(t, entry)
+	return entry
+}
+
+func opcodePositions(instructions code.Instructions, target code.Opcode) []int {
+	positions := []int{}
+	for i := 0; i < len(instructions); {
+		op := code.Opcode(instructions[i])
+		if op == target {
+			positions = append(positions, i)
+		}
+		def, err := code.Lookup(byte(op))
+		if err != nil {
+			i++
+			continue
+		}
+		_, read := code.ReadOperands(def, instructions[i+1:])
+		i += 1 + read
+	}
+	return positions
+}
+
+func callWritePairs(instructions code.Instructions) []int {
+	positions := []int{}
+	for i := 0; i < len(instructions); {
+		op := code.Opcode(instructions[i])
+		def, err := code.Lookup(byte(op))
+		if err != nil {
+			i++
+			continue
+		}
+		_, read := code.ReadOperands(def, instructions[i+1:])
+		next := i + 1 + read
+		if op == code.OpCall && next < len(instructions) && code.Opcode(instructions[next]) == code.OpWrite {
+			positions = append(positions, i)
+		}
+		i = next
+	}
+	return positions
+}
+
+func instructionContainsSequenceForVM(instructions code.Instructions, first, second code.Opcode) bool {
+	for i := 0; i < len(instructions); {
+		op := code.Opcode(instructions[i])
+		def, err := code.Lookup(byte(op))
+		if err != nil {
+			i++
+			continue
+		}
+		_, read := code.ReadOperands(def, instructions[i+1:])
+		next := i + 1 + read
+		if op == first && next < len(instructions) && code.Opcode(instructions[next]) == second {
+			return true
+		}
+		i = next
+	}
+	return false
+}

--- a/VM/vm/write_name_call_helpers_test.go
+++ b/VM/vm/write_name_call_helpers_test.go
@@ -1,0 +1,174 @@
+package vm
+
+import (
+	"html/template"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/VM/code"
+	"github.com/gobuffalo/plush/v5/VM/compiler"
+	"github.com/gobuffalo/plush/v5/VM/object"
+	"github.com/stretchr/testify/require"
+)
+
+func newWriteNameCallTestVM(ctx *plush.Context, names ...string) *VM {
+	constants := make([]object.Object, len(names))
+	for i, name := range names {
+		constants[i] = &object.String{Value: name}
+	}
+	return NewWithContext(&compiler.Bytecode{
+		Constants:    constants,
+		Instructions: code.Make(code.OpNull),
+	}, ctx)
+}
+
+func Test_VM_Execute_Write_Name_Call_Branches(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"raw": func() string {
+			return "<raw>"
+		},
+		"native": &object.Native{Value: func() string {
+			return "<native>"
+		}},
+		"len": object.GetBuiltinByName("len"),
+		"closure": &object.Closure{Fn: &object.CompiledFunction{
+			Instructions: code.Instructions(append(
+				code.Make(code.OpConstant, 4),
+				code.Make(code.OpReturnValue)...,
+			)),
+			NumParameters: 0,
+			NumLocals:     0,
+		}},
+		"bad": 7,
+		"fast": func() string {
+			return "<slow>"
+		},
+		"fastNative": &object.Native{Value: func() string {
+			return "<slow-native>"
+		}},
+	})
+	SetFastHelper(ctx, "fast", func(w FastWriter, args FastArgs) error {
+		w.WriteEscapedString("<fast>")
+		return nil
+	})
+	SetFastHelper(ctx, "fastNative", func(w FastWriter, args FastArgs) error {
+		w.WriteEscapedString("<fast-native>")
+		return nil
+	})
+	machine := newWriteNameCallTestVM(ctx, "raw", "native", "len", "closure", "<closure>", "missing", "bad", "fast", "fastNative")
+
+	var rawSlot object.InlineCacheSlot
+	require.NoError(t, machine.executeWriteNameCall(0, 0, &rawSlot))
+	require.Equal(t, "&lt;raw&gt;", machine.currentFrame().output.String())
+
+	machine.currentFrame().output.Reset()
+	var nativeSlot object.InlineCacheSlot
+	require.NoError(t, machine.executeWriteNameCall(1, 0, &nativeSlot))
+	require.Equal(t, "&lt;native&gt;", machine.currentFrame().output.String())
+
+	machine.currentFrame().output.Reset()
+	require.NoError(t, machine.push(&object.Array{Elements: []object.Object{&object.Integer{Value: 1}, &object.Integer{Value: 2}}}))
+	require.NoError(t, machine.executeWriteNameCall(2, 1, nil))
+	require.Equal(t, "2", machine.currentFrame().output.String())
+
+	machine.currentFrame().output.Reset()
+	require.NoError(t, machine.executeWriteNameCall(3, 0, nil))
+	require.Equal(t, 2, machine.framesIndex)
+	require.NoError(t, machine.Run())
+	require.Equal(t, "&lt;closure&gt;", machine.currentFrame().output.String())
+
+	machine.currentFrame().output.Reset()
+	require.NoError(t, machine.executeWriteNameCall(7, 0, nil))
+	require.Equal(t, "&lt;fast&gt;", machine.currentFrame().output.String())
+
+	machine.currentFrame().output.Reset()
+	require.NoError(t, machine.executeWriteNameCall(8, 0, nil))
+	require.Equal(t, "&lt;fast-native&gt;", machine.currentFrame().output.String())
+
+	require.ErrorContains(t, machine.executeWriteNameCall(5, 0, nil), `"missing": unknown identifier`)
+	require.ErrorContains(t, machine.executeWriteNameCall(6, 0, nil), "invalid function")
+
+	budgetCtx := plush.NewContextWith(map[string]interface{}{"raw": func() string { return "raw" }}).WithBudget(plush.NewBudget(0))
+	budgetMachine := newWriteNameCallTestVM(budgetCtx, "raw")
+	require.ErrorContains(t, budgetMachine.executeWriteNameCall(0, 0, nil), "budget")
+}
+
+func Test_VM_Execute_Write_Call_Branches(t *testing.T) {
+	ctx := plush.NewContext()
+	machine := newRuntimeHelperTestVM(ctx)
+
+	machine.stack[0] = object.GetBuiltinByName("len")
+	machine.stack[1] = &object.Array{Elements: []object.Object{&object.Integer{Value: 1}, &object.Integer{Value: 2}}}
+	machine.sp = 2
+	require.NoError(t, machine.executeWriteCall("len", 1, nil))
+	require.Equal(t, "2", machine.currentFrame().output.String())
+
+	SetFastHelper(ctx, "fast", func(w FastWriter, args FastArgs) error {
+		w.WriteEscapedString("<fast>")
+		return nil
+	})
+	machine.currentFrame().output.Reset()
+	machine.stack[0] = &object.Native{Value: func() string { return "<slow>" }}
+	machine.sp = 1
+	require.NoError(t, machine.executeWriteCall("fast", 0, nil))
+	require.Equal(t, "&lt;fast&gt;", machine.currentFrame().output.String())
+
+	machine.currentFrame().output.Reset()
+	machine.stack[0] = &object.Integer{Value: 7}
+	machine.sp = 1
+	require.ErrorContains(t, machine.executeWriteCall("bad", 0, nil), "invalid function")
+}
+
+func Test_VM_Execute_Write_Name_Call_Direct_Literal_Partial(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"partial": vmPartialHelper,
+		"partialFeeder": func(name string) (string, error) {
+			require.Equal(t, "row.plush", name)
+			return `<span>ok</span>`, nil
+		},
+	})
+	machine := newWriteNameCallTestVM(ctx, "partial")
+
+	require.NoError(t, machine.push(&object.String{Value: "row.plush"}))
+	require.NoError(t, machine.executeWriteNameCall(0, 1, nil))
+	require.Equal(t, `<span>ok</span>`, machine.currentFrame().output.String())
+	require.True(t, machine.currentFrame().hasOutput)
+	require.Equal(t, 0, machine.sp)
+}
+
+func Test_VM_Execute_Write_Name_Call_Direct_Literal_Partial_Respects_Custom_Helper(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"partial": func(string) template.HTML {
+			return template.HTML("<custom>")
+		},
+		"partialFeeder": func(string) (string, error) {
+			require.FailNow(t, "custom partial helper should bypass direct partial rendering")
+			return "", nil
+		},
+	})
+	machine := newWriteNameCallTestVM(ctx, "partial")
+
+	require.NoError(t, machine.push(&object.String{Value: "row.plush"}))
+	require.NoError(t, machine.executeWriteNameCall(0, 1, nil))
+	require.Equal(t, `<custom>`, machine.currentFrame().output.String())
+	require.True(t, machine.currentFrame().hasOutput)
+	require.Equal(t, 0, machine.sp)
+}
+
+func Test_VM_Execute_Write_Name_Call_Direct_Literal_Partial_Skips_When_Frame_Has_Locals(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"partial": vmPartialHelper,
+		"partialFeeder": func(name string) (string, error) {
+			require.Equal(t, "fallback_skip.plush", name)
+			return `<span>fallback</span>`, nil
+		},
+	})
+	machine := newWriteNameCallTestVM(ctx, "partial")
+	machine.currentFrame().cl.Fn.NumLocals = 1
+
+	require.NoError(t, machine.push(&object.String{Value: "fallback_skip.plush"}))
+	require.NoError(t, machine.executeWriteNameCall(0, 1, nil))
+	require.Equal(t, `<span>fallback</span>`, machine.currentFrame().output.String())
+	require.True(t, machine.currentFrame().hasOutput)
+	require.Equal(t, 0, machine.sp)
+}

--- a/budget_test.go
+++ b/budget_test.go
@@ -9,7 +9,7 @@ import (
 
 // --- Core budget enforcement ---
 
-func TestBudget_LoopExceedsLimit(t *testing.T) {
+func Test_Budget_Loop_Exceeds_Limit(t *testing.T) {
 	r := require.New(t)
 	// 5 iterations, each costs 1, limit is 3 → should exceed
 	tmpl := `<% for (i,v) in items { } %>`
@@ -20,7 +20,7 @@ func TestBudget_LoopExceedsLimit(t *testing.T) {
 	r.True(errors.Is(err, ErrBudgetExceeded), "expected ErrBudgetExceeded, got %v", err)
 }
 
-func TestBudget_LoopWithinLimit(t *testing.T) {
+func Test_Budget_Loop_Within_Limit(t *testing.T) {
 	r := require.New(t)
 	tmpl := `<% for (i,v) in items { } %>`
 	ctx := NewContext()
@@ -32,7 +32,7 @@ func TestBudget_LoopWithinLimit(t *testing.T) {
 
 // --- Nil budget = unlimited (backwards compat) ---
 
-func TestBudget_NilIsUnlimited(t *testing.T) {
+func Test_Budget_Nil_Is_Unlimited(t *testing.T) {
 	r := require.New(t)
 	tmpl := `<% for (i,v) in items { } %>`
 	ctx := NewContext()
@@ -44,7 +44,7 @@ func TestBudget_NilIsUnlimited(t *testing.T) {
 
 // --- Zero cost fields are skipped ---
 
-func TestBudget_ZeroCostNeverExceeds(t *testing.T) {
+func Test_Budget_Zero_Cost_Never_Exceeds(t *testing.T) {
 	r := require.New(t)
 	costs := ZeroCosts()
 	costs.LoopIteration = 0 // free
@@ -59,7 +59,7 @@ func TestBudget_ZeroCostNeverExceeds(t *testing.T) {
 
 // --- Custom helper call costs ---
 
-func TestBudget_CustomHelperCost(t *testing.T) {
+func Test_Budget_Custom_Helper_Cost(t *testing.T) {
 	r := require.New(t)
 	costs := ZeroCosts()
 	costs.HelperCall = 100 // each call costs 100
@@ -75,7 +75,7 @@ func TestBudget_CustomHelperCost(t *testing.T) {
 
 // --- Remaining / Used ---
 
-func TestBudget_UsedAndRemaining(t *testing.T) {
+func Test_Budget_Used_And_Remaining(t *testing.T) {
 	r := require.New(t)
 	b := NewBudget(100)
 	ctx := NewContext()
@@ -91,7 +91,7 @@ func TestBudget_UsedAndRemaining(t *testing.T) {
 
 // --- Condition check cost ---
 
-func TestBudget_ConditionExceedsLimit(t *testing.T) {
+func Test_Budget_Condition_Exceeds_Limit(t *testing.T) {
 	r := require.New(t)
 	costs := ZeroCosts()
 	costs.ConditionCheck = 5
@@ -106,7 +106,7 @@ func TestBudget_ConditionExceedsLimit(t *testing.T) {
 
 // --- Sub-render shares parent budget (unit test on Budget directly) ---
 
-func TestBudget_SubRenderSharesParentBudget(t *testing.T) {
+func Test_Budget_Sub_Render_Shares_Parent_Budget(t *testing.T) {
 	r := require.New(t)
 	costs := ZeroCosts()
 	costs.SubRender = 50 // each snippet costs 50
@@ -124,7 +124,7 @@ func TestBudget_SubRenderSharesParentBudget(t *testing.T) {
 
 // --- NewBudget / WithCosts / Costs ---
 
-func TestBudget_WithCosts(t *testing.T) {
+func Test_Budget_With_Costs(t *testing.T) {
 	r := require.New(t)
 	b := NewBudget(1000)
 	custom := ZeroCosts()
@@ -134,7 +134,7 @@ func TestBudget_WithCosts(t *testing.T) {
 	r.Equal(int64(42), b.Costs().HelperCall)
 }
 
-func TestBudget_NewBudgetWithCosts(t *testing.T) {
+func Test_Budget_New_Budget_With_Costs(t *testing.T) {
 	r := require.New(t)
 	costs := DefaultBudgetCosts()
 	b := NewBudgetWithCosts(500, costs)
@@ -145,7 +145,7 @@ func TestBudget_NewBudgetWithCosts(t *testing.T) {
 
 // --- Per-function cost override ---
 
-func TestBudget_FunctionCostOverride_Exceeds(t *testing.T) {
+func Test_Budget_Function_Cost_Override_Exceeds(t *testing.T) {
 	r := require.New(t)
 	costs := ZeroCosts()
 	costs.FunctionCosts = map[string]int64{
@@ -161,7 +161,7 @@ func TestBudget_FunctionCostOverride_Exceeds(t *testing.T) {
 	r.True(errors.Is(err, ErrBudgetExceeded), "expected ErrBudgetExceeded, got %v", err)
 }
 
-func TestBudget_FunctionCostOverride_FallsBackToHelperCall(t *testing.T) {
+func Test_Budget_Function_Cost_Override_Falls_Back_To_Helper_Call(t *testing.T) {
 	r := require.New(t)
 	costs := ZeroCosts()
 	costs.HelperCall = 10
@@ -178,7 +178,7 @@ func TestBudget_FunctionCostOverride_FallsBackToHelperCall(t *testing.T) {
 	r.True(errors.Is(err, ErrBudgetExceeded), "expected ErrBudgetExceeded, got %v", err)
 }
 
-func TestBudget_FunctionCostOverride_CheapFunctionDoesNotExceed(t *testing.T) {
+func Test_Budget_Function_Cost_Override_Cheap_Function_Does_Not_Exceed(t *testing.T) {
 	r := require.New(t)
 	costs := ZeroCosts()
 	costs.HelperCall = 100 // default is huge
@@ -197,7 +197,7 @@ func TestBudget_FunctionCostOverride_CheapFunctionDoesNotExceed(t *testing.T) {
 
 // --- Stats report ---
 
-func TestBudget_Stats_LoopIterations(t *testing.T) {
+func Test_Budget_Stats_Loop_Iterations(t *testing.T) {
 	r := require.New(t)
 	b := NewBudget(1_000)
 	ctx := NewContext()
@@ -214,7 +214,7 @@ func TestBudget_Stats_LoopIterations(t *testing.T) {
 	r.Equal(int64(0), s.ConditionChecks)
 }
 
-func TestBudget_Stats_FunctionCalls(t *testing.T) {
+func Test_Budget_Stats_Function_Calls(t *testing.T) {
 	r := require.New(t)
 	b := NewBudget(1_000)
 	ctx := NewContext()
@@ -230,7 +230,7 @@ func TestBudget_Stats_FunctionCalls(t *testing.T) {
 	r.Equal(int64(15), s.ByFunction["greet"])
 }
 
-func TestBudget_Stats_ByFunctionPerFunctionCost(t *testing.T) {
+func Test_Budget_Stats_By_Function_Per_Function_Cost(t *testing.T) {
 	r := require.New(t)
 	costs := ZeroCosts()
 	costs.FunctionCosts = map[string]int64{
@@ -253,7 +253,7 @@ func TestBudget_Stats_ByFunctionPerFunctionCost(t *testing.T) {
 	r.Equal(int64(24), s.TotalUsed)
 }
 
-func TestBudget_Stats_MixedOperations(t *testing.T) {
+func Test_Budget_Stats_Mixed_Operations(t *testing.T) {
 	r := require.New(t)
 	costs := BudgetCosts{
 		LoopIteration:  2,
@@ -277,7 +277,7 @@ func TestBudget_Stats_MixedOperations(t *testing.T) {
 	r.Equal(int64(23), s.TotalUsed)
 }
 
-func TestBudget_Stats_NilBudgetReturnsZero(t *testing.T) {
+func Test_Budget_Stats_Nil_Budget_Returns_Zero(t *testing.T) {
 	r := require.New(t)
 	var b *Budget
 	s := b.Stats()

--- a/comments_test.go
+++ b/comments_test.go
@@ -28,7 +28,7 @@ func Test_Comment(t *testing.T) {
 	}
 }
 
-func Test_BlockComment(t *testing.T) {
+func Test_Block_Comment(t *testing.T) {
 	r := require.New(t)
 	input := map[string]string{
 		"test1": `

--- a/compiler.go
+++ b/compiler.go
@@ -39,13 +39,12 @@ type compiler struct {
 	ctx               hctx.Context
 	program           *ast.Program
 	curStmt           ast.Statement
-	inCheck           bool
 	positionStartEnds []HoleMarker
 }
 
 // budget returns the active Budget from the current context, or nil if unlimited.
 func (c *compiler) budget() *Budget {
-	if ctx, ok := c.ctx.(*Context); ok {
+	if ctx, ok := c.ctx.(interface{ Budget() *Budget }); ok {
 		return ctx.Budget()
 	}
 	return nil
@@ -269,7 +268,7 @@ func (c *compiler) evalIfExpression(node *ast.IfExpression) (interface{}, error)
 	if err := c.budget().SpendCondition(); err != nil {
 		return nil, err
 	}
-	octx := c.ctx.(*Context)
+	octx := c.ctx
 	defer func() {
 		c.ctx = octx
 	}()
@@ -554,6 +553,14 @@ func (c *compiler) evalInfixExpression(node *ast.InfixExpression) (interface{}, 
 		return c.nilsOperator(lres, rres, node.Operator)
 	}
 
+	if isNumericOperator(node.Operator) {
+		if lnum, lok := numericValueFromGo(lres); lok {
+			if rnum, rok := numericValueFromGo(rres); rok {
+				return evalNumericOperator(lnum, rnum, node.Operator)
+			}
+		}
+	}
+
 	switch t := lres.(type) {
 	case string:
 		return c.stringsOperator(t, rres, node.Operator)
@@ -804,16 +811,9 @@ func (c *compiler) evalCallExpression(node *ast.CallExpression) (interface{}, er
 				return nil, err
 			}
 
-			var ar reflect.Value
 			expectedT := rt.In(pos)
-			if v != nil {
-				ar = reflect.ValueOf(v)
-			} else {
-				ar = reflect.New(expectedT).Elem()
-			}
-
-			actualT := ar.Type()
-			if !actualT.AssignableTo(expectedT) {
+			ar, ok := reflectValueForCallArgument(v, expectedT)
+			if !ok {
 				return nil, fmt.Errorf("%+v (%T) is an invalid argument for %s at pos %d: expected (%s)", v, v, node.Function.String(), pos, expectedT)
 			}
 
@@ -883,16 +883,9 @@ func (c *compiler) evalCallExpression(node *ast.CallExpression) (interface{}, er
 				return nil, err
 			}
 
-			var ar reflect.Value
 			expectedT := rt.In(pos)
-			if v != nil {
-				ar = reflect.ValueOf(v)
-			} else {
-				ar = reflect.New(expectedT).Elem()
-			}
-
-			actualT := ar.Type()
-			if !actualT.AssignableTo(expectedT) {
+			ar, ok := reflectValueForCallArgument(v, expectedT)
+			if !ok {
 				return nil, fmt.Errorf("%+v (%T) is an invalid argument for %s at pos %d: expected (%s)", v, v, node.Function.String(), pos, expectedT)
 			}
 
@@ -907,15 +900,8 @@ func (c *compiler) evalCallExpression(node *ast.CallExpression) (interface{}, er
 				return nil, err
 			}
 
-			var ar reflect.Value
-			if v != nil {
-				ar = reflect.ValueOf(v)
-			} else {
-				ar = reflect.New(expectedT)
-			}
-
-			actualT := ar.Type()
-			if !actualT.AssignableTo(expectedT) {
+			ar, ok := reflectValueForCallArgument(v, expectedT)
+			if !ok {
 				return nil, fmt.Errorf("%+v (%T) is an invalid argument for %s at pos %d: expected (%s)", v, v, node.Function.String(), pos, expectedT)
 			}
 
@@ -929,7 +915,7 @@ func (c *compiler) evalCallExpression(node *ast.CallExpression) (interface{}, er
 			return nil, fmt.Errorf("could not call %s function: %w", node.Function, e)
 		}
 		if node.ChainCallee != nil {
-			octx := c.ctx.(*Context)
+			octx := c.ctx
 			defer func() {
 				c.ctx = octx
 			}()
@@ -948,8 +934,35 @@ func (c *compiler) evalCallExpression(node *ast.CallExpression) (interface{}, er
 	return nil, nil
 }
 
+func reflectValueForCallArgument(value interface{}, expected reflect.Type) (reflect.Value, bool) {
+	arg := reflect.ValueOf(value)
+	if !arg.IsValid() {
+		return reflect.New(expected).Elem(), true
+	}
+	if arg.Type().AssignableTo(expected) {
+		return arg, true
+	}
+	if arg.Type().ConvertibleTo(expected) {
+		return arg.Convert(expected), true
+	}
+	if expected.Kind() == reflect.Ptr {
+		elem := expected.Elem()
+		if arg.Type().AssignableTo(elem) {
+			ptr := reflect.New(elem)
+			ptr.Elem().Set(arg)
+			return ptr, true
+		}
+		if arg.Type().ConvertibleTo(elem) {
+			ptr := reflect.New(elem)
+			ptr.Elem().Set(arg.Convert(elem))
+			return ptr, true
+		}
+	}
+	return reflect.Value{}, false
+}
+
 func (c *compiler) evalForExpression(node *ast.ForExpression) (interface{}, error) {
-	octx := c.ctx.(*Context)
+	octx := c.ctx
 	defer func() {
 		c.ctx = octx
 	}()
@@ -1166,7 +1179,7 @@ func (c *compiler) evalArrayLiteral(node *ast.ArrayLiteral) (interface{}, error)
 }
 
 func (c *compiler) evalIndexCallee(rv reflect.Value, node *ast.IndexExpression) (interface{}, error) {
-	octx := c.ctx.(*Context)
+	octx := c.ctx
 	defer func() {
 		c.ctx = octx
 	}()

--- a/context.go
+++ b/context.go
@@ -12,10 +12,11 @@ var _ context.Context = &Context{}
 // Context holds all of the data for the template that is being rendered.
 type Context struct {
 	context.Context
-	data   *SymbolTable
-	outer  *Context
-	moot   *sync.RWMutex
-	budget *Budget
+	data    *SymbolTable
+	helpers *SymbolTable
+	outer   *Context
+	moot    sync.RWMutex
+	budget  *Budget
 }
 
 // WithBudget attaches a Budget to this context. Returns self for chaining.
@@ -40,7 +41,7 @@ func (c *Context) Budget() *Budget {
 // will not be set onto the original context, however, the original context's
 // values will be available to the new context.
 func (c *Context) New() hctx.Context {
-	cc := NewContextWithOuter(map[string]interface{}{}, c)
+	cc := NewContextWithOuter(nil, c)
 
 	return cc
 }
@@ -52,10 +53,41 @@ func (c *Context) Set(key string, value interface{}) {
 	c.data.Declare(key, value)
 }
 
+func (c *Context) InternID(key string) int {
+	c.moot.Lock()
+	defer c.moot.Unlock()
+	return c.data.localInterner.Intern(key)
+}
+
+func (c *Context) InternIDs(keys []string, ids []int) {
+	if len(keys) == 0 || len(ids) < len(keys) {
+		return
+	}
+	c.moot.Lock()
+	defer c.moot.Unlock()
+	c.data.localInterner.mw.Lock()
+	defer c.data.localInterner.mw.Unlock()
+	for i, key := range keys {
+		ids[i] = c.data.localInterner.internUnsafe(key)
+	}
+}
+
+func (c *Context) SetID(id int, value interface{}) {
+	c.moot.Lock()
+	defer c.moot.Unlock()
+	c.data.DeclareID(id, value)
+}
+
 func (c *Context) Update(key string, value interface{}) bool {
 	c.moot.Lock()
 	defer c.moot.Unlock()
 	return c.data.Assign(key, value)
+}
+
+func (c *Context) UpdateID(id int, value interface{}) bool {
+	c.moot.Lock()
+	defer c.moot.Unlock()
+	return c.data.AssignID(id, value)
 }
 
 // Value from the context, or it's parent's context if one exists.
@@ -69,9 +101,40 @@ func (c *Context) Value(key interface{}) interface{} {
 		if ok {
 			return gg
 		}
+		if c.helpers != nil {
+			if gg, ok := c.helpers.Resolve(s); ok {
+				return gg
+			}
+		}
 	}
 
 	return c.Context.Value(key)
+}
+
+func (c *Context) Lookup(key string) (interface{}, bool) {
+	c.moot.RLock()
+	defer c.moot.RUnlock()
+	if value, ok := c.data.Resolve(key); ok {
+		return value, true
+	}
+	if c.helpers != nil {
+		return c.helpers.Resolve(key)
+	}
+	return nil, false
+}
+
+func (c *Context) LookupID(id int) (interface{}, bool) {
+	c.moot.RLock()
+	defer c.moot.RUnlock()
+	if value, ok := c.data.ResolveID(id); ok {
+		return value, true
+	}
+	if c.helpers != nil {
+		if name, ok := c.data.SymbolName(id); ok {
+			return c.helpers.Resolve(name)
+		}
+	}
+	return nil, false
 }
 
 // Has checks the existence of the key in the context.
@@ -79,45 +142,28 @@ func (c *Context) Has(key string) bool {
 	c.moot.RLock()
 	defer c.moot.RUnlock()
 
-	return c.data.Has(key)
-}
-
-// Export all the known values in the context.
-// Note this can't reach up into other implemenations
-// of context.Context.
-func (c *Context) export() map[string]interface{} {
-	m := map[string]interface{}{}
-	if c.outer != nil {
-		for k, v := range c.outer.export() {
-			m[k] = v
-		}
+	if c.data.Has(key) {
+		return true
 	}
-
-	return m
+	if c.helpers != nil {
+		return c.helpers.Has(key)
+	}
+	return false
 }
 
 // NewContext returns a fully formed context ready to go
 func NewContext() *Context {
-	return NewContextWith(map[string]interface{}{})
+	return NewContextWith(nil)
 }
 
 // NewContextWith returns a fully formed context using the data
 // provided.
 func NewContextWith(data map[string]interface{}) *Context {
-
 	c := &Context{
 		Context: context.Background(),
-		data:    NewScope(nil),
+		data:    newRootScopeFromMap(data),
+		helpers: cachedHelperScope(),
 		outer:   nil,
-		moot:    &sync.RWMutex{},
-	}
-	for k, v := range data {
-		c.Set(k, v)
-	}
-	for k, v := range Helpers.All() {
-		if !c.Has(k) {
-			c.Set(k, v)
-		}
 	}
 
 	return c
@@ -129,12 +175,12 @@ func NewContextWith(data map[string]interface{}) *Context {
 func NewContextWithOuter(data map[string]interface{}, out *Context) *Context {
 	c := &Context{
 		Context: context.Background(),
-		data:    NewScope(out.data),
+		data:    newScopeWithCapacity(out.data, len(data)),
+		helpers: out.helpers,
 		outer:   out,
-		moot:    &sync.RWMutex{},
 	}
 	for k, v := range data {
-		c.Set(k, v)
+		c.data.Declare(k, v)
 	}
 	return c
 }

--- a/context_test.go
+++ b/context_test.go
@@ -1,6 +1,7 @@
 package plush_test
 
 import (
+	"fmt"
 	"html/template"
 	"testing"
 
@@ -42,7 +43,7 @@ func Test_Context_Get(t *testing.T) {
 	r.Equal("bar", c.Value("foo"))
 }
 
-func Test_NewSubContext_Set(t *testing.T) {
+func Test_New_Sub_Context_Set(t *testing.T) {
 	r := require.New(t)
 
 	c := plush.NewContext()
@@ -56,7 +57,7 @@ func Test_NewSubContext_Set(t *testing.T) {
 	r.Nil(c.Value("foo"))
 }
 
-func Test_NewSubContext_Get(t *testing.T) {
+func Test_New_Sub_Context_Get(t *testing.T) {
 	r := require.New(t)
 
 	c := plush.NewContext()
@@ -74,4 +75,142 @@ func Test_Context_Override_Helper(t *testing.T) {
 	})
 	s := c.Value("debug").(func(interface{}) template.HTML)(nil)
 	r.Equal(template.HTML("DEBUG"), s)
+}
+
+func Test_New_Context_With_Override_Helper(t *testing.T) {
+	r := require.New(t)
+	c := plush.NewContextWith(map[string]interface{}{
+		"debug": func(i interface{}) template.HTML {
+			return template.HTML("DEBUG")
+		},
+	})
+
+	s := c.Value("debug").(func(interface{}) template.HTML)(nil)
+	r.Equal(template.HTML("DEBUG"), s)
+}
+
+func Test_New_Context_With_Nil_Helper_Override_Falls_Back_To_Global(t *testing.T) {
+	r := require.New(t)
+	c := plush.NewContextWith(map[string]interface{}{
+		"partial": nil,
+	})
+
+	r.NotNil(c.Value("partial"))
+}
+
+func Test_New_Context_With_Bulk_Construction_Matches_Set_Behavior(t *testing.T) {
+	r := require.New(t)
+	c := plush.NewContextWith(map[string]interface{}{
+		"name":  "Mido",
+		"count": 3,
+		"empty": nil,
+	})
+
+	r.Equal("Mido", c.Value("name"))
+	r.Equal(3, c.Value("count"))
+	r.Nil(c.Value("empty"))
+	r.True(c.Has("name"))
+	r.False(c.Has("empty"))
+
+	id := c.InternID("name")
+	value, ok := c.LookupID(id)
+	r.True(ok)
+	r.Equal("Mido", value)
+}
+
+func Test_Context_Intern_I_Ds_Are_Stable_Across_Root_Contexts(t *testing.T) {
+	r := require.New(t)
+
+	first := plush.NewContextWith(map[string]interface{}{
+		"z":     true,
+		"name":  "Mido",
+		"title": "Engineer",
+	})
+	second := plush.NewContextWith(map[string]interface{}{
+		"a":     true,
+		"title": "Pilot",
+		"name":  "Fry",
+	})
+
+	nameID := first.InternID("name")
+	titleID := first.InternID("title")
+	r.Equal(nameID, second.InternID("name"))
+	r.Equal(titleID, second.InternID("title"))
+
+	value, ok := first.LookupID(nameID)
+	r.True(ok)
+	r.Equal("Mido", value)
+
+	value, ok = second.LookupID(nameID)
+	r.True(ok)
+	r.Equal("Fry", value)
+
+	value, ok = second.LookupID(titleID)
+	r.True(ok)
+	r.Equal("Pilot", value)
+}
+
+func Test_Context_Intern_I_Ds_Are_Safe_Across_Concurrent_Root_Contexts(t *testing.T) {
+	r := require.New(t)
+	keys := []string{"name", "items", "local", "__plush_internal_render_diagnostics_test__"}
+
+	wg := errgroup.Group{}
+	for i := 0; i < 64; i++ {
+		i := i
+		wg.Go(func() error {
+			name := fmt.Sprintf("name-%d", i)
+			ctx := plush.NewContextWith(map[string]interface{}{
+				"name":  name,
+				"items": []string{"a", "b"},
+			})
+			ids := make([]int, len(keys))
+
+			for j := 0; j < 32; j++ {
+				ctx.InternIDs(keys, ids)
+				for keyIndex, key := range keys {
+					if ids[keyIndex] != ctx.InternID(key) {
+						return fmt.Errorf("intern id mismatch for %s", key)
+					}
+				}
+				value, ok := ctx.LookupID(ids[0])
+				if !ok || value != name {
+					return fmt.Errorf("lookup id mismatch: %v %v", value, ok)
+				}
+				_ = ctx.Value(keys[3])
+			}
+			return nil
+		})
+	}
+
+	r.NoError(wg.Wait())
+}
+
+func Test_Context_Shared_Helpers_Do_Not_Leak_Overrides(t *testing.T) {
+	r := require.New(t)
+	c1 := plush.NewContextWith(map[string]interface{}{
+		"debug": func(i interface{}) template.HTML {
+			return template.HTML("LOCAL")
+		},
+	})
+	c2 := plush.NewContext()
+
+	local := c1.Value("debug").(func(interface{}) template.HTML)(nil)
+	global := c2.Value("debug").(func(interface{}) template.HTML)(nil)
+	r.Equal(template.HTML("LOCAL"), local)
+	r.NotEqual(template.HTML("LOCAL"), global)
+}
+
+func Test_Context_Shared_Helpers_Refreshes_For_New_Helpers(t *testing.T) {
+	r := require.New(t)
+	name := fmt.Sprintf("test_helper_%p", t)
+
+	before := plush.NewContext()
+	r.False(before.Has(name))
+
+	r.NoError(plush.Helpers.Add(name, func() string { return "ok" }))
+	after := plush.NewContext()
+
+	r.False(before.Has(name))
+	r.True(after.Has(name))
+	r.Equal("ok", after.Value(name).(func() string)())
 }

--- a/error_test.go
+++ b/error_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestErrorType(t *testing.T) {
+func Test_Error_Type(t *testing.T) {
 	r := require.New(t)
 
 	ctx := plush.NewContext()

--- a/escape_test.go
+++ b/escape_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_Render_EscapedString(t *testing.T) {
+func Test_Render_Escaped_String(t *testing.T) {
 	r := require.New(t)
 
 	input := `<p><%= "<script>alert('pwned')</script>" %></p>`
@@ -33,7 +33,7 @@ func Test_Render_HTML_Escape(t *testing.T) {
 	r.Equal("&lt;b&gt;unsafe&lt;/b&gt;|<b>unsafe</b>|<b>unsafe</b>", s)
 }
 
-func Test_Escaping_EscapeExpression(t *testing.T) {
+func Test_Escaping_Escape_Expression(t *testing.T) {
 	r := require.New(t)
 	input := `C:\\<%= "temp" %>`
 

--- a/for_test.go
+++ b/for_test.go
@@ -104,7 +104,7 @@ func Test_Render_For_Array_Continue(t *testing.T) {
 	r.Equal("StartOddStart2StartOddStart4StartOddStart6StartOddStart8StartOddStart10", s)
 }
 
-func Test_Render_For_Array_WithNoOutput(t *testing.T) {
+func Test_Render_For_Array_With_No_Output(t *testing.T) {
 	r := require.New(t)
 	input := `<%= for (i,v) in [1, 2, 3,4,5,6,7,8,9,10] {
 
@@ -121,7 +121,7 @@ func Test_Render_For_Array_WithNoOutput(t *testing.T) {
 	r.Equal("", s)
 }
 
-func Test_Render_For_Array_WithoutContinue(t *testing.T) {
+func Test_Render_For_Array_Without_Continue(t *testing.T) {
 	r := require.New(t)
 	input := `<%= for (i,v) in [1, 2, 3,4,5,6,7,8,9,10] {
 		if (v == 1 || v ==3 || v == 5 || v == 7 || v == 9) {
@@ -134,7 +134,7 @@ func Test_Render_For_Array_WithoutContinue(t *testing.T) {
 	r.Equal("12345678910", s)
 }
 
-func Test_Render_For_Array_ContinueNoControl(t *testing.T) {
+func Test_Render_For_Array_Continue_No_Control(t *testing.T) {
 	r := require.New(t)
 	input := `<%= for (i,v) in [1, 2, 3,4,5,6,7,8,9,10] {
 		continue
@@ -165,7 +165,7 @@ func Test_Render_For_Array_Break_String(t *testing.T) {
 	r.Equal("Start1Start2Start3Start4StartOdd", s)
 }
 
-func Test_Render_For_Array_WithBreakFirstValue(t *testing.T) {
+func Test_Render_For_Array_With_Break_First_Value(t *testing.T) {
 	r := require.New(t)
 	input := `<%= for (i,v) in [1, 2, 3,4,5,6,7,8,9,10] {
 		if (v == 1 || v ==3 || v == 5 || v == 7 || v == 9) {
@@ -179,7 +179,7 @@ func Test_Render_For_Array_WithBreakFirstValue(t *testing.T) {
 	r.Equal("", s)
 }
 
-func Test_Render_For_Array_WithBreakFirstValueWithReturn(t *testing.T) {
+func Test_Render_For_Array_With_Break_First_Value_With_Return(t *testing.T) {
 	r := require.New(t)
 	input := `<%= for (i,v) in [1, 2, 3,4,5,6,7,8,9,10] {
 		if (v == 1 || v ==3 || v == 5 || v == 7 || v == 9) {
@@ -301,7 +301,7 @@ type Product struct {
 	Name []string
 }
 
-func Test_Render_For_Array_OutofBoundIndex(t *testing.T) {
+func Test_Render_For_Array_Outof_Bound_Index(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
 	product_listing := Category{}

--- a/functions_test.go
+++ b/functions_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type functionPointerArgSection struct {
+	Name string
+}
+
 func Test_Render_Function_Call(t *testing.T) {
 	r := require.New(t)
 
@@ -56,6 +60,22 @@ func Test_Render_Function_Call_With_Variable_Arg(t *testing.T) {
 	}))
 	r.NoError(err)
 	r.Equal("<p>hi mark!</p>", s)
+}
+
+func Test_Render_Function_Call_With_Value_For_Pointer_Arg(t *testing.T) {
+	r := require.New(t)
+
+	input := `<p><%= f(section) %></p>`
+	section := functionPointerArgSection{Name: "hero"}
+	s, err := plush.Render(input, plush.NewContextWith(map[string]interface{}{
+		"section": section,
+		"f": func(s *functionPointerArgSection) string {
+			return s.Name
+		},
+	}))
+	r.NoError(err)
+	r.Equal("<p>hero</p>", s)
+	r.Equal("hero", section.Name)
 }
 
 func Test_Render_Function_Call_With_Hash(t *testing.T) {

--- a/generate_cache_key.go
+++ b/generate_cache_key.go
@@ -15,7 +15,8 @@ var (
 	// String pools for reducing allocations
 	stringPool = sync.Pool{
 		New: func() interface{} {
-			return make([]byte, 0, 1024) // Larger initial capacity for file paths
+			buf := make([]byte, 0, 1024) // Larger initial capacity for file paths
+			return &buf
 		},
 	}
 )
@@ -40,11 +41,17 @@ func sanitizeCacheKey(input string) string {
 	if input == "" {
 		return ""
 	}
+	if cacheKeyAlreadySanitized(input) {
+		return input
+	}
 
 	// Get buffer from pool with larger capacity for file paths
-	buf := stringPool.Get().([]byte)
-	buf = buf[:0]
-	defer stringPool.Put(buf)
+	bufPtr := stringPool.Get().(*[]byte)
+	buf := (*bufPtr)[:0]
+	defer func() {
+		*bufPtr = buf
+		stringPool.Put(bufPtr)
+	}()
 
 	// Ensure buffer has enough capacity to avoid reallocations
 	if cap(buf) < len(input) {
@@ -78,24 +85,64 @@ func sanitizeCacheKey(input string) string {
 	return string(buf)
 }
 
+func cacheKeyAlreadySanitized(input string) bool {
+	if input == "" {
+		return true
+	}
+	lastWasUnderscore := false
+	for i := 0; i < len(input); i++ {
+		char := input[i]
+		if charTable[char] != char {
+			return false
+		}
+		if char == '_' {
+			if lastWasUnderscore {
+				return false
+			}
+			lastWasUnderscore = true
+			continue
+		}
+		lastWasUnderscore = false
+	}
+	return !lastWasUnderscore
+}
+
 // Enhanced file path cleaning for better performance
 func cleanFilePath(filename string) string {
 	if filename == "" {
 		return ""
 	}
-	// Fast path separator normalization
 	var cleanPath string
 	if strings.ContainsRune(filename, '\\') {
 		cleanPath = strings.ReplaceAll(filename, "\\", "/")
 	} else {
 		cleanPath = filename
 	}
-
-	// Trim slashes
+	absolutePath := strings.HasPrefix(cleanPath, "/")
 	cleanPath = strings.Trim(cleanPath, "/")
+	if cleanPath == "" {
+		if absolutePath {
+			return "/"
+		}
+		return ""
+	}
 
-	// Sanitize in single pass
-	return sanitizeCacheKey(cleanPath)
+	parts := strings.Split(cleanPath, "/")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		part = sanitizeCacheKey(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	cleanPath = strings.Join(out, "/")
+	if absolutePath && cleanPath != "" {
+		return "/" + cleanPath
+	}
+	return cleanPath
 }
 
 // Enhanced URL cleaning with optimized performance
@@ -142,6 +189,7 @@ func cleanFullURL(rawURL string) string {
 	slashCount := 0
 
 	// Parse URL components in single pass
+parseURL:
 	for i, r := range rawURL {
 		switch {
 		case !foundSlashes && r == ':':
@@ -165,7 +213,7 @@ func cleanFullURL(rawURL string) string {
 			} else if r == '?' || r == '#' {
 				// Query or fragment - end of host, no path
 				hostEnd = i
-				break
+				break parseURL
 			}
 			continue
 
@@ -173,7 +221,7 @@ func cleanFullURL(rawURL string) string {
 			if r == '?' || r == '#' {
 				// End of path
 				pathEnd = i
-				break
+				break parseURL
 			}
 		}
 	}
@@ -214,30 +262,29 @@ func cleanFullURL(rawURL string) string {
 	return strings.Join(parts, "_")
 }
 
-func generateCacheKey(filename string, ctx hctx.Context) string {
-	cleanFilename := cleanFilePath(filename)
-
-	if ctx.Value(meta.TemplateCurrentUrlKey) == nil {
+func generateCacheKeyFromCleanFilename(cleanFilename string, ctx hctx.Context) string {
+	currentURL := ctx.Value(meta.TemplateCurrentUrlKey)
+	if currentURL == nil {
 		return cleanFilename
 	}
-
-	keyParts := make([]string, 0, 2)
-	keyParts = append(keyParts, cleanFilename)
-	if url, ok := ctx.Value(meta.TemplateCurrentUrlKey).(string); ok && url != "" {
+	if url, ok := currentURL.(string); ok && url != "" {
 		cleanURL := cleanRequestURL(url)
 		if cleanURL != "" {
-			keyParts = append(keyParts, "url:"+cleanURL)
+			return cleanFilename + "|url:" + cleanURL
 		}
 	}
-
-	return strings.Join(keyParts, "|")
+	return cleanFilename
 }
 
 func GenerateASTKey(filename string) string {
 	cleanFilename := cleanFilePath(filename)
+	return GenerateASTKeyFromCleanFilename(cleanFilename)
+}
+
+func GenerateASTKeyFromCleanFilename(cleanFilename string) string {
 	return "ast:" + cleanFilename
 }
 
-func generateFullKey(filename string, ctx hctx.Context) string {
-	return "full:" + generateCacheKey(filename, ctx)
+func generateFullKeyFromCleanFilename(cleanFilename string, ctx hctx.Context) string {
+	return "full:" + generateCacheKeyFromCleanFilename(cleanFilename, ctx)
 }

--- a/generate_cache_key_test.go
+++ b/generate_cache_key_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_SanitizeCacheKey(t *testing.T) {
+func Test_Sanitize_Cache_Key(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
@@ -38,7 +38,33 @@ func Test_SanitizeCacheKey(t *testing.T) {
 	}
 }
 
-func Test_CleanFilePath(t *testing.T) {
+func Test_Cache_Key_Already_Sanitized(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"empty", "", true},
+		{"simple filename", "template.plush", true},
+		{"dash underscore dot", "user-profile_template.plush", true},
+		{"slash needs cleaning", "path/to/template.plush", false},
+		{"space needs cleaning", "path with spaces", false},
+		{"consecutive underscores collapse", "path__template.plush", false},
+		{"trailing underscore trims", "path_", false},
+		{"unicode needs cleaning", "файл", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, cacheKeyAlreadySanitized(tt.input))
+			if tt.expected {
+				require.Equal(t, tt.input, sanitizeCacheKey(tt.input))
+			}
+		})
+	}
+}
+
+func Test_Clean_File_Path(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
@@ -46,15 +72,15 @@ func Test_CleanFilePath(t *testing.T) {
 	}{
 		{"empty path", "", ""},
 		{"simple filename", "template.plush", "template.plush"},
-		{"unix path", "/path/to/template.plush", "path_to_template.plush"},
-		{"windows path", "\\path\\to\\template.plush", "path_to_template.plush"},
-		{"mixed separators", "/path\\to/template.plush", "path_to_template.plush"},
-		{"trailing slash", "/path/to/template/", "path_to_template"},
-		{"leading slash", "/template.plush", "template.plush"},
-		{"multiple leading slashes", "///path/to/file", "path_to_file"},
-		{"deep path", "/very/deep/path/to/user/profile.plush", "very_deep_path_to_user_profile.plush"},
-		{"path with spaces", "/path with spaces/template.plush", "path_with_spaces_template.plush"},
-		{"path with special chars", "/path@#$/template!.plush", "path_template_.plush"},
+		{"unix path", "/path/to/template.plush", "/path/to/template.plush"},
+		{"windows rooted path", "\\path\\to\\template.plush", "/path/to/template.plush"},
+		{"mixed separators", "/path\\to/template.plush", "/path/to/template.plush"},
+		{"trailing slash", "/path/to/template/", "/path/to/template"},
+		{"leading slash", "/template.plush", "/template.plush"},
+		{"multiple leading slashes", "///path/to/file", "/path/to/file"},
+		{"deep path", "/very/deep/path/to/user/profile.plush", "/very/deep/path/to/user/profile.plush"},
+		{"path with spaces", "/path with spaces/template.plush", "/path_with_spaces/template.plush"},
+		{"path with special chars", "/path@#$/template!.plush", "/path/template_.plush"},
 	}
 
 	for _, tt := range tests {
@@ -65,7 +91,7 @@ func Test_CleanFilePath(t *testing.T) {
 	}
 }
 
-func Test_CleanURLPath(t *testing.T) {
+func Test_Clean_URL_Path(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
@@ -93,7 +119,7 @@ func Test_CleanURLPath(t *testing.T) {
 	}
 }
 
-func Test_CleanFullURL(t *testing.T) {
+func Test_Clean_Full_URL(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
@@ -123,7 +149,7 @@ func Test_CleanFullURL(t *testing.T) {
 	}
 }
 
-func Test_CleanRequestURL(t *testing.T) {
+func Test_Clean_Request_URL(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
@@ -147,7 +173,7 @@ func Test_CleanRequestURL(t *testing.T) {
 	}
 }
 
-func Test_GenerateCacheKey(t *testing.T) {
+func Test_Generate_Cache_Key(t *testing.T) {
 	tests := []struct {
 		name     string
 		filename string
@@ -164,19 +190,19 @@ func Test_GenerateCacheKey(t *testing.T) {
 			name:     "filename with path URL",
 			filename: "user/profile.plush",
 			url:      "/users/123",
-			expected: "user_profile.plush|url:users_123",
+			expected: "user/profile.plush|url:users_123",
 		},
 		{
 			name:     "filename with full URL",
 			filename: "templates/admin/dashboard.plush",
 			url:      "https://admin.example.com/dashboard",
-			expected: "templates_admin_dashboard.plush|url:admin.example.com_dashboard",
+			expected: "templates/admin/dashboard.plush|url:admin.example.com_dashboard",
 		},
 		{
 			name:     "complex filename and URL",
 			filename: "/very/deep/path/to/user-profile_template.plush",
 			url:      "https://api.example.com/v1/users/profile?id=123",
-			expected: "very_deep_path_to_user-profile_template.plush|url:api.example.com_v1_users_profile",
+			expected: "/very/deep/path/to/user-profile_template.plush|url:api.example.com_v1_users_profile",
 		},
 	}
 
@@ -187,22 +213,22 @@ func Test_GenerateCacheKey(t *testing.T) {
 				ctx.Set(meta.TemplateCurrentUrlKey, tt.url)
 			}
 
-			result := generateCacheKey(tt.filename, ctx)
+			result := generateCacheKeyFromCleanFilename(cleanFilePath(tt.filename), ctx)
 			require.Equal(t, tt.expected, result)
 		})
 	}
 }
 
-func Test_GenerateASTKey(t *testing.T) {
+func Test_Generate_AST_Key(t *testing.T) {
 	tests := []struct {
 		name     string
 		filename string
 		expected string
 	}{
 		{"simple filename", "template.plush", "ast:template.plush"},
-		{"path filename", "/path/to/template.plush", "ast:path_to_template.plush"},
-		{"windows path", "\\path\\to\\template.plush", "ast:path_to_template.plush"},
-		{"complex path", "/very/deep/path/user-profile.plush", "ast:very_deep_path_user-profile.plush"},
+		{"path filename", "/path/to/template.plush", "ast:/path/to/template.plush"},
+		{"windows rooted path", "\\path\\to\\template.plush", "ast:/path/to/template.plush"},
+		{"complex path", "/very/deep/path/user-profile.plush", "ast:/very/deep/path/user-profile.plush"},
 	}
 
 	for _, tt := range tests {
@@ -213,7 +239,18 @@ func Test_GenerateASTKey(t *testing.T) {
 	}
 }
 
-func Test_GenerateFullKey(t *testing.T) {
+func Test_Generate_AST_Key_Uses_Full_Path_Not_Basename(t *testing.T) {
+	require.NotEqual(t,
+		GenerateASTKey("/templates/client-1/index.plush"),
+		GenerateASTKey("/templates/client-2/index.plush"),
+	)
+	require.NotEqual(t,
+		GenerateASTKey("/templates/client/index.plush"),
+		GenerateASTKey("/templates_client/index.plush"),
+	)
+}
+
+func Test_Generate_Full_Key(t *testing.T) {
 	tests := []struct {
 		name     string
 		filename string
@@ -230,13 +267,13 @@ func Test_GenerateFullKey(t *testing.T) {
 			name:     "with URL",
 			filename: "user/profile.plush",
 			url:      "/users/123",
-			expected: "full:user_profile.plush|url:users_123",
+			expected: "full:user/profile.plush|url:users_123",
 		},
 		{
 			name:     "complex case",
 			filename: "/templates/admin/dashboard.plush",
 			url:      "https://admin.site.com/dashboard?tab=users",
-			expected: "full:templates_admin_dashboard.plush|url:admin.site.com_dashboard",
+			expected: "full:/templates/admin/dashboard.plush|url:admin.site.com_dashboard",
 		},
 	}
 
@@ -247,13 +284,13 @@ func Test_GenerateFullKey(t *testing.T) {
 				ctx.Set(meta.TemplateCurrentUrlKey, tt.url)
 			}
 
-			result := generateFullKey(tt.filename, ctx)
+			result := generateFullKeyFromCleanFilename(cleanFilePath(tt.filename), ctx)
 			require.Equal(t, tt.expected, result)
 		})
 	}
 }
 
-func Test_CacheKeyConsistency(t *testing.T) {
+func Test_Cache_Key_Consistency(t *testing.T) {
 	r := require.New(t)
 
 	// Test that same input produces same output
@@ -266,13 +303,14 @@ func Test_CacheKeyConsistency(t *testing.T) {
 	ctx2 := NewContext()
 	ctx2.Set(meta.TemplateCurrentUrlKey, url)
 
-	key1 := generateCacheKey(filename, ctx1)
-	key2 := generateCacheKey(filename, ctx2)
+	cleanFilename := cleanFilePath(filename)
+	key1 := generateCacheKeyFromCleanFilename(cleanFilename, ctx1)
+	key2 := generateCacheKeyFromCleanFilename(cleanFilename, ctx2)
 
 	r.Equal(key1, key2, "Same inputs should produce same cache keys")
 }
 
-func Test_CacheKeyVariations(t *testing.T) {
+func Test_Cache_Key_Variations(t *testing.T) {
 	r := require.New(t)
 
 	filename := "template.plush"
@@ -284,26 +322,27 @@ func Test_CacheKeyVariations(t *testing.T) {
 	ctx2 := NewContext()
 	ctx2.Set(meta.TemplateCurrentUrlKey, "/users/456")
 
-	key1 := generateCacheKey(filename, ctx1)
-	key2 := generateCacheKey(filename, ctx2)
+	cleanFilename := cleanFilePath(filename)
+	key1 := generateCacheKeyFromCleanFilename(cleanFilename, ctx1)
+	key2 := generateCacheKeyFromCleanFilename(cleanFilename, ctx2)
 
 	r.NotEqual(key1, key2, "Different URLs should produce different cache keys")
 }
 
-func Test_EdgeCases(t *testing.T) {
+func Test_Edge_Cases(t *testing.T) {
 	r := require.New(t)
 
 	// Test with nil context
 	ctx := NewContext()
-	key := generateCacheKey("test.plush", ctx)
+	key := generateCacheKeyFromCleanFilename(cleanFilePath("test.plush"), ctx)
 	r.Equal("test.plush", key)
 
 	// Test with empty filename
-	key = generateCacheKey("", ctx)
+	key = generateCacheKeyFromCleanFilename(cleanFilePath(""), ctx)
 	r.Equal("", key)
 
 	// Test with very long inputs
 	longFilename := strings.Repeat("a", 1000) + ".plush"
-	key = generateCacheKey(longFilename, ctx)
+	key = generateCacheKeyFromCleanFilename(cleanFilePath(longFilename), ctx)
 	r.Contains(key, strings.Repeat("a", 1000))
 }

--- a/hashes_test.go
+++ b/hashes_test.go
@@ -46,7 +46,7 @@ func Test_Render_Hash_Array_Index(t *testing.T) {
 	r.Equal("Mark Bates|paul", s)
 }
 
-func Test_Render_HashCall(t *testing.T) {
+func Test_Render_Hash_Call(t *testing.T) {
 	r := require.New(t)
 	input := `<%= m["a"] %>`
 	ctx := plush.NewContext()
@@ -58,7 +58,7 @@ func Test_Render_HashCall(t *testing.T) {
 	r.Equal("A", s)
 }
 
-func Test_Render_HashCall_OnAttribute(t *testing.T) {
+func Test_Render_Hash_Call_On_Attribute(t *testing.T) {
 	r := require.New(t)
 	input := `<%= m.MyMap[key] %>`
 	ctx := plush.NewContext()
@@ -73,7 +73,7 @@ func Test_Render_HashCall_OnAttribute(t *testing.T) {
 	r.Equal("A", s)
 }
 
-func Test_Render_HashCall_OnAttribute_IntoFunction(t *testing.T) {
+func Test_Render_Hash_Call_On_Attribute_Into_Function(t *testing.T) {
 	r := require.New(t)
 	input := `<%= debug(m.MyMap[key]) %>`
 	ctx := plush.NewContext()

--- a/helper_context.go
+++ b/helper_context.go
@@ -16,11 +16,20 @@ var _ hctx.HelperContext = &HelperContext{}
 // within the helper.
 type HelperContext struct {
 	hctx.Context
-	compiler *compiler
-	block    *ast.BlockStatement
+	compiler    *compiler
+	block       *ast.BlockStatement
+	blockRunner func(hctx.Context) (string, error)
 }
 
-const helperContextKind = "HelperContext"
+// NewHelperContext returns a HelperContext that can execute an optional block
+// using the supplied runner. It is used by alternate execution engines that
+// need to interoperate with helpers accepting plush.HelperContext.
+func NewHelperContext(ctx hctx.Context, runner func(hctx.Context) (string, error)) HelperContext {
+	return HelperContext{
+		Context:     ctx,
+		blockRunner: runner,
+	}
+}
 
 // Render a string with the current context
 func (h HelperContext) Render(s string) (string, error) {
@@ -29,7 +38,7 @@ func (h HelperContext) Render(s string) (string, error) {
 
 // HasBlock returns true if a block is associated with the helper function
 func (h HelperContext) HasBlock() bool {
-	return h.block != nil
+	return h.block != nil || h.blockRunner != nil
 }
 
 // Block executes the block of template associated with
@@ -43,15 +52,18 @@ func (h HelperContext) Block() (string, error) {
 // the helper, think the block inside of an "if" or "each"
 // statement, but with it's own context.
 func (h HelperContext) BlockWith(hc hctx.Context) (string, error) {
-	ctx, ok := hc.(*Context)
-	if !ok {
-		return "", fmt.Errorf("expected *Context, got %T", hc)
+	if h.blockRunner != nil {
+		return h.blockRunner(hc)
+	}
+
+	if hc == nil {
+		return "", fmt.Errorf("invalid context. abort")
 	}
 
 	octx := h.compiler.ctx
 	defer func() { h.compiler.ctx = octx }()
 
-	h.compiler.ctx = ctx.New()
+	h.compiler.ctx = hc.New()
 
 	if h.block == nil {
 		return "", fmt.Errorf("no block defined")

--- a/helper_scope.go
+++ b/helper_scope.go
@@ -1,0 +1,37 @@
+package plush
+
+import "sync"
+
+var sharedHelperScope = struct {
+	sync.RWMutex
+	version uint64
+	scope   *SymbolTable
+}{}
+
+func cachedHelperScope() *SymbolTable {
+	version := Helpers.Version()
+
+	sharedHelperScope.RLock()
+	if sharedHelperScope.scope != nil && sharedHelperScope.version == version {
+		scope := sharedHelperScope.scope
+		sharedHelperScope.RUnlock()
+		return scope
+	}
+	sharedHelperScope.RUnlock()
+
+	sharedHelperScope.Lock()
+	defer sharedHelperScope.Unlock()
+	if sharedHelperScope.scope != nil && sharedHelperScope.version == version {
+		return sharedHelperScope.scope
+	}
+
+	helpers, version := Helpers.Snapshot()
+	if sharedHelperScope.scope != nil && sharedHelperScope.version == version {
+		return sharedHelperScope.scope
+	}
+
+	scope := newRootScopeFromMap(helpers)
+	sharedHelperScope.scope = scope
+	sharedHelperScope.version = version
+	return scope
+}

--- a/helpers/content/for_test.go
+++ b/helpers/content/for_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_ContentFor(t *testing.T) {
+func Test_Content_For(t *testing.T) {
 	r := require.New(t)
 
 	in := "<button>hi</button>"
@@ -25,7 +25,7 @@ func Test_ContentFor(t *testing.T) {
 	r.Contains(s, in)
 }
 
-func Test_ContentFor_Fail(t *testing.T) {
+func Test_Content_For_Fail(t *testing.T) {
 	r := require.New(t)
 
 	hc := helptest.NewContext()

--- a/helpers/content/of_test.go
+++ b/helpers/content/of_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_ContentOf_MissingBlock(t *testing.T) {
+func Test_Content_Of_Missing_Block(t *testing.T) {
 	r := require.New(t)
 
 	cf := helptest.NewContext()
@@ -18,7 +18,7 @@ func Test_ContentOf_MissingBlock(t *testing.T) {
 	r.Empty(s)
 }
 
-func Test_ContentOf_MissingBlock_DefaultBlock(t *testing.T) {
+func Test_Content_Of_Missing_Block_Default_Block(t *testing.T) {
 	r := require.New(t)
 
 	cf := helptest.NewContext()
@@ -31,7 +31,7 @@ func Test_ContentOf_MissingBlock_DefaultBlock(t *testing.T) {
 	r.Equal(s, template.HTML("default"))
 }
 
-func Test_ContentOf(t *testing.T) {
+func Test_Content_Of(t *testing.T) {
 	r := require.New(t)
 
 	cf := helptest.NewContext()

--- a/helpers/encoders/json_test.go
+++ b/helpers/encoders/json_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_ToJSON(t *testing.T) {
+func Test_To_JSON(t *testing.T) {
 	x := struct {
 		A string
 		B int

--- a/helpers/escapes/html_test.go
+++ b/helpers/escapes/html_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_HTMLEscape(t *testing.T) {
+func Test_HTML_Escape(t *testing.T) {
 	r := require.New(t)
 
 	in := `<a href="/path?foo=Bar">foo</a>`
@@ -19,7 +19,7 @@ func Test_HTMLEscape(t *testing.T) {
 	r.Equal(template.HTMLEscapeString(in), s)
 }
 
-func Test_HTMLEscape_Block(t *testing.T) {
+func Test_HTML_Escape_Block(t *testing.T) {
 	r := require.New(t)
 
 	in := `<a href="/path?foo=Bar">foo</a>`

--- a/helpers/hctx/map_test.go
+++ b/helpers/hctx/map_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestMerge(t *testing.T) {
+func Test_Merge(t *testing.T) {
 	map1 := Map{
 		"Test": 1,
 		"Take": 2,

--- a/helpers/iterators/group_by_test.go
+++ b/helpers/iterators/group_by_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_GroupBy(t *testing.T) {
+func Test_Group_By(t *testing.T) {
 	r := require.New(t)
 	g, err := GroupBy(2, []string{"a", "b", "c", "d", "e"})
 	r.NoError(err)
@@ -17,7 +17,7 @@ func Test_GroupBy(t *testing.T) {
 	r.Nil(g.Next())
 }
 
-func Test_GroupBy_Exact(t *testing.T) {
+func Test_Group_By_Exact(t *testing.T) {
 	r := require.New(t)
 	g, err := GroupBy(2, []string{"a", "b"})
 	r.NoError(err)
@@ -26,7 +26,7 @@ func Test_GroupBy_Exact(t *testing.T) {
 	r.Nil(g.Next())
 }
 
-func Test_GroupBy_Pointer(t *testing.T) {
+func Test_Group_By_Pointer(t *testing.T) {
 	r := require.New(t)
 	g, err := GroupBy(2, &[]string{"a", "b", "c", "d", "e"})
 	r.NoError(err)
@@ -37,7 +37,7 @@ func Test_GroupBy_Pointer(t *testing.T) {
 	r.Nil(g.Next())
 }
 
-func Test_GroupBy_SmallGroup(t *testing.T) {
+func Test_Group_By_Small_Group(t *testing.T) {
 	r := require.New(t)
 	g, err := GroupBy(1, []string{"a", "b", "c", "d", "e"})
 	r.NoError(err)
@@ -46,13 +46,13 @@ func Test_GroupBy_SmallGroup(t *testing.T) {
 	r.Nil(g.Next())
 }
 
-func Test_GroupBy_NonGroupable(t *testing.T) {
+func Test_Group_By_Non_Groupable(t *testing.T) {
 	r := require.New(t)
 	_, err := GroupBy(1, 1)
 	r.Error(err)
 }
 
-func Test_GroupBy_ZeroSize(t *testing.T) {
+func Test_Group_By_Zero_Size(t *testing.T) {
 	r := require.New(t)
 	_, err := GroupBy(0, []string{"a"})
 	r.Error(err)

--- a/helpers/map.go
+++ b/helpers/map.go
@@ -1,11 +1,16 @@
 package helpers
 
-import "sync"
+import (
+	"sync"
+	"sync/atomic"
+)
 
 // HelperMap holds onto helpers and validates they are properly formed.
 type HelperMap struct {
 	helpers map[string]interface{}
 	moot    *sync.Mutex
+	version uint64
+	latest  uint64
 }
 
 // NewHelperMap containing all of the "default" helpers from "plush.Helpers".
@@ -29,6 +34,8 @@ func (h *HelperMap) Add(key string, helper interface{}) error {
 	}
 
 	h.helpers[key] = helper
+	h.version++
+	atomic.StoreUint64(&h.latest, h.version)
 
 	return nil
 }
@@ -52,4 +59,19 @@ func (h HelperMap) Helpers() map[string]interface{} {
 
 func (h HelperMap) All() map[string]interface{} {
 	return h.helpers
+}
+
+func (h *HelperMap) Version() uint64 {
+	return atomic.LoadUint64(&h.latest)
+}
+
+func (h *HelperMap) Snapshot() (map[string]interface{}, uint64) {
+	h.moot.Lock()
+	defer h.moot.Unlock()
+
+	out := make(map[string]interface{}, len(h.helpers))
+	for k, v := range h.helpers {
+		out[k] = v
+	}
+	return out, h.version
 }

--- a/helpers/paths/path_for_test.go
+++ b/helpers/paths/path_for_test.go
@@ -31,7 +31,7 @@ type BadCar struct {
 	IDs int
 }
 
-func Test_PathFor(t *testing.T) {
+func Test_Path_For(t *testing.T) {
 	table := []struct {
 		in  interface{}
 		out string

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_Helpers_WithoutData(t *testing.T) {
+func Test_Helpers_Without_Data(t *testing.T) {
 	type data map[string]interface{}
 	r := require.New(t)
 

--- a/if_test.go
+++ b/if_test.go
@@ -171,7 +171,7 @@ func Test_If_Updating_Variable_Inside_IF_Scope(t *testing.T) {
 	r.Equal("<p>hi</p>", s)
 }
 
-func Test_If_UserName_Is_Declared(t *testing.T) {
+func Test_If_User_Name_Is_Declared(t *testing.T) {
 	r := require.New(t)
 
 	ctx := plush.NewContext()
@@ -183,7 +183,7 @@ func Test_If_UserName_Is_Declared(t *testing.T) {
 	r.Empty(s)
 }
 
-func Test_If_BlockScope_Declare(t *testing.T) {
+func Test_If_Block_Scope_Declare(t *testing.T) {
 	r := require.New(t)
 
 	ctx := plush.NewContext()
@@ -200,7 +200,7 @@ func Test_If_BlockScope_Declare(t *testing.T) {
 	r.Equal("<p>Hello World</p>", s)
 }
 
-func Test_If_BlockScope_Nested_Declare(t *testing.T) {
+func Test_If_Block_Scope_Nested_Declare(t *testing.T) {
 	r := require.New(t)
 
 	ctx := plush.NewContext()
@@ -220,7 +220,7 @@ func Test_If_BlockScope_Nested_Declare(t *testing.T) {
 	r.Equal("<p>Hello World</p>", s)
 }
 
-func Test_If_BlockScope_Nested_Overwrite(t *testing.T) {
+func Test_If_Block_Scope_Nested_Overwrite(t *testing.T) {
 	r := require.New(t)
 
 	ctx := plush.NewContext()

--- a/intern.go
+++ b/intern.go
@@ -9,9 +9,13 @@ type InternTable struct {
 }
 
 func NewInternTable() *InternTable {
+	return newInternTableWithCapacity(0)
+}
+
+func newInternTableWithCapacity(capacity int) *InternTable {
 	return &InternTable{
-		stringToID: make(map[string]int),
-		idToString: []string{},
+		stringToID: make(map[string]int, capacity),
+		idToString: make([]string, 0, capacity),
 		mw:         sync.RWMutex{},
 	}
 }
@@ -19,6 +23,10 @@ func NewInternTable() *InternTable {
 func (it *InternTable) Intern(name string) int {
 	it.mw.Lock()
 	defer it.mw.Unlock()
+	return it.internUnsafe(name)
+}
+
+func (it *InternTable) internUnsafe(name string) int {
 	if id, ok := it.stringToID[name]; ok {
 		return id
 	}
@@ -42,4 +50,13 @@ func (it *InternTable) SymbolName(id int) string {
 		return it.idToString[id]
 	}
 	return "<unknown>"
+}
+
+func (it *InternTable) Name(id int) (string, bool) {
+	it.mw.RLock()
+	defer it.mw.RUnlock()
+	if id < 0 || id >= len(it.idToString) {
+		return "", false
+	}
+	return it.idToString[id], true
 }

--- a/intern_test.go
+++ b/intern_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestInternTable(t *testing.T) {
+func Test_Intern_Table(t *testing.T) {
 	r := require.New(t)
 
 	it := plush.NewInternTable()
@@ -47,7 +47,7 @@ func TestInternTable(t *testing.T) {
 	r.Equal("<unknown>", unknown)
 }
 
-func TestNewInternTable(t *testing.T) {
+func Test_New_Intern_Table(t *testing.T) {
 	r := require.New(t)
 
 	rs := plush.NewInternTable()

--- a/iterators.go
+++ b/iterators.go
@@ -10,31 +10,6 @@ type Iterator interface {
 	Next() interface{}
 }
 
-type ranger struct {
-	pos int
-	end int
-}
-
-func (r *ranger) Next() interface{} {
-	if r.pos < r.end {
-		r.pos++
-		return r.pos
-	}
-	return nil
-}
-
-func rangeHelper(a, b int) Iterator {
-	return &ranger{pos: a - 1, end: b}
-}
-
-func betweenHelper(a, b int) Iterator {
-	return &ranger{pos: a, end: b - 1}
-}
-
-func untilHelper(a int) Iterator {
-	return &ranger{pos: -1, end: a - 1}
-}
-
 func GroupByHelper(size int, underlying interface{}) (*groupBy, error) {
 	if size <= 0 {
 		return nil, fmt.Errorf("size must be greater than zero")

--- a/iterators_test.go
+++ b/iterators_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_groupByHelper(t *testing.T) {
+func Test_Group_By_Helper(t *testing.T) {
 	r := require.New(t)
 	g, err := plush.GroupByHelper(2, []string{"a", "b", "c", "d", "e"})
 	r.NoError(err)
@@ -18,7 +18,7 @@ func Test_groupByHelper(t *testing.T) {
 	r.Nil(g.Next())
 }
 
-func Test_groupByHelper_Exact(t *testing.T) {
+func Test_Group_By_Helper_Exact(t *testing.T) {
 	r := require.New(t)
 	g, err := plush.GroupByHelper(2, []string{"a", "b"})
 	r.NoError(err)
@@ -27,7 +27,7 @@ func Test_groupByHelper_Exact(t *testing.T) {
 	r.Nil(g.Next())
 }
 
-func Test_groupByHelper_Pointer(t *testing.T) {
+func Test_Group_By_Helper_Pointer(t *testing.T) {
 	r := require.New(t)
 	g, err := plush.GroupByHelper(2, &[]string{"a", "b", "c", "d", "e"})
 	r.NoError(err)
@@ -38,7 +38,7 @@ func Test_groupByHelper_Pointer(t *testing.T) {
 	r.Nil(g.Next())
 }
 
-func Test_groupByHelper_SmallGroup(t *testing.T) {
+func Test_Group_By_Helper_Small_Group(t *testing.T) {
 	r := require.New(t)
 	g, err := plush.GroupByHelper(1, []string{"a", "b", "c", "d", "e"})
 	r.NoError(err)
@@ -47,13 +47,13 @@ func Test_groupByHelper_SmallGroup(t *testing.T) {
 	r.Nil(g.Next())
 }
 
-func Test_groupByHelper_NonGroupable(t *testing.T) {
+func Test_Group_By_Helper_Non_Groupable(t *testing.T) {
 	r := require.New(t)
 	_, err := plush.GroupByHelper(1, 1)
 	r.Error(err)
 }
 
-func Test_groupByHelper_ZeroSize(t *testing.T) {
+func Test_Group_By_Helper_Zero_Size(t *testing.T) {
 	r := require.New(t)
 	_, err := plush.GroupByHelper(0, []string{"a"})
 	r.Error(err)

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_NextToken_Simple(t *testing.T) {
+func Test_Next_Token_Simple(t *testing.T) {
 	r := require.New(t)
 	input := `<%= 1 %>`
 	tests := []struct {
@@ -29,7 +29,7 @@ func Test_NextToken_Simple(t *testing.T) {
 	}
 }
 
-func Test_NextToken_SkipLineComments(t *testing.T) {
+func Test_Next_Token_Skip_Line_Comments(t *testing.T) {
 	r := require.New(t)
 	input := `<%=
 		# comment
@@ -53,7 +53,7 @@ func Test_NextToken_SkipLineComments(t *testing.T) {
 	}
 }
 
-func Test_HoleCache(t *testing.T) {
+func Test_Hole_Cache(t *testing.T) {
 	r := require.New(t)
 	input := `<%H "mark \"cool\" bates" %><%= a %>`
 	tests := []struct {
@@ -75,7 +75,7 @@ func Test_HoleCache(t *testing.T) {
 	}
 }
 
-func Test_HoleCacheIF(t *testing.T) {
+func Test_Hole_Cache_IF(t *testing.T) {
 	r := require.New(t)
 	input := `<%H if(a == 2) { %> 
 	
@@ -106,7 +106,7 @@ func Test_HoleCacheIF(t *testing.T) {
 	}
 }
 
-func Test_HoleCacheF(t *testing.T) {
+func Test_Hole_Cache_F(t *testing.T) {
 	r := require.New(t)
 	input := `<%H for (i,v) in myArray { %> 
 	
@@ -132,7 +132,7 @@ func Test_HoleCacheF(t *testing.T) {
 		r.Equal(tt.tokenLiteral, tok.Literal)
 	}
 }
-func Test_EscapeStringQuote(t *testing.T) {
+func Test_Escape_String_Quote(t *testing.T) {
 	r := require.New(t)
 	input := `<%= "mark \"cool\" bates" %>`
 	tests := []struct {
@@ -152,7 +152,7 @@ func Test_EscapeStringQuote(t *testing.T) {
 	}
 }
 
-func Test_EscapeExpression(t *testing.T) {
+func Test_Escape_Expression(t *testing.T) {
 	r := require.New(t)
 	input := `<p>\<%= 1 %></p>`
 	tests := []struct {
@@ -170,7 +170,7 @@ func Test_EscapeExpression(t *testing.T) {
 	}
 }
 
-func Test_Escaping_EscapeExpression(t *testing.T) {
+func Test_Escaping_Escape_Expression(t *testing.T) {
 	r := require.New(t)
 	input := `C:\\<%= "temp" %>`
 	l := lexer.New(input)
@@ -192,7 +192,7 @@ func Test_Escaping_EscapeExpression(t *testing.T) {
 	}
 }
 
-func Test_NextToken_WithHTML(t *testing.T) {
+func Test_Next_Token_With_HTML(t *testing.T) {
 	r := require.New(t)
 	input := `<p class="foo"><%= 1 %></p>`
 	tests := []struct {
@@ -213,7 +213,7 @@ func Test_NextToken_WithHTML(t *testing.T) {
 		r.Equal(tt.tokenLiteral, tok.Literal)
 	}
 }
-func Test_NextToken_Complete(t *testing.T) {
+func Test_Next_Token_Complete(t *testing.T) {
 	r := require.New(t)
 	input := `<% break
 	continue

--- a/line_number_test.go
+++ b/line_number_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_LineNumberErrors(t *testing.T) {
+func Test_Line_Number_Errors(t *testing.T) {
 	r := require.New(t)
 	input := `<p>
 	<%= f.Foo %>
@@ -18,7 +18,7 @@ func Test_LineNumberErrors(t *testing.T) {
 	r.Contains(err.Error(), "line 2:")
 }
 
-func Test_LineNumberErrors_ForLoop(t *testing.T) {
+func Test_Line_Number_Errors_For_Loop(t *testing.T) {
 	r := require.New(t)
 	input := `
 	<%= for (n) in numbers.Foo { %>
@@ -31,7 +31,7 @@ func Test_LineNumberErrors_ForLoop(t *testing.T) {
 	r.Contains(err.Error(), "line 2:")
 }
 
-func Test_LineNumberErrors_ForLoop2(t *testing.T) {
+func Test_Line_Number_Errors_For_Loop_2(t *testing.T) {
 	r := require.New(t)
 	input := `
 	<%= for (n in numbers.Foo { %>
@@ -46,7 +46,7 @@ func Test_LineNumberErrors_ForLoop2(t *testing.T) {
 	r.Contains(err.Error(), "line 2:")
 }
 
-func Test_LineNumberErrors_InsideForLoop(t *testing.T) {
+func Test_Line_Number_Errors_Inside_For_Loop(t *testing.T) {
 	r := require.New(t)
 	input := `
 	<%= for (n) in numbers { %>
@@ -60,7 +60,7 @@ func Test_LineNumberErrors_InsideForLoop(t *testing.T) {
 	r.Contains(err.Error(), "line 3:")
 }
 
-func Test_LineNumberErrors_MissingKeyword(t *testing.T) {
+func Test_Line_Number_Errors_Missing_Keyword(t *testing.T) {
 	r := require.New(t)
 	input := `
 

--- a/math_test.go
+++ b/math_test.go
@@ -2,6 +2,7 @@ package plush_test
 
 import (
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/gobuffalo/plush/v5"
@@ -112,7 +113,7 @@ func Test_Render_String_Math(t *testing.T) {
 	}
 }
 
-func Test_Render_Operator_UndefinedVar(t *testing.T) {
+func Test_Render_Operator_Undefined_Var(t *testing.T) {
 	tests := []struct {
 		operator      string
 		result        interface{}
@@ -178,4 +179,39 @@ func Test_Render_Bool_Concat(t *testing.T) {
 	s, err := plush.Render(input, plush.NewContext())
 	r.Equal("true", s)
 	r.NoError(err)
+}
+
+func Test_Render_Safe_Mixed_Numeric_Comparisons(t *testing.T) {
+	type stats struct {
+		Count uint64
+	}
+	type robot struct {
+		Count uint32
+		Stats stats
+	}
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"i32":     int32(0),
+		"i32v":    int32(3),
+		"neg":     int32(-1),
+		"u32":     uint32(0),
+		"u32v":    uint32(3),
+		"u64":     uint64(0),
+		"u64one":  uint64(1),
+		"u64max":  uint64(math.MaxUint64),
+		"f32":     float32(3.5),
+		"f32i":    float32(3),
+		"f64":     float64(3.5),
+		"f64i":    float64(3),
+		"counts":  map[string]uint32{"active": 0},
+		"values":  []uint32{0},
+		"robot":   robot{Count: 0, Stats: stats{Count: 0}},
+		"robots":  []robot{{Count: 1, Stats: stats{Count: 0}}},
+		"counter": func() uint32 { return 0 },
+	})
+
+	input := `<%= i32 == 0 %>|<%= u32 == 0 %>|<%= u64 == 0 %>|<%= u64one > 0 %>|<%= u64max > 0 %>|<%= neg < 0 %>|<%= neg < u64 %>|<%= neg == u64 %>|<%= u32v == 3 %>|<%= f32 == 3.5 %>|<%= f64 > 3 %>|<%= f32i == 3 %>|<%= f64i == i32v %>|<%= u32v == 3.0 %>|<%= u64one == 1.0 %>|<%= robot.Count == 0 %>|<%= robots[0].Stats.Count == 0 %>|<%= counts["active"] == 0 %>|<%= values[0] == 0 %>|<%= counter() == 0 %>|<%= robot.Count + 1 %>`
+	s, err := plush.Render(input, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "true|true|true|true|true|true|true|false|true|true|true|true|true|true|true|true|true|true|true|true|1", s)
 }

--- a/numbers_test.go
+++ b/numbers_test.go
@@ -21,7 +21,7 @@ func Test_Identifiers_With_Digits(t *testing.T) {
 	r.Equal("hi mark", s)
 }
 
-func Test_Render_Var_ends_in_Number(t *testing.T) {
+func Test_Render_Var_Ends_In_Number(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContextWith(map[string]interface{}{
 		"myvar1": []string{"john", "paul"},
@@ -31,7 +31,7 @@ func Test_Render_Var_ends_in_Number(t *testing.T) {
 	r.Equal("johnpaul", s)
 }
 
-func Test_Render_AllowsManyNumericTypes(t *testing.T) {
+func Test_Render_Allows_Many_Numeric_Types(t *testing.T) {
 	r := require.New(t)
 	input := `<%= i32 %> <%= u32 %> <%= i8 %>`
 

--- a/numeric.go
+++ b/numeric.go
@@ -1,0 +1,285 @@
+package plush
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+)
+
+type numericKind int
+
+const (
+	numericSigned numericKind = iota
+	numericUnsigned
+	numericFloat
+)
+
+type numericValue struct {
+	kind numericKind
+	i    int64
+	u    uint64
+	f    float64
+}
+
+func isNumericOperator(op string) bool {
+	switch op {
+	case "+", "-", "*", "/", "<", ">", "<=", ">=", "==", "!=":
+		return true
+	default:
+		return false
+	}
+}
+
+func numericValueFromGo(value interface{}) (numericValue, bool) {
+	if value == nil {
+		return numericValue{}, false
+	}
+
+	rv := reflect.ValueOf(value)
+	for rv.Kind() == reflect.Interface {
+		if rv.IsNil() {
+			return numericValue{}, false
+		}
+		rv = rv.Elem()
+	}
+
+	switch rv.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return numericValue{kind: numericSigned, i: rv.Int()}, true
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return numericValue{kind: numericUnsigned, u: rv.Uint()}, true
+	case reflect.Float32, reflect.Float64:
+		return numericValue{kind: numericFloat, f: rv.Convert(reflect.TypeOf(float64(0))).Float()}, true
+	default:
+		return numericValue{}, false
+	}
+}
+
+func evalNumericOperator(left, right numericValue, op string) (interface{}, error) {
+	switch op {
+	case "==":
+		return compareNumericEquality(left, right), nil
+	case "!=":
+		return !compareNumericEquality(left, right), nil
+	case "<", ">", "<=", ">=":
+		return compareNumericOrdered(op, left, right)
+	default:
+		return numericArithmetic(left, right, op)
+	}
+}
+
+func (n numericValue) float64() float64 {
+	switch n.kind {
+	case numericFloat:
+		return n.f
+	case numericUnsigned:
+		return float64(n.u)
+	default:
+		return float64(n.i)
+	}
+}
+
+func (n numericValue) int64() (int64, bool) {
+	switch n.kind {
+	case numericSigned:
+		return n.i, true
+	case numericUnsigned:
+		if n.u <= uint64(math.MaxInt64) {
+			return int64(n.u), true
+		}
+	}
+	return 0, false
+}
+
+func (n numericValue) uint64() (uint64, bool) {
+	switch n.kind {
+	case numericUnsigned:
+		return n.u, true
+	case numericSigned:
+		if n.i >= 0 {
+			return uint64(n.i), true
+		}
+	}
+	return 0, false
+}
+
+func compareNumericEquality(left, right numericValue) bool {
+	if left.kind == numericFloat || right.kind == numericFloat {
+		return left.float64() == right.float64()
+	}
+
+	if l, ok := left.int64(); ok {
+		if r, ok := right.int64(); ok {
+			return l == r
+		}
+	}
+
+	if left.kind == numericSigned && left.i < 0 {
+		return false
+	}
+	if right.kind == numericSigned && right.i < 0 {
+		return false
+	}
+
+	l, lok := left.uint64()
+	r, rok := right.uint64()
+	return lok && rok && l == r
+}
+
+func compareNumericOrdered(op string, left, right numericValue) (bool, error) {
+	if left.kind == numericFloat || right.kind == numericFloat {
+		l := left.float64()
+		r := right.float64()
+		switch op {
+		case "<":
+			return l < r, nil
+		case ">":
+			return l > r, nil
+		case "<=":
+			return l <= r, nil
+		case ">=":
+			return l >= r, nil
+		}
+	}
+
+	if left.kind == numericSigned && right.kind == numericSigned {
+		switch op {
+		case "<":
+			return left.i < right.i, nil
+		case ">":
+			return left.i > right.i, nil
+		case "<=":
+			return left.i <= right.i, nil
+		case ">=":
+			return left.i >= right.i, nil
+		}
+	}
+	if left.kind == numericUnsigned && right.kind == numericUnsigned {
+		return compareUintOrdered(op, left.u, right.u)
+	}
+	if left.kind == numericSigned {
+		if left.i < 0 {
+			switch op {
+			case "<":
+				return true, nil
+			case ">":
+				return false, nil
+			case "<=":
+				return true, nil
+			case ">=":
+				return false, nil
+			}
+		}
+		return compareUintOrdered(op, uint64(left.i), right.u)
+	}
+
+	if right.i < 0 {
+		switch op {
+		case "<":
+			return false, nil
+		case ">":
+			return true, nil
+		case "<=":
+			return false, nil
+		case ">=":
+			return true, nil
+		}
+	}
+	return compareUintOrdered(op, left.u, uint64(right.i))
+}
+
+func compareUintOrdered(op string, left, right uint64) (bool, error) {
+	switch op {
+	case "<":
+		return left < right, nil
+	case ">":
+		return left > right, nil
+	case "<=":
+		return left <= right, nil
+	case ">=":
+		return left >= right, nil
+	default:
+		return false, fmt.Errorf("unknown operator for numeric %s", op)
+	}
+}
+
+func numericArithmetic(left, right numericValue, op string) (interface{}, error) {
+	if left.kind == numericFloat || right.kind == numericFloat {
+		l := left.float64()
+		r := right.float64()
+		switch op {
+		case "+":
+			return l + r, nil
+		case "-":
+			return l - r, nil
+		case "*":
+			return l * r, nil
+		case "/":
+			if r == 0 {
+				return nil, fmt.Errorf("division by zero %v %s %v", l, op, r)
+			}
+			return l / r, nil
+		default:
+			return nil, fmt.Errorf("unknown operator for numeric %s", op)
+		}
+	}
+
+	lSigned, lok := left.int64()
+	rSigned, rok := right.int64()
+	if lok && rok {
+		switch op {
+		case "+":
+			return signedNumericResult(lSigned + rSigned), nil
+		case "-":
+			return signedNumericResult(lSigned - rSigned), nil
+		case "*":
+			return signedNumericResult(lSigned * rSigned), nil
+		case "/":
+			if rSigned == 0 {
+				return nil, fmt.Errorf("division by zero %v %s %v", lSigned, op, rSigned)
+			}
+			return signedNumericResult(lSigned / rSigned), nil
+		default:
+			return nil, fmt.Errorf("unknown operator for numeric %s", op)
+		}
+	}
+
+	lUnsigned, lok := left.uint64()
+	rUnsigned, rok := right.uint64()
+	if !lok || !rok {
+		return nil, fmt.Errorf("unsupported mixed signed/unsigned operation")
+	}
+
+	switch op {
+	case "+":
+		if math.MaxUint64-lUnsigned < rUnsigned {
+			return nil, fmt.Errorf("integer overflow %v + %v", lUnsigned, rUnsigned)
+		}
+		return lUnsigned + rUnsigned, nil
+	case "-":
+		if lUnsigned < rUnsigned {
+			return nil, fmt.Errorf("integer underflow %v - %v", lUnsigned, rUnsigned)
+		}
+		return lUnsigned - rUnsigned, nil
+	case "*":
+		if rUnsigned != 0 && lUnsigned > math.MaxUint64/rUnsigned {
+			return nil, fmt.Errorf("integer overflow %v * %v", lUnsigned, rUnsigned)
+		}
+		return lUnsigned * rUnsigned, nil
+	case "/":
+		if rUnsigned == 0 {
+			return nil, fmt.Errorf("division by zero %v / %v", lUnsigned, rUnsigned)
+		}
+		return lUnsigned / rUnsigned, nil
+	default:
+		return nil, fmt.Errorf("unknown operator for numeric %s", op)
+	}
+}
+
+func signedNumericResult(value int64) interface{} {
+	asInt := int(value)
+	if int64(asInt) == value {
+		return asInt
+	}
+	return value
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -337,16 +337,6 @@ func (p *parser) parseHoleStatment() ast.Statement {
 		Statements: p.curToken.Literal,
 	}
 }
-func (p *parser) parseContinue() ast.Expression {
-	if !p.inForBlock {
-		p.errors = append(p.errors, fmt.Sprintf("line %d: continue is not in a loop", p.curToken.LineNumber))
-		return nil
-	}
-
-	stmt := &ast.ContinueExpression{TokenAble: ast.TokenAble{Token: p.curToken}}
-
-	return stmt
-}
 
 func (p *parser) parseIntegerLiteral() ast.Expression {
 	lit := &ast.IntegerLiteral{TokenAble: ast.TokenAble{Token: p.curToken}}
@@ -506,23 +496,8 @@ func (p *parser) parseForExpression() ast.Expression {
 func (p *parser) parseIfExpression() ast.Expression {
 	expression := &ast.IfExpression{TokenAble: ast.TokenAble{Token: p.curToken}}
 
-	if !p.expectPeek(token.LPAREN) {
-		return nil
-	}
-
-	p.nextToken()
-	expression.Condition = p.parseExpression(LOWEST)
-
-	//Confrim that expression is comparable
-	if !p.confrimIfCondition(expression.Condition) {
-		return nil
-	}
-
-	if !p.expectPeek(token.RPAREN) {
-		return nil
-	}
-
-	if !p.expectPeek(token.LBRACE) {
+	expression.Condition = p.parseIfCondition()
+	if expression.Condition == nil {
 		return nil
 	}
 
@@ -555,14 +530,29 @@ func (p *parser) parseIfExpression() ast.Expression {
 func (p *parser) parseElseIfExpression() *ast.ElseIfExpression {
 	expression := &ast.ElseIfExpression{TokenAble: ast.TokenAble{Token: p.curToken}}
 
-	if !p.expectPeek(token.LPAREN) {
+	expression.Condition = p.parseIfCondition()
+	if expression.Condition == nil {
+		return nil
+	}
+
+	expression.Block = p.parseBlockStatement()
+
+	return expression
+}
+
+func (p *parser) parseIfCondition() ast.Expression {
+	if p.peekTokenIs(token.LBRACE) || p.peekTokenIs(token.E_END) || p.peekTokenIs(token.EOF) {
+		p.errors = append(p.errors, fmt.Sprintf("line %d: syntax error: missing if condition", p.curToken.LineNumber))
 		return nil
 	}
 
 	p.nextToken()
-	expression.Condition = p.parseExpression(LOWEST)
+	condition := p.parseExpression(LOWEST)
+	if condition == nil {
+		return nil
+	}
 
-	if !p.expectPeek(token.RPAREN) {
+	if !p.confrimIfCondition(condition) {
 		return nil
 	}
 
@@ -570,9 +560,7 @@ func (p *parser) parseElseIfExpression() *ast.ElseIfExpression {
 		return nil
 	}
 
-	expression.Block = p.parseBlockStatement()
-
-	return expression
+	return condition
 }
 
 func (p *parser) parseBlockStatement() *ast.BlockStatement {
@@ -690,7 +678,7 @@ func (p *parser) parseCallExpression(function ast.Expression) ast.Expression {
 		calleeIdent := &ast.Identifier{Value: exp.Function.String()}
 		p.nextToken()
 		p.nextToken()
-		parseExp := p.parseExpression(LOWEST)
+		parseExp := p.parseExpression(EQUALS)
 
 		exp.ChainCallee = p.assignCallee(parseExp, calleeIdent)
 		if exp.ChainCallee == nil {
@@ -752,7 +740,7 @@ func (p *parser) parseIndexExpression(left ast.Expression) ast.Expression {
 		calleeIdent := &ast.Identifier{Value: left.String()}
 		p.nextToken()
 		p.nextToken()
-		parseExp := p.parseExpression(LOWEST)
+		parseExp := p.parseExpression(EQUALS)
 
 		exp.Callee = p.assignCallee(parseExp, calleeIdent)
 		if exp.Callee == nil {
@@ -779,11 +767,14 @@ func (p *parser) assignCallee(exp ast.Expression, calleeIdent *ast.Identifier) (
 	assignedCallee = nil
 	switch ss := exp.(type) {
 	case *ast.IndexExpression:
-		ff, ok := ss.Left.(*ast.Identifier)
-		if ok {
+		switch ff := ss.Left.(type) {
+		case *ast.Identifier:
 			ff.OriginalCallee.Callee = calleeIdent
 			assignedCallee = ss
-		} else {
+		case *ast.CallExpression:
+			ff.Callee = calleeIdent
+			assignedCallee = ss
+		default:
 			msg := fmt.Sprintf("line %d: syntax error: invalid nested index access, expected an identifier %v", p.curToken.LineNumber, ss)
 			p.errors = append(p.errors, msg)
 		}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_LetStatements(t *testing.T) {
+func Test_Let_Statements(t *testing.T) {
 	r := require.New(t)
 	tests := []struct {
 		input              string
@@ -40,7 +40,7 @@ func Test_LetStatements(t *testing.T) {
 	}
 }
 
-func Test_ReturnStatements(t *testing.T) {
+func Test_Return_Statements(t *testing.T) {
 	r := require.New(t)
 	tests := []struct {
 		input         string
@@ -64,7 +64,7 @@ func Test_ReturnStatements(t *testing.T) {
 	}
 }
 
-func Test_IdentifierExpression(t *testing.T) {
+func Test_Identifier_Expression(t *testing.T) {
 	r := require.New(t)
 	input := "<% foobar; %>"
 
@@ -78,7 +78,7 @@ func Test_IdentifierExpression(t *testing.T) {
 	r.Equal("foobar", ident.TokenLiteral())
 }
 
-func Test_IntegerLiteralExpression(t *testing.T) {
+func Test_Integer_Literal_Expression(t *testing.T) {
 	r := require.New(t)
 	input := "<% 5; %>"
 
@@ -92,7 +92,7 @@ func Test_IntegerLiteralExpression(t *testing.T) {
 	r.Equal("5", literal.TokenLiteral())
 }
 
-func Test_FloatLiteralExpression(t *testing.T) {
+func Test_Float_Literal_Expression(t *testing.T) {
 	r := require.New(t)
 	input := "<% 1.23 %>"
 
@@ -107,7 +107,7 @@ func Test_FloatLiteralExpression(t *testing.T) {
 	r.Equal("1.23", literal.TokenLiteral())
 }
 
-func Test_PrefixExpressions(t *testing.T) {
+func Test_Prefix_Expressions(t *testing.T) {
 	r := require.New(t)
 	prefixTests := []struct {
 		input    string
@@ -137,7 +137,7 @@ func Test_PrefixExpressions(t *testing.T) {
 	}
 }
 
-func Test_InfixExpressions(t *testing.T) {
+func Test_Infix_Expressions(t *testing.T) {
 	r := require.New(t)
 	infixTests := []struct {
 		input      string
@@ -176,7 +176,7 @@ func Test_InfixExpressions(t *testing.T) {
 	}
 }
 
-func Test_OperatorPrecedence(t *testing.T) {
+func Test_Operator_Precedence(t *testing.T) {
 	r := require.New(t)
 	tests := []struct {
 		input    string
@@ -312,7 +312,7 @@ func Test_OperatorPrecedence(t *testing.T) {
 	}
 }
 
-func Test_BooleanExpression(t *testing.T) {
+func Test_Boolean_Expression(t *testing.T) {
 	r := require.New(t)
 	tests := []struct {
 		input           string
@@ -335,7 +335,7 @@ func Test_BooleanExpression(t *testing.T) {
 	}
 }
 
-func Test_IfExpression(t *testing.T) {
+func Test_If_Expression(t *testing.T) {
 	r := require.New(t)
 	input := `<% if (x < y) { x } %>`
 
@@ -358,7 +358,7 @@ func Test_IfExpression(t *testing.T) {
 	r.Nil(exp.ElseBlock)
 }
 
-func Test_IfExpression_ComapreWithFunction(t *testing.T) {
+func Test_If_Expression_Comapre_With_Function(t *testing.T) {
 	r := require.New(t)
 	input := `<% if (f() != "yes") { x } %>`
 
@@ -390,7 +390,7 @@ func Test_IfExpression_ComapreWithFunction(t *testing.T) {
 	r.True(testIdentifier(t, consequence.Expression, "x"))
 	r.Nil(exp.ElseBlock)
 }
-func Test_IfExpression_PrefixExpressions_InvalidCompar(t *testing.T) {
+func Test_If_Expression_Prefix_Expressions_Invalid_Compar(t *testing.T) {
 	r := require.New(t)
 	input := `<% if (!(x = 1)) { x } %>`
 
@@ -398,7 +398,7 @@ func Test_IfExpression_PrefixExpressions_InvalidCompar(t *testing.T) {
 
 	r.Error(err, "syntax error: invalid if condition, got x = 1")
 }
-func Test_IfExpression_With_Map_Array_Index(t *testing.T) {
+func Test_If_Expression_With_Map_Array_Index(t *testing.T) {
 	r := require.New(t)
 	input := `<% if (flash["error"] ) { x } %>`
 
@@ -407,7 +407,7 @@ func Test_IfExpression_With_Map_Array_Index(t *testing.T) {
 	r.NoError(err)
 }
 
-func Test_IfExpression_InfixExpressions_InvalidCompare(t *testing.T) {
+func Test_If_Expression_Infix_Expressions_Invalid_Compare(t *testing.T) {
 	r := require.New(t)
 	input := `<% if ( y == 1 && x = 1) { x } %>`
 
@@ -416,7 +416,7 @@ func Test_IfExpression_InfixExpressions_InvalidCompare(t *testing.T) {
 	r.Error(err, "syntax error: invalid if condition, got x = 1")
 }
 
-func Test_IfExpression_Boolean(t *testing.T) {
+func Test_If_Expression_Boolean(t *testing.T) {
 	r := require.New(t)
 	input := `<% if (true) { x } %>`
 
@@ -426,7 +426,57 @@ func Test_IfExpression_Boolean(t *testing.T) {
 
 }
 
-func Test_IfExpression_Condition_CompareToString(t *testing.T) {
+func Test_If_Expression_Optional_Parentheses(t *testing.T) {
+	tests := []string{
+		`<% if true { x } %>`,
+		`<% if name { x } %>`,
+		`<% if !name { x } %>`,
+		`<% if name == "mark" { x } %>`,
+		`<% if name == "mark" || admin { x } %>`,
+		`<% if (name == "mark") || admin { x } %>`,
+		`<% if robots[0].Name == "mark" { x } %>`,
+		`<% if robots[0] == mark { x } %>`,
+		`<% if robots["TESTING"] == "mark" { x } %>`,
+		`<% if (true) { x } %>`,
+	}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			_, err := parser.Parse(input)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func Test_If_Expression_Optional_Parentheses_Else_If(t *testing.T) {
+	r := require.New(t)
+	input := `<% if false { x } else if name == "mark" { y } else if (admin) { z } else { q } %>`
+
+	program, err := parser.Parse(input)
+	r.NoError(err)
+	r.Len(program.Statements, 1)
+
+	stmt := program.Statements[0].(*ast.ExpressionStatement)
+	exp := stmt.Expression.(*ast.IfExpression)
+	r.Len(exp.ElseIf, 2)
+	r.NotNil(exp.ElseBlock)
+}
+
+func Test_If_Expression_Optional_Parentheses_Errors(t *testing.T) {
+	tests := []string{
+		`<% if { x } %>`,
+		`<% if true x } %>`,
+	}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			_, err := parser.Parse(input)
+			require.Error(t, err)
+		})
+	}
+}
+
+func Test_If_Expression_Condition_Compare_To_String(t *testing.T) {
 	r := require.New(t)
 	input := `<% if (x == "yes") { x } %>`
 
@@ -435,7 +485,7 @@ func Test_IfExpression_Condition_CompareToString(t *testing.T) {
 	r.NoError(err, "syntax error: invalid if condition, got x = y")
 
 }
-func Test_IfExpression_Condition_Assign(t *testing.T) {
+func Test_If_Expression_Condition_Assign(t *testing.T) {
 	r := require.New(t)
 	input := `<% if (x = y) { x } %>`
 
@@ -445,7 +495,7 @@ func Test_IfExpression_Condition_Assign(t *testing.T) {
 
 }
 
-func Test_IfExpression_Condition_EmptyHash(t *testing.T) {
+func Test_If_Expression_Condition_Empty_Hash(t *testing.T) {
 	r := require.New(t)
 	input := `<% if ({}}) { x } %>`
 
@@ -453,7 +503,7 @@ func Test_IfExpression_Condition_EmptyHash(t *testing.T) {
 	r.Error(err, "syntax error: invalid if statment, got {}")
 }
 
-func Test_IfExpression_HTML(t *testing.T) {
+func Test_If_Expression_HTML(t *testing.T) {
 	r := require.New(t)
 	input := `<p><% if (x < y) { %><%= x %><% } %></p>`
 
@@ -480,7 +530,7 @@ func Test_IfExpression_HTML(t *testing.T) {
 	r.Nil(ifs.ElseBlock)
 }
 
-func Test_IfExpression_HTML_NoClosingTag(t *testing.T) {
+func Test_If_Expression_HTML_No_Closing_Tag(t *testing.T) {
 	r := require.New(t)
 	// the template should have a missing '%>' after the if condition
 	input := `<p><% if (x < y) { <title>Hello Buffalo</title> <% } %>`
@@ -503,7 +553,7 @@ func Test_IfExpression_HTML_NoClosingTag(t *testing.T) {
 	// after that, parsing failed so don't expect any more expressions
 }
 
-func Test_IfExpression_Return_HTML_NoClosingTag(t *testing.T) {
+func Test_If_Expression_Return_HTML_No_Closing_Tag(t *testing.T) {
 	r := require.New(t)
 	// the template should have a missing '%>' after the if condition
 	input := `<p><%= if (x < y) { <title>Hello Buffalo</title> <% } %>`
@@ -526,7 +576,7 @@ func Test_IfExpression_Return_HTML_NoClosingTag(t *testing.T) {
 	// after that, parsing failed so don't expect any more expressions
 }
 
-func Test_IfElseExpression(t *testing.T) {
+func Test_If_Else_Expression(t *testing.T) {
 	r := require.New(t)
 	input := `<% if (x < y) { x } else { y } %>`
 
@@ -554,7 +604,7 @@ func Test_IfElseExpression(t *testing.T) {
 	r.True(testIdentifier(t, alternative.Expression, "y"))
 }
 
-func Test_FunctionLiteralParsing(t *testing.T) {
+func Test_Function_Literal_Parsing(t *testing.T) {
 	r := require.New(t)
 	input := `<% fn(x, y) { x + y; } %>`
 
@@ -579,7 +629,7 @@ func Test_FunctionLiteralParsing(t *testing.T) {
 	r.True(testInfixExpression(t, bodyStmt.Expression, "x", "+", "y"))
 }
 
-func Test_FunctionParameterParsing(t *testing.T) {
+func Test_Function_Parameter_Parsing(t *testing.T) {
 	r := require.New(t)
 	tests := []struct {
 		input          string
@@ -604,7 +654,7 @@ func Test_FunctionParameterParsing(t *testing.T) {
 	}
 }
 
-func Test_CallExpression(t *testing.T) {
+func Test_Call_Expression(t *testing.T) {
 	r := require.New(t)
 	input := "<% add(1, 2 * 3, 4 + 5); %>"
 
@@ -626,7 +676,7 @@ func Test_CallExpression(t *testing.T) {
 	r.True(testInfixExpression(t, exp.Arguments[2], 4, "+", 5))
 }
 
-func Test_CallExpressionParameter(t *testing.T) {
+func Test_Call_Expression_Parameter(t *testing.T) {
 	r := require.New(t)
 	tests := []struct {
 		input         string
@@ -667,7 +717,7 @@ func Test_CallExpressionParameter(t *testing.T) {
 	}
 }
 
-func Test_CallExpressionParsing_WithCallee(t *testing.T) {
+func Test_Call_Expression_Parsing_With_Callee(t *testing.T) {
 	r := require.New(t)
 	input := `<%= g.Greet("mark"); %>`
 
@@ -688,7 +738,7 @@ func Test_CallExpressionParsing_WithCallee(t *testing.T) {
 	r.Equal(exp.Arguments[0].String(), "\"mark\"")
 }
 
-func Test_CallExpressionParsing_WithMultipleCallees(t *testing.T) {
+func Test_Call_Expression_Parsing_With_Multiple_Callees(t *testing.T) {
 	r := require.New(t)
 	input := `<%= g.Foo.Greet("mark"); %>`
 
@@ -709,7 +759,7 @@ func Test_CallExpressionParsing_WithMultipleCallees(t *testing.T) {
 	r.Equal(exp.Arguments[0].String(), "\"mark\"")
 }
 
-func Test_IndexExpression_Nested_Structs_Start_WithCallee(t *testing.T) {
+func Test_Index_Expression_Nested_Structs_Start_With_Callee(t *testing.T) {
 	r := require.New(t)
 	input := `<% myarray[0].Name.Final %>`
 
@@ -731,7 +781,7 @@ func Test_IndexExpression_Nested_Structs_Start_WithCallee(t *testing.T) {
 	r.Equal("Name", gg.Callee.Value)
 }
 
-func Test_IndexExpression_Nested_Structs_Start_WithNested_Array(t *testing.T) {
+func Test_Index_Expression_Nested_Structs_Start_With_Nested_Array(t *testing.T) {
 	r := require.New(t)
 	input := `<% myarray[0].Name[1].Final %>`
 
@@ -757,7 +807,78 @@ func Test_IndexExpression_Nested_Structs_Start_WithNested_Array(t *testing.T) {
 	r.Equal("Final", cc.Value)
 }
 
-func Test_CallExpressionParsing_WithBlock(t *testing.T) {
+func Test_Index_Expression_Nested_Structs_With_Comparison(t *testing.T) {
+	r := require.New(t)
+	input := `<% robots[0].Stats.Count == 0 %>`
+
+	program, err := parser.Parse(input)
+	r.NoError(err)
+
+	r.Len(program.Statements, 1)
+
+	stmt := program.Statements[0].(*ast.ExpressionStatement)
+	exp := stmt.Expression.(*ast.InfixExpression)
+	r.Equal("==", exp.Operator)
+	left := exp.Left.(*ast.IndexExpression)
+	r.Equal("robots", left.Left.String())
+	r.Equal("0", left.Index.String())
+	r.Equal("robots.Stats.Count", left.Callee.String())
+	r.Equal("0", exp.Right.String())
+}
+
+func Test_Call_Expression_Index_Chain_From_Call_Receiver(t *testing.T) {
+	r := require.New(t)
+	input := `<% factory().Robots()[0].Name.Echo() %>`
+
+	program, err := parser.Parse(input)
+	r.NoError(err)
+	r.Len(program.Statements, 1)
+}
+
+func Test_Index_Expression_Nested_Map_Slice_Callee_Chain(t *testing.T) {
+	r := require.New(t)
+	input := `<% robot.Nested.Map[nestedKey].Items[0].Name.Echo() %>`
+
+	program, err := parser.Parse(input)
+	r.NoError(err)
+	r.Len(program.Statements, 1)
+
+	stmt := program.Statements[0].(*ast.ExpressionStatement)
+	exp := stmt.Expression.(*ast.IndexExpression)
+	r.Equal("robot.Nested.Map", exp.Left.String())
+	r.Equal("nestedKey", exp.Index.String())
+
+	items := exp.Callee.(*ast.IndexExpression)
+	r.Equal("robot.Nested.Map.Items", items.Left.String())
+	r.Equal("0", items.Index.String())
+	r.Equal("Name.Echo()", items.Callee.String())
+}
+
+func Test_Index_Expression_Method_Return_Slice_Callee_Chain(t *testing.T) {
+	r := require.New(t)
+	input := `<% robot.GetFriends()[0].Name.Echo() %>`
+
+	program, err := parser.Parse(input)
+	r.NoError(err)
+	r.Len(program.Statements, 1)
+
+	stmt := program.Statements[0].(*ast.ExpressionStatement)
+	exp := stmt.Expression.(*ast.IndexExpression)
+	r.Equal("robot.GetFriends()", exp.Left.String())
+	r.Equal("0", exp.Index.String())
+	r.Equal("Name.Echo()", exp.Callee.String())
+}
+
+func Test_Call_Expression_Nested_Function_Return_Callee_Chain(t *testing.T) {
+	r := require.New(t)
+	input := `<% factory().Robots().Name().Echo() %>`
+
+	program, err := parser.Parse(input)
+	r.NoError(err)
+	r.Len(program.Statements, 1)
+}
+
+func Test_Call_Expression_Parsing_With_Block(t *testing.T) {
 	r := require.New(t)
 	input := `<p><%= foo() { %>hi<% } %></p>`
 
@@ -782,7 +903,7 @@ func Test_CallExpressionParsing_WithBlock(t *testing.T) {
 	r.Nil(exp.Callee)
 }
 
-func Test_StringLiteralExpression(t *testing.T) {
+func Test_String_Literal_Expression(t *testing.T) {
 	r := require.New(t)
 	input := `<% "hello world"; %>`
 
@@ -795,7 +916,7 @@ func Test_StringLiteralExpression(t *testing.T) {
 	r.Equal("hello world", literal.Value)
 }
 
-func Test_StringBlockExpression(t *testing.T) {
+func Test_String_Block_Expression(t *testing.T) {
 	r := require.New(t)
 	input := "<% `hello world`; %>"
 
@@ -808,7 +929,7 @@ func Test_StringBlockExpression(t *testing.T) {
 	r.Equal("hello world", literal.Value)
 }
 
-func Test_EmptyArrayLiterals(t *testing.T) {
+func Test_Empty_Array_Literals(t *testing.T) {
 	r := require.New(t)
 	input := "<% [] %>"
 
@@ -821,7 +942,7 @@ func Test_EmptyArrayLiterals(t *testing.T) {
 	r.Len(array.Elements, 0)
 }
 
-func Test_ArrayLiterals(t *testing.T) {
+func Test_Array_Literals(t *testing.T) {
 	r := require.New(t)
 	input := "<% [1, 2 * 2, 3 + 3] %>"
 
@@ -838,7 +959,7 @@ func Test_ArrayLiterals(t *testing.T) {
 	r.True(testInfixExpression(t, array.Elements[2], 3, "+", 3))
 }
 
-func Test_IndexExpressionsAssign(t *testing.T) {
+func Test_Index_Expressions_Assign(t *testing.T) {
 	r := require.New(t)
 	input := "<% myArray[2] = 1 %>"
 
@@ -854,7 +975,7 @@ func Test_IndexExpressionsAssign(t *testing.T) {
 	//r.True(testInfixExpression(t, indexExp.Index, 2, "=", 1))
 }
 
-func Test_IndexExpressions(t *testing.T) {
+func Test_Index_Expressions(t *testing.T) {
 	r := require.New(t)
 	input := "<% myArray[1 + 1] %>"
 
@@ -869,7 +990,7 @@ func Test_IndexExpressions(t *testing.T) {
 	r.True(testInfixExpression(t, indexExp.Index, 1, "+", 1))
 }
 
-func Test_EmptyHashLiteral(t *testing.T) {
+func Test_Empty_Hash_Literal(t *testing.T) {
 	r := require.New(t)
 	input := "<% {} %>"
 
@@ -882,7 +1003,7 @@ func Test_EmptyHashLiteral(t *testing.T) {
 	r.Len(hash.Pairs, 0)
 }
 
-func Test_HashLiteralsStringKeys(t *testing.T) {
+func Test_Hash_Literals_String_Keys(t *testing.T) {
 	r := require.New(t)
 	input := `<% {"one": 1, "two": 2, "three": 3} %>`
 
@@ -908,7 +1029,7 @@ func Test_HashLiteralsStringKeys(t *testing.T) {
 	}
 }
 
-func Test_HashLiteralsBooleanKeys(t *testing.T) {
+func Test_Hash_Literals_Boolean_Keys(t *testing.T) {
 	r := require.New(t)
 	input := `<%{true: 1, false: 2}%>`
 
@@ -933,7 +1054,7 @@ func Test_HashLiteralsBooleanKeys(t *testing.T) {
 	}
 }
 
-func Test_HashLiteralsIntegerKeys(t *testing.T) {
+func Test_Hash_Literals_Integer_Keys(t *testing.T) {
 	r := require.New(t)
 	input := `<% {1: 1, 2: 2, 3: 3} %>`
 
@@ -960,7 +1081,7 @@ func Test_HashLiteralsIntegerKeys(t *testing.T) {
 	}
 }
 
-func Test_HashLiteralsWithExpressions(t *testing.T) {
+func Test_Hash_Literals_With_Expressions(t *testing.T) {
 	r := require.New(t)
 	input := `<% {"one": 0 + 1, "two": 10 - 8, "three": 15 / 5} %>`
 
@@ -1049,7 +1170,7 @@ func testBooleanLiteral(t *testing.T, exp ast.Expression, value bool) bool {
 	return true
 }
 
-func Test_ForExpression_WithContinue(t *testing.T) {
+func Test_For_Expression_With_Continue(t *testing.T) {
 	r := require.New(t)
 	input := `<% for (k,v) in myArray {  continue } %>`
 
@@ -1074,7 +1195,7 @@ func Test_ForExpression_WithContinue(t *testing.T) {
 	//r.True(testIdentifier(t, consequence.Expression, "v"))
 }
 
-func Test_ForExpression_WithBreak(t *testing.T) {
+func Test_For_Expression_With_Break(t *testing.T) {
 	r := require.New(t)
 	input := `<% for (k,v) in myArray {  break } %>`
 
@@ -1099,7 +1220,7 @@ func Test_ForExpression_WithBreak(t *testing.T) {
 	//r.True(testIdentifier(t, consequence.Expression, "v"))
 }
 
-func Test_Continue_IfCondtion(t *testing.T) {
+func Test_Continue_If_Condtion(t *testing.T) {
 	r := require.New(t)
 	input := `<% if(x == 2) { continue } %>`
 
@@ -1107,7 +1228,7 @@ func Test_Continue_IfCondtion(t *testing.T) {
 	r.Error(err)
 }
 
-func Test_Break_IfCondtion(t *testing.T) {
+func Test_Break_If_Condtion(t *testing.T) {
 	r := require.New(t)
 	input := `<% if(x == 2) { break } %>`
 
@@ -1115,7 +1236,7 @@ func Test_Break_IfCondtion(t *testing.T) {
 	r.Error(err)
 }
 
-func Test_Empty_IfCondtion(t *testing.T) {
+func Test_Empty_If_Condtion(t *testing.T) {
 	r := require.New(t)
 	input := `<% if() { v } %>`
 
@@ -1123,7 +1244,7 @@ func Test_Empty_IfCondtion(t *testing.T) {
 	r.Error(err)
 }
 
-func Test_Parse_HoleLiteralFunction(t *testing.T) {
+func Test_Parse_Hole_Literal_Function(t *testing.T) {
 	r := require.New(t)
 	input := `<% let a = myArray %><% a = a + "1" %><%=a %><%H "testing Helo WORD"   a + 1 %><%= a %>`
 
@@ -1150,7 +1271,7 @@ func Test_Break_Function(t *testing.T) {
 	r.Error(err)
 }
 
-func Test_ForExpression(t *testing.T) {
+func Test_For_Expression(t *testing.T) {
 	r := require.New(t)
 	input := `<% for (k,v) in myArray { v } %>`
 
@@ -1174,7 +1295,7 @@ func Test_ForExpression(t *testing.T) {
 	r.True(testIdentifier(t, consequence.Expression, "v"))
 }
 
-func Test_ForExpression_Split(t *testing.T) {
+func Test_For_Expression_Split(t *testing.T) {
 	r := require.New(t)
 	input := `<% for (k,v) in anArray { %>
 	<p><%= v %></p>
@@ -1195,7 +1316,7 @@ func Test_ForExpression_Split(t *testing.T) {
 	r.Len(exp.Block.Statements, 3)
 }
 
-func Test_ForExpression_Func(t *testing.T) {
+func Test_For_Expression_Func(t *testing.T) {
 	r := require.New(t)
 	input := `<% for (k,v) in range(1,3) { %>
 	<p><%= v %></p>
@@ -1216,7 +1337,7 @@ func Test_ForExpression_Func(t *testing.T) {
 	r.Len(exp.Block.Statements, 3)
 }
 
-func Test_AndOrInfixExpressions(t *testing.T) {
+func Test_And_Or_Infix_Expressions(t *testing.T) {
 	r := require.New(t)
 	infixTests := []struct {
 		input      string
@@ -1269,7 +1390,7 @@ drop_column("table_name", "column2_name")`
 	r.NoError(err)
 	r.Equal(input, p.String())
 }
-func Test_HashLiteralsMixWithIfAndFn(t *testing.T) {
+func Test_Hash_Literals_Mix_With_If_And_Fn(t *testing.T) {
 	r := require.New(t)
 	cases := []string{
 
@@ -1313,7 +1434,7 @@ func Test_HashLiteralsMixWithIfAndFn(t *testing.T) {
 	}
 }
 
-func Test_IndexExpression_MixWithFnBrackets(t *testing.T) {
+func Test_Index_Expression_Mix_With_Fn_Brackets(t *testing.T) {
 	r := require.New(t)
 
 	cases := []string{
@@ -1333,7 +1454,7 @@ func Test_IndexExpression_MixWithFnBrackets(t *testing.T) {
 	}
 }
 
-func Test_ForExpression_MixWithFnBrackets(t *testing.T) {
+func Test_For_Expression_Mix_With_Fn_Brackets(t *testing.T) {
 	r := require.New(t)
 
 	cases := []string{
@@ -1352,7 +1473,7 @@ func Test_ForExpression_MixWithFnBrackets(t *testing.T) {
 	}
 }
 
-func Test_ParseCallExpression_NilFunction_ReactLikePatterns_Panic(t *testing.T) {
+func Test_Parse_Call_Expression_Nil_Function_React_Like_Patterns_Panic(t *testing.T) {
 	r := require.New(t)
 	// These patterns might occur in React compiled files or malformed templates
 	cases := []string{

--- a/partial_helper.go
+++ b/partial_helper.go
@@ -86,7 +86,12 @@ func PartialHelper(name string, data map[string]interface{}, help HelperContext)
 			help.Set(meta.TemplateExtensionKey, origExt)
 		}()
 	}
-	if part, err = Render(part, help.Context); err != nil {
+	if useInterpreterPartialRender(help.Context) {
+		part, err = RenderInterpreter(part, help.Context)
+	} else {
+		part, err = Render(part, help.Context)
+	}
+	if err != nil {
 		return "", err
 	}
 	if ct, ok := help.Value("contentType").(string); ok {

--- a/partial_helper_test.go
+++ b/partial_helper_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_PartialHelper_Nil_Context(t *testing.T) {
+func Test_Partial_Helper_Nil_Context(t *testing.T) {
 	r := require.New(t)
 
 	name := "index"
@@ -24,7 +24,7 @@ func Test_PartialHelper_Nil_Context(t *testing.T) {
 	r.Equal("", string(html))
 }
 
-func Test_PartialHelper_Blank_Context(t *testing.T) {
+func Test_Partial_Helper_Blank_Context(t *testing.T) {
 	r := require.New(t)
 
 	name := "index"
@@ -37,7 +37,7 @@ func Test_PartialHelper_Blank_Context(t *testing.T) {
 	r.Equal("", string(html))
 }
 
-func Test_PartialHelper_Invalid_Feeder(t *testing.T) {
+func Test_Partial_Helper_Invalid_Feeder(t *testing.T) {
 	r := require.New(t)
 
 	name := "index"
@@ -51,7 +51,7 @@ func Test_PartialHelper_Invalid_Feeder(t *testing.T) {
 	r.Equal("", string(html))
 }
 
-func Test_PartialHelper_NestedPartial_PathHandling(t *testing.T) {
+func Test_Partial_Helper_Nested_Partial_Path_Handling(t *testing.T) {
 	r := require.New(t)
 	gg := meta.TemplateFileKey
 	partials := map[string]string{
@@ -75,7 +75,7 @@ func Test_PartialHelper_NestedPartial_PathHandling(t *testing.T) {
 	r.Equal("CODE3 PRINT /fake/templates/testing/code-3.plush.html", normalized)
 }
 
-func Test_PartialHelper_Invalid_FeederFunction(t *testing.T) {
+func Test_Partial_Helper_Invalid_Feeder_Function(t *testing.T) {
 	r := require.New(t)
 
 	name := "index"
@@ -91,7 +91,7 @@ func Test_PartialHelper_Invalid_FeederFunction(t *testing.T) {
 	r.Equal("", string(html))
 }
 
-func Test_PartialHelper_Feeder_Error(t *testing.T) {
+func Test_Partial_Helper_Feeder_Error(t *testing.T) {
 	r := require.New(t)
 
 	name := "index"
@@ -106,7 +106,7 @@ func Test_PartialHelper_Feeder_Error(t *testing.T) {
 	r.Contains(err.Error(), "me-rong")
 }
 
-func Test_PartialHelper_Good(t *testing.T) {
+func Test_Partial_Helper_Good(t *testing.T) {
 	r := require.New(t)
 
 	name := "index"
@@ -121,7 +121,7 @@ func Test_PartialHelper_Good(t *testing.T) {
 	r.Equal(`<div class="test">Plush!</div>`, string(html))
 }
 
-func Test_PartialHelper_With_Data(t *testing.T) {
+func Test_Partial_Helper_With_Data(t *testing.T) {
 	r := require.New(t)
 
 	name := "index"
@@ -136,7 +136,7 @@ func Test_PartialHelper_With_Data(t *testing.T) {
 	r.Equal(`<div class="test">Hello Yonghwan</div>`, string(html))
 }
 
-func Test_PartialHelper_With_InternalChange(t *testing.T) {
+func Test_Partial_Helper_With_Internal_Change(t *testing.T) {
 	r := require.New(t)
 
 	name := "index"
@@ -155,7 +155,7 @@ func Test_PartialHelper_With_InternalChange(t *testing.T) {
 	r.Equal(3, help.Value("number"))
 }
 
-func Test_PartialHelper_With_Recursion(t *testing.T) {
+func Test_Partial_Helper_With_Recursion(t *testing.T) {
 	r := require.New(t)
 
 	name := "index"
@@ -177,7 +177,7 @@ func Test_PartialHelper_With_Recursion(t *testing.T) {
 	r.Equal(3, help.Value("number"))
 }
 
-func Test_PartialHelper_Render_Error(t *testing.T) {
+func Test_Partial_Helper_Render_Error(t *testing.T) {
 	r := require.New(t)
 
 	name := "index"
@@ -191,7 +191,7 @@ func Test_PartialHelper_Render_Error(t *testing.T) {
 	r.Error(err)
 }
 
-func Test_PartialHelper_With_Layout(t *testing.T) {
+func Test_Partial_Helper_With_Layout(t *testing.T) {
 	r := require.New(t)
 
 	name := "index"
@@ -212,7 +212,7 @@ func Test_PartialHelper_With_Layout(t *testing.T) {
 	r.Equal(`<html><div class="test">Hello Yonghwan</div></html>`, string(html))
 }
 
-func Test_PartialHelper_JavaScript(t *testing.T) {
+func Test_Partial_Helper_Java_Script(t *testing.T) {
 	r := require.New(t)
 
 	name := "index.js"
@@ -228,7 +228,7 @@ func Test_PartialHelper_JavaScript(t *testing.T) {
 	r.Equal(`alert('\'Hello\'');`, string(html))
 }
 
-func Test_PartialHelper_JavaScript_Without_Extension(t *testing.T) {
+func Test_Partial_Helper_Java_Script_Without_Extension(t *testing.T) {
 	r := require.New(t)
 
 	name := "index"
@@ -244,7 +244,7 @@ func Test_PartialHelper_JavaScript_Without_Extension(t *testing.T) {
 	r.Equal(`alert('\'Hello\'');`, string(html))
 }
 
-func Test_PartialHelper_Javascript_With_HTML(t *testing.T) {
+func Test_Partial_Helper_Javascript_With_HTML(t *testing.T) {
 	r := require.New(t)
 
 	name := "index.html"
@@ -260,7 +260,7 @@ func Test_PartialHelper_Javascript_With_HTML(t *testing.T) {
 	r.Equal(`alert(\'\\\'Hello\\\'\');`, string(html))
 }
 
-func Test_PartialHelper_Javascript_With_HTML_Partial(t *testing.T) {
+func Test_Partial_Helper_Javascript_With_HTML_Partial(t *testing.T) {
 	// https://github.com/gobuffalo/plush/issues/106
 	r := require.New(t)
 
@@ -302,7 +302,7 @@ func Test_PartialHelper_Javascript_With_HTML_Partial(t *testing.T) {
 	r.Equal(`alert('\u003Cdiv\u003E\\u003Cspan\\u003EFORM\\u003C/span\\u003E\u003C/div\u003E');`, string(html))
 }
 
-func Test_PartialHelper_NoDefaultHelperOverride(t *testing.T) {
+func Test_Partial_Helper_No_Default_Helper_Override(t *testing.T) {
 	r := require.New(t)
 
 	t.Run("Existing key", func(t *testing.T) {

--- a/plush.go
+++ b/plush.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"io/ioutil"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gobuffalo/plush/v5/helpers/hctx"
@@ -29,9 +30,24 @@ var DefaultTimeFormat = "January 02, 2006 15:04:05 -0700"
 var PunchHoleCacheLifetime = 1 * time.Minute
 var cacheEnabled bool
 var holeTemplateFileKey = "__plush_internal_hole_render_key_" + fmt.Sprintf("%d", time.Now().UnixNano()) + "__"
+var interpreterPartialRenderKey = "__plush_internal_interpreter_partial_render_" + fmt.Sprintf("%d", time.Now().UnixNano()) + "__"
 var errClearCache error = errors.New("template recently cached, skipping")
+var punchHoleConcurrencyLimit atomic.Int64
 
 var templateCacheBackend TemplateCache
+
+func init() {
+	punchHoleConcurrencyLimit.Store(int64(runtime.GOMAXPROCS(0)))
+}
+
+func SetPunchHoleConcurrencyLimit(limit int) int {
+	previous := int(punchHoleConcurrencyLimit.Swap(int64(limit)))
+	return previous
+}
+
+func GetPunchHoleConcurrencyLimit() int {
+	return int(punchHoleConcurrencyLimit.Load())
+}
 
 func PlushCacheSetup(ts TemplateCache) {
 	cacheEnabled = true
@@ -41,6 +57,13 @@ func PlushCacheSetup(ts TemplateCache) {
 // BuffaloRenderer implements the render.TemplateEngine interface allowing velvet to be used as a template engine
 // for Buffalo
 func BuffaloRenderer(input string, data map[string]interface{}, helpers map[string]interface{}) (string, error) {
+	return BuffaloRendererWithContext(input, data, helpers, nil)
+}
+
+// BuffaloRendererWithContext is BuffaloRenderer with an optional context
+// configuration hook. The hook runs after data/helpers are loaded and before
+// rendering, so callers can attach per-render options such as VM fast helpers.
+func BuffaloRendererWithContext(input string, data map[string]interface{}, helpers map[string]interface{}, configure func(*Context)) (string, error) {
 	if data == nil {
 		data = make(map[string]interface{})
 	}
@@ -48,6 +71,9 @@ func BuffaloRenderer(input string, data map[string]interface{}, helpers map[stri
 		data[k] = v
 	}
 	ctx := NewContextWith(data)
+	if configure != nil {
+		configure(ctx)
+	}
 	defer func() {
 		if data != nil {
 			for k := range ctx.data.localInterner.stringToID {
@@ -65,6 +91,7 @@ func Parse(input ...string) (*Template, error) {
 	}
 
 	filename := input[1]
+	sourceHash := templateSourceHash(preprocessTrimTags(input[0]))
 	var astKey string
 	isPlushFile := isFilePlush(filename)
 	if isPlushFile {
@@ -73,12 +100,24 @@ func Parse(input ...string) (*Template, error) {
 	}
 	if filename != "" && templateCacheBackend != nil && isPlushFile {
 		t, ok := templateCacheBackend.Get(astKey)
-		if ok {
-			cloned := &Template{
-				Program: t.Program,
-				IsCache: true,
+		if ok && templateSourceMatches(t, sourceHash) {
+			if t.Program != nil {
+				return cachedParseTemplate(t), nil
 			}
-			return cloned, nil
+			if t.Input != "" {
+				parsed, err := NewTemplate(t.Input)
+				if err != nil {
+					return parsed, err
+				}
+				astTemplate := &Template{
+					Program:    parsed.Program,
+					VMBytecode: t.VMBytecode,
+					SourceHash: sourceHash,
+					IsCache:    false,
+				}
+				templateCacheBackend.Set(astKey, astTemplate)
+				return cachedParseTemplate(astTemplate), nil
+			}
 		}
 	}
 
@@ -89,12 +128,26 @@ func Parse(input ...string) (*Template, error) {
 	// Cache the AST
 	if cacheEnabled && templateCacheBackend != nil && filename != "" && isPlushFile {
 		astTemplate := &Template{
-			Program: t.Program,
-			IsCache: false,
+			Program:    t.Program,
+			SourceHash: sourceHash,
+			IsCache:    false,
+		}
+		if cached, ok := templateCacheBackend.Get(astKey); ok && cached != nil && templateSourceMatches(cached, sourceHash) {
+			astTemplate.VMBytecode = cached.VMBytecode
 		}
 		templateCacheBackend.Set(astKey, astTemplate)
 	}
 	return t, nil
+}
+
+func cachedParseTemplate(t *Template) *Template {
+	return &Template{
+		Input:      t.Input,
+		Program:    t.Program,
+		VMBytecode: t.VMBytecode,
+		SourceHash: t.SourceHash,
+		IsCache:    true,
+	}
 }
 
 // RenderWithBudget renders a template and enforces a work-unit limit.
@@ -114,6 +167,9 @@ func RenderWithBudgetConfig(input string, limit int64, costs BudgetCosts, ctx *C
 }
 
 func isHole(ctx hctx.Context) bool {
+	if c, ok := ctx.(*Context); ok {
+		return isHoleContext(c)
+	}
 	if ctx.Value(holeTemplateFileKey) == nil {
 		return false
 	}
@@ -127,24 +183,208 @@ func isHole(ctx hctx.Context) bool {
 
 }
 
-// Render a string using the given context.
-func Render(input string, ctx hctx.Context) (string, error) {
-	var filename string
+func IsHoleRender(ctx hctx.Context) bool {
+	return isHole(ctx)
+}
 
-	// Extract filename from context if we're not in a hole rendering pass.
-	// The filename is used for template caching - only main templates (not holes) should use cache.
-	if !isHole(ctx) && ctx.Value(meta.TemplateFileKey) != nil {
-		if rawFilename, ok := ctx.Value(meta.TemplateFileKey).(string); ok {
-			filename = cleanFilePath(rawFilename) // ✅ Clean once here
+func PunchHoleTemplateFilename(ctx hctx.Context) string {
+	if c, ok := ctx.(*Context); ok {
+		return punchHoleTemplateFilenameContext(c)
+	}
+	if isHole(ctx) || ctx.Value(meta.TemplateFileKey) == nil {
+		return ""
+	}
+	rawFilename, ok := ctx.Value(meta.TemplateFileKey).(string)
+	if !ok {
+		return ""
+	}
+	return cleanFilePath(rawFilename)
+}
+
+func isHoleContext(ctx *Context) bool {
+	if ctx == nil {
+		return false
+	}
+	ctx.moot.RLock()
+	defer ctx.moot.RUnlock()
+
+	holeFile, ok := ctx.data.Resolve(holeTemplateFileKey)
+	if !ok || holeFile == nil {
+		return false
+	}
+	templateFile, ok := ctx.data.Resolve(meta.TemplateFileKey)
+	if !ok || templateFile == nil {
+		return false
+	}
+
+	holeName, _ := holeFile.(string)
+	templateName, _ := templateFile.(string)
+	return templateName == holeName
+}
+
+func punchHoleTemplateFilenameContext(ctx *Context) string {
+	if ctx == nil {
+		return ""
+	}
+	ctx.moot.RLock()
+	defer ctx.moot.RUnlock()
+
+	templateFile, templateOK := ctx.data.Resolve(meta.TemplateFileKey)
+	if !templateOK || templateFile == nil {
+		return ""
+	}
+	holeFile, holeOK := ctx.data.Resolve(holeTemplateFileKey)
+	if holeOK && holeFile != nil {
+		holeName, _ := holeFile.(string)
+		templateName, _ := templateFile.(string)
+		if templateName == holeName {
+			return ""
 		}
 	}
+
+	rawFilename, ok := templateFile.(string)
+	if !ok {
+		return ""
+	}
+	return cleanFilePath(rawFilename)
+}
+
+func IsPlushTemplateFile(filename string) bool {
+	return isFilePlush(filename)
+}
+
+func IsVMBytecodeCacheableTemplateFile(filename string) bool {
+	return isVMBytecodeCacheableFile(filename)
+}
+
+func RenderFromPunchHoleCache(filename string, ctx hctx.Context) (string, error) {
+	return RenderFromPunchHoleCacheWithSource(filename, "", ctx)
+}
+
+func RenderFromPunchHoleCacheWithSource(filename string, source string, ctx hctx.Context) (string, error) {
+	return renderFromCache(filename, source, ctx)
+}
+
+func IsPunchHoleCacheExpired(err error) bool {
+	return errors.Is(err, errClearCache)
+}
+
+func CachePunchHoleSkeleton(filename string, ctx hctx.Context, skeleton string, holes []HoleMarker, force bool) {
+	CachePunchHoleSkeletonWithSource(filename, ctx, skeleton, holes, force, "")
+}
+
+func CachePunchHoleSkeletonWithSource(filename string, ctx hctx.Context, skeleton string, holes []HoleMarker, force bool, source string) {
+	if filename == "" || !cacheEnabled || templateCacheBackend == nil || !isFilePlush(filename) || len(holes) == 0 {
+		return
+	}
+	sourceHash := templateSourceCacheHash(source)
+	if !force {
+		if cached, ok := templateCacheBackend.Get(generateFullKeyFromCleanFilename(filename, ctx)); ok && templateSourceMatches(cached, sourceHash) {
+			return
+		}
+	}
+	astKey := GenerateASTKeyFromCleanFilename(filename)
+	if _, ok := templateCacheBackend.Get(astKey); !ok {
+		templateCacheBackend.Set(astKey, &Template{IsCache: false})
+	}
+	templateCacheBackend.Set(generateFullKeyFromCleanFilename(filename, ctx), &Template{
+		Skeleton:   skeleton,
+		PunchHole:  holesCopy(holes),
+		SourceHash: sourceHash,
+		IsCache:    false,
+		LastCached: time.Now(),
+	})
+}
+
+func FinalizePunchHolePositions(rendered string, holes []HoleMarker) []HoleMarker {
+	out := holesCopy(holes)
+	for i := range out {
+		hole := &out[i]
+		if hole.start == -1 && hole.end == -1 {
+			pos := strings.Index(rendered, hole.marker_name)
+			if pos != -1 {
+				hole.start = pos
+				hole.end = pos + len(hole.marker_name)
+			}
+		}
+	}
+	return out
+}
+
+func RenderPunchHolesConcurrently(holes []HoleMarker, ctx hctx.Context) []HoleMarker {
+	return renderHolesConcurrently(holesCopy(holes), ctx)
+}
+
+func RenderPunchHolesConcurrentlyWith(holes []HoleMarker, ctx hctx.Context, renderer func(string, hctx.Context) (string, error)) []HoleMarker {
+	return renderHolesConcurrentlyWith(holesCopy(holes), ctx, renderer)
+}
+
+func FillPunchHoles(rendered string, holes []HoleMarker) (string, error) {
+	return fillHoles(rendered, holes)
+}
+
+// Render a string using the given context.
+func Render(input string, ctx hctx.Context) (string, error) {
+	if ctx == nil {
+		ctx = NewContext()
+	}
+	restoreDiagnosticsRoot := SetRenderDiagnosticsRootActive(ctx, true)
+	if restoreDiagnosticsRoot != nil {
+		defer restoreDiagnosticsRoot()
+	}
+	start := time.Now()
+	mode := RenderModeNameInterpreter
+	if GetRenderMode() == RenderModeVM {
+		mode = RenderModeNameVM
+	}
+	filename := PunchHoleTemplateFilename(ctx)
+	UpdateRenderDiagnosticsForTemplate(ctx, filename, func(d *RenderDiagnostics) {
+		d.Mode = mode
+		d.TemplateFilename = filename
+		if mode == RenderModeNameInterpreter {
+			d.VMBytecodeCache = VMBytecodeCacheDisabled
+			if d.FastPath == "" {
+				d.FastPath = RenderFastPathGeneric
+			}
+		}
+		if d.PunchHoleCache == "" {
+			d.PunchHoleCache = PunchHoleCacheDisabled
+		}
+	})
+	defer func() {
+		UpdateRenderDiagnostics(ctx, func(d *RenderDiagnostics) {
+			d.Mode = mode
+			if d.TemplateFilename == "" {
+				d.TemplateFilename = filename
+			}
+			if mode == RenderModeNameInterpreter {
+				d.VMBytecodeCache = VMBytecodeCacheDisabled
+			}
+			d.EngineDuration += time.Since(start)
+		})
+	}()
+
+	if GetRenderMode() == RenderModeVM {
+		renderer, ok := registeredVMRenderer()
+		if !ok {
+			return "", fmt.Errorf("%w: import github.com/gobuffalo/plush/v5/VM/plush to register it", ErrVMRendererNotRegistered)
+		}
+		return renderer(input, ctx)
+	}
+	return renderInterpreter(input, ctx)
+}
+
+func renderInterpreter(input string, ctx hctx.Context) (string, error) {
+	// Extract filename from context if we're not in a hole rendering pass.
+	// The filename is used for template caching - only main templates (not holes) should use cache.
+	filename := PunchHoleTemplateFilename(ctx)
 	forceCacheClear := false
 	// Try to render from cache if conditions are met:
 	// - Not in hole rendering pass (prevents infinite recursion)
 	// - Cache is enabled and backend is available
 	// - Template has a filename for cache key
-	if !isHole(ctx) && filename != "" {
-		cacheT, cacheErr := renderFromCache(filename, ctx)
+	if filename != "" {
+		cacheT, cacheErr := renderFromCache(filename, input, ctx)
 		if cacheErr == nil {
 			return cacheT, nil
 		} else if cacheErr == errClearCache {
@@ -177,10 +417,11 @@ func Render(input string, ctx hctx.Context) (string, error) {
 	if (!t.IsCache || forceCacheClear) && cacheEnabled {
 		defer func() {
 			if templateCacheBackend != nil && filename != "" && isPlushFile && len(holeMarkers) > 0 {
-				fullKey := generateFullKey(filename, ctx)
+				fullKey := generateFullKeyFromCleanFilename(filename, ctx)
 				cacheableTemplate := &Template{
 					Skeleton:   t.Skeleton,
 					PunchHole:  holesCopy(t.PunchHole),
+					SourceHash: templateSourceHash(preprocessTrimTags(input)),
 					IsCache:    false,
 					LastCached: time.Now(),
 				}
@@ -198,6 +439,44 @@ func Render(input string, ctx hctx.Context) (string, error) {
 
 	// Return skeleton as-is (either no holes or we're in hole rendering pass)
 	return s, nil
+}
+
+func RenderInterpreter(input string, ctx hctx.Context) (string, error) {
+	if ctx == nil {
+		ctx = NewContext()
+	}
+	restore := forceInterpreterPartialRender(ctx)
+	defer restore()
+	return renderInterpreter(input, ctx)
+}
+
+func forceInterpreterPartialRender(ctx hctx.Context) func() {
+	if ctx == nil {
+		return func() {}
+	}
+	previous := ctx.Value(interpreterPartialRenderKey)
+	ctx.Set(interpreterPartialRenderKey, true)
+	return func() {
+		if previous == nil {
+			ctx.Set(interpreterPartialRenderKey, false)
+			return
+		}
+		ctx.Set(interpreterPartialRenderKey, previous)
+	}
+}
+
+func useInterpreterPartialRender(ctx hctx.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	useInterpreter, _ := ctx.Value(interpreterPartialRenderKey).(bool)
+	return useInterpreter
+}
+
+// InterpreterPartialRenderEnabled reports whether partials should stay on the
+// interpreter path for the current render.
+func InterpreterPartialRenderEnabled(ctx hctx.Context) bool {
+	return useInterpreterPartialRender(ctx)
 }
 
 // fillHoles replaces all markers in the rendered string with their rendered content using stored positions.
@@ -218,19 +497,21 @@ func fillHoles(rendered string, holes []HoleMarker) (string, error) {
 }
 
 func renderHolesConcurrently(holes []HoleMarker, ctx hctx.Context) []HoleMarker {
+	if useInterpreterPartialRender(ctx) {
+		return renderHolesConcurrentlyWith(holes, ctx, RenderInterpreter)
+	}
+	return renderHolesConcurrentlyWith(holes, ctx, Render)
+}
+
+func renderHolesConcurrentlyWith(holes []HoleMarker, ctx hctx.Context, renderer func(string, hctx.Context) (string, error)) []HoleMarker {
 	if len(holes) == 0 {
 		return holes
 	}
-
-	var wg sync.WaitGroup
-	wg.Add(len(holes))
+	if renderer == nil {
+		renderer = Render
+	}
 
 	holeCtx := ctx.New()
-
-	octx := holeCtx.(*Context)
-	defer func() {
-		ctx = octx
-	}()
 	var currentfileName string
 	if holeCtx.Value(meta.TemplateFileKey) != nil {
 
@@ -240,24 +521,38 @@ func renderHolesConcurrently(holes []HoleMarker, ctx hctx.Context) []HoleMarker 
 		}
 	}
 	holeCtx.Set(holeTemplateFileKey, holeCtx.Value(meta.TemplateFileKey))
-	for k, hole := range holes {
-		go func(k int, childCtx hctx.Context, h HoleMarker) {
-			defer wg.Done()
 
-			content, err := Render(h.input, childCtx)
-			if err != nil {
-				content = err.Error() + " in " + currentfileName
-
-			}
-			holes[k].content = content
-		}(k, holeCtx.New(), hole)
+	workerCount := GetPunchHoleConcurrencyLimit()
+	if workerCount <= 0 || workerCount > len(holes) {
+		workerCount = len(holes)
 	}
+
+	jobs := make(chan int)
+	var wg sync.WaitGroup
+	wg.Add(workerCount)
+	for worker := 0; worker < workerCount; worker++ {
+		go func() {
+			defer wg.Done()
+			for k := range jobs {
+				childCtx := holeCtx.New()
+				content, err := renderer(holes[k].input, childCtx)
+				if err != nil {
+					content = err.Error() + " in " + currentfileName
+				}
+				holes[k].content = content
+			}
+		}()
+	}
+	for k := range holes {
+		jobs <- k
+	}
+	close(jobs)
 	wg.Wait()
 	return holes
 }
 
 func RenderR(input io.Reader, ctx hctx.Context) (string, error) {
-	b, err := ioutil.ReadAll(input)
+	b, err := io.ReadAll(input)
 	if err != nil {
 		return "", err
 	}
@@ -307,21 +602,23 @@ func holesCopy(holes []HoleMarker) []HoleMarker {
 // If there is no filename, we should not use the cache.
 // If cache is disabled, we should not use the cache.
 // If there is no templateCacheBackend, we should not use the cache.
-func renderFromCache(filename string, ctx hctx.Context) (string, error) {
+func renderFromCache(filename string, source string, ctx hctx.Context) (string, error) {
 	if filename == "" || !cacheEnabled || templateCacheBackend == nil || isHole(ctx) {
 		return "", errors.New("cache not available")
 	}
 
-	astKey := GenerateASTKey(filename)
-	_, astExists := templateCacheBackend.Get(astKey)
-	if !astExists {
+	sourceHash := templateSourceCacheHash(preprocessTrimTags(source))
+	astKey := GenerateASTKeyFromCleanFilename(filename)
+	astTemplate, astExists := templateCacheBackend.Get(astKey)
+	if !astExists || !templateSourceMatches(astTemplate, sourceHash) {
 		return "", errors.New("AST not cached")
 	}
 
-	fullKey := generateFullKey(filename, ctx)
+	fullKey := generateFullKeyFromCleanFilename(filename, ctx)
 	inCacheTemplate, inCache := templateCacheBackend.Get(fullKey)
 	if inCache &&
 		inCacheTemplate != nil &&
+		templateSourceMatches(inCacheTemplate, sourceHash) &&
 		inCacheTemplate.Skeleton != "" &&
 		len(inCacheTemplate.PunchHole) > 0 {
 		if time.Since(inCacheTemplate.LastCached) > PunchHoleCacheLifetime {
@@ -344,4 +641,11 @@ func isFilePlush(filename string) bool {
 	}
 	// Check for .plush
 	return filename[len(filename)-6:] == ".plush"
+}
+
+func isVMBytecodeCacheableFile(filename string) bool {
+	if isFilePlush(filename) {
+		return true
+	}
+	return strings.HasSuffix(filename, ".html")
 }

--- a/plush_test.go
+++ b/plush_test.go
@@ -96,8 +96,12 @@ func Test_Render_Diagnostics_Interpreter_Context(t *testing.T) {
 
 	ctx := plush.NewContext()
 	ctx.Set(meta.TemplateFileKey, "products/show.plush")
+	ctx.Set("renderValue", func() string {
+		time.Sleep(20 * time.Millisecond)
+		return "interpreter"
+	})
 
-	s, err := plush.Render(`<%= "interpreter" %>`, ctx)
+	s, err := plush.Render(`<%= renderValue() %>`, ctx)
 	r.NoError(err)
 	r.Equal("interpreter", s)
 
@@ -116,8 +120,12 @@ func Test_Render_Diagnostics_From_Data_After_Buffalo_Renderer(t *testing.T) {
 
 	data := map[string]interface{}{
 		meta.TemplateFileKey: "products/show.plush",
+		"renderValue": func() string {
+			time.Sleep(20 * time.Millisecond)
+			return "interpreter"
+		},
 	}
-	rendered, err := plush.BuffaloRenderer(`<%= "interpreter" %>`, data, nil)
+	rendered, err := plush.BuffaloRenderer(`<%= renderValue() %>`, data, nil)
 	r.NoError(err)
 	r.Equal("interpreter", rendered)
 
@@ -136,8 +144,16 @@ func Test_Render_Diagnostics_Accumulates_Sequential_Template_Durations(t *testin
 
 	ctx := plush.NewContext()
 	ctx.Set(meta.TemplateFileKey, "products/show.plush")
+	ctx.Set("renderBody", func() string {
+		time.Sleep(20 * time.Millisecond)
+		return "body"
+	})
+	ctx.Set("renderLayout", func() string {
+		time.Sleep(40 * time.Millisecond)
+		return "layout"
+	})
 
-	_, err := plush.Render(`<%= "body" %>`, ctx)
+	_, err := plush.Render(`<%= renderBody() %>`, ctx)
 	r.NoError(err)
 	first, ok := plush.RenderDiagnosticsFromContext(ctx)
 	r.True(ok)
@@ -145,7 +161,7 @@ func Test_Render_Diagnostics_Accumulates_Sequential_Template_Durations(t *testin
 	r.NotZero(first.EngineDuration)
 
 	ctx.Set(meta.TemplateFileKey, "application.plush")
-	_, err = plush.Render(`<%= "layout" %>`, ctx)
+	_, err = plush.Render(`<%= renderLayout() %>`, ctx)
 	r.NoError(err)
 	second, ok := plush.RenderDiagnosticsFromContext(ctx)
 	r.True(ok)

--- a/plush_test.go
+++ b/plush_test.go
@@ -1,9 +1,12 @@
 package plush_test
 
 import (
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/helpers/meta"
 	"github.com/gobuffalo/plush/v5/templatecache/inmemory"
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +33,7 @@ func Test_Render_Keeps_Spacing(t *testing.T) {
 	r.Equal("hi mark", s)
 }
 
-func Test_Render_HTML_InjectedString(t *testing.T) {
+func Test_Render_HTML_Injected_String(t *testing.T) {
 	r := require.New(t)
 
 	input := `<p><%= "mark" %></p>`
@@ -58,7 +61,7 @@ func Test_Render_Missing_Variable(t *testing.T) {
 	r.Error(err)
 }
 
-func Test_Render_ShowNoShow(t *testing.T) {
+func Test_Render_Show_No_Show(t *testing.T) {
 	r := require.New(t)
 	input := `<%= "shown" %><% "notshown" %>`
 	s, err := plush.Render(input, plush.NewContext())
@@ -66,7 +69,7 @@ func Test_Render_ShowNoShow(t *testing.T) {
 	r.Equal("shown", s)
 }
 
-func Test_Render_ScriptFunction(t *testing.T) {
+func Test_Render_Script_Function(t *testing.T) {
 	r := require.New(t)
 
 	input := `<% let add = fn(x) { return x + 2; }; %><%= add(2) %>`
@@ -76,7 +79,191 @@ func Test_Render_ScriptFunction(t *testing.T) {
 	r.Equal("4", s)
 }
 
-func Test_Render_HasBlock(t *testing.T) {
+func Test_Render_Mode_Default_Interpreter(t *testing.T) {
+	r := require.New(t)
+	previous := plush.SetRenderMode(plush.RenderModeInterpreter)
+	defer plush.SetRenderMode(previous)
+
+	s, err := plush.Render(`<%= "interpreter" %>`, plush.NewContext())
+	r.NoError(err)
+	r.Equal("interpreter", s)
+}
+
+func Test_Render_Diagnostics_Interpreter_Context(t *testing.T) {
+	r := require.New(t)
+	previous := plush.SetRenderMode(plush.RenderModeInterpreter)
+	defer plush.SetRenderMode(previous)
+
+	ctx := plush.NewContext()
+	ctx.Set(meta.TemplateFileKey, "products/show.plush")
+
+	s, err := plush.Render(`<%= "interpreter" %>`, ctx)
+	r.NoError(err)
+	r.Equal("interpreter", s)
+
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	r.True(ok)
+	r.Equal(plush.RenderModeNameInterpreter, diagnostics.Mode)
+	r.Equal("products/show.plush", diagnostics.TemplateFilename)
+	r.Equal(plush.VMBytecodeCacheDisabled, diagnostics.VMBytecodeCache)
+	r.NotZero(diagnostics.EngineDuration)
+}
+
+func Test_Render_Diagnostics_From_Data_After_Buffalo_Renderer(t *testing.T) {
+	r := require.New(t)
+	previous := plush.SetRenderMode(plush.RenderModeInterpreter)
+	defer plush.SetRenderMode(previous)
+
+	data := map[string]interface{}{
+		meta.TemplateFileKey: "products/show.plush",
+	}
+	rendered, err := plush.BuffaloRenderer(`<%= "interpreter" %>`, data, nil)
+	r.NoError(err)
+	r.Equal("interpreter", rendered)
+
+	diagnostics, ok := plush.RenderDiagnosticsFromData(data)
+	r.True(ok)
+	r.Equal(plush.RenderModeNameInterpreter, diagnostics.Mode)
+	r.Equal("products/show.plush", diagnostics.TemplateFilename)
+	r.Equal(plush.VMBytecodeCacheDisabled, diagnostics.VMBytecodeCache)
+	r.NotZero(diagnostics.EngineDuration)
+}
+
+func Test_Render_Diagnostics_Accumulates_Sequential_Template_Durations(t *testing.T) {
+	r := require.New(t)
+	previous := plush.SetRenderMode(plush.RenderModeInterpreter)
+	defer plush.SetRenderMode(previous)
+
+	ctx := plush.NewContext()
+	ctx.Set(meta.TemplateFileKey, "products/show.plush")
+
+	_, err := plush.Render(`<%= "body" %>`, ctx)
+	r.NoError(err)
+	first, ok := plush.RenderDiagnosticsFromContext(ctx)
+	r.True(ok)
+	r.Equal("products/show.plush", first.TemplateFilename)
+	r.NotZero(first.EngineDuration)
+
+	ctx.Set(meta.TemplateFileKey, "application.plush")
+	_, err = plush.Render(`<%= "layout" %>`, ctx)
+	r.NoError(err)
+	second, ok := plush.RenderDiagnosticsFromContext(ctx)
+	r.True(ok)
+	r.Equal("products/show.plush", second.TemplateFilename)
+	r.Greater(second.EngineDuration, first.EngineDuration)
+}
+
+func Test_Render_Interpreter_AST_Cache_Invalidates_When_Source_Changes(t *testing.T) {
+	r := require.New(t)
+	cache := inmemory.NewMemoryCache()
+	plush.PlushCacheSetup(cache)
+	defer plush.ClearTemplateCache()
+
+	previous := plush.SetRenderMode(plush.RenderModeInterpreter)
+	defer plush.SetRenderMode(previous)
+
+	ctx := plush.NewContext()
+	ctx.Set(meta.TemplateFileKey, "interpreter-source-change.plush")
+
+	out, err := plush.Render(`<%= "first" %>`, ctx)
+	r.NoError(err)
+	r.Equal("first", out)
+
+	out, err = plush.Render(`<%= "second" %>`, ctx)
+	r.NoError(err)
+	r.Equal("second", out)
+}
+
+func Test_Buffalo_Renderer_With_Context_Configures_Context(t *testing.T) {
+	r := require.New(t)
+	previous := plush.SetRenderMode(plush.RenderModeInterpreter)
+	defer plush.SetRenderMode(previous)
+
+	configured := false
+	data := map[string]interface{}{
+		meta.TemplateFileKey: "products/show.plush",
+	}
+	rendered, err := plush.BuffaloRendererWithContext(`<%= marker %>`, data, nil, func(ctx *plush.Context) {
+		configured = true
+		ctx.Set("marker", "configured")
+	})
+	r.NoError(err)
+	r.True(configured)
+	r.Equal("configured", rendered)
+	r.Equal("configured", data["marker"])
+
+	diagnostics, ok := plush.RenderDiagnosticsFromData(data)
+	r.True(ok)
+	r.Equal(plush.RenderModeNameInterpreter, diagnostics.Mode)
+}
+
+func Test_Render_Diagnostics_VM_Hotspots_Header(t *testing.T) {
+	r := require.New(t)
+	ctx := plush.NewContext()
+	plush.EnableRenderVMHotspotDiagnostics(ctx)
+
+	plush.AddRenderDiagnosticVMHelperTiming(ctx, "slow:helper", 3*time.Millisecond)
+	plush.AddRenderDiagnosticVMHelperTiming(ctx, "slow:helper", 2*time.Millisecond)
+	plush.AddRenderDiagnosticVMHelperTiming(ctx, "fast", time.Millisecond)
+	plush.AddRenderDiagnosticVMPartialTiming(ctx, "row,card", 4*time.Millisecond)
+
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	r.True(ok)
+	r.Equal(3, diagnostics.VMHotspots.HelperCalls)
+	r.Equal(1, diagnostics.VMHotspots.PartialCalls)
+	r.InDelta(6.0, diagnostics.VMHelperDurationMilliseconds(), 0.001)
+	r.InDelta(4.0, diagnostics.VMPartialDurationMilliseconds(), 0.001)
+	r.Equal("slow_helper:2:5.000;fast:1:1.000", diagnostics.VMHelperHotspotsHeader())
+	r.Equal("row_card:1:4.000", diagnostics.VMPartialHotspotsHeader())
+}
+
+func Test_Render_Diagnostics_VM_Hotspots_Default_Off(t *testing.T) {
+	r := require.New(t)
+	ctx := plush.NewContext()
+
+	plush.AddRenderDiagnosticVMHelperTiming(ctx, "helper", time.Millisecond)
+	plush.AddRenderDiagnosticVMPartialTiming(ctx, "partial", time.Millisecond)
+
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	r.False(ok)
+	r.Zero(diagnostics.VMHotspots.HelperCalls)
+	r.Zero(diagnostics.VMHotspots.PartialCalls)
+}
+
+func Test_Render_Diagnostics_VM_Hotspots_Concurrent_Update(t *testing.T) {
+	r := require.New(t)
+	ctx := plush.NewContext()
+	plush.EnableRenderVMHotspotDiagnostics(ctx)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				plush.AddRenderDiagnosticVMHelperTiming(ctx, "helper", time.Microsecond)
+				plush.AddRenderDiagnosticVMPartialTiming(ctx, "partial", time.Microsecond)
+			}
+		}()
+	}
+	wg.Wait()
+
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	r.True(ok)
+	r.Equal(400, diagnostics.VMHotspots.HelperCalls)
+	r.Equal(400, diagnostics.VMHotspots.PartialCalls)
+}
+
+func Test_Render_Mode_VM_Requires_Registered_Renderer(t *testing.T) {
+	r := require.New(t)
+	previous := plush.SetRenderMode(plush.RenderModeVM)
+	defer plush.SetRenderMode(previous)
+
+	_, err := plush.Render(`<%= "vm" %>`, plush.NewContext())
+	r.ErrorIs(err, plush.ErrVMRendererNotRegistered)
+}
+
+func Test_Render_Has_Block(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
 	ctx.Set("blockCheck", func(help plush.HelperContext) string {
@@ -92,7 +279,7 @@ func Test_Render_HasBlock(t *testing.T) {
 	r.Equal("block|no block", s)
 }
 
-func Test_Render_Dash_in_Helper(t *testing.T) {
+func Test_Render_Dash_In_Helper(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContextWith(map[string]interface{}{
 		"my-helper": func() string {
@@ -104,7 +291,7 @@ func Test_Render_Dash_in_Helper(t *testing.T) {
 	r.Equal("hello", s)
 }
 
-func Test_BuffaloRenderer(t *testing.T) {
+func Test_Buffalo_Renderer(t *testing.T) {
 	r := require.New(t)
 	input := `<%= foo() %><%= name %>`
 	data := map[string]interface{}{
@@ -120,7 +307,7 @@ func Test_BuffaloRenderer(t *testing.T) {
 	r.Equal("GeorgeRingo", s)
 }
 
-func Test_BuffaloRenderer_Nil_Data(t *testing.T) {
+func Test_Buffalo_Renderer_Nil_Data(t *testing.T) {
 	r := require.New(t)
 	input := `<%= foo() %>`
 	helpers := map[string]interface{}{
@@ -133,7 +320,7 @@ func Test_BuffaloRenderer_Nil_Data(t *testing.T) {
 	r.Equal("test", s)
 }
 
-func Test_BuffaloRenderer_Data_Persistence(t *testing.T) {
+func Test_Buffalo_Renderer_Data_Persistence(t *testing.T) {
 	r := require.New(t)
 	input := `<%= contentFor("name") { %>MD<% }  %>`
 	data := map[string]interface{}{}
@@ -162,7 +349,7 @@ func Test_Helper_Nil_Arg(t *testing.T) {
 	r.Equal("test", s)
 }
 
-func Test_UndefinedArg(t *testing.T) {
+func Test_Undefined_Arg(t *testing.T) {
 	r := require.New(t)
 	input := `<%= foo(bar) %>`
 	ctx := plush.NewContext()
@@ -197,7 +384,7 @@ func Test_Caching(t *testing.T) {
 	r.NotEqual(tc, template)
 }
 
-func Test_Caching_EmptyFileName(t *testing.T) {
+func Test_Caching_Empty_File_Name(t *testing.T) {
 	r := require.New(t)
 
 	fileCacheName := "testing 123"

--- a/punch_hole.go
+++ b/punch_hole.go
@@ -1,5 +1,7 @@
 package plush
 
+import "fmt"
+
 var punch_hole_constant = "<PLUSH_HOLE_%d>"
 
 type HoleMarker struct {
@@ -8,4 +10,43 @@ type HoleMarker struct {
 	start, end  int
 	content     string
 	err         error
+}
+
+func PunchHoleMarkerName(index int) string {
+	return fmt.Sprintf(punch_hole_constant, index)
+}
+
+func NewHoleMarker(markerName, input string, start, end int) HoleMarker {
+	return HoleMarker{
+		marker_name: markerName,
+		input:       input,
+		start:       start,
+		end:         end,
+		content:     "",
+		err:         nil,
+	}
+}
+
+func (h HoleMarker) MarkerName() string {
+	return h.marker_name
+}
+
+func (h HoleMarker) Input() string {
+	return h.input
+}
+
+func (h HoleMarker) Start() int {
+	return h.start
+}
+
+func (h HoleMarker) End() int {
+	return h.end
+}
+
+func (h HoleMarker) Content() string {
+	return h.content
+}
+
+func (h HoleMarker) Err() error {
+	return h.err
 }

--- a/punch_hole_test.go
+++ b/punch_hole_test.go
@@ -1,15 +1,18 @@
 package plush_test
 
 import (
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
 	"github.com/gobuffalo/plush/v5/helpers/meta"
 	"github.com/gobuffalo/plush/v5/templatecache/inmemory"
 	"github.com/stretchr/testify/require"
 )
 
-func Test_Render_HolePunching_IntermediateOutput(t *testing.T) {
+func Test_Render_Hole_Punching_Intermediate_Output(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
 	ctx.Set("myArray", []string{"a", "b"})
@@ -29,7 +32,36 @@ func Test_Render_HolePunching_IntermediateOutput(t *testing.T) {
 	r.Contains(s, "ab1<PLUSH_HOLE_0>ab1<PLUSH_HOLE_1>")
 }
 
-func Test_Render_HolePunching_ErrorInHole(t *testing.T) {
+func Test_Render_Hole_Punching_Concurrency_Limit(t *testing.T) {
+	oldLimit := plush.SetPunchHoleConcurrencyLimit(2)
+	defer plush.SetPunchHoleConcurrencyLimit(oldLimit)
+
+	holes := make([]plush.HoleMarker, 8)
+	for i := range holes {
+		holes[i] = plush.NewHoleMarker(plush.PunchHoleMarkerName(i), "hole", -1, -1)
+	}
+
+	var active int64
+	var maxActive int64
+	renderer := func(input string, ctx hctx.Context) (string, error) {
+		current := atomic.AddInt64(&active, 1)
+		for {
+			maximum := atomic.LoadInt64(&maxActive)
+			if current <= maximum || atomic.CompareAndSwapInt64(&maxActive, maximum, current) {
+				break
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+		atomic.AddInt64(&active, -1)
+		return input, nil
+	}
+
+	rendered := plush.RenderPunchHolesConcurrentlyWith(holes, plush.NewContext(), renderer)
+	require.Len(t, rendered, len(holes))
+	require.LessOrEqual(t, atomic.LoadInt64(&maxActive), int64(2))
+}
+
+func Test_Render_Hole_Punching_Error_In_Hole(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
 	cacheFileName := "myfile.plush"
@@ -43,7 +75,7 @@ func Test_Render_HolePunching_ErrorInHole(t *testing.T) {
 	r.Nil(err)
 	r.Contains(ss, `line 1: "hole_punch_first_error": unknown identifier`)
 }
-func Test_Render_HolePunching_SecondPass_NoCache(t *testing.T) {
+func Test_Render_Hole_Punching_Second_Pass_No_Cache(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
 	cacheFileName := "myfile.plush"
@@ -57,7 +89,28 @@ func Test_Render_HolePunching_SecondPass_NoCache(t *testing.T) {
 	r.Equal(`ab1testingab1sssss`, ss)
 }
 
-func Test_Render_HolePunching_MultipleHolesAtEnd(t *testing.T) {
+func Test_Render_Hole_Punching_Skeleton_Cache_Invalidates_When_Source_Changes(t *testing.T) {
+	r := require.New(t)
+	cache := inmemory.NewMemoryCache()
+	plush.PlushCacheSetup(cache)
+	defer plush.ClearTemplateCache()
+
+	previous := plush.SetRenderMode(plush.RenderModeInterpreter)
+	defer plush.SetRenderMode(previous)
+
+	ctx := plush.NewContext()
+	ctx.Set(meta.TemplateFileKey, "holes-source-change.plush")
+
+	ss, err := plush.Render(`A<%H "hole" %>B`, ctx)
+	r.NoError(err)
+	r.Equal(`AholeB`, ss)
+
+	ss, err = plush.Render(`C<%H "hole" %>D`, ctx)
+	r.NoError(err)
+	r.Equal(`CholeD`, ss)
+}
+
+func Test_Render_Hole_Punching_Multiple_Holes_At_End(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
 	cacheFileName := "myfile.plush"
@@ -72,7 +125,7 @@ func Test_Render_HolePunching_MultipleHolesAtEnd(t *testing.T) {
 	r.Equal(`ab1testingab1sssssddddeeee`, ss)
 }
 
-func Test_Render_HolePunching_HolesAtStart(t *testing.T) {
+func Test_Render_Hole_Punching_Holes_At_Start(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
 	cacheFileName := "myfile.plush"
@@ -86,7 +139,7 @@ func Test_Render_HolePunching_HolesAtStart(t *testing.T) {
 	r.NoError(err)
 	r.Equal(`testingab1testingab1sssssddddeeee`, ss)
 }
-func Test_Render_HolePunching_SecondPass_WithCache(t *testing.T) {
+func Test_Render_Hole_Punching_Second_Pass_With_Cache(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
 
@@ -107,11 +160,11 @@ func Test_Render_HolePunching_SecondPass_WithCache(t *testing.T) {
 	r.True(ok)
 	r.NotEmpty(templ)
 
-	//This should still work and use the cached template even if we update the input
+	// Source changes under the same filename must invalidate the cached skeleton.
 	input = `<% let a = myArray %><% a = a + "2" %><%=a %><%H "testing" %><%= a %><%H "sssss" %>`
 	ss, err = plush.Render(input, ctx)
 	r.NoError(err)
-	r.Equal(`ab1testingab1sssss`, ss, "The output should be the same as the first render since it is cached as the first template")
+	r.Equal(`ab2testingab2sssss`, ss)
 
 	ff.Delete(astKey)
 	ss, err = plush.Render(input, ctx)
@@ -119,7 +172,7 @@ func Test_Render_HolePunching_SecondPass_WithCache(t *testing.T) {
 	r.Equal(`ab2testingab2sssss`, ss)
 }
 
-func Test_Render_HolePunching_HoleAtStartAndEnd(t *testing.T) {
+func Test_Render_Hole_Punching_Hole_At_Start_And_End(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
 	cacheFileName := "myfile.plush"
@@ -132,7 +185,7 @@ func Test_Render_HolePunching_HoleAtStartAndEnd(t *testing.T) {
 	r.Equal("startend", ss)
 }
 
-func Test_Render_HolePunching_EmptyHoleContent(t *testing.T) {
+func Test_Render_Hole_Punching_Empty_Hole_Content(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
 	cacheFileName := "myfile.plush"
@@ -145,7 +198,7 @@ func Test_Render_HolePunching_EmptyHoleContent(t *testing.T) {
 	r.Equal("foo", ss)
 }
 
-func Test_Render_HolePunching_ManyHoles(t *testing.T) {
+func Test_Render_Hole_Punching_Many_Holes(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
 	cacheFileName := "myfile.plush"
@@ -163,7 +216,7 @@ func Test_Render_HolePunching_ManyHoles(t *testing.T) {
 	r.Equal(expected, ss)
 }
 
-func Test_Render_HolePunching_TemplateContainsHolePunch(t *testing.T) {
+func Test_Render_Hole_Punching_Template_Contains_Hole_Punch(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
 	cacheFileName := "myfile.plush"
@@ -175,7 +228,7 @@ func Test_Render_HolePunching_TemplateContainsHolePunch(t *testing.T) {
 	r.NoError(err)
 	r.Equal("<PLUSH_HOLE_0>startend", ss)
 }
-func Test_Render_HolePunching_InBlockStatment(t *testing.T) {
+func Test_Render_Hole_Punching_In_Block_Statment(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
 	cacheFileName := "myfile.plush"
@@ -189,7 +242,7 @@ func Test_Render_HolePunching_InBlockStatment(t *testing.T) {
 	r.Equal(`testing`, ss)
 }
 
-func Test_Render_HolePunching_InForLoop(t *testing.T) {
+func Test_Render_Hole_Punching_In_For_Loop(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
 	cacheFileName := "myfile.plush"
@@ -203,7 +256,7 @@ func Test_Render_HolePunching_InForLoop(t *testing.T) {
 	r.Equal(`testingatestingbtestingc`, ss)
 }
 
-func Test_Render_HolePunching_ForLoopAsHole(t *testing.T) {
+func Test_Render_Hole_Punching_For_Loop_As_Hole(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
 	cacheFileName := "myfile.plush"
@@ -217,7 +270,7 @@ func Test_Render_HolePunching_ForLoopAsHole(t *testing.T) {
 	r.Equal(`abc`, ss)
 }
 
-func Test_Render_HolePunching_IfElse(t *testing.T) {
+func Test_Render_Hole_Punching_If_Else(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
 	cacheFileName := "myfile.plush"
@@ -231,7 +284,7 @@ func Test_Render_HolePunching_IfElse(t *testing.T) {
 	r.Equal(`3`, ss)
 }
 
-func Test_Render_HolePunching_IfTruthyA(t *testing.T) {
+func Test_Render_Hole_Punching_If_Truthy_A(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
 	cacheFileName := "myfile.plush"
@@ -244,7 +297,7 @@ func Test_Render_HolePunching_IfTruthyA(t *testing.T) {
 	r.NoError(err)
 	r.Equal(`NUMBER`, ss)
 }
-func Test_Render_HolePunching_IfTruthy(t *testing.T) {
+func Test_Render_Hole_Punching_If_Truthy(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
 	cacheFileName := "myfile.plush"
@@ -257,7 +310,7 @@ func Test_Render_HolePunching_IfTruthy(t *testing.T) {
 	r.NoError(err)
 	r.Equal(`NUMBER`, ss)
 }
-func Test_PartialHelper_With_RecursionHole(t *testing.T) {
+func Test_Partial_Helper_With_Recursion_Hole(t *testing.T) {
 	r := require.New(t)
 
 	ctx := plush.NewContext()

--- a/render_diagnostics.go
+++ b/render_diagnostics.go
@@ -1,0 +1,341 @@
+package plush
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+)
+
+const (
+	RenderModeNameInterpreter = "interpreter"
+	RenderModeNameVM          = "vm"
+
+	VMBytecodeCacheDisabled        = "disabled"
+	VMBytecodeCacheHit             = "hit"
+	VMBytecodeCacheHitStatic       = "hit-static"
+	VMBytecodeCacheHitSource       = "hit-source"
+	VMBytecodeCacheMiss            = "miss"
+	VMBytecodeCacheMissStore       = "miss-store"
+	VMBytecodeCacheMissStoreSource = "miss-store-source"
+	VMBytecodeCacheDirect          = "compiled-template"
+
+	RenderFastPathStatic              = "static"
+	RenderFastPathFast                = "fast"
+	RenderFastPathGeneric             = "generic"
+	RenderFastPathInterpreterFallback = "interpreter-fallback"
+
+	PunchHoleCacheDisabled = "disabled"
+	PunchHoleCacheHit      = "hit"
+	PunchHoleCacheMiss     = "miss"
+)
+
+var renderDiagnosticsKey = "__plush_internal_render_diagnostics_" + fmt.Sprintf("%d", time.Now().UnixNano()) + "__"
+var renderVMHotspotDiagnosticsKey = "__plush_internal_render_vm_hotspot_diagnostics_" + fmt.Sprintf("%d", time.Now().UnixNano()) + "__"
+var renderDiagnosticsRootActiveKey = "__plush_internal_render_diagnostics_root_active_" + fmt.Sprintf("%d", time.Now().UnixNano()) + "__"
+
+type renderDiagnosticsState struct {
+	mu          sync.Mutex
+	diagnostics RenderDiagnostics
+}
+
+type RenderDiagnostics struct {
+	Mode             string
+	TemplateFilename string
+	VMBytecodeCache  string
+	FastPath         string
+	FastRejectLine   int
+	FastReject       string
+	PunchHoleCache   string
+	EngineDuration   time.Duration
+	FastPlan         RenderFastPlanDiagnostics
+	VMHotspots       RenderVMHotspotDiagnostics
+}
+
+type RenderFastPlanDiagnostics struct {
+	Bindings       int
+	Segments       int
+	StaticSegments int
+	NameSegments   int
+	PropertyReads  int
+	ValueWrites    int
+	HelperCalls    int
+	Conditionals   int
+	Loops          int
+	LoopParts      int
+	Partials       int
+	MaxDepth       int
+	HelperNames    []string
+	PartialNames   []string
+}
+
+type RenderVMHotspotDiagnostics struct {
+	HelperCalls     int
+	HelperDuration  time.Duration
+	PartialCalls    int
+	PartialDuration time.Duration
+	Helpers         []RenderVMHotspot
+	Partials        []RenderVMHotspot
+}
+
+type RenderVMHotspot struct {
+	Name     string
+	Calls    int
+	Duration time.Duration
+}
+
+func (d RenderDiagnostics) EngineDurationMilliseconds() float64 {
+	return float64(d.EngineDuration) / float64(time.Millisecond)
+}
+
+func (d RenderDiagnostics) VMHelperDurationMilliseconds() float64 {
+	return float64(d.VMHotspots.HelperDuration) / float64(time.Millisecond)
+}
+
+func (d RenderDiagnostics) VMPartialDurationMilliseconds() float64 {
+	return float64(d.VMHotspots.PartialDuration) / float64(time.Millisecond)
+}
+
+func (d RenderDiagnostics) FastPlanHelperNamesHeader() string {
+	return strings.Join(d.FastPlan.HelperNames, ";")
+}
+
+func (d RenderDiagnostics) FastPlanPartialNamesHeader() string {
+	return strings.Join(d.FastPlan.PartialNames, ";")
+}
+
+func (d RenderDiagnostics) VMHelperHotspotsHeader() string {
+	return renderVMHotspotsHeader(d.VMHotspots.Helpers)
+}
+
+func (d RenderDiagnostics) VMPartialHotspotsHeader() string {
+	return renderVMHotspotsHeader(d.VMHotspots.Partials)
+}
+
+func AddRenderDiagnosticVMHelperTiming(ctx hctx.Context, name string, duration time.Duration) {
+	addRenderDiagnosticVMHotspot(ctx, name, duration, true)
+}
+
+func AddRenderDiagnosticVMPartialTiming(ctx hctx.Context, name string, duration time.Duration) {
+	addRenderDiagnosticVMHotspot(ctx, name, duration, false)
+}
+
+func EnableRenderVMHotspotDiagnostics(ctx hctx.Context) {
+	SetRenderVMHotspotDiagnostics(ctx, true)
+}
+
+func DisableRenderVMHotspotDiagnostics(ctx hctx.Context) {
+	SetRenderVMHotspotDiagnostics(ctx, false)
+}
+
+func SetRenderVMHotspotDiagnostics(ctx hctx.Context, enabled bool) {
+	if ctx == nil {
+		return
+	}
+	ctx.Set(renderVMHotspotDiagnosticsKey, enabled)
+	if enabled {
+		renderDiagnosticsStateFromContext(ctx, true)
+	}
+}
+
+func RenderVMHotspotDiagnosticsEnabled(ctx hctx.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	enabled, _ := ctx.Value(renderVMHotspotDiagnosticsKey).(bool)
+	return enabled
+}
+
+func RenderDiagnosticsFromContext(ctx hctx.Context) (RenderDiagnostics, bool) {
+	if ctx == nil {
+		return RenderDiagnostics{}, false
+	}
+	return renderDiagnosticsFromValue(ctx.Value(renderDiagnosticsKey))
+}
+
+func RenderDiagnosticsFromData(data map[string]interface{}) (RenderDiagnostics, bool) {
+	if data == nil {
+		return RenderDiagnostics{}, false
+	}
+	return renderDiagnosticsFromValue(data[renderDiagnosticsKey])
+}
+
+func SetRenderDiagnostics(ctx hctx.Context, diagnostics RenderDiagnostics) {
+	if ctx == nil {
+		return
+	}
+	if state := renderDiagnosticsStateFromContext(ctx, true); state != nil {
+		state.mu.Lock()
+		state.diagnostics = diagnostics
+		state.mu.Unlock()
+	}
+}
+
+func UpdateRenderDiagnostics(ctx hctx.Context, update func(*RenderDiagnostics)) {
+	if ctx == nil || update == nil {
+		return
+	}
+	state := renderDiagnosticsStateFromContext(ctx, true)
+	if state == nil {
+		return
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	update(&state.diagnostics)
+}
+
+func UpdateRenderDiagnosticsForTemplate(ctx hctx.Context, filename string, update func(*RenderDiagnostics)) {
+	if update == nil {
+		return
+	}
+	UpdateRenderDiagnostics(ctx, func(d *RenderDiagnostics) {
+		if !renderDiagnosticsCanUpdateTemplate(d, filename) {
+			return
+		}
+		update(d)
+	})
+}
+
+func renderDiagnosticsCanUpdateTemplate(d *RenderDiagnostics, filename string) bool {
+	if d == nil || d.TemplateFilename == "" {
+		return true
+	}
+	return filename != "" && d.TemplateFilename == filename
+}
+
+func SetRenderDiagnosticsRootActive(ctx hctx.Context, active bool) func() {
+	if ctx == nil {
+		return nil
+	}
+	previous, _ := ctx.Value(renderDiagnosticsRootActiveKey).(bool)
+	ctx.Set(renderDiagnosticsRootActiveKey, active)
+	return func() {
+		ctx.Set(renderDiagnosticsRootActiveKey, previous)
+	}
+}
+
+func RenderDiagnosticsRootActive(ctx hctx.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	active, _ := ctx.Value(renderDiagnosticsRootActiveKey).(bool)
+	return active
+}
+
+func renderDiagnosticsStateFromContext(ctx hctx.Context, create bool) *renderDiagnosticsState {
+	if ctx == nil {
+		return nil
+	}
+	switch value := ctx.Value(renderDiagnosticsKey).(type) {
+	case *renderDiagnosticsState:
+		return value
+	case RenderDiagnostics:
+		state := &renderDiagnosticsState{diagnostics: value}
+		if create {
+			ctx.Set(renderDiagnosticsKey, state)
+		}
+		return state
+	case *RenderDiagnostics:
+		if value == nil {
+			break
+		}
+		state := &renderDiagnosticsState{diagnostics: *value}
+		if create {
+			ctx.Set(renderDiagnosticsKey, state)
+		}
+		return state
+	}
+	if !create {
+		return nil
+	}
+	state := &renderDiagnosticsState{}
+	ctx.Set(renderDiagnosticsKey, state)
+	return state
+}
+
+func renderDiagnosticsFromValue(value interface{}) (RenderDiagnostics, bool) {
+	switch value := value.(type) {
+	case *renderDiagnosticsState:
+		if value == nil {
+			return RenderDiagnostics{}, false
+		}
+		value.mu.Lock()
+		defer value.mu.Unlock()
+		return value.diagnostics, true
+	case RenderDiagnostics:
+		return value, true
+	case *RenderDiagnostics:
+		if value == nil {
+			return RenderDiagnostics{}, false
+		}
+		return *value, true
+	default:
+		return RenderDiagnostics{}, false
+	}
+}
+
+func addRenderDiagnosticVMHotspot(ctx hctx.Context, name string, duration time.Duration, helper bool) {
+	if ctx == nil || duration < 0 || !RenderVMHotspotDiagnosticsEnabled(ctx) {
+		return
+	}
+	if name == "" {
+		name = "<anonymous>"
+	}
+	UpdateRenderDiagnostics(ctx, func(d *RenderDiagnostics) {
+		if helper {
+			d.VMHotspots.HelperCalls++
+			d.VMHotspots.HelperDuration += duration
+			addRenderVMHotspot(&d.VMHotspots.Helpers, name, duration)
+			return
+		}
+		d.VMHotspots.PartialCalls++
+		d.VMHotspots.PartialDuration += duration
+		addRenderVMHotspot(&d.VMHotspots.Partials, name, duration)
+	})
+}
+
+func addRenderVMHotspot(stats *[]RenderVMHotspot, name string, duration time.Duration) {
+	for i := range *stats {
+		if (*stats)[i].Name == name {
+			(*stats)[i].Calls++
+			(*stats)[i].Duration += duration
+			return
+		}
+	}
+	*stats = append(*stats, RenderVMHotspot{Name: name, Calls: 1, Duration: duration})
+}
+
+func renderVMHotspotsHeader(stats []RenderVMHotspot) string {
+	if len(stats) == 0 {
+		return ""
+	}
+	copyStats := append([]RenderVMHotspot(nil), stats...)
+	sort.Slice(copyStats, func(i, j int) bool {
+		if copyStats[i].Duration == copyStats[j].Duration {
+			return copyStats[i].Name < copyStats[j].Name
+		}
+		return copyStats[i].Duration > copyStats[j].Duration
+	})
+	if len(copyStats) > 8 {
+		copyStats = copyStats[:8]
+	}
+	parts := make([]string, 0, len(copyStats))
+	for _, stat := range copyStats {
+		parts = append(parts, fmt.Sprintf("%s:%d:%.3f", renderVMHotspotHeaderName(stat.Name), stat.Calls, float64(stat.Duration)/float64(time.Millisecond)))
+	}
+	return strings.Join(parts, ";")
+}
+
+func renderVMHotspotHeaderName(name string) string {
+	name = strings.ReplaceAll(name, ",", "_")
+	name = strings.ReplaceAll(name, ";", "_")
+	name = strings.ReplaceAll(name, ":", "_")
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "<anonymous>"
+	}
+	return name
+}

--- a/render_mode.go
+++ b/render_mode.go
@@ -1,0 +1,59 @@
+package plush
+
+import (
+	"errors"
+	"sync/atomic"
+
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+)
+
+type RenderMode int32
+
+const (
+	RenderModeInterpreter RenderMode = iota
+	RenderModeVM
+)
+
+var renderMode atomic.Int32
+var vmGenericFallback atomic.Bool
+var vmRenderer atomic.Value
+
+var ErrVMRendererNotRegistered = errors.New("plush VM renderer is not registered")
+
+type RenderFunc func(string, hctx.Context) (string, error)
+
+func SetRenderMode(mode RenderMode) RenderMode {
+	if mode != RenderModeInterpreter && mode != RenderModeVM {
+		mode = RenderModeInterpreter
+	}
+	previous := RenderMode(renderMode.Swap(int32(mode)))
+	return previous
+}
+
+func GetRenderMode() RenderMode {
+	return RenderMode(renderMode.Load())
+}
+
+func SetVMGenericFallback(enabled bool) bool {
+	return vmGenericFallback.Swap(enabled)
+}
+
+func VMGenericFallbackEnabled() bool {
+	return vmGenericFallback.Load()
+}
+
+func RegisterVMRenderer(renderer RenderFunc) {
+	if renderer == nil {
+		return
+	}
+	vmRenderer.Store(renderer)
+}
+
+func registeredVMRenderer() (RenderFunc, bool) {
+	renderer := vmRenderer.Load()
+	if renderer == nil {
+		return nil, false
+	}
+	fn, ok := renderer.(RenderFunc)
+	return fn, ok && fn != nil
+}

--- a/return_exit_test.go
+++ b/return_exit_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_Return_Exit_With__InfixExpression(t *testing.T) {
+func Test_Return_Exit_With_Infix_Expression(t *testing.T) {
 	tests := []struct {
 		name     string
 		success  bool

--- a/script_test.go
+++ b/script_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_RunScript(t *testing.T) {
+func Test_Run_Script(t *testing.T) {
 	r := require.New(t)
 	bb := &bytes.Buffer{}
 	ctx := plush.NewContextWith(map[string]interface{}{

--- a/source_hash.go
+++ b/source_hash.go
@@ -1,0 +1,23 @@
+package plush
+
+import (
+	"hash/maphash"
+	"strconv"
+)
+
+var templateSourceHashSeed = maphash.MakeSeed()
+
+func templateSourceHash(input string) string {
+	return strconv.FormatUint(maphash.String(templateSourceHashSeed, input), 16)
+}
+
+func templateSourceCacheHash(input string) string {
+	if input == "" {
+		return ""
+	}
+	return templateSourceHash(input)
+}
+
+func templateSourceMatches(t *Template, sourceHash string) bool {
+	return t != nil && (sourceHash == "" || t.SourceHash == "" || t.SourceHash == sourceHash)
+}

--- a/struct_test.go
+++ b/struct_test.go
@@ -22,7 +22,7 @@ func Test_Render_Struct_Attribute(t *testing.T) {
 	r.Equal("Mark", s)
 }
 
-func Test_Render_UnknownAttribute_on_Callee(t *testing.T) {
+func Test_Render_Unknown_Attribute_On_Callee(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
 	ctx.Set("m", struct{}{})
@@ -47,7 +47,7 @@ func (r *Robot) Name() string {
 	return r.name
 }
 
-func Test_Render_Function_on_sub_Struct(t *testing.T) {
+func Test_Render_Function_On_Sub_Struct(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
 	bender := Robot{
@@ -60,7 +60,7 @@ func Test_Render_Function_on_sub_Struct(t *testing.T) {
 	r.Equal("BENDER.JPG", s)
 }
 
-func Test_Render_Struct_PointerMethod(t *testing.T) {
+func Test_Render_Struct_Pointer_Method(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
 	robot := Robot{name: "robot"}
@@ -81,7 +81,7 @@ func Test_Render_Struct_PointerMethod(t *testing.T) {
 	})
 }
 
-func Test_Render_Struct_PointerMethod_IsNil(t *testing.T) {
+func Test_Render_Struct_Pointer_Method_Is_Nil(t *testing.T) {
 	r := require.New(t)
 
 	type mylist struct {
@@ -116,7 +116,7 @@ func Test_Render_Struct_PointerMethod_IsNil(t *testing.T) {
 	}
 }
 
-func Test_Render_Struct_PointerValue_Nil(t *testing.T) {
+func Test_Render_Struct_Pointer_Value_Nil(t *testing.T) {
 	r := require.New(t)
 
 	type user struct {
@@ -138,7 +138,7 @@ func Test_Render_Struct_PointerValue_Nil(t *testing.T) {
 	r.Equal(`Garn Clapstick: `, res)
 }
 
-func Test_Render_Struct_PointerValue_NonNil(t *testing.T) {
+func Test_Render_Struct_Pointer_Value_Non_Nil(t *testing.T) {
 	r := require.New(t)
 
 	type user struct {
@@ -484,7 +484,7 @@ func (a person) Likes() []string {
 	return a.likes
 }
 
-func Test_Render_Struct_With_ChainingFunction_ArrayAccess(t *testing.T) {
+func Test_Render_Struct_With_Chaining_Function_Array_Access(t *testing.T) {
 	r := require.New(t)
 
 	tt := person{likes: []string{"pringles", "galaxy", "carrot cake", "world pendant", "gold braclet"},
@@ -497,7 +497,7 @@ func Test_Render_Struct_With_ChainingFunction_ArrayAccess(t *testing.T) {
 	r.Equal("pringles", res)
 }
 
-func Test_Render_Struct_With_ChainingFunction_ArrayAccess_Outofbound(t *testing.T) {
+func Test_Render_Struct_With_Chaining_Function_Array_Access_Outofbound(t *testing.T) {
 	r := require.New(t)
 
 	tt := person{likes: []string{"pringles", "galaxy", "carrot cake", "world pendant", "gold bracelet"},
@@ -509,7 +509,7 @@ func Test_Render_Struct_With_ChainingFunction_ArrayAccess_Outofbound(t *testing.
 	r.Error(err)
 }
 
-func Test_Render_Struct_With_ChainingFunction_FunctionCall(t *testing.T) {
+func Test_Render_Struct_With_Chaining_Function_Function_Call(t *testing.T) {
 	r := require.New(t)
 
 	tt := person{born: time.Date(2024, time.January, 11, 0, 0, 0, 0, time.UTC).AddDate(-31, 0, 0)}
@@ -521,7 +521,7 @@ func Test_Render_Struct_With_ChainingFunction_FunctionCall(t *testing.T) {
 	r.Equal("Jan 11, 1993", res)
 }
 
-func Test_Render_Struct_With_ChainingFunction_UndefinedStructProperty(t *testing.T) {
+func Test_Render_Struct_With_Chaining_Function_Undefined_Struct_Property(t *testing.T) {
 	r := require.New(t)
 
 	tt := person{born: time.Now()}
@@ -533,7 +533,7 @@ func Test_Render_Struct_With_ChainingFunction_UndefinedStructProperty(t *testing
 
 }
 
-func Test_Render_Struct_With_ChainingFunction_InvalidFunctionCall(t *testing.T) {
+func Test_Render_Struct_With_Chaining_Function_Invalid_Function_Call(t *testing.T) {
 	r := require.New(t)
 
 	tt := person{born: time.Now()}
@@ -545,7 +545,7 @@ func Test_Render_Struct_With_ChainingFunction_InvalidFunctionCall(t *testing.T) 
 	r.Contains(err.Error(), "'nour.GetBorn' does not have a method named 'TEST' (nour.GetBorn.TEST)")
 }
 
-func Test_Render_Function_on_Invalid_Function_Struct(t *testing.T) {
+func Test_Render_Function_On_Invalid_Function_Struct(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
 	bender := Robot{

--- a/symbol_table.go
+++ b/symbol_table.go
@@ -9,13 +9,19 @@ type SymbolTable struct {
 	globalInterner *InternTable
 }
 
+var rootContextLocalInterner = NewInternTable()
+
 // NewScope creates a new scope with an optional parent
 func NewScope(parent *SymbolTable) *SymbolTable {
+	return newScopeWithCapacity(parent, 0)
+}
+
+func newScopeWithCapacity(parent *SymbolTable, capacity int) *SymbolTable {
 	if parent == nil {
-		global := NewInternTable()
-		local := NewInternTable()
+		global := newInternTableWithCapacity(capacity)
+		local := newInternTableWithCapacity(capacity)
 		return &SymbolTable{
-			vars:           make(map[int]interface{}),
+			vars:           make(map[int]interface{}, capacity),
 			parent:         nil,
 			globalInterner: global,
 			localInterner:  local,
@@ -24,11 +30,31 @@ func NewScope(parent *SymbolTable) *SymbolTable {
 
 	// Inherit interning from parent
 	return &SymbolTable{
-		vars:           make(map[int]interface{}),
+		vars:           make(map[int]interface{}, capacity),
 		parent:         parent,
 		globalInterner: parent.globalInterner,
 		localInterner:  parent.localInterner,
 	}
+}
+
+func newRootScopeFromMap(data map[string]interface{}) *SymbolTable {
+	capacity := len(data)
+	scope := &SymbolTable{
+		vars:           make(map[int]interface{}, capacity),
+		parent:         nil,
+		globalInterner: rootContextLocalInterner,
+		localInterner:  rootContextLocalInterner,
+	}
+	rootContextLocalInterner.mw.Lock()
+	defer rootContextLocalInterner.mw.Unlock()
+	for name, value := range data {
+		if value == nil {
+			continue
+		}
+		id := rootContextLocalInterner.internUnsafe(name)
+		scope.vars[id] = value
+	}
+	return scope
 }
 
 // Declare adds or updates a variable in the current scope
@@ -37,6 +63,13 @@ func (s *SymbolTable) Declare(name string, value interface{}) {
 		return
 	}
 	id := s.localInterner.Intern(name)
+	s.vars[id] = value
+}
+
+func (s *SymbolTable) DeclareID(id int, value interface{}) {
+	if value == nil {
+		return
+	}
 	s.vars[id] = value
 }
 
@@ -70,6 +103,16 @@ func (s *SymbolTable) Assign(name string, value interface{}) bool {
 		}
 	}
 
+	return false
+}
+
+func (s *SymbolTable) AssignID(id int, value interface{}) bool {
+	for curr := s; curr != nil; curr = curr.parent {
+		if _, exists := curr.vars[id]; exists {
+			curr.vars[id] = value
+			return true
+		}
+	}
 	return false
 }
 
@@ -135,4 +178,20 @@ func (s *SymbolTable) Resolve(name string) (interface{}, bool) {
 	}
 
 	return nil, false
+}
+
+func (s *SymbolTable) ResolveID(id int) (interface{}, bool) {
+	for curr := s; curr != nil; curr = curr.parent {
+		if val, exists := curr.vars[id]; exists {
+			return val, true
+		}
+	}
+	return nil, false
+}
+
+func (s *SymbolTable) SymbolName(id int) (string, bool) {
+	if s == nil || s.localInterner == nil {
+		return "", false
+	}
+	return s.localInterner.Name(id)
 }

--- a/symbol_table_test.go
+++ b/symbol_table_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSymbolTable_NewSymbolTable(t *testing.T) {
+func Test_Symbol_Table_New_Symbol_Table(t *testing.T) {
 	r := require.New(t)
 
 	scope := plush.NewScope(nil)
@@ -15,7 +15,7 @@ func TestSymbolTable_NewSymbolTable(t *testing.T) {
 	r.NotNil(scope)
 }
 
-func TestSymbolTable_Declare_And_Resolve(t *testing.T) {
+func Test_Symbol_Table_Declare_And_Resolve(t *testing.T) {
 	r := require.New(t)
 
 	scope := plush.NewScope(nil)
@@ -28,7 +28,7 @@ func TestSymbolTable_Declare_And_Resolve(t *testing.T) {
 	r.Equal(42, val)
 }
 
-func TestSymbolTable_Declare_And_Has(t *testing.T) {
+func Test_Symbol_Table_Declare_And_Has(t *testing.T) {
 	r := require.New(t)
 
 	scope := plush.NewScope(nil)
@@ -40,7 +40,7 @@ func TestSymbolTable_Declare_And_Has(t *testing.T) {
 	r.True(ok)
 }
 
-func TestSymbolTable_Declare_And_Has_Child(t *testing.T) {
+func Test_Symbol_Table_Declare_And_Has_Child(t *testing.T) {
 	r := require.New(t)
 
 	scope := plush.NewScope(nil)
@@ -59,7 +59,7 @@ func TestSymbolTable_Declare_And_Has_Child(t *testing.T) {
 	ok = childA.Has("d")
 	r.False(ok)
 }
-func TestSymbolTable_Resolve_From_Parent_Scope(t *testing.T) {
+func Test_Symbol_Table_Resolve_From_Parent_Scope(t *testing.T) {
 	r := require.New(t)
 
 	parent := plush.NewScope(nil)
@@ -77,7 +77,7 @@ func TestSymbolTable_Resolve_From_Parent_Scope(t *testing.T) {
 	r.True(ok)
 }
 
-func TestSymbolTable_Assign_To_ParentScope(t *testing.T) {
+func Test_Symbol_Table_Assign_To_Parent_Scope(t *testing.T) {
 	r := require.New(t)
 	parent := plush.NewScope(nil)
 
@@ -104,7 +104,7 @@ func TestSymbolTable_Assign_To_ParentScope(t *testing.T) {
 	r.Equal(200, val)
 }
 
-func TestSymbolTable_Assign_Non_Existent_Fails(t *testing.T) {
+func Test_Symbol_Table_Assign_Non_Existent_Fails(t *testing.T) {
 	r := require.New(t)
 
 	scope := plush.NewScope(nil)
@@ -116,7 +116,7 @@ func TestSymbolTable_Assign_Non_Existent_Fails(t *testing.T) {
 	r.False(assigned)
 }
 
-func TestSymbolTable_Declare_Nil_Ignored(t *testing.T) {
+func Test_Symbol_Table_Declare_Nil_Ignored(t *testing.T) {
 	r := require.New(t)
 	scope := plush.NewScope(nil)
 
@@ -128,7 +128,7 @@ func TestSymbolTable_Declare_Nil_Ignored(t *testing.T) {
 	r.False(ok)
 }
 
-func TestSymbolTable_Shadowing(t *testing.T) {
+func Test_Symbol_Table_Shadowing(t *testing.T) {
 
 	r := require.New(t)
 

--- a/syntax_features_test.go
+++ b/syntax_features_test.go
@@ -1,0 +1,158 @@
+package plush_test
+
+import (
+	"html/template"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Render_Whitespace_Trim_Tags(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+		ctx      *plush.Context
+	}{
+		{
+			name:     "issue newline example",
+			input:    "<pre>\n<%- \"Hello\" %>\n</pre>",
+			expected: "<pre>Hello</pre>",
+			ctx:      plush.NewContext(),
+		},
+		{
+			name:     "issue inline spaces example",
+			input:    `<pre> <%- "Hello" %> </pre>`,
+			expected: "<pre>Hello</pre>",
+			ctx:      plush.NewContext(),
+		},
+		{
+			name:     "middle of document",
+			input:    "<p>A</p>\n<%- \"B\" %>\n<p>C</p>",
+			expected: "<p>A</p>B<p>C</p>",
+			ctx:      plush.NewContext(),
+		},
+		{
+			name:     "raw html safety unchanged",
+			input:    `<%- raw("<b>x</b>") %>`,
+			expected: "<b>x</b>",
+			ctx:      plush.NewContext(),
+		},
+		{
+			name:     "inside if",
+			input:    "<%= if true { %>\n<%- \"yes\" %>\n<% } %>",
+			expected: "yes",
+			ctx:      plush.NewContext(),
+		},
+		{
+			name:     "inside for",
+			input:    "<%= for (i,v) in items { %>\n<%- v %>\n<% } %>",
+			expected: "ab",
+			ctx: plush.NewContextWith(map[string]interface{}{
+				"items": []string{"a", "b"},
+			}),
+		},
+		{
+			name:     "inside helper block",
+			input:    "<%= wrap() { %>\n<%- \"x\" %>\n<% } %>",
+			expected: "<span>x</span>",
+			ctx: plush.NewContextWith(map[string]interface{}{
+				"wrap": func(help plush.HelperContext) (template.HTML, error) {
+					body, err := help.Block()
+					return template.HTML("<span>" + body + "</span>"), err
+				},
+			}),
+		},
+		{
+			name:     "inside partial",
+			input:    `<%= partial("row.plush") %>`,
+			expected: "<span>x</span>",
+			ctx: plush.NewContextWith(map[string]interface{}{
+				"partialFeeder": func(string) (string, error) {
+					return "<span>\n<%- \"x\" %>\n</span>", nil
+				},
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := plush.Render(tt.input, tt.ctx)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, out)
+		})
+	}
+}
+
+func Test_Render_Old_Eval_Whitespace_Behavior_Unchanged(t *testing.T) {
+	out, err := plush.Render("<pre>\n<%= \"Hello\" %>\n</pre>", plush.NewContext())
+	require.NoError(t, err)
+	require.Equal(t, "<pre>\nHello\n</pre>", out)
+}
+
+func Test_Render_Optional_If_Parentheses(t *testing.T) {
+	type robot struct {
+		Name string
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+		ctx      *plush.Context
+	}{
+		{
+			name:     "literal true",
+			input:    `<%= if true { %>yes<% } %>`,
+			expected: "yes",
+			ctx:      plush.NewContext(),
+		},
+		{
+			name:     "identifier truthy",
+			input:    `<%= if name { %><%= name %><% } %>`,
+			expected: "mark",
+			ctx: plush.NewContextWith(map[string]interface{}{
+				"name": "mark",
+			}),
+		},
+		{
+			name:     "equality",
+			input:    `<%= if name == "mark" { %>yes<% } %>`,
+			expected: "yes",
+			ctx: plush.NewContextWith(map[string]interface{}{
+				"name": "mark",
+			}),
+		},
+		{
+			name:     "else if expression",
+			input:    `<%= if false { %>no<% } else if name == "mark" { %>yes<% } %>`,
+			expected: "yes",
+			ctx: plush.NewContextWith(map[string]interface{}{
+				"name": "mark",
+			}),
+		},
+		{
+			name:     "indexed struct field",
+			input:    `<%= if robots[0].Name == "mark" { %>yes<% } %>`,
+			expected: "yes",
+			ctx: plush.NewContextWith(map[string]interface{}{
+				"robots": []robot{{Name: "mark"}},
+			}),
+		},
+		{
+			name:     "old syntax still works",
+			input:    `<%= if (true) { %>yes<% } else if (false) { %>no<% } %>`,
+			expected: "yes",
+			ctx:      plush.NewContext(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := plush.Render(tt.input, tt.ctx)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, out)
+		})
+	}
+}

--- a/template.go
+++ b/template.go
@@ -16,6 +16,8 @@ type Template struct {
 	Program    *ast.Program
 	PunchHole  []HoleMarker
 	Skeleton   string
+	VMBytecode interface{}
+	SourceHash string
 	IsCache    bool
 	LastCached time.Time
 }
@@ -44,7 +46,7 @@ func (t *Template) Parse() error {
 		return nil
 	}
 
-	program, err := parser.Parse(t.Input)
+	program, err := parser.Parse(preprocessTrimTags(t.Input))
 	if err != nil {
 		return err
 	}
@@ -72,8 +74,10 @@ func (t *Template) Exec(ctx hctx.Context) (string, []HoleMarker, error) {
 // Clone a template. This is useful for defining helpers on per "instance" of the template.
 func (t *Template) Clone() *Template {
 	t2 := &Template{
-		Input:   t.Input,
-		Program: t.Program,
+		Input:      t.Input,
+		Program:    t.Program,
+		VMBytecode: t.VMBytecode,
+		SourceHash: t.SourceHash,
 	}
 	return t2
 }

--- a/template_cache.go
+++ b/template_cache.go
@@ -1,5 +1,10 @@
 package plush
 
+import (
+	"github.com/gobuffalo/plush/v5/ast"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+)
+
 type TemplateCache interface {
 	// Get retrieves a cached template by key.
 	Get(key string) (*Template, bool)
@@ -15,4 +20,109 @@ func ClearTemplateCache() {
 	if templateCacheBackend != nil {
 		templateCacheBackend.Clear()
 	}
+}
+
+func CachedVMBytecode(filename string, ctx hctx.Context) (interface{}, bool) {
+	if filename == "" || !cacheEnabled || templateCacheBackend == nil || !isVMBytecodeCacheableFile(filename) || isHole(ctx) {
+		return nil, false
+	}
+	return CachedVMBytecodeForFilename(filename)
+}
+
+func CachedVMBytecodeForFilename(filename string) (interface{}, bool) {
+	return CachedVMBytecodeForFilenameWithSource(filename, "")
+}
+
+func CachedVMBytecodeForFilenameWithSource(filename string, source string) (interface{}, bool) {
+	if filename == "" || !cacheEnabled || templateCacheBackend == nil || !isVMBytecodeCacheableFile(filename) {
+		return nil, false
+	}
+	t, ok := templateCacheBackend.Get(GenerateASTKey(filename))
+	if !ok || t == nil || t.VMBytecode == nil || !templateSourceMatches(t, templateSourceCacheHash(source)) {
+		return nil, false
+	}
+	return t.VMBytecode, true
+}
+
+func CachedVMBytecodeForCleanFilename(filename string) (interface{}, bool) {
+	return CachedVMBytecodeForCleanFilenameWithSource(filename, "")
+}
+
+func CachedVMBytecodeForCleanFilenameWithSource(filename string, source string) (interface{}, bool) {
+	if filename == "" || !cacheEnabled || templateCacheBackend == nil || !isVMBytecodeCacheableFile(filename) {
+		return nil, false
+	}
+	t, ok := templateCacheBackend.Get(GenerateASTKeyFromCleanFilename(filename))
+	if !ok || t == nil || t.VMBytecode == nil || !templateSourceMatches(t, templateSourceCacheHash(source)) {
+		return nil, false
+	}
+	return t.VMBytecode, true
+}
+
+func CachedASTProgram(filename string, ctx hctx.Context) (*ast.Program, bool) {
+	return CachedASTProgramWithSource(filename, ctx, "")
+}
+
+func CachedASTProgramWithSource(filename string, ctx hctx.Context, source string) (*ast.Program, bool) {
+	if filename == "" || !cacheEnabled || templateCacheBackend == nil || !isFilePlush(filename) || isHole(ctx) {
+		return nil, false
+	}
+	t, ok := templateCacheBackend.Get(GenerateASTKey(filename))
+	if !ok || t == nil || t.Program == nil || !templateSourceMatches(t, templateSourceCacheHash(source)) {
+		return nil, false
+	}
+	return t.Program, true
+}
+
+func CacheVMBytecode(filename string, ctx hctx.Context, program *ast.Program, bytecode interface{}) {
+	cacheVMBytecode(filename, ctx, program, bytecode)
+}
+
+func cacheVMBytecode(filename string, ctx hctx.Context, program *ast.Program, bytecode interface{}) {
+	if filename == "" || !cacheEnabled || templateCacheBackend == nil || !isVMBytecodeCacheableFile(filename) || isHole(ctx) || bytecode == nil {
+		return
+	}
+	CacheVMBytecodeForFilename(filename, program, bytecode)
+}
+
+func CacheVMBytecodeForFilename(filename string, program *ast.Program, bytecode interface{}) {
+	CacheVMBytecodeForFilenameWithSource(filename, program, bytecode, "")
+}
+
+func CacheVMBytecodeForFilenameWithSource(filename string, program *ast.Program, bytecode interface{}, source string) {
+	if filename == "" || !cacheEnabled || templateCacheBackend == nil || !isVMBytecodeCacheableFile(filename) || bytecode == nil {
+		return
+	}
+
+	key := GenerateASTKey(filename)
+	cacheVMBytecodeWithKey(key, program, bytecode, templateSourceCacheHash(source))
+}
+
+func CacheVMBytecodeForCleanFilename(filename string, program *ast.Program, bytecode interface{}) {
+	CacheVMBytecodeForCleanFilenameWithSource(filename, program, bytecode, "")
+}
+
+func CacheVMBytecodeForCleanFilenameWithSource(filename string, program *ast.Program, bytecode interface{}, source string) {
+	if filename == "" || !cacheEnabled || templateCacheBackend == nil || !isVMBytecodeCacheableFile(filename) || bytecode == nil {
+		return
+	}
+	cacheVMBytecodeWithKey(GenerateASTKeyFromCleanFilename(filename), program, bytecode, templateSourceCacheHash(source))
+}
+
+func cacheVMBytecodeWithKey(key string, program *ast.Program, bytecode interface{}, sourceHash string) {
+	t, ok := templateCacheBackend.Get(key)
+	if !ok || t == nil || !templateSourceMatches(t, sourceHash) {
+		t = &Template{}
+	} else {
+		cloned := *t
+		t = &cloned
+	}
+	if program != nil {
+		t.Program = program
+	}
+	t.Input = ""
+	t.VMBytecode = bytecode
+	t.SourceHash = sourceHash
+	t.IsCache = false
+	templateCacheBackend.Set(key, t)
 }

--- a/trim_tags.go
+++ b/trim_tags.go
@@ -1,0 +1,47 @@
+package plush
+
+import "strings"
+
+func preprocessTrimTags(input string) string {
+	if !strings.Contains(input, "<%-") {
+		return input
+	}
+
+	out := make([]byte, 0, len(input))
+	for i := 0; i < len(input); {
+		if strings.HasPrefix(input[i:], "<%-") {
+			out = trimWhitespaceSuffix(out)
+			out = append(out, "<%="...)
+			i += len("<%-")
+
+			end := strings.Index(input[i:], "%>")
+			if end < 0 {
+				out = append(out, input[i:]...)
+				return string(out)
+			}
+
+			out = append(out, input[i:i+end+len("%>")]...)
+			i += end + len("%>")
+			for i < len(input) && isTrimWhitespace(input[i]) {
+				i++
+			}
+			continue
+		}
+
+		out = append(out, input[i])
+		i++
+	}
+
+	return string(out)
+}
+
+func trimWhitespaceSuffix(input []byte) []byte {
+	for len(input) > 0 && isTrimWhitespace(input[len(input)-1]) {
+		input = input[:len(input)-1]
+	}
+	return input
+}
+
+func isTrimWhitespace(ch byte) bool {
+	return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r'
+}

--- a/variables_test.go
+++ b/variables_test.go
@@ -31,7 +31,7 @@ func Test_Let_Reassignment(t *testing.T) {
 	r.Equal("bar\n    \n  \nbaz", strings.TrimSpace(s))
 }
 
-func Test_Let_SyntaxError_NoEqualSign(t *testing.T) {
+func Test_Let_Syntax_Error_No_Equal_Sign(t *testing.T) {
 	r := require.New(t)
 	input := `<% let foo %>`
 
@@ -41,7 +41,7 @@ func Test_Let_SyntaxError_NoEqualSign(t *testing.T) {
 	r.ErrorContains(err, "expected next token to be =")
 }
 
-func Test_Let_SyntaxError_NoIdentifier(t *testing.T) {
+func Test_Let_Syntax_Error_No_Identifier(t *testing.T) {
 	r := require.New(t)
 	input := `<% let = %>`
 
@@ -51,7 +51,7 @@ func Test_Let_SyntaxError_NoIdentifier(t *testing.T) {
 	r.ErrorContains(err, "expected next token to be IDENT")
 }
 
-func Test_Let_Reassignment_UnknownIdent(t *testing.T) {
+func Test_Let_Reassignment_Unknown_Ident(t *testing.T) {
 	r := require.New(t)
 	input := `<% foo = "baz" %>`
 
@@ -147,7 +147,7 @@ func Test_Render_Let_Array(t *testing.T) {
 	}
 }
 
-func Test_Render_Let_ArrayAsssign_Unassignable(t *testing.T) {
+func Test_Render_Let_Array_Asssign_Unassignable(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
 
@@ -162,7 +162,7 @@ func Test_Render_Let_ArrayAsssign_Unassignable(t *testing.T) {
 	r.Contains(err.Error(), "cannot use 'HELLO WORLD' (untyped string constant) as plush_test.tt value in assignment")
 }
 
-func Test_Render_Let_ArrayAsssign_AssignableToArrayInterface(t *testing.T) {
+func Test_Render_Let_Array_Asssign_Assignable_To_Array_Interface(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
 
@@ -176,7 +176,7 @@ func Test_Render_Let_ArrayAsssign_AssignableToArrayInterface(t *testing.T) {
 	r.NoError(err)
 }
 
-func Test_Render_AppendArray_WithTypeIntArrayTypeString(t *testing.T) {
+func Test_Render_Append_Array_With_Type_Int_Array_Type_String(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
 
@@ -187,7 +187,7 @@ func Test_Render_AppendArray_WithTypeIntArrayTypeString(t *testing.T) {
 	r.Contains(err.Error(), "cannot append '1' (untyped int constant) as string value in assignment")
 }
 
-func Test_Render_AppendArray_ItemAppenedNotReflectValue(t *testing.T) {
+func Test_Render_Append_Array_Item_Appened_Not_Reflect_Value(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
 	input := `<% let a = [1,"22",33] %><% a = a + 1 %><%= a %>`
@@ -199,7 +199,7 @@ func Test_Render_AppendArray_ItemAppenedNotReflectValue(t *testing.T) {
 	r.Equal(reflect.Int, reflect.TypeOf(val[3]).Kind())
 }
 
-func Test_Render_AppendArray_CreatedInPlush(t *testing.T) {
+func Test_Render_Append_Array_Created_In_Plush(t *testing.T) {
 	r := require.New(t)
 
 	input := `<% let a = [1,2,"HelloWorld"] %><% a = a + 2.2 %><%= a %>`
@@ -207,7 +207,7 @@ func Test_Render_AppendArray_CreatedInPlush(t *testing.T) {
 	r.NoError(err)
 	r.Equal(s, "12HelloWorld2.2")
 }
-func Test_Render_AppendArray_WithTypeInterface(t *testing.T) {
+func Test_Render_Append_Array_With_Type_Interface(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
 
@@ -226,7 +226,7 @@ type Product1 struct {
 	Name []string
 }
 
-func Test_Render_Access_CalleeArray(t *testing.T) {
+func Test_Render_Access_Callee_Array(t *testing.T) {
 	tests := []struct {
 		name     string
 		success  bool

--- a/variadic_test.go
+++ b/variadic_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_VariadicHelper(t *testing.T) {
+func Test_Variadic_Helper(t *testing.T) {
 	r := require.New(t)
 	input := `<%= foo(1, 2, 3) %>`
 	ctx := plush.NewContext()
@@ -20,7 +20,7 @@ func Test_VariadicHelper(t *testing.T) {
 	r.Equal("3", s)
 }
 
-func Test_VariadicHelper_SecondArg(t *testing.T) {
+func Test_Variadic_Helper_Second_Arg(t *testing.T) {
 	r := require.New(t)
 	input := `<%= foo("hello") %>`
 	ctx := plush.NewContext()
@@ -33,7 +33,7 @@ func Test_VariadicHelper_SecondArg(t *testing.T) {
 	r.Equal("hello", s)
 }
 
-func Test_VariadicHelperNoParam(t *testing.T) {
+func Test_Variadic_Helper_No_Param(t *testing.T) {
 	r := require.New(t)
 	input := `<%= foo() %>`
 	ctx := plush.NewContext()
@@ -46,7 +46,7 @@ func Test_VariadicHelperNoParam(t *testing.T) {
 	r.Equal("0", s)
 }
 
-func Test_VariadicHelperNoVariadicParam(t *testing.T) {
+func Test_Variadic_Helper_No_Variadic_Param(t *testing.T) {
 	r := require.New(t)
 	input := `<%= foo(1) %>`
 	ctx := plush.NewContext()
@@ -59,7 +59,7 @@ func Test_VariadicHelperNoVariadicParam(t *testing.T) {
 	r.Equal("1", s)
 }
 
-func Test_VariadicHelperWithWrongParam(t *testing.T) {
+func Test_Variadic_Helper_With_Wrong_Param(t *testing.T) {
 	r := require.New(t)
 	input := `<%= foo(1, 2, "test") %>`
 	ctx := plush.NewContext()


### PR DESCRIPTION
This [PR](https://github.com/gobuffalo/plush/issues/223) adds an opt-in compiled VM renderer for Plush while keeping the existing interpreter path as the default. The new renderer lives under `VM/` and supports the same user-facing Plush behavior as the interpreter: expressions, variables, functions, closures, helpers, struct and map access, nested chains, loops, conditionals, partials, punch-hole rendering, render budgets, escaping, trim tags, optional `if` parentheses, and mixed Go numeric comparisons.

The root package can now switch render engines with `plush.SetRenderMode(plush.RenderModeVM)` after importing `github.com/gobuffalo/plush/v5/VM/plush`. Applications that want direct compiled reuse can call `VM/plush.Compile` and render the returned template repeatedly.

## Major Changes

- Added VM packages for bytecode, objects, compiler, runtime execution, and VM-backed Plush rendering.
- Added compiler support for Plush template nodes, script expressions, closures, recursion, globals, locals, free variables, arrays, hashes, indexes, infix expressions, helper calls, method calls, block helpers, loops, partials, holes, budgets, line metadata, and render output opcodes.
- Added root render-mode support:
  - `RenderModeInterpreter` remains the default.
  - `RenderModeVM` routes root `plush.Render` through the compiled renderer when the VM package is imported.
- Added compiled-template reuse through `VM/plush.Compile`.
- Added shared template-cache support for VM bytecode.
- Added parity coverage across root Plush behavior and VM rendering.
- Added focused compiler, VM, object, code, cache, fast path, concurrency, budget, partial, and parity tests.
- Added benchmark coverage for one-shot renders, compiled-template reuse, cached filenames, reused contexts, and render-mode comparisons.

## Compatibility

This is opt-in. Existing applications continue using the interpreter unless they explicitly enable VM render mode or call the VM package directly.

```go
import (
  plush "github.com/gobuffalo/plush/v5"
  _ "github.com/gobuffalo/plush/v5/VM/plush"
)

func init() {
  plush.SetRenderMode(plush.RenderModeVM)
}
```

For repeated direct renders:

```go
import vmplush "github.com/gobuffalo/plush/v5/VM/plush"

tmpl, err := vmplush.Compile(`<h1><%= title %></h1>`)
if err != nil {
  return err
}

out, err := tmpl.Render(ctx)
```

## VM Bytecode Cache

The VM bytecode cache reuses compiled bytecode for file-backed templates. The interpreter already caches parsed ASTs through the template cache. This PR extends the same cache entry so the VM can store compiled bytecode beside the AST.

The first render of a cached file-backed template does this:

1. Parse template source.
2. Compile the AST into VM bytecode.
3. Store the bytecode on the shared template-cache entry.
4. Execute the bytecode.

Later renders of the same filename can skip parse and compile:

1. Look up the template-cache entry by filename cache key.
2. Load the cached VM bytecode.
3. Execute it with the current request context.

The cache stores bytecode and execution plans, not request data. It does not cache context values, helper return values, struct fields, branch results, rendered HTML, or partial output. Each render still reads fresh values from the provided context.

The cache also respects Plush safety rules:

- File-backed `.plush`, `.plush.html`, and compatible `.html` templates can use the filename bytecode cache.
- Punch-hole renders avoid unsafe full-template bytecode reuse when the hole context requires separate behavior.
- Partial bytecode links are keyed by partial identity and source hash so updated partial source does not reuse stale bytecode.
- Source-unknown plain `.html` partials still consult the current partial feeder when needed, so cached bytecode does not silently reuse stale partial source.

## Fast Paths

The VM includes automatic fast paths for common Plush shapes. These require no template changes:

- static text and raw output opcodes
- direct output writing through `strings.Builder`
- simple variable interpolation
- top-level property chains like `<%= item.Name %>`
- nested property/index chains like `<%= robots[0].Name.Echo() %>`
- typed map access such as `labels["status"]`
- top-level infix output such as `<%= count + 1 %>`
- safe mixed numeric comparisons such as `uint32 == 0` and `float32 == 3`
- simple conditionals and infix conditions
- static and mixed templates with reusable execution plans
- loop-local slot specialization
- typed loop field getters for slices of structs and pointers
- helper calls in hot output positions
- method calls in hot output positions
- optional custom fast helpers for application-specific hotspots
- inline partial rendering when the partial bytecode can be safely linked
- partial data maps such as `partial("row", {name: item.Name})`
- partial data maps with helper-call values such as `partial("row", {label: label(item.Name, prefix)})`

Fast paths cache lookup plans and call plans, not the current values. For example, a loop over items may cache how to read `Name` from the item type, but it still reads each item's current `Name` value on every render.

## New Language And Runtime Behavior

This PR also brings the following behavior into both the interpreter and VM paths where applicable:

- optional parentheses around `if` conditions [#102](https://github.com/gobuffalo/plush/issues/102)
- trim-tag whitespace handling [#89](https://github.com/gobuffalo/plush/issues/89)
- partial rendering with explicit data maps
- safe mixed numeric equality and ordering across common Go numeric types
- safer comparisons for backend values such as `int32`, `uint32`, `uint64`, `float32`, and `float64`
- render budgets with work counters, helper cost overrides, object traversal cost, and sub-render accounting
- struct, pointer, map, method, and nested chain access parity

## Benchmarks

Latest local checkpoint, comparing VM bytecode cache with interpreter AST cache:

| Scenario | Speed | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| Full render-mode matrix, 26 scenarios | 61.2% faster | 59.6% less | 71.8% fewer |
| Realistic mixed template | 59.6% faster | 73.3% less | 81.3% fewer |
| Simple conditional access output | 45.0% faster | 32.8% less | 65.6% fewer |
| Nested access/simple access output | 55.4% faster | 56.7% less | 61.8% fewer |
| Partial simple access bodies | 52.5% faster | 49.6% less | 70.6% fewer |
| Partial rendering with data maps | 53.6% faster | 55.6% less | 68.9% fewer |
| Partial data maps with helper-call values | 63.4% faster | 53.5% less | 68.0% fewer |
| Typed map access | 35.6% faster | 24.8% less | 56.8% fewer |
| Loop helper direct string calls | 69.6% faster | 50.6% less | 74.5% fewer |
| Loop helper direct int calls | 58.9% faster | 51.1% less | 70.3% fewer |
| Mixed numeric operator output | 46.4% faster | 28.3% less | 61.5% fewer |

These numbers come from local benchmark medians using `count=3` and `500ms` benchtime. Exact results will vary by machine and template shape. One-shot VM rendering is intentionally not the headline number because parse and compile time are included; the main performance path is cached bytecode or compiled-template reuse.

Integrated application validation was also run against a live local Buffalo application using response headers from the render engine. These measurements include real application helpers, nested partials, large generated output, request context setup, and application-specific template work, so they are intentionally more conservative than the VM microbenchmarks:

| Live scenario | Interpreter avg | VM avg | VM avg gain | Interpreter p95 | VM p95 | VM p95 gain |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Light template scenario | 69.737ms | 47.214ms | 32.30% faster | 111.960ms | 85.337ms | 23.78% faster |
| Mixed template scenario | 103.631ms | 71.615ms | 30.89% faster | 149.934ms | 104.843ms | 30.07% faster |
| Heavy helper/partial scenario | 333.565ms | 279.348ms | 16.25% faster | 442.746ms | 344.368ms | 22.22% faster |

The live scenario tests were run by toggling the application render mode, warming each page, then collecting 100 HTTPS requests at concurrency 10 with `curl -k`. The comparison uses the `X-Plush-Render-Engine-Time-Ms` response header, not total ApacheBench wall time, so the numbers are scoped to the Plush render engine and the helpers/partials executed during render.

These `X-Plush-*` headers are new render diagnostics added for the VM work. They are intended for validation, profiling, and A/B testing; they are not nginx, Buffalo, or browser-provided timings.

For each scenario:

1. Start in interpreter mode with `PLUSH_RENDER_MODE=interpreter`.
2. Warm the page and collect the interpreter header CSV.
3. Switch to compiled mode with `PLUSH_RENDER_MODE=vm`.
4. Warm until `X-Plush-Vm-Bytecode-Cache: hit` and `X-Plush-Fast-Path: fast`.
5. Collect the VM header CSV.
6. Compare averages and p95 values from the saved CSV files.

Example live benchmark commands:

```bash
make headers-interpreter AB_URL="https://example.test/path" HEADER_RESULTS_DIR=tmp/render-headers-scenario HEADER_REQUESTS=100 HEADER_CONCURRENCY=10
make headers-vm AB_URL="https://example.test/path" HEADER_RESULTS_DIR=tmp/render-headers-scenario HEADER_REQUESTS=100 HEADER_CONCURRENCY=10
make headers-compare HEADER_RESULTS_DIR=tmp/render-headers-scenario
```

The generated response body sizes were also measured from the live scenarios with `curl` using the downloaded body byte count. These are uncompressed body bytes as seen by `curl` during local HTTPS requests:

| Live scenario | Generated body bytes | Generated body size |
| --- | ---: | ---: |
| Light template scenario | 45,999 bytes | 44.92 KiB |
| Mixed template scenario | 628,002 bytes | 613.28 KiB |
| Heavy helper/partial scenario | 22,536,853 bytes | 21.49 MiB |

The live benchmark headers mean:

| Metric | Meaning |
| --- | --- |
| `X-Plush-Render-Engine-Time-Ms` | Time spent inside Plush rendering for this request. This includes Plush execution plus helpers and partials called while rendering, but not full network/nginx/client time. |
| `X-Plush-Render-Mode` | Which Plush engine handled the render: `interpreter` or `vm`. |
| `X-Plush-Vm-Bytecode-Cache` | VM bytecode cache state. A warmed VM benchmark should show `hit`; a first render may show `miss-store`; interpreter mode reports `disabled`. |
| `X-Plush-Fast-Path` | Whether the VM used its optimized render path. `fast` means the compiled fast plan handled the render; `generic` means first compile/generic execution/fallback behavior. |
| `X-Plush-Fast-Plan-*` | Static complexity counters from the compiled plan, such as bindings, segments, property reads, helper calls, conditionals, loops, partials, and max nesting depth. These describe the template shape, not elapsed time. |
| `X-Plush-VM-Helper-Time-Ms` | Optional hotspot diagnostic: total time spent inside VM fast helper calls for the render. It is populated only when VM hotspot diagnostics are enabled. |
| `X-Plush-VM-Helper-Calls` | Optional hotspot diagnostic: number of VM fast helper calls observed during the render. |
| `X-Plush-VM-Helper-Hotspots` | Optional hotspot diagnostic in `name:calls:time_ms` form, for example `format_label:700:3465.659` in an aggregated CSV sample. |
| `X-Plush-VM-Partial-Time-Ms` | Optional hotspot diagnostic: total time spent rendering VM partials. |
| `X-Plush-VM-Partial-Calls` | Optional hotspot diagnostic: number of partial renders observed during the render. |
| `X-Plush-VM-Partial-Hotspots` | Optional hotspot diagnostic in `partial:calls:time_ms` form, useful for identifying expensive nested partials. |

The tested pages had very different template shapes:

| Live scenario | Bindings | Segments | Static segments | Property reads | Value writes | Helper calls | Conditionals | Loops | Loop parts | Partials | Max depth |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Light template scenario | 1 | 3 | 2 | 0 | 0 | 1 | 0 | 0 | 0 | 0 | 3 |
| Mixed template scenario | 26 | 80 | 193 | 162 | 41 | 27 | 41 | 7 | 116 | 1 | 12 |
| Heavy helper/partial scenario | 14 | 13 | 63 | 39 | 2 | 18 | 12 | 2 | 20 | 6 | 12 |

The light scenario is a compact template with one helper call, so it mostly measures the fixed overhead of entering the render engine and executing a simple plan. The mixed scenario exercises a wider template shape with many property reads, conditionals, loops, helper calls, and one partial. The heavy helper/partial scenario has fewer top-level compiled-plan operations than the mixed scenario, but it performs much more work at runtime because its partials and helpers expand into additional nested rendering and data-preparation work.

The heavy helper/partial scenario is intentionally a large stress case rather than a small synthetic template. It includes many nested partial renders and real template helpers, such as formatting helpers, asset/tag helpers, URL/path helpers, content helpers, and helpers that prepare structured data for output. In one VM hotspot sample, the render spent about 36.461ms/request inside helpers and about 157.198ms/request inside partial rendering. That means a large part of the remaining render time was not VM bytecode execution itself; it was work the VM correctly had to call into. This makes the scenario a useful ceiling check: the VM still wins, but once parse, compile, lookup, and opcode dispatch overhead are reduced, the next bottlenecks become helper logic, data formatting, and nested partial rendering.

Benchmark command:

```bash
go test ./VM/vm -run '^$' -bench '^BenchmarkRenderModeMatrix/.*/(interpreter_ast_cache|vm_bytecode_cache)$' -benchmem -count=3 -benchtime=500ms
```

Additional benchmark entry points:

```bash
go test ./VM/vm -run '^$' -bench '^BenchmarkRenderOneShot$' -benchmem
go test ./VM/vm -run '^$' -bench '^BenchmarkRenderCompiledReuse$' -benchmem
go test ./VM/vm -run '^$' -bench '^BenchmarkRenderReusedContextMatrix$' -benchmem
go test ./VM/vm -run '^$' -bench '^BenchmarkRenderCachedFilename$' -benchmem
```

## Test Plan

Full package test suite:

```bash
go test ./...
```

VM-specific package tests:

```bash
go test ./VM/...
```
