### PR TITLE
ci: update Go versions to 1.25 and 1.26

### DIFF
--- a/.github/workflows/standard-go-test.yml
+++ b/.github/workflows/standard-go-test.yml
@@ -20,8 +20,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.21"
-          - "1.22"
+          - "1.25"
+          - "1.26"
         os:
           - "ubuntu-latest"
           - "macos-latest"


### PR DESCRIPTION
Updates the CI matrix to test against the two most recent Go releases.

This also resolves the race-detector abort on macOS runners caused by Go 1.22's dyld LC_UUID incompatibility, which was failing tests in #224 before any assertions ran.