### PR TITLE
Fix/vm partial overlay bindings & memory improvements 

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,6 +669,45 @@ Useful fields:
 | `FastPlan` | Static complexity counters for the compiled fast plan: bindings, segments, static segments, name segments, property reads, value writes, helper calls, conditionals, loops, loop parts, partials, max depth, helper names, and partial names. |
 | `VMHotspots` | Optional helper and partial call counts/timings when VM hotspot diagnostics are enabled. |
 
+#### VM Execution Paths
+
+`Mode` and `FastPath` describe different layers of rendering. `Mode` says
+which top-level renderer was selected. `FastPath` says which path that renderer
+used after parsing or loading cached bytecode.
+
+When `Mode` is `interpreter`, Plush uses the classic AST interpreter and VM
+bytecode is disabled for that render.
+
+When `Mode` is `vm`, Plush enters the compiled VM renderer. From there,
+`FastPath` can report:
+
+- `static`: the template compiled to static output and no runtime execution was
+  needed.
+- `fast`: the VM compiled bytecode and used an optimized fast render plan.
+- `generic`: the VM compiled bytecode, but the specialized fast planner either
+  was not needed or used a generic VM segment for syntax it does not model as a
+  custom fast operation yet.
+- `interpreter-fallback`: the VM renderer intentionally delegated this render to
+  the classic AST interpreter.
+
+The old interpreter remains a compatibility safety net. Plush templates can
+exercise many subtle behaviors: helper block scoping, partial context overlays,
+form helpers that inject values into a block, assignments, punch holes, budgets,
+and older template quirks. The fast render planner is intentionally
+conservative; it only handles syntax it can render with the same behavior as the
+normal renderer.
+
+If the interpreter fallback is disabled, templates that cannot use specialized
+fast operations should run through the `generic` VM bytecode path instead. That
+is still VM execution, but it means any remaining VM parity gap becomes visible
+as a render error or output difference instead of falling back to the known-good
+interpreter behavior. Template-defined functions and function literals use this
+generic VM path. Punch holes remain on the punch-hole-specific path so skeleton
+caching and hole filling keep their existing behavior. If the classic
+interpreter is removed entirely, `RenderModeInterpreter` and
+`interpreter-fallback` are no longer available, and applications must rely on VM
+compile/runtime support for every template shape they render.
+
 `FastPlan` describes the compiled template shape, not elapsed time. It includes bindings, segments, static segments, name segments, property reads, value writes, helper calls, conditionals, loops, loop parts, partials, max depth, helper names, and partial names.
 
 Hotspot diagnostics are optional. They time VM helper and partial calls, so enable them only when profiling or sampling because they add measurement overhead:
@@ -795,7 +834,7 @@ Common header meanings:
 | `X-Plush-VM-Bytecode-Cache` | VM cache status. Warm file-backed templates should usually move from `miss-store` on first render to `hit`, `hit-static`, or `hit-source` on later renders. |
 | `X-Plush-Template-Filename` | Filename used as the cache key when `meta.TemplateFileKey` was set on the context. |
 | `X-Plush-Render-Engine-Time-Ms` | Time spent inside Plush rendering only, in milliseconds. Use this instead of total request time when comparing interpreter vs VM. |
-| `X-Plush-Fast-Path` | VM execution path: `static`, `fast`, `generic`, or `interpreter-fallback`. The best steady-state VM path is usually `fast`; `interpreter-fallback` means the VM intentionally delegated unsupported syntax to the old interpreter. |
+| `X-Plush-Fast-Path` | VM execution path: `static`, `fast`, `generic`, or `interpreter-fallback`. The best steady-state VM path is usually `fast`; `generic` still runs VM bytecode; `interpreter-fallback` means VM mode intentionally delegated unsupported syntax to the classic interpreter. |
 | `X-Plush-Punch-Hole-Cache` | Punch-hole cache status for templates that mix static HTML with embedded Plush code. |
 | `X-Plush-Fast-Plan-*` | Static counters captured from the compiled fast plan. These describe template complexity, not elapsed time. |
 | `X-Plush-Fast-Plan-Helper-Names` | Helper names the fast plan found while compiling. Useful for spotting expensive helper-heavy templates. |
@@ -846,15 +885,21 @@ Most VM optimizations need no template changes. The VM automatically specializes
 - safe mixed numeric comparisons such as `uint32 == 0` and `float32 == 3`
 - struct fields, nested property chains, indexed property chains, and no-arg method tails
 - typed Go map access with static string keys, such as `labels["status"]` and `robots["bender"].Name`
-- loops over strings, slices, structs, and pointers to structs
+- loops over `nil`, strings, slices, structs, and pointers to structs
 - simple top-level conditionals whose branches contain static/name/property/access/infix output
 - conditionals and infix conditions inside loops
 - direct helper calls for common helper signatures
+- silent script helper calls for side effects, such as `<% touch(name) %>`
 - direct scalar helper calls for common string, int, uint32, bool, and float64 argument shapes
+- dynamic callable values and chained receiver calls, such as `helpers[name]("x")` and `makeUser(name).Render("short")`
+- top-level `let`, assignment, return, loop return, loop iterator assignment, and index assignment statements
 - regex match expressions
+- unary negation with `-`
+- arrays, hashes, non-string literal hash keys, and dynamic index reads as supported fast values
 - partials with no data, including direct linked rendering when the partial body is simple and does not need partial metadata
 - partials with simple static-key data maps, such as `partial("row", {name: product.Name})`; the VM prepares the keys and value lookup plan, then reads fresh values each render
 - partial data maps with helper-call values, such as `partial("row", {label: label(product.Name, prefix)})`; the VM compiles the call arguments and uses direct value invokers for common helper signatures
+- dynamic partial names and `layout` data values through the regular VM partial helper-call path
 - linked partial bodies that contain simple property/access/infix output, such as `<%= robot.Name %>` or `<%= labels["status"] %>`
 - clean filename cache keys and punch-hole filename checks for file-backed cached renders
 

--- a/README.md
+++ b/README.md
@@ -774,6 +774,15 @@ if ok {
   w.Header().Set("X-Plush-Render-Engine-Time-Ms",
     fmt.Sprintf("%.3f", diagnostics.EngineDurationMilliseconds()))
   w.Header().Set("X-Plush-Punch-Hole-Cache", diagnostics.PunchHoleCache)
+  if outputSize := diagnostics.OutputSizeHeader(); outputSize != "" {
+    w.Header().Set("X-Plush-Output-Size", outputSize)
+  }
+  if partialOutput := diagnostics.PartialOutputSizeHeader(); partialOutput != "" {
+    w.Header().Set("X-Plush-Partial-Output-Size", partialOutput)
+  }
+  if partialDetails := diagnostics.PartialOutputSizeDetailsHeader(); partialDetails != "" {
+    w.Header().Set("X-Plush-Partial-Output-Details", partialDetails)
+  }
   w.Header().Set("X-Plush-Fast-Plan-Bindings",
     fmt.Sprintf("%d", diagnostics.FastPlan.Bindings))
   w.Header().Set("X-Plush-Fast-Plan-Segments",
@@ -836,12 +845,91 @@ Common header meanings:
 | `X-Plush-Render-Engine-Time-Ms` | Time spent inside Plush rendering only, in milliseconds. Use this instead of total request time when comparing interpreter vs VM. |
 | `X-Plush-Fast-Path` | VM execution path: `static`, `fast`, `generic`, or `interpreter-fallback`. The best steady-state VM path is usually `fast`; `generic` still runs VM bytecode; `interpreter-fallback` means VM mode intentionally delegated unsupported syntax to the classic interpreter. |
 | `X-Plush-Punch-Hole-Cache` | Punch-hole cache status for templates that mix static HTML with embedded Plush code. |
+| `X-Plush-Output-Size` | Adaptive output-size estimator stats for top-level VM renders. `scope=template` describes a direct file render. For a Buffalo layout, `scope=file` predicts the fully assembled response as the exact current `yield` byte length plus learned layout overhead selected from the root template's bounded `profile` band. `actual` is this render's byte length, `learned` is the prediction before this render, `error` is their percentage difference, and `within-10` is `1` only below 10% error. `min`, `max`, `unstable`, and `limited` describe lifetime variability and whether the allocation policy constrained the hint. `grow-allocated` is capacity added by the explicit speculative grow, while `cap-final` and `unused-cap` report the builder's final capacity and unused portion. |
+| `X-Plush-Partial-Output-Size` | Request aggregate for compiled partial calls. `learned` and `actual` are summed across calls, while `absolute-error` prevents over- and under-estimates from cancelling each other. `within-10` counts calls whose learned estimate was below 10% error. `unstable` counts calls whose partial has at least a 4x observed output range; `limited` counts calls where Plush capped the speculative hint; `grow-allocated` reports the capacity actually added by explicit grows. |
+| `X-Plush-Partial-Output-Details` | Bounded details for up to eight partial filenames, with per-file call totals, learned/actual error, updated estimate, lifetime range and sample count, instability/limit state, and explicit grow allocation. |
 | `X-Plush-Fast-Plan-*` | Static counters captured from the compiled fast plan. These describe template complexity, not elapsed time. |
 | `X-Plush-Fast-Plan-Helper-Names` | Helper names the fast plan found while compiling. Useful for spotting expensive helper-heavy templates. |
 | `X-Plush-Fast-Plan-Partial-Names` | Partial names the fast plan found while compiling. Useful for spotting partial-heavy templates. |
 | `X-Plush-VM-Helper-*` | Optional helper-call count and timing fields. They are zero unless `EnableRenderVMHotspotDiagnostics` was enabled for that context. |
 | `X-Plush-VM-Partial-*` | Optional partial-call count and timing fields. They are zero unless `EnableRenderVMHotspotDiagnostics` was enabled for that context. |
 | `Server-Timing` | Browser/devtools-friendly timing summary. The example maps Plush engine time plus optional VM helper and partial hotspot time into server timing metrics. |
+
+### Adaptive Output-Size Estimator
+
+The estimator is implemented across the VM's whole-template, loop, composed-layout, and partial render paths, with bounded state, diagnostics, a runtime off switch, race coverage, benchmarks, and CPU/allocation profiles.
+
+#### How it works
+
+The estimator is a capacity planner for `strings.Builder`; it is not an output cache. A hint only reserves likely capacity before Plush writes the response. An inaccurate hint can cause an extra allocation or leave unused capacity, but it cannot change the rendered output. The stages below are cumulative layers of the same estimator, not seven rendering passes applied to every request.
+
+**Stage 1: Compile-time metadata**
+
+When Plush compiles a template, it counts bytes that are already known from literal HTML, constant writes, or static fast-plan segments. This becomes `StaticSize`, the safe first-render baseline. The resulting bytecode also owns atomic statistics for the complete template, layout overhead, partial output, and each eligible fast loop. Statistics therefore follow the compiled file instead of a route, request, tenant value, or rendered string.
+
+No sample exists on the first render. Plush starts with the best static or fast-plan hint available, renders normally, and measures the actual bytes afterward. Recompiling a changed source creates new bytecode and fresh statistics, so one template version does not train another version.
+
+**Stage 2: Whole-template learning**
+
+Before a top-level render starts, Plush grows an empty output builder using the larger of the known static size and the learned estimate. After a successful render it records the builder's actual length. Failed renders, nested renders that are not partials, and punch-hole sub-renders do not update these statistics.
+
+The first valid sample becomes the estimate. Later samples use an asymmetric moving update:
+
+- If actual output is larger, the estimate moves halfway toward it so underestimates recover quickly. A single upward sample can contribute at most four times the current estimate.
+- If actual output is smaller, the estimate moves one eighth of the way down so one unusually small response does not immediately discard useful capacity.
+- Estimate values have a 4 MiB ceiling. This limits speculative growth; it does not limit response size.
+
+The estimate used for the current response is captured before rendering. The newly observed value becomes the estimate for later responses, which is why the first render of newly compiled bytecode learns and the next render benefits.
+
+**Stage 3: Per-loop learning**
+
+Every eligible fast loop owns a separate `bytes per item` statistic, including nested loops. After a successful loop, Plush divides the bytes produced by the number of rendered items and feeds that value through the same fast-up/slow-down update. Silent loops, empty loops, failed loops, and loops whose iterable length is unknown do not produce a growth hint.
+
+On a later render, Plush multiplies learned bytes per item by the current iterable length. This uses today's item count rather than a historical page total, so a list that changes from 10 to 100 items can scale its hint immediately. Explicit loop growth is capped at 256 KiB; normal builder growth handles any remaining output. Request diagnostics aggregate loop predictions and retain bounded details for up to eight iterable-name/source-line pairs.
+
+**Stage 4: Composed layouts and `yield`**
+
+A composed page contains output that Plush already knows exactly: the current rendered `yield`. Learning the whole composed size as one average would over-allocate when small and large pages share a layout. Instead, Plush estimates only layout overhead:
+
+```text
+grow hint = exact current yield bytes + learned layout overhead
+observed overhead = final layout bytes - current yield bytes
+```
+
+The root file's bytecode keeps eight fixed overhead profiles for yield ranges from `0-4k` through `4m+`. Buffalo render-pass identity and template filenames associate one layout render with its root render, preventing unrelated nested work from training that profile. Layout overhead growth is capped at 4 MiB, while the exact current yield is still included in full.
+
+**Stage 5: Partials and variable-output safety**
+
+Each compiled partial owns its own estimate. Plush measures the parent's builder length immediately before and after a successful inline partial, so the sample contains only that partial's bytes. Before the next call, Plush grows the parent only when its spare capacity is insufficient. It avoids explicit partial growth once the parent already has at least 64 KiB of capacity, allowing the parent and loop estimators to remain the primary planners.
+
+For whole templates, layouts, and partials, Plush tracks the lifetime minimum and maximum observed output. When `maximum / minimum` reaches 4, the output is marked unstable. Conservative rules then replace a potentially expensive average:
+
+- Whole-template and layout growth use at most the larger of static bytes and the observed minimum.
+- Unstable partial growth is capped at the larger of 64 KiB and its static bytes.
+- Loops continue using current item count, so changing cardinality does not require a route-sized historical estimate.
+
+These limits affect only explicit preallocation. Rendering can always grow beyond them as needed.
+
+**Stage 6: Control and diagnostics**
+
+`SetOutputSizeEstimatorEnabled(false)` atomically disables learned template, layout, partial, and loop hints process-wide. Disabled mode records no new samples, but preserves the pre-existing static fast-plan hint. Re-enabling resumes from the statistics already attached to the cached bytecode.
+
+For enabled top-level renders, diagnostics report the estimate used before rendering (`learned`), actual bytes, the updated estimate, sample count, minimum/maximum, instability and limiting decisions, requested hint, real capacity allocated by `Grow`, and final unused capacity. `error` is the absolute difference between the pre-render estimate and actual output as a percentage of actual output; `within-10=1` means that value is strictly below 10%. Loop diagnostics provide request totals plus bounded per-loop bytes-per-item details, and partial diagnostics provide both totals and bounded per-file details.
+
+**Stage 7: Verification**
+
+Generic tests exercise first-sample learning, asymmetric updates, cache ownership, changed source, loops, nested loops, layouts, partials, instability limits, disabled mode, and concurrent access. The stable benchmark measures the intended reusable-template case; the alternating benchmark deliberately stresses variable output. CPU and allocation profiles then verify that lower `B/op` comes from replacing repeated builder copying with one planned grow, rather than from skipping rendering work.
+
+Each compiled template owns its own statistics. The cache stores estimates beside bytecode, never rendered values or context data. Replacing a cache entry after a source change creates fresh statistics automatically. Layout profiles are fixed at eight entries per root bytecode, so state cannot grow with request paths or input identities.
+
+The estimator is enabled by default. Disable it process-wide at startup, in a benchmark, or around a controlled test:
+
+```go
+previous := plush.SetOutputSizeEstimatorEnabled(false)
+defer plush.SetOutputSizeEstimatorEnabled(previous)
+```
+
+Disabled mode performs no adaptive learning, layout/partial estimation, or learned loop growth. It preserves the VM's static fast-plan hint, providing a direct pre-estimator baseline without changing rendering semantics.
 
 For fair VM measurements, warm file-backed templates until `VMBytecodeCache` reports `hit` and `FastPath` reports `fast`. A first render may report `miss-store` because the VM is parsing, compiling, storing bytecode, and then rendering. Fast-plan counters describe template shape, not elapsed time; use `EngineDurationMilliseconds`, `VMHelperDurationMilliseconds`, and `VMPartialDurationMilliseconds` for timings.
 

--- a/compiler.go
+++ b/compiler.go
@@ -90,6 +90,9 @@ func (c *compiler) compile() (string, error) {
 		}
 
 		if err != nil {
+			if IsTemplateTraceError(err) {
+				return "", err
+			}
 			s := stmt
 			if c.curStmt != nil {
 				s = c.curStmt
@@ -259,6 +262,20 @@ func (c *compiler) evalPrefixExpression(node *ast.PrefixExpression) (interface{}
 	switch node.Operator {
 	case "!":
 		return !c.isTruthy(res), nil
+	case "-":
+		var rV interface{}
+		switch res := res.(type) {
+
+		case int64:
+			rV = (-1 * res)
+		case int:
+			rV = (-1 * res)
+		case float64:
+			rV = (-1 * res)
+		}
+		if rV != nil {
+			return rV, nil
+		}
 	}
 
 	return nil, fmt.Errorf("unknown operator %s", node.Operator)
@@ -827,6 +844,7 @@ func (c *compiler) evalCallExpression(node *ast.CallExpression) (interface{}, er
 					Context:  c.ctx,
 					compiler: c,
 					block:    node.Block,
+					callLine: node.T().LineNumber,
 				}
 				args = append(args, reflect.ValueOf(hargs))
 				return
@@ -912,6 +930,9 @@ func (c *compiler) evalCallExpression(node *ast.CallExpression) (interface{}, er
 	res := rv.Call(args)
 	if len(res) > 0 {
 		if e, ok := res[len(res)-1].Interface().(error); ok {
+			if IsTemplateTraceError(e) {
+				return nil, e
+			}
 			return nil, fmt.Errorf("could not call %s function: %w", node.Function, e)
 		}
 		if node.ChainCallee != nil {

--- a/helper_context.go
+++ b/helper_context.go
@@ -19,16 +19,26 @@ type HelperContext struct {
 	compiler    *compiler
 	block       *ast.BlockStatement
 	blockRunner func(hctx.Context) (string, error)
+	callLine    int
 }
 
 // NewHelperContext returns a HelperContext that can execute an optional block
 // using the supplied runner. It is used by alternate execution engines that
 // need to interoperate with helpers accepting plush.HelperContext.
 func NewHelperContext(ctx hctx.Context, runner func(hctx.Context) (string, error)) HelperContext {
+	return NewHelperContextWithLine(ctx, runner, 0)
+}
+
+func NewHelperContextWithLine(ctx hctx.Context, runner func(hctx.Context) (string, error), line int) HelperContext {
 	return HelperContext{
 		Context:     ctx,
 		blockRunner: runner,
+		callLine:    line,
 	}
+}
+
+func (h HelperContext) CallLine() int {
+	return h.callLine
 }
 
 // Render a string with the current context

--- a/numbers_test.go
+++ b/numbers_test.go
@@ -44,3 +44,71 @@ func Test_Render_Allows_Many_Numeric_Types(t *testing.T) {
 	r.NoError(err)
 	r.Equal("1 2 3", s)
 }
+
+func Test_Identifier_With_Digits_And_Unary_Minus(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		values   map[string]interface{}
+		expected string
+	}{
+		{
+			name:  "float64 identifier",
+			input: `<%= -my123greet %>`,
+			values: map[string]interface{}{
+				"my123greet": float64(5.5),
+			},
+			expected: "-5.5",
+		},
+		{
+			name:  "float64 identifier plus integer literal",
+			input: `<%= -my123greet + 10 %>`,
+			values: map[string]interface{}{
+				"my123greet": float64(5.5),
+			},
+			expected: "4.5",
+		},
+		{
+			name:  "float64 identifier minus integer literal",
+			input: `<%= -my123greet - 10 %>`,
+			values: map[string]interface{}{
+				"my123greet": float64(5.5),
+			},
+			expected: "-15.5",
+		},
+		{
+			name:  "float64 identifier plus negative int64 identifier",
+			input: `<%= -my123greet + my123greet2 %>`,
+			values: map[string]interface{}{
+				"my123greet":  float64(5.5),
+				"my123greet2": int64(-10),
+			},
+			expected: "-15.5",
+		},
+		{
+			name:  "int64 identifier plus float64 identifier",
+			input: `<%= -my123greet + my123greet2 %>`,
+			values: map[string]interface{}{
+				"my123greet":  int64(10),
+				"my123greet2": float64(5.5),
+			},
+			expected: "-4.5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := require.New(t)
+			ctx := plush.NewContext()
+
+			for name, value := range tt.values {
+				ctx.Set(name, value)
+			}
+
+			s, err := plush.Render(tt.input, ctx)
+
+			r.NoError(err)
+			r.Equal(tt.expected, s)
+		})
+	}
+}

--- a/partial_helper.go
+++ b/partial_helper.go
@@ -30,6 +30,8 @@ func PartialHelper(name string, data map[string]interface{}, help HelperContext)
 		}
 	}
 
+	parentFile := TemplateFilenameForError(help.Context)
+	parentLine := help.CallLine()
 	help.Context = help.New()
 	for k, v := range data {
 		help.Set(k, v)
@@ -60,16 +62,17 @@ func PartialHelper(name string, data map[string]interface{}, help HelperContext)
 	} else {
 		help.Set(meta.TemplateFileKey, name)
 	}
+	childFile := TemplateFilenameForError(help.Context)
 
 	pf, ok := help.Value("partialFeeder").(func(string) (string, error))
 	if !ok {
-		return "", fmt.Errorf("could not find partial feeder from helpers")
+		return "", WrapPartialRenderError(parentFile, parentLine, childFile, fmt.Errorf("could not find partial feeder from helpers"))
 	}
 
 	var part string
 	var err error
 	if part, err = pf(name); err != nil {
-		return "", err
+		return "", WrapPartialRenderError(parentFile, parentLine, childFile, err)
 	}
 	if help.Value(already_in_partial) == nil {
 		help.Set(already_in_partial, name)
@@ -92,7 +95,7 @@ func PartialHelper(name string, data map[string]interface{}, help HelperContext)
 		part, err = Render(part, help.Context)
 	}
 	if err != nil {
-		return "", err
+		return "", WrapPartialRenderError(parentFile, parentLine, childFile, err)
 	}
 	if ct, ok := help.Value("contentType").(string); ok {
 		ext := filepath.Ext(name)

--- a/partial_helper_test.go
+++ b/partial_helper_test.go
@@ -75,6 +75,22 @@ func Test_Partial_Helper_Nested_Partial_Path_Handling(t *testing.T) {
 	r.Equal("CODE3 PRINT /fake/templates/testing/code-3.plush.html", normalized)
 }
 
+func Test_Partial_Helper_Error_Includes_Parent_And_Partial_Filenames(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"partialFeeder": func(name string) (string, error) {
+			require.Equal(t, "partials/row.plush", name)
+			return "first\n<%= missing %>", nil
+		},
+	})
+	ctx.Set(meta.TemplateBaseFileNameKey, "application")
+	ctx.Set(meta.TemplateFileKey, "application.plush")
+	ctx.Set(meta.TemplateExtensionKey, "plush")
+
+	_, err := plush.RenderInterpreter("<p>top</p>\n<%= partial(\"partials/row.plush\") %>", ctx)
+	require.Error(t, err)
+	require.EqualError(t, err, `application.plush:2:partials/row.plush:2: "missing": unknown identifier`)
+}
+
 func Test_Partial_Helper_Invalid_Feeder_Function(t *testing.T) {
 	r := require.New(t)
 

--- a/partial_helper_test.go
+++ b/partial_helper_test.go
@@ -82,13 +82,13 @@ func Test_Partial_Helper_Error_Includes_Parent_And_Partial_Filenames(t *testing.
 			return "first\n<%= missing %>", nil
 		},
 	})
-	ctx.Set(meta.TemplateBaseFileNameKey, "application")
-	ctx.Set(meta.TemplateFileKey, "application.plush")
+	ctx.Set(meta.TemplateBaseFileNameKey, "layout")
+	ctx.Set(meta.TemplateFileKey, "layout.plush")
 	ctx.Set(meta.TemplateExtensionKey, "plush")
 
 	_, err := plush.RenderInterpreter("<p>top</p>\n<%= partial(\"partials/row.plush\") %>", ctx)
 	require.Error(t, err)
-	require.EqualError(t, err, `application.plush:2:partials/row.plush:2: "missing": unknown identifier`)
+	require.EqualError(t, err, `layout.plush:2:partials/row.plush:2: "missing": unknown identifier`)
 }
 
 func Test_Partial_Helper_Invalid_Feeder_Function(t *testing.T) {

--- a/plush.go
+++ b/plush.go
@@ -33,6 +33,14 @@ var holeTemplateFileKey = "__plush_internal_hole_render_key_" + fmt.Sprintf("%d"
 var interpreterPartialRenderKey = "__plush_internal_interpreter_partial_render_" + fmt.Sprintf("%d", time.Now().UnixNano()) + "__"
 var errClearCache error = errors.New("template recently cached, skipping")
 var punchHoleConcurrencyLimit atomic.Int64
+var buffaloRenderPassCounter atomic.Uint64
+
+const buffaloRenderPassKey = "__plush_internal_buffalo_render_pass__"
+
+type BuffaloRenderPass struct {
+	ID               uint64
+	TemplateFilename string
+}
 
 var templateCacheBackend TemplateCache
 
@@ -72,6 +80,10 @@ func BuffaloRendererWithContext(input string, data map[string]interface{}, helpe
 		renderData[k] = v
 	}
 	ctx := NewContextWith(renderData)
+	ctx.Set(buffaloRenderPassKey, BuffaloRenderPass{
+		ID:               buffaloRenderPassCounter.Add(1),
+		TemplateFilename: PunchHoleTemplateFilename(ctx),
+	})
 	if configure != nil {
 		configure(ctx)
 	}
@@ -83,6 +95,14 @@ func BuffaloRendererWithContext(input string, data map[string]interface{}, helpe
 		}
 	}()
 	return Render(input, ctx)
+}
+
+func BuffaloRenderPassFromContext(ctx hctx.Context) (BuffaloRenderPass, bool) {
+	if ctx == nil {
+		return BuffaloRenderPass{}, false
+	}
+	pass, ok := ctx.Value(buffaloRenderPassKey).(BuffaloRenderPass)
+	return pass, ok && pass.ID != 0
 }
 
 // Parse an input string and return a Template, and caches the parsed template.

--- a/plush_test.go
+++ b/plush_test.go
@@ -298,6 +298,68 @@ func Test_Render_Diagnostics_VM_Hotspots_Header(t *testing.T) {
 	r.Equal("row_card:1:4.000", diagnostics.VMPartialHotspotsHeader())
 }
 
+func Test_Render_Diagnostics_Output_Size_Header(t *testing.T) {
+	r := require.New(t)
+	diagnostics := plush.RenderDiagnostics{
+		OutputSize: plush.RenderOutputSizeDiagnostics{
+			Available:      true,
+			StaticSize:     10,
+			FallbackHint:   20,
+			GrowHint:       30,
+			EstimateBefore: 25,
+			Actual:         28,
+			EstimateAfter:  27,
+			SamplesBefore:  2,
+			SamplesAfter:   3,
+			Observed:       true,
+		},
+	}
+
+	r.Equal("scope=template;static=10;fallback=20;hint=30;learned=25;actual=28;error=10.71;within-10=0;estimate=27;samples=3;observed=1;min=0;max=0;unstable=0;limited=0;grow-called=0;grow-allocated=0;cap-before=0;cap-after-grow=0;cap-final=0;unused-cap=0", diagnostics.OutputSizeHeader())
+	r.Empty(plush.RenderDiagnostics{}.OutputSizeHeader())
+}
+
+func Test_Render_Diagnostics_Contextual_Output_Size_Header(t *testing.T) {
+	diagnostics := plush.RenderDiagnostics{
+		OutputSize: plush.RenderOutputSizeDiagnostics{
+			Available:      true,
+			Scope:          "file",
+			Contextual:     true,
+			ProfileBand:    "0-4k",
+			YieldSize:      100,
+			OverheadBefore: 20,
+			OverheadActual: 21,
+			OverheadAfter:  21,
+			StaticSize:     10,
+			FallbackHint:   115,
+			GrowHint:       120,
+			EstimateBefore: 120,
+			Actual:         121,
+			EstimateAfter:  121,
+			SamplesAfter:   2,
+			Observed:       true,
+		},
+	}
+
+	require.Equal(t, "scope=file;profile=0-4k;yield=100;overhead=20;overhead-actual=21;overhead-estimate=21;static=10;fallback=115;hint=120;learned=120;actual=121;error=0.83;within-10=1;estimate=121;samples=2;observed=1;min=0;max=0;unstable=0;limited=0;grow-called=0;grow-allocated=0;cap-before=0;cap-after-grow=0;cap-final=0;unused-cap=0", diagnostics.OutputSizeHeader())
+}
+
+func Test_Render_Diagnostics_Partial_Output_Size_Headers(t *testing.T) {
+	r := require.New(t)
+	ctx := plush.NewContext()
+
+	plush.AddRenderDiagnosticPartialOutput(ctx, "components/item.plush", 90, 100, 100, 95, 3)
+	plush.AddRenderDiagnosticPartialOutput(ctx, "components/item.plush", 110, 110, 100, 105, 4)
+	plush.AddRenderDiagnosticPartialOutput(ctx, "nav;main.plush", 40, 45, 50, 45, 2)
+
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	r.True(ok)
+	r.Equal("calls=3;learned=240;hint=255;actual=250;absolute-error=30;error=12.00;within-10=0;unstable=0;limited=0;grow-calls=0;grow-allocated=0", diagnostics.PartialOutputSizeHeader())
+	r.Equal("name=components/item.plush,calls=2,learned=200,hint=210,actual=200,error=10.00,estimate=105,samples=4,min=0,max=0,unstable=0,limited=0,grow-calls=0,grow-allocated=0|name=nav main.plush,calls=1,learned=40,hint=45,actual=50,error=20.00,estimate=45,samples=2,min=0,max=0,unstable=0,limited=0,grow-calls=0,grow-allocated=0", diagnostics.PartialOutputSizeDetailsHeader())
+	r.Empty(plush.RenderDiagnostics{}.PartialOutputSizeHeader())
+	r.Empty(plush.RenderDiagnostics{}.PartialOutputSizeDetailsHeader())
+}
+
 func Test_Render_Diagnostics_VM_Hotspots_Default_Off(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()
@@ -309,6 +371,17 @@ func Test_Render_Diagnostics_VM_Hotspots_Default_Off(t *testing.T) {
 	r.False(ok)
 	r.Zero(diagnostics.VMHotspots.HelperCalls)
 	r.Zero(diagnostics.VMHotspots.PartialCalls)
+}
+
+func Test_Output_Size_Estimator_Can_Be_Disabled_And_Restored(t *testing.T) {
+	r := require.New(t)
+	previous := plush.SetOutputSizeEstimatorEnabled(false)
+	defer plush.SetOutputSizeEstimatorEnabled(previous)
+
+	r.True(previous)
+	r.False(plush.OutputSizeEstimatorEnabled())
+	r.False(plush.SetOutputSizeEstimatorEnabled(true))
+	r.True(plush.OutputSizeEstimatorEnabled())
 }
 
 func Test_Render_Diagnostics_VM_Hotspots_Concurrent_Update(t *testing.T) {

--- a/punch_hole_test.go
+++ b/punch_hole_test.go
@@ -284,19 +284,6 @@ func Test_Render_Hole_Punching_If_Else(t *testing.T) {
 	r.Equal(`3`, ss)
 }
 
-func Test_Render_Hole_Punching_If_Truthy_A(t *testing.T) {
-	r := require.New(t)
-	ctx := plush.NewContext()
-	cacheFileName := "myfile.plush"
-	ff := inmemory.NewMemoryCache()
-	plush.PlushCacheSetup(ff)
-	ctx.Set(meta.TemplateFileKey, cacheFileName)
-	ctx.Set("number", 3)
-	input := `<%H if (number > 0){ %><%= "NUMBER" %><% } else { %><%= number %><%  }%>`
-	ss, err := plush.Render(input, ctx)
-	r.NoError(err)
-	r.Equal(`NUMBER`, ss)
-}
 func Test_Render_Hole_Punching_If_Truthy(t *testing.T) {
 	r := require.New(t)
 	ctx := plush.NewContext()

--- a/render_diagnostics.go
+++ b/render_diagnostics.go
@@ -31,6 +31,9 @@ const (
 	PunchHoleCacheDisabled = "disabled"
 	PunchHoleCacheHit      = "hit"
 	PunchHoleCacheMiss     = "miss"
+
+	renderPartialOutputDetailLimit = 8
+	renderLoopOutputDetailLimit    = 8
 )
 
 var renderDiagnosticsKey = "__plush_internal_render_diagnostics_" + fmt.Sprintf("%d", time.Now().UnixNano()) + "__"
@@ -52,7 +55,116 @@ type RenderDiagnostics struct {
 	PunchHoleCache   string
 	EngineDuration   time.Duration
 	FastPlan         RenderFastPlanDiagnostics
+	OutputSize       RenderOutputSizeDiagnostics
+	LoopOutput       RenderLoopOutputSizeDiagnostics
+	PartialOutput    RenderPartialOutputSizeDiagnostics
 	VMHotspots       RenderVMHotspotDiagnostics
+}
+
+type RenderOutputSizeDiagnostics struct {
+	Available      bool
+	Scope          string
+	Contextual     bool
+	YieldSize      int
+	OverheadBefore int
+	OverheadActual int
+	OverheadAfter  int
+	StaticSize     int
+	FallbackHint   int
+	GrowHint       int
+	EstimateBefore int
+	Actual         int
+	EstimateAfter  int
+	SamplesBefore  uint64
+	SamplesAfter   uint64
+	Observed       bool
+	ProfileBand    string
+	Minimum        int
+	Maximum        int
+	Unstable       bool
+	Limited        bool
+	GrowCalled     bool
+	CapacityBefore int
+	CapacityGrow   int
+	CapacityFinal  int
+	UnusedCapacity int
+	GrowAllocated  int
+}
+
+type RenderLoopOutputSizeDiagnostics struct {
+	Calls         int
+	Items         int
+	KnownCount    int
+	Learned       int
+	GrowHint      int
+	Actual        int
+	AbsoluteError int
+	WithinTen     int
+	Limited       int
+	GrowCalls     int
+	GrowAllocated int
+	Details       []RenderLoopOutputSizeDetail
+}
+
+type RenderLoopOutputSizeDetail struct {
+	Name                 string
+	Line                 int
+	Calls                int
+	Items                int
+	Learned              int
+	GrowHint             int
+	Actual               int
+	AbsoluteError        int
+	WithinTen            int
+	KnownCount           int
+	LearnedBytesPerItem  int
+	ActualBytesPerItem   int
+	EstimateBytesPerItem int
+	SamplesBefore        uint64
+	SamplesAfter         uint64
+	Limited              int
+	GrowCalls            int
+	GrowAllocated        int
+}
+
+type RenderPartialOutputSizeDiagnostics struct {
+	Calls         int
+	Learned       int
+	GrowHint      int
+	Actual        int
+	AbsoluteError int
+	WithinTen     int
+	Unstable      int
+	Limited       int
+	GrowCalls     int
+	GrowAllocated int
+	Details       []RenderPartialOutputSizeDetail
+}
+
+type RenderPartialOutputSizeDetail struct {
+	Name          string
+	Calls         int
+	Learned       int
+	GrowHint      int
+	Actual        int
+	AbsoluteError int
+	Estimate      int
+	Samples       uint64
+	Minimum       int
+	Maximum       int
+	Unstable      bool
+	Limited       int
+	GrowCalls     int
+	GrowAllocated int
+}
+
+type RenderPartialOutputAllocation struct {
+	GrowCalled           bool
+	SpeculativeAllocated int
+	Unstable             bool
+	Limited              bool
+	Minimum              int
+	Maximum              int
 }
 
 type RenderFastPlanDiagnostics struct {
@@ -105,6 +217,351 @@ func (d RenderDiagnostics) FastPlanHelperNamesHeader() string {
 
 func (d RenderDiagnostics) FastPlanPartialNamesHeader() string {
 	return strings.Join(d.FastPlan.PartialNames, ";")
+}
+
+func (d RenderDiagnostics) OutputSizeHeader() string {
+	if !d.OutputSize.Available {
+		return ""
+	}
+	scope := d.OutputSize.Scope
+	if scope == "" {
+		scope = "template"
+	}
+	observed := 0
+	withinTen := 0
+	if d.OutputSize.Observed {
+		observed = 1
+		errorSize := d.OutputSize.EstimateBefore - d.OutputSize.Actual
+		if errorSize < 0 {
+			errorSize = -errorSize
+		}
+		if outputSizeErrorPercent(errorSize, d.OutputSize.Actual) < 10 {
+			withinTen = 1
+		}
+	}
+	errorSize := d.OutputSize.EstimateBefore - d.OutputSize.Actual
+	if errorSize < 0 {
+		errorSize = -errorSize
+	}
+	header := fmt.Sprintf(
+		"scope=%s;static=%d;fallback=%d;hint=%d;learned=%d;actual=%d;error=%.2f;within-10=%d;estimate=%d;samples=%d;observed=%d;min=%d;max=%d;unstable=%d;limited=%d;grow-called=%d;grow-allocated=%d;cap-before=%d;cap-after-grow=%d;cap-final=%d;unused-cap=%d",
+		scope,
+		d.OutputSize.StaticSize,
+		d.OutputSize.FallbackHint,
+		d.OutputSize.GrowHint,
+		d.OutputSize.EstimateBefore,
+		d.OutputSize.Actual,
+		outputSizeErrorPercent(errorSize, d.OutputSize.Actual),
+		withinTen,
+		d.OutputSize.EstimateAfter,
+		d.OutputSize.SamplesAfter,
+		observed,
+		d.OutputSize.Minimum,
+		d.OutputSize.Maximum,
+		boolHeaderValue(d.OutputSize.Unstable),
+		boolHeaderValue(d.OutputSize.Limited),
+		boolHeaderValue(d.OutputSize.GrowCalled),
+		d.OutputSize.GrowAllocated,
+		d.OutputSize.CapacityBefore,
+		d.OutputSize.CapacityGrow,
+		d.OutputSize.CapacityFinal,
+		d.OutputSize.UnusedCapacity,
+	)
+	if !d.OutputSize.Contextual {
+		return header
+	}
+	return fmt.Sprintf(
+		"scope=%s;profile=%s;yield=%d;overhead=%d;overhead-actual=%d;overhead-estimate=%d;static=%d;fallback=%d;hint=%d;learned=%d;actual=%d;error=%.2f;within-10=%d;estimate=%d;samples=%d;observed=%d;min=%d;max=%d;unstable=%d;limited=%d;grow-called=%d;grow-allocated=%d;cap-before=%d;cap-after-grow=%d;cap-final=%d;unused-cap=%d",
+		scope,
+		outputSizeProfileBand(d.OutputSize.ProfileBand),
+		d.OutputSize.YieldSize,
+		d.OutputSize.OverheadBefore,
+		d.OutputSize.OverheadActual,
+		d.OutputSize.OverheadAfter,
+		d.OutputSize.StaticSize,
+		d.OutputSize.FallbackHint,
+		d.OutputSize.GrowHint,
+		d.OutputSize.EstimateBefore,
+		d.OutputSize.Actual,
+		outputSizeErrorPercent(errorSize, d.OutputSize.Actual),
+		withinTen,
+		d.OutputSize.EstimateAfter,
+		d.OutputSize.SamplesAfter,
+		observed,
+		d.OutputSize.Minimum,
+		d.OutputSize.Maximum,
+		boolHeaderValue(d.OutputSize.Unstable),
+		boolHeaderValue(d.OutputSize.Limited),
+		boolHeaderValue(d.OutputSize.GrowCalled),
+		d.OutputSize.GrowAllocated,
+		d.OutputSize.CapacityBefore,
+		d.OutputSize.CapacityGrow,
+		d.OutputSize.CapacityFinal,
+		d.OutputSize.UnusedCapacity,
+	)
+}
+
+func (d RenderDiagnostics) PartialOutputSizeHeader() string {
+	partial := d.PartialOutput
+	if partial.Calls == 0 {
+		return ""
+	}
+	return fmt.Sprintf(
+		"calls=%d;learned=%d;hint=%d;actual=%d;absolute-error=%d;error=%.2f;within-10=%d;unstable=%d;limited=%d;grow-calls=%d;grow-allocated=%d",
+		partial.Calls,
+		partial.Learned,
+		partial.GrowHint,
+		partial.Actual,
+		partial.AbsoluteError,
+		outputSizeErrorPercent(partial.AbsoluteError, partial.Actual),
+		partial.WithinTen,
+		partial.Unstable,
+		partial.Limited,
+		partial.GrowCalls,
+		partial.GrowAllocated,
+	)
+}
+
+func (d RenderDiagnostics) PartialOutputSizeDetailsHeader() string {
+	if len(d.PartialOutput.Details) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(d.PartialOutput.Details))
+	for _, detail := range d.PartialOutput.Details {
+		parts = append(parts, fmt.Sprintf(
+			"name=%s,calls=%d,learned=%d,hint=%d,actual=%d,error=%.2f,estimate=%d,samples=%d,min=%d,max=%d,unstable=%d,limited=%d,grow-calls=%d,grow-allocated=%d",
+			partialOutputHeaderName(detail.Name),
+			detail.Calls,
+			detail.Learned,
+			detail.GrowHint,
+			detail.Actual,
+			outputSizeErrorPercent(detail.AbsoluteError, detail.Actual),
+			detail.Estimate,
+			detail.Samples,
+			detail.Minimum,
+			detail.Maximum,
+			boolHeaderValue(detail.Unstable),
+			detail.Limited,
+			detail.GrowCalls,
+			detail.GrowAllocated,
+		))
+	}
+	return strings.Join(parts, "|")
+}
+
+func AddRenderDiagnosticPartialOutput(ctx hctx.Context, name string, learned, growHint, actual, estimate int, samples uint64) {
+	AddRenderDiagnosticPartialOutputAllocation(ctx, name, learned, growHint, actual, estimate, samples, RenderPartialOutputAllocation{})
+}
+
+func AddRenderDiagnosticLoopOutput(ctx hctx.Context, name string, line, items, learnedBytesPerItem, growHint, actual, estimateBytesPerItem int, samplesBefore, samplesAfter uint64, itemCountKnown, limited, growCalled bool, growAllocated int) {
+	if ctx == nil || items <= 0 || actual < 0 {
+		return
+	}
+	if name == "" {
+		name = "<expression>"
+	}
+	learned := outputSizeProduct(learnedBytesPerItem, items)
+	errorSize := learned - actual
+	if errorSize < 0 {
+		errorSize = -errorSize
+	}
+	withinTen := outputSizeErrorPercent(errorSize, actual) < 10
+	actualBytesPerItem := actual / items
+
+	UpdateRenderDiagnostics(ctx, func(d *RenderDiagnostics) {
+		loop := &d.LoopOutput
+		loop.Calls++
+		loop.Items += items
+		if itemCountKnown {
+			loop.KnownCount++
+		}
+		loop.Learned += learned
+		loop.GrowHint += growHint
+		loop.Actual += actual
+		loop.AbsoluteError += errorSize
+		if withinTen {
+			loop.WithinTen++
+		}
+		if limited {
+			loop.Limited++
+		}
+		if growCalled {
+			loop.GrowCalls++
+		}
+		loop.GrowAllocated += growAllocated
+
+		for i := range loop.Details {
+			if loop.Details[i].Name == name && loop.Details[i].Line == line {
+				addLoopOutputDetail(&loop.Details[i], items, learned, growHint, actual, errorSize, learnedBytesPerItem, actualBytesPerItem, estimateBytesPerItem, samplesBefore, samplesAfter, withinTen, itemCountKnown, limited, growCalled, growAllocated)
+				return
+			}
+		}
+		if len(loop.Details) >= renderLoopOutputDetailLimit {
+			return
+		}
+		detail := RenderLoopOutputSizeDetail{Name: name, Line: line}
+		addLoopOutputDetail(&detail, items, learned, growHint, actual, errorSize, learnedBytesPerItem, actualBytesPerItem, estimateBytesPerItem, samplesBefore, samplesAfter, withinTen, itemCountKnown, limited, growCalled, growAllocated)
+		loop.Details = append(loop.Details, detail)
+	})
+}
+
+func addLoopOutputDetail(detail *RenderLoopOutputSizeDetail, items, learned, growHint, actual, errorSize, learnedBytesPerItem, actualBytesPerItem, estimateBytesPerItem int, samplesBefore, samplesAfter uint64, withinTen, itemCountKnown, limited, growCalled bool, growAllocated int) {
+	detail.Calls++
+	detail.Items += items
+	detail.Learned += learned
+	detail.GrowHint += growHint
+	detail.Actual += actual
+	detail.AbsoluteError += errorSize
+	if withinTen {
+		detail.WithinTen++
+	}
+	if itemCountKnown {
+		detail.KnownCount++
+	}
+	detail.LearnedBytesPerItem = learnedBytesPerItem
+	detail.ActualBytesPerItem = actualBytesPerItem
+	detail.EstimateBytesPerItem = estimateBytesPerItem
+	detail.SamplesBefore = samplesBefore
+	detail.SamplesAfter = samplesAfter
+	if limited {
+		detail.Limited++
+	}
+	if growCalled {
+		detail.GrowCalls++
+	}
+	detail.GrowAllocated += growAllocated
+}
+
+func AddRenderDiagnosticPartialOutputAllocation(ctx hctx.Context, name string, learned, growHint, actual, estimate int, samples uint64, allocation RenderPartialOutputAllocation) {
+	if ctx == nil || actual < 0 {
+		return
+	}
+	if name == "" {
+		name = "<anonymous>"
+	}
+	errorSize := learned - actual
+	if errorSize < 0 {
+		errorSize = -errorSize
+	}
+	withinTen := outputSizeErrorPercent(errorSize, actual) < 10
+	UpdateRenderDiagnostics(ctx, func(d *RenderDiagnostics) {
+		partial := &d.PartialOutput
+		partial.Calls++
+		partial.Learned += learned
+		partial.GrowHint += growHint
+		partial.Actual += actual
+		partial.AbsoluteError += errorSize
+		if withinTen {
+			partial.WithinTen++
+		}
+		if allocation.Unstable {
+			partial.Unstable++
+		}
+		if allocation.Limited {
+			partial.Limited++
+		}
+		if allocation.GrowCalled {
+			partial.GrowCalls++
+		}
+		partial.GrowAllocated += allocation.SpeculativeAllocated
+
+		for i := range partial.Details {
+			if partial.Details[i].Name == name {
+				addPartialOutputDetail(&partial.Details[i], learned, growHint, actual, errorSize, estimate, samples, allocation)
+				return
+			}
+		}
+		if len(partial.Details) >= renderPartialOutputDetailLimit {
+			return
+		}
+		detail := RenderPartialOutputSizeDetail{Name: name}
+		addPartialOutputDetail(&detail, learned, growHint, actual, errorSize, estimate, samples, allocation)
+		partial.Details = append(partial.Details, detail)
+	})
+}
+
+func addPartialOutputDetail(detail *RenderPartialOutputSizeDetail, learned, growHint, actual, errorSize, estimate int, samples uint64, allocation RenderPartialOutputAllocation) {
+	detail.Calls++
+	detail.Learned += learned
+	detail.GrowHint += growHint
+	detail.Actual += actual
+	detail.AbsoluteError += errorSize
+	detail.Estimate = estimate
+	detail.Samples = samples
+	detail.Minimum = allocation.Minimum
+	detail.Maximum = allocation.Maximum
+	detail.Unstable = allocation.Unstable
+	if allocation.Limited {
+		detail.Limited++
+	}
+	if allocation.GrowCalled {
+		detail.GrowCalls++
+	}
+	detail.GrowAllocated += allocation.SpeculativeAllocated
+}
+
+func boolHeaderValue(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}
+
+func outputSizeProfileBand(band string) string {
+	if band == "" {
+		return "none"
+	}
+	return band
+}
+
+func outputSizeErrorPercent(errorSize, actual int) float64 {
+	if actual <= 0 {
+		if errorSize == 0 {
+			return 0
+		}
+		return 100
+	}
+	return float64(errorSize) * 100 / float64(actual)
+}
+
+func outputSizeProduct(left, right int) int {
+	if left <= 0 || right <= 0 {
+		return 0
+	}
+	maximum := int(^uint(0) >> 1)
+	if left > maximum/right {
+		return maximum
+	}
+	return left * right
+}
+
+func partialOutputHeaderName(name string) string {
+	name = strings.ReplaceAll(name, "\\", "/")
+	pathParts := strings.Split(name, "/")
+	trimmed := false
+	for i := len(pathParts) - 1; i >= 0; i-- {
+		if pathParts[i] == "templates" {
+			name = ".../" + strings.Join(pathParts[i:], "/")
+			trimmed = true
+			break
+		}
+	}
+	if !trimmed && len(pathParts) > 3 {
+		name = ".../" + strings.Join(pathParts[len(pathParts)-3:], "/")
+	}
+	name = strings.Map(func(r rune) rune {
+		switch r {
+		case ',', ';', '|', '=':
+			return ' '
+		default:
+			return r
+		}
+	}, name)
+	runes := []rune(name)
+	if len(runes) > 120 {
+		name = string(runes[:120])
+	}
+	return name
 }
 
 func (d RenderDiagnostics) VMHelperHotspotsHeader() string {

--- a/render_mode.go
+++ b/render_mode.go
@@ -16,6 +16,7 @@ const (
 
 var renderMode atomic.Int32
 var vmGenericFallback atomic.Bool
+var outputSizeEstimatorDisabled atomic.Bool
 var vmRenderer atomic.Value
 
 var ErrVMRendererNotRegistered = errors.New("plush VM renderer is not registered")
@@ -40,6 +41,19 @@ func SetVMGenericFallback(enabled bool) bool {
 
 func VMGenericFallbackEnabled() bool {
 	return vmGenericFallback.Load()
+}
+
+// SetOutputSizeEstimatorEnabled enables or disables adaptive output-size
+// learning and growth hints. It returns the previous setting.
+func SetOutputSizeEstimatorEnabled(enabled bool) bool {
+	wasDisabled := outputSizeEstimatorDisabled.Swap(!enabled)
+	return !wasDisabled
+}
+
+// OutputSizeEstimatorEnabled reports whether adaptive output-size estimation
+// is enabled. The estimator is enabled by default.
+func OutputSizeEstimatorEnabled() bool {
+	return !outputSizeEstimatorDisabled.Load()
 }
 
 func RegisterVMRenderer(renderer RenderFunc) {

--- a/template_error.go
+++ b/template_error.go
@@ -1,0 +1,121 @@
+package plush
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+	"github.com/gobuffalo/plush/v5/helpers/meta"
+)
+
+type TemplateErrorFrame struct {
+	File string
+	Line int
+}
+
+type TemplateTraceError struct {
+	Frames  []TemplateErrorFrame
+	Message string
+}
+
+func (e *TemplateTraceError) Error() string {
+	if e == nil {
+		return ""
+	}
+	parts := make([]string, 0, len(e.Frames))
+	for _, frame := range e.Frames {
+		if part := templateErrorFrameString(frame); part != "" {
+			parts = append(parts, part)
+		}
+	}
+	message := strings.TrimSpace(e.Message)
+	if len(parts) == 0 {
+		return message
+	}
+	if message == "" {
+		return strings.Join(parts, ":")
+	}
+	return strings.Join(parts, ":") + ": " + message
+}
+
+func IsTemplateTraceError(err error) bool {
+	var trace *TemplateTraceError
+	return errors.As(err, &trace)
+}
+
+func WrapPartialRenderError(parentFile string, parentLine int, childFile string, err error) error {
+	if err == nil {
+		return nil
+	}
+	parent := TemplateErrorFrame{File: parentFile, Line: parentLine}
+	var trace *TemplateTraceError
+	if errors.As(err, &trace) {
+		frames := append([]TemplateErrorFrame{}, parent)
+		frames = append(frames, trace.Frames...)
+		return &TemplateTraceError{Frames: compactTemplateErrorFrames(frames), Message: trace.Message}
+	}
+	message := strings.TrimSpace(err.Error())
+	childLine, rest, ok := splitLineErrorPrefix(message)
+	if ok {
+		message = rest
+	}
+	frames := []TemplateErrorFrame{parent, {File: childFile, Line: childLine}}
+	return &TemplateTraceError{Frames: compactTemplateErrorFrames(frames), Message: message}
+}
+
+func TemplateFilenameForError(ctx hctx.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if filename, ok := ctx.Value(meta.TemplateFileKey).(string); ok {
+		return filename
+	}
+	return ""
+}
+
+func templateErrorFrameString(frame TemplateErrorFrame) string {
+	file := strings.TrimSpace(frame.File)
+	switch {
+	case file != "" && frame.Line > 0:
+		return fmt.Sprintf("%s:%d", file, frame.Line)
+	case file != "":
+		return file
+	case frame.Line > 0:
+		return fmt.Sprintf("line %d", frame.Line)
+	default:
+		return ""
+	}
+}
+
+func compactTemplateErrorFrames(frames []TemplateErrorFrame) []TemplateErrorFrame {
+	if len(frames) == 0 {
+		return nil
+	}
+	out := make([]TemplateErrorFrame, 0, len(frames))
+	for _, frame := range frames {
+		if frame.File == "" && frame.Line <= 0 {
+			continue
+		}
+		out = append(out, frame)
+	}
+	return out
+}
+
+func splitLineErrorPrefix(message string) (int, string, bool) {
+	message = strings.TrimSpace(message)
+	if !strings.HasPrefix(message, "line ") {
+		return 0, message, false
+	}
+	rest := strings.TrimPrefix(message, "line ")
+	colon := strings.Index(rest, ":")
+	if colon <= 0 {
+		return 0, message, false
+	}
+	line, err := strconv.Atoi(strings.TrimSpace(rest[:colon]))
+	if err != nil {
+		return 0, message, false
+	}
+	return line, strings.TrimSpace(rest[colon+1:]), true
+}

--- a/vm/FAST_PATHS.md
+++ b/vm/FAST_PATHS.md
@@ -1,0 +1,306 @@
+# VM Fast Paths
+
+A map of the fast render paths used by the VM. Each path has one rule: match
+normal template behavior exactly, or step aside and let the bytecode VM render.
+
+## Principles
+
+- Fast paths cache plans, bytecode, reflection metadata, and stable context
+  binding IDs.
+- Fast paths do not cache request values, helper return values, rendered HTML,
+  partial output, loop items, or branch decisions.
+- Unsupported shapes fall back to the normal VM path instead of changing
+  template behavior. Some unsupported AST shapes are wrapped as a generic VM
+  segment so VM mode can stay in bytecode execution while the specialized fast
+  planner remains conservative.
+- Custom fast helpers are optional accelerators. They should return
+  `ErrFastUnsupported` when they cannot safely handle the current argument
+  values.
+
+## Compiler Plan
+
+The compiler builds a `FastRenderPlan` from the AST when every supported
+top-level statement can be represented as a fast segment. If any statement does
+not fit the supported shapes, the template still compiles to bytecode and runs
+through the normal VM interpreter.
+
+Supported fast render segment kinds include:
+
+- static output
+- name output
+- property output
+- value/path output
+- helper calls
+- block helper calls
+- conditionals
+- loops
+- partials
+- top-level and loop `let` statements
+- top-level and loop assignment statements
+- top-level and loop index assignments
+- top-level `return` statements
+- loop `return` statements
+- generic VM whole-template segments for bytecode-safe shapes that do not have a
+  specialized fast segment yet
+
+The compiler records a reject reason and line number when analysis declines a
+fast render plan.
+
+Plush comments (`<%# ... %>`) are treated as no-op statements by the fast
+planner, matching normal render behavior.
+
+## Direct Write Opcodes
+
+Direct write opcodes fuse common "load or call, then write" instruction pairs.
+They avoid extra stack traffic by writing directly to the current frame output.
+
+Examples include:
+
+- constants and strings
+- local, global, and context names
+- property reads from locals, globals, and context names
+- helper calls and named helper calls
+
+These opcodes still use the same escaping and helper-call rules as regular VM
+execution.
+
+## Prepared Render Plans
+
+At runtime, a compiler `FastRenderPlan` is prepared into VM-side plans. Prepared
+plans are cached on the compiler plan so repeated renders can reuse the same
+analysis.
+
+The runtime tries prepared plans in this order:
+
+1. Static-name plan for templates made of static text and repeated name output.
+2. Simple plan for compact mixed output that can be handled with specialized
+   operations.
+3. Mixed plan for the general supported fast-render shape.
+
+For stable contexts, binding plans cache interned context IDs for the plan's
+binding names. The cached binding plan only stores how to find values, not the
+values themselves.
+
+## Access Paths
+
+Property and access fast paths specialize common reflection work.
+
+Supported access shapes include:
+
+- exported Go struct fields
+- pointer-to-struct field chains
+- no-argument method tails
+- slice and array indexes
+- Go map indexes with static integer or string keys
+- dynamic index reads, such as `data[key]`
+- string-keyed map property access, when a dotted property can be treated like a
+  string map key
+
+Inline caches store reflection lookup metadata for a small number of receiver
+types at a call site. They do not store receiver values.
+
+## Helper Calls
+
+The VM has direct helper invokers for common signatures, including zero-arg and
+scalar-arg helpers returning strings, trusted HTML, booleans, numbers, objects,
+or `(value, error)`.
+
+The reflective helper path handles general Go helpers. It also mirrors
+interpreter behavior for supported omitted helper tail arguments:
+
+- `plush.HelperContext` or `hctx.HelperContext`
+- `map[string]interface{}` options maps
+- a single ordinary trailing parameter before one of those helper arguments,
+  filled with that parameter type's Go zero value
+
+Custom fast helpers registered with `SetFastHelper` receive only the arguments
+written in the template. They can use `FastWriter.Context()` when they need the
+current render context. If a custom fast helper cannot handle the argument
+shape, it should return `ErrFastUnsupported` so the normal helper remains the
+source of truth.
+
+Receiver method calls can also be planned when their arguments are representable
+as fast values. For example, `builder.RenderControl({name: "Email", type:
+inputType})` is planned as a receiver path on `builder`, followed by a method
+call step with a planned hash argument.
+
+Method call inline caches store call metadata for the receiver type. Argument
+values are evaluated fresh for every render.
+
+Plain helper calls in script tags, such as `<% touch(name) %>`, are planned as
+silent calls: the helper still runs and can mutate state, but its return value is
+discarded. Dynamic callable values and chained receiver calls can be represented
+when their receiver and arguments are fast values, including shapes such as
+`helpers[name]("x")` and `makeUser(name).Render("short")`.
+
+## Assignments
+
+Fast plans follow the bytecode distinction between `let` and `=`:
+
+- `let name = value` creates or updates the current local scope.
+- `name = value` updates an existing binding; it does not create a new outer
+  binding by accident.
+- `container[index] = value` mutates the evaluated map, hash, slice, or array
+  target.
+
+Assignment values may be literals, names, access paths, helper calls, receiver
+method calls, prefix/infix expressions, concatenations, arrays, hashes, and
+dynamic index reads.
+
+Index assignments evaluate the container, index, and value at render time. Go
+map keys and slice/array indexes use the same conversion and bounds behavior as
+the VM helpers.
+
+## Loops
+
+Loop fast paths support iteration over:
+
+- template arrays and hashes
+- strings
+- Go arrays and slices
+- Go maps
+- structs and pointers to structs when a struct-loop writer plan can be built
+
+Loop bodies may contain static output, key/value output, property and access
+chains, helper calls, nested conditionals, nested loops, partials, `let`,
+assignment, index assignment, `return`, `break`, and `continue` when the
+compiler can represent those statements in the loop plan.
+
+Output loops (`<%= for ... %>`) write their body output normally. Silent script
+loops (`<% for ... %>`) execute their body for side effects but discard any body
+output. That covers setup patterns such as:
+
+```plush
+<% let collected = [] %>
+<% for (_, item) in items { %>
+  <% collected = collected + item.Value %>
+<% } %>
+```
+
+Loop assignments can update outer bindings, but loop-local variables created by
+`let` stay scoped to the loop iteration. When a loop has local `let` statements,
+the VM renders it with scoped bindings and syncs only non-local assignments back
+to the outer binding set.
+
+Loops over `nil` are planned and render as empty loops. Assignments to the
+current loop iterator variables are also planned and remain scoped to the
+current iteration, so `item = "x"` changes subsequent reads of `item` in that
+iteration without leaking to the next iteration or the outer context.
+
+Script `return` inside a loop writes its return value and ends the current
+iteration, matching the normal renderer. Output produced earlier in the same
+branch is committed when that branch exits through `return`, `break`, or
+`continue`; otherwise script conditional body output remains discarded.
+
+Inside an output loop, script conditionals such as `<% if item.Visible { %>`
+can commit branch body output when the branch exits through `return`, `break`,
+or `continue`. Inside a top-level script loop, the same output is discarded
+because the enclosing loop is silent.
+
+Struct-loop writer plans specialize repeated reflection for loop bodies that
+render fields, access chains, method calls, and helper calls for each item.
+
+## Block Helpers
+
+Block helper calls are planned when the helper callee and arguments are
+representable and the block body can be compiled. The block body is compiled to
+bytecode and may itself use a fast render plan.
+
+The helper block receives a scoped context built from the current fast bindings.
+For block helpers inside loops, the current loop key and value are added to that
+block scope.
+
+Assignments inside a block helper body are allowed when they target names
+declared inside that block body, including indexed writes to local maps or
+hashes. Assignments to outer bindings are also allowed when the block runs
+through the helper block context; the VM syncs the binding changes after the
+helper renders the block.
+
+Output block helpers (`<%= helper(...) { %>`) write the helper return value.
+Silent block helpers (`<% helper(...) { %>`) execute the helper and render the
+block when the helper asks for it, but discard the helper return value. This
+matches helper patterns that capture block output for later use:
+
+```plush
+<% capture("extraStyle") { %>
+  <style>.online { color: green; }</style>
+<% } %>
+<%= readCapture("extraStyle") %>
+```
+
+`form(...) { ... }` is handled through this block-helper path. It is not a
+special VM opcode. The VM calls the `form` helper with its planned arguments and
+a `plush.HelperContext`; when the helper calls `Block()` or `BlockWith(ctx)`,
+the fast block runner renders the compiled block with that helper-provided
+context. Bindings created by the helper for the block, such as `f`, remain
+visible inside the block, so receiver method calls on helper-provided values can
+be planned.
+
+```plush
+<%= form({action: submitPath(), method: "POST"}) { %>
+  <% let options = {} %>
+  <% for (_, option) in availableOptions { %>
+    <% options[option.Label] = option.ID %>
+  <% } %>
+  <%= builder.RenderSelect({name: "Record.OptionID", options: options}) %>
+<% } %>
+```
+
+## Partials
+
+Partial fast paths optimize common partial calls while keeping partial data
+scoped to the partial render.
+
+Supported paths include:
+
+- partials without data
+- partials with static-key data maps
+- data-map values from literals, names, property/access chains, and helper calls
+- linked partial bytecode reuse when the partial body is compatible with inline
+  rendering
+- dynamic partial names and `layout` data values through the regular VM partial
+  helper-call path
+
+Partial data binding plans prepare the keys and value lookup strategy. They read
+fresh values for every render.
+
+## Conditions And Operators
+
+Fast value plans support common truthiness, prefix, infix, and concatenation
+expressions used by output, conditional, and loop plans.
+
+Supported optimized cases include:
+
+- string concatenation
+- unary negation with `-`
+- native slice append through `+` in assignment expressions
+- logical `&&` and `||`
+- numeric equality and ordering across common Go numeric types
+- regex match expressions with cached compiled regex patterns
+- arrays, hashes, non-string literal hash keys, and dynamic index reads when
+  used as supported fast values
+
+When a condition or operand cannot be represented safely, the compiler declines
+the fast plan and normal VM bytecode handles the template.
+
+## Generic VM Segments
+
+When the compiler can produce bytecode but the specialized fast planner does not
+yet model a template shape, VM mode can keep execution inside the VM by creating
+a single generic VM segment. Template-defined functions and function literals
+use this path today. Diagnostics report `FastPath` as `generic`, not
+`interpreter-fallback`, and `FastReject` stays empty because the VM handled the
+template.
+
+Punch holes are intentionally excluded from generic VM segments. They still use
+the punch-hole-specific path so skeleton caching and hole filling keep their
+existing behavior.
+
+## Diagnostics
+
+Fast render diagnostics record why a fast plan was accepted or rejected and
+summarize the shape of accepted plans. Optional hotspot diagnostics can count
+and time VM helper and partial calls.
+
+Diagnostics describe the compiled template shape and runtime helper/partial
+activity. They do not imply that request values or rendered output were cached.

--- a/vm/code/code.go
+++ b/vm/code/code.go
@@ -135,6 +135,7 @@ const (
 	OpWriteNameProperty
 	OpWriteCall
 	OpWriteNameCall
+	OpGetNameOrJumpMissing
 )
 
 type Definition struct {
@@ -191,35 +192,36 @@ var definitions = map[Opcode]*Definition{
 
 	OpCurrentClosure: {"OpCurrentClosure", []int{}},
 
-	OpGreaterEqual:        {"OpGreaterEqual", []int{}},
-	OpMatches:             {"OpMatches", []int{}},
-	OpAnd:                 {"OpAnd", []int{}},
-	OpOr:                  {"OpOr", []int{}},
-	OpGetName:             {"OpGetName", []int{2}},
-	OpSetName:             {"OpSetName", []int{2}},
-	OpAssignName:          {"OpAssignName", []int{2}},
-	OpGetProperty:         {"OpGetProperty", []int{2}},
-	OpSetIndex:            {"OpSetIndex", []int{}},
-	OpWrite:               {"OpWrite", []int{}},
-	OpFor:                 {"OpFor", []int{2, 2, 2, 1}},
-	OpBreak:               {"OpBreak", []int{}},
-	OpContinue:            {"OpContinue", []int{}},
-	OpCallBlock:           {"OpCallBlock", []int{1, 2, 1}},
-	OpRenderTemplate:      {"OpRenderTemplate", []int{}},
-	OpGetNameOrNull:       {"OpGetNameOrNull", []int{2}},
-	OpHole:                {"OpHole", []int{2}},
-	OpWriteConstant:       {"OpWriteConstant", []int{2}},
-	OpWriteName:           {"OpWriteName", []int{2}},
-	OpWriteNameOrNull:     {"OpWriteNameOrNull", []int{2}},
-	OpWriteLocal:          {"OpWriteLocal", []int{1}},
-	OpWriteGlobal:         {"OpWriteGlobal", []int{2}},
-	OpWriteString:         {"OpWriteString", []int{2}},
-	OpWriteHTML:           {"OpWriteHTML", []int{2}},
-	OpWriteLocalProperty:  {"OpWriteLocalProperty", []int{1, 2}},
-	OpWriteGlobalProperty: {"OpWriteGlobalProperty", []int{2, 2}},
-	OpWriteNameProperty:   {"OpWriteNameProperty", []int{2, 2}},
-	OpWriteCall:           {"OpWriteCall", []int{1}},
-	OpWriteNameCall:       {"OpWriteNameCall", []int{2, 1}},
+	OpGreaterEqual:         {"OpGreaterEqual", []int{}},
+	OpMatches:              {"OpMatches", []int{}},
+	OpAnd:                  {"OpAnd", []int{}},
+	OpOr:                   {"OpOr", []int{}},
+	OpGetName:              {"OpGetName", []int{2}},
+	OpSetName:              {"OpSetName", []int{2}},
+	OpAssignName:           {"OpAssignName", []int{2}},
+	OpGetProperty:          {"OpGetProperty", []int{2}},
+	OpSetIndex:             {"OpSetIndex", []int{}},
+	OpWrite:                {"OpWrite", []int{}},
+	OpFor:                  {"OpFor", []int{2, 2, 2, 1}},
+	OpBreak:                {"OpBreak", []int{}},
+	OpContinue:             {"OpContinue", []int{}},
+	OpCallBlock:            {"OpCallBlock", []int{1, 2, 1}},
+	OpRenderTemplate:       {"OpRenderTemplate", []int{}},
+	OpGetNameOrNull:        {"OpGetNameOrNull", []int{2}},
+	OpHole:                 {"OpHole", []int{2}},
+	OpWriteConstant:        {"OpWriteConstant", []int{2}},
+	OpWriteName:            {"OpWriteName", []int{2}},
+	OpWriteNameOrNull:      {"OpWriteNameOrNull", []int{2}},
+	OpWriteLocal:           {"OpWriteLocal", []int{1}},
+	OpWriteGlobal:          {"OpWriteGlobal", []int{2}},
+	OpWriteString:          {"OpWriteString", []int{2}},
+	OpWriteHTML:            {"OpWriteHTML", []int{2}},
+	OpWriteLocalProperty:   {"OpWriteLocalProperty", []int{1, 2}},
+	OpWriteGlobalProperty:  {"OpWriteGlobalProperty", []int{2, 2}},
+	OpWriteNameProperty:    {"OpWriteNameProperty", []int{2, 2}},
+	OpWriteCall:            {"OpWriteCall", []int{1}},
+	OpWriteNameCall:        {"OpWriteNameCall", []int{2, 1}},
+	OpGetNameOrJumpMissing: {"OpGetNameOrJumpMissing", []int{2, 2}},
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/vm/code/code_test.go
+++ b/vm/code/code_test.go
@@ -19,6 +19,7 @@ func Test_Make(t *testing.T) {
 		{OpFor, []int{65534, 65533, 65532, 255}, []byte{byte(OpFor), 255, 254, 255, 253, 255, 252, 255}},
 		{OpCallBlock, []int{7, 65534, 1}, []byte{byte(OpCallBlock), 7, 255, 254, 1}},
 		{OpWriteNameCall, []int{65534, 2}, []byte{byte(OpWriteNameCall), 255, 254, 2}},
+		{OpGetNameOrJumpMissing, []int{65534, 65533}, []byte{byte(OpGetNameOrJumpMissing), 255, 254, 255, 253}},
 	}
 
 	for _, tt := range tests {
@@ -66,6 +67,7 @@ func Test_Read_Operands(t *testing.T) {
 		{OpFor, []int{1, 2, 3, 4}, 7, 7},
 		{OpCallBlock, []int{1, 65535, 2}, 4, 4},
 		{OpWriteNameCall, []int{65535, 3}, 3, 3},
+		{OpGetNameOrJumpMissing, []int{65535, 65534}, 4, 4},
 	}
 
 	for _, tt := range tests {

--- a/vm/compiler/compiler.go
+++ b/vm/compiler/compiler.go
@@ -334,7 +334,7 @@ func (c *Compiler) compileWriteNameCallExpression(node *ast.CallExpression) (boo
 	}
 
 	for _, arg := range node.Arguments {
-		if err := c.compileHard(arg); err != nil {
+		if err := c.compileCallArgument(arg); err != nil {
 			return true, err
 		}
 	}
@@ -745,7 +745,7 @@ func (c *Compiler) compileReceiverCallee(exp ast.Expression, base string) error 
 		}
 
 		for _, a := range exp.Arguments {
-			if err := c.compileHard(a); err != nil {
+			if err := c.compileCallArgument(a); err != nil {
 				return err
 			}
 		}
@@ -953,7 +953,7 @@ func (c *Compiler) compileCallExpression(node *ast.CallExpression) error {
 	c.markLastPropertyAsMethod()
 
 	for _, a := range node.Arguments {
-		if err := c.compileHard(a); err != nil {
+		if err := c.compileCallArgument(a); err != nil {
 			return err
 		}
 	}
@@ -975,13 +975,15 @@ func (c *Compiler) compileCallExpression(node *ast.CallExpression) error {
 	return nil
 }
 
-func (c *Compiler) compileCondition(node ast.Expression) error {
-	switch node.(type) {
-	case *ast.Identifier:
-		return c.compileSoft(node)
-	default:
-		return c.Compile(node)
+func (c *Compiler) compileCallArgument(arg ast.Expression) error {
+	if c.softNames > 0 {
+		return c.compileSoft(arg)
 	}
+	return c.compileHard(arg)
+}
+
+func (c *Compiler) compileCondition(node ast.Expression) error {
+	return c.compileSoft(node)
 }
 
 func (c *Compiler) compileSoft(node interface{}) error {
@@ -1090,7 +1092,7 @@ func (c *Compiler) Bytecode() *Bytecode {
 		}
 	}
 	features := bytecodeFeaturesFromInstructions(instructions, c.constants, callNames)
-	if fastRenderPlan == nil && fastReject.Reason != "" && !features.HasHoles {
+	if fastRenderPlan == nil && fastReject.Reason != "" {
 		fastRenderPlan = genericVMFastRenderPlan(fastReject)
 		fastReject = FastRenderReject{}
 	}

--- a/vm/compiler/compiler.go
+++ b/vm/compiler/compiler.go
@@ -1096,6 +1096,7 @@ func (c *Compiler) Bytecode() *Bytecode {
 		fastRenderPlan = genericVMFastRenderPlan(fastReject)
 		fastReject = FastRenderReject{}
 	}
+	staticSize := bytecodeStaticSize(staticOutput, static, fastRenderPlan, instructions, c.constants)
 
 	return &Bytecode{
 		Instructions:     instructions,
@@ -1111,12 +1112,16 @@ func (c *Compiler) Bytecode() *Bytecode {
 		GlobalNames:      names,
 		Static:           static,
 		StaticOutput:     staticOutput,
+		StaticSize:       staticSize,
 		FastRenderPlan:   fastRenderPlan,
 		FastRejectLine:   fastReject.Line,
 		FastReject:       fastReject.Reason,
 		HasHoles:         features.HasHoles,
 		HasPartials:      features.HasPartials,
 		HasContextWrites: features.HasContextWrites,
+		OutputSizeStats:  &OutputSizeStats{},
+		LayoutSizeStats:  &OutputSizeStats{},
+		PartialSizeStats: &OutputSizeStats{},
 	}
 }
 
@@ -1137,6 +1142,69 @@ func genericVMFastRenderPlan(reject FastRenderReject) *FastRenderPlan {
 		}},
 		NameCount: 1,
 	}
+}
+
+func bytecodeStaticSize(staticOutput string, static bool, plan *FastRenderPlan, instructions code.Instructions, constants []object.Object) int {
+	if static {
+		return len(staticOutput)
+	}
+	if size := topLevelFastRenderStaticSize(plan); size > 0 {
+		return size
+	}
+	return linearInstructionStaticSize(instructions, constants)
+}
+
+func topLevelFastRenderStaticSize(plan *FastRenderPlan) int {
+	if plan == nil {
+		return 0
+	}
+	size := 0
+	for i := range plan.Segments {
+		if plan.Segments[i].Kind == FastRenderSegmentStatic {
+			size += len(plan.Segments[i].Value)
+		}
+	}
+	return size
+}
+
+func linearInstructionStaticSize(instructions code.Instructions, constants []object.Object) int {
+	size := 0
+	for i := 0; i < len(instructions); {
+		op := code.Opcode(instructions[i])
+		def, err := code.Lookup(instructions[i])
+		if err != nil {
+			return 0
+		}
+		operands, read := code.ReadOperands(def, instructions[i+1:])
+		switch op {
+		case code.OpWriteHTML:
+			value, ok := htmlConstantValue(constants, operands[0])
+			if !ok {
+				return 0
+			}
+			size += len(value)
+		case code.OpWriteString:
+			value, ok := stringConstantValue(constants, operands[0])
+			if !ok {
+				return 0
+			}
+			size += len(template.HTMLEscapeString(value))
+		case code.OpWriteConstant:
+			value, ok := staticConstantOutput(constants, operands[0])
+			if !ok {
+				return 0
+			}
+			size += len(value)
+		case code.OpWriteName, code.OpWriteNameOrNull, code.OpWriteLocal, code.OpWriteGlobal,
+			code.OpWriteLocalProperty, code.OpWriteGlobalProperty, code.OpWriteNameProperty,
+			code.OpWriteCall, code.OpWriteNameCall, code.OpWrite, code.OpPop, code.OpSetName,
+			code.OpAssignName, code.OpSetGlobal, code.OpSetLocal, code.OpSetIndex:
+		default:
+			return 0
+		}
+		i += 1 + read
+	}
+	return size
 }
 
 func compileFastRenderPlanBlocks(plan *FastRenderPlan) FastRenderReject {

--- a/vm/compiler/compiler.go
+++ b/vm/compiler/compiler.go
@@ -947,11 +947,49 @@ func (c *Compiler) compileFunctionLiteral(node *ast.FunctionLiteral, name string
 }
 
 func (c *Compiler) compileCallExpression(node *ast.CallExpression) error {
+	if c.shouldGuardMissingCall(node) {
+		return c.compileGuardedCallExpression(node)
+	}
+	return c.compileResolvedCallExpression(node)
+}
+
+func (c *Compiler) shouldGuardMissingCall(node *ast.CallExpression) bool {
+	if c.softNames == 0 || node == nil {
+		return false
+	}
+	ident, ok := node.Function.(*ast.Identifier)
+	if !ok || ident.Callee != nil || ident.Value == "nil" {
+		return false
+	}
+	_, resolved := c.symbolTable.Resolve(ident.Value)
+	return !resolved
+}
+
+func (c *Compiler) compileGuardedCallExpression(node *ast.CallExpression) error {
+	ident := node.Function.(*ast.Identifier)
+	nameIndex := c.addStringConstant(ident.Value)
+	missingPos := c.emit(code.OpGetNameOrJumpMissing, nameIndex, 9999)
+	if err := c.compileCallWithFunction(node); err != nil {
+		return err
+	}
+
+	endPos := c.emit(code.OpJump, 9999)
+	nullPos := len(c.currentInstructions())
+	c.replaceInstruction(missingPos, code.Make(code.OpGetNameOrJumpMissing, nameIndex, nullPos))
+	c.emit(code.OpNull)
+	c.changeOperand(endPos, len(c.currentInstructions()))
+	return nil
+}
+
+func (c *Compiler) compileResolvedCallExpression(node *ast.CallExpression) error {
 	if err := c.compileHard(node.Function); err != nil {
 		return err
 	}
 	c.markLastPropertyAsMethod()
+	return c.compileCallWithFunction(node)
+}
 
+func (c *Compiler) compileCallWithFunction(node *ast.CallExpression) error {
 	for _, a := range node.Arguments {
 		if err := c.compileCallArgument(a); err != nil {
 			return err

--- a/vm/compiler/compiler.go
+++ b/vm/compiler/compiler.go
@@ -1090,6 +1090,10 @@ func (c *Compiler) Bytecode() *Bytecode {
 		}
 	}
 	features := bytecodeFeaturesFromInstructions(instructions, c.constants, callNames)
+	if fastRenderPlan == nil && fastReject.Reason != "" && !features.HasHoles {
+		fastRenderPlan = genericVMFastRenderPlan(fastReject)
+		fastReject = FastRenderReject{}
+	}
 
 	return &Bytecode{
 		Instructions:     instructions,
@@ -1111,6 +1115,25 @@ func (c *Compiler) Bytecode() *Bytecode {
 		HasHoles:         features.HasHoles,
 		HasPartials:      features.HasPartials,
 		HasContextWrites: features.HasContextWrites,
+	}
+}
+
+func genericVMFastRenderPlan(reject FastRenderReject) *FastRenderPlan {
+	line := reject.Line
+	if line <= 0 {
+		line = 1
+	}
+	return &FastRenderPlan{
+		Segments: []FastRenderSegment{{
+			Kind: FastRenderSegmentGeneric,
+			Generic: &FastGenericPlan{
+				WholeTemplate: true,
+				Reason:        reject.Reason,
+				Line:          line,
+			},
+			Line: line,
+		}},
+		NameCount: 1,
 	}
 }
 

--- a/vm/compiler/compiler_test.go
+++ b/vm/compiler/compiler_test.go
@@ -523,7 +523,8 @@ func Test_Compiler_Fast_Loop_Value_Helper_Edges(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, FastValueIndex, value.Kind)
 
-	value, ok = fastValuePlanFromLoopIndex(loop, parseCompilerExpression(t, `product[dynamic]`), 1)
+	itemLoop := &FastLoopPlan{KeyName: "i", ValueName: "item"}
+	value, ok = fastValuePlanFromLoopIndex(itemLoop, parseCompilerExpression(t, `item[dynamic]`), 1)
 	require.True(t, ok)
 	require.Equal(t, FastValueIndex, value.Kind)
 
@@ -555,18 +556,18 @@ func Test_Compiler_Fast_Loop_Value_Helper_Edges(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, FastPathStepCall, value.Path[len(value.Path)-1].Kind)
 
-	_, ok = fastLoopCallPlanFromExpression(plan, loop, nil, 1)
+	_, ok = fastLoopCallPlanFromExpression(plan, loop, nil, 1, false)
 	require.False(t, ok)
 
 	_, ok = fastLoopCallPlanFromExpression(plan, loop, &ast.CallExpression{
 		Function:    &ast.Identifier{Value: "label"},
 		ChainCallee: &ast.Identifier{Value: "Echo"},
-	}, 1)
+	}, 1, false)
 	require.False(t, ok)
 
 	_, ok = fastLoopCallPlanFromExpression(plan, loop, &ast.CallExpression{
 		Function: &ast.Identifier{Callee: &ast.Identifier{Value: "helpers"}, Value: "label"},
-	}, 1)
+	}, 1, false)
 	require.False(t, ok)
 }
 
@@ -610,7 +611,8 @@ func Test_Compiler_Fast_Loop_And_Conditional_Plan_Edges(t *testing.T) {
 
 	parts := []FastLoopPart{}
 	require.False(t, appendFastLoopStatements(plan, loop, &parts, []ast.Statement{&ast.BlockStatement{}}))
-	require.True(t, appendFastLoopStatement(plan, loop, &parts, &ast.ReturnStatement{Type: token.RETURN, ReturnValue: &ast.Identifier{Value: "product"}}))
+	itemLoop := &FastLoopPlan{KeyName: "i", ValueName: "item"}
+	require.True(t, appendFastLoopStatement(plan, itemLoop, &parts, &ast.ReturnStatement{Type: token.RETURN, ReturnValue: &ast.Identifier{Value: "item"}}))
 	require.False(t, appendFastLoopStatement(plan, loop, &parts, &ast.ExpressionStatement{Expression: &ast.Identifier{Value: "notHTML"}}))
 
 	parts = nil
@@ -742,6 +744,28 @@ func Test_Compiler_Fast_Loop_And_Conditional_Plan_Edges(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, loopConditional.Branches, 2)
 	require.Len(t, loopConditional.ElseParts, 1)
+}
+
+func Test_Compiler_Fast_Call_Arguments_Inherit_Nullable_Context(t *testing.T) {
+	condition, ok := fastValuePlanFromExpression(&FastRenderPlan{}, parseCompilerExpression(t, `present(missing) == true`), false, 1)
+	require.True(t, ok)
+	require.Equal(t, FastValueInfix, condition.Kind)
+	require.NotNil(t, condition.Left)
+	require.NotNil(t, condition.Left.Call)
+	require.Len(t, condition.Left.Call.Args, 1)
+	require.True(t, condition.Left.Call.Args[0].NullOnMissing)
+
+	output, ok := fastCallPlanFromExpression(&FastRenderPlan{}, parseCompilerExpression(t, `present(missing)`).(*ast.CallExpression), 1, false)
+	require.True(t, ok)
+	require.Len(t, output.Args, 1)
+	require.False(t, output.Args[0].NullOnMissing)
+
+	loopCondition, ok := fastValuePlanFromLoopCondition(&FastRenderPlan{}, &FastLoopPlan{KeyName: "i", ValueName: "entry"}, parseCompilerExpression(t, `present(missing) == true`), 1)
+	require.True(t, ok)
+	require.NotNil(t, loopCondition.Left)
+	require.NotNil(t, loopCondition.Left.Call)
+	require.Len(t, loopCondition.Left.Call.Args, 1)
+	require.True(t, loopCondition.Left.Call.Args[0].NullOnMissing)
 }
 
 func Test_Compiler_Core_Helper_Branch_Edges(t *testing.T) {
@@ -2420,8 +2444,8 @@ func Test_Fast_Render_Plan_Block_Helper_Source_Preserves_Output_Tags(t *testing.
 func Test_Fast_Render_Plan_Block_Helper_Source_Preserves_Form_Controls(t *testing.T) {
 	input := `<%= form({action: submitPath(), method: "POST", id: "sampleForm"}) { %>
 	<%= builder.RenderControl({name:"Record.ID", value: record.ID}) %>
-	<%= builder.RenderControl({name: "Record.OptionID[]", value: record.Options[0].ID}) %>
-	<%= builder.RenderControl({name:"Record.Quantity", value: "1"}) %>
+	<%= builder.RenderControl({name: "Record.EntryID[]", value: record.Entries[0].ID}) %>
+	<%= builder.RenderControl({name:"Record.Count", value: "1"}) %>
 	<%= builder.RenderControl({type:"text", label:"Display Name", name:"Profile.DisplayName", value:"test"} ) %>
 <button class="btn btn-success" role="submit">Save</button>
 <% } %>`

--- a/vm/compiler/compiler_test.go
+++ b/vm/compiler/compiler_test.go
@@ -1442,6 +1442,18 @@ func Test_Soft_Undefined_Equality_Names(t *testing.T) {
 	runCompilerTests(t, tests)
 }
 
+func Test_Soft_Missing_Call_Guards_The_Callee(t *testing.T) {
+	program, err := ParseScript(`if (missing(1)) { 10 } else { 20 };`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	instructions := compiler.Bytecode().Instructions
+	require.True(t, instructionContainsOpcode(instructions, code.OpGetNameOrJumpMissing))
+	require.True(t, instructionContainsOpcode(instructions, code.OpCall))
+}
+
 func Test_Conditionals(t *testing.T) {
 	tests := []compilerTestCase{
 		{

--- a/vm/compiler/compiler_test.go
+++ b/vm/compiler/compiler_test.go
@@ -433,8 +433,11 @@ func Test_Compiler_Fast_Value_And_Partial_Data_Helper_Edges(t *testing.T) {
 	_, ok = fastValuePlanFromIndexExpression(plan, parseCompilerExpression(t, `1[0]`).(*ast.IndexExpression), false, 1)
 	require.False(t, ok)
 
-	_, ok = fastValuePlanFromIndexExpression(plan, parseCompilerExpression(t, `items[key]`).(*ast.IndexExpression), false, 1)
-	require.False(t, ok)
+	value, ok = fastValuePlanFromIndexExpression(plan, parseCompilerExpression(t, `items[key]`).(*ast.IndexExpression), false, 1)
+	require.True(t, ok)
+	require.Equal(t, FastValueIndex, value.Kind)
+	require.Equal(t, FastValueName, value.Left.Kind)
+	require.Equal(t, FastValueName, value.Right.Kind)
 
 	_, ok = fastPartialDataPlanFromExpression(plan, &ast.Identifier{Value: "name"}, 1)
 	require.False(t, ok)
@@ -516,11 +519,13 @@ func Test_Compiler_Fast_Loop_Value_Helper_Edges(t *testing.T) {
 	_, ok = fastValuePlanFromLoopIndex(loop, &ast.Identifier{Value: "product"}, 1)
 	require.False(t, ok)
 
-	_, ok = fastValuePlanFromLoopIndex(loop, parseCompilerExpression(t, `other[0]`), 1)
-	require.False(t, ok)
+	value, ok = fastValuePlanFromLoopIndex(loop, parseCompilerExpression(t, `other[0]`), 1)
+	require.True(t, ok)
+	require.Equal(t, FastValueIndex, value.Kind)
 
-	_, ok = fastValuePlanFromLoopIndex(loop, parseCompilerExpression(t, `product[dynamic]`), 1)
-	require.False(t, ok)
+	value, ok = fastValuePlanFromLoopIndex(loop, parseCompilerExpression(t, `product[dynamic]`), 1)
+	require.True(t, ok)
+	require.Equal(t, FastValueIndex, value.Kind)
 
 	value, ok = fastValuePlanFromLoopIndex(loop, parseCompilerExpression(t, `product.Tags[0].Name`), 1)
 	require.True(t, ok)
@@ -585,7 +590,7 @@ func Test_Compiler_Fast_Loop_And_Conditional_Plan_Edges(t *testing.T) {
 		Iterable: &ast.Identifier{Value: "nil"},
 		Block:    &ast.BlockStatement{},
 	}, 1)
-	require.False(t, ok)
+	require.True(t, ok)
 
 	fastLoop, ok := fastLoopPlanFromExpression(plan, &ast.ForExpression{
 		KeyName:   "i",
@@ -605,7 +610,7 @@ func Test_Compiler_Fast_Loop_And_Conditional_Plan_Edges(t *testing.T) {
 
 	parts := []FastLoopPart{}
 	require.False(t, appendFastLoopStatements(plan, loop, &parts, []ast.Statement{&ast.BlockStatement{}}))
-	require.False(t, appendFastLoopStatement(plan, loop, &parts, &ast.ReturnStatement{Type: token.RETURN, ReturnValue: &ast.Identifier{Value: "product"}}))
+	require.True(t, appendFastLoopStatement(plan, loop, &parts, &ast.ReturnStatement{Type: token.RETURN, ReturnValue: &ast.Identifier{Value: "product"}}))
 	require.False(t, appendFastLoopStatement(plan, loop, &parts, &ast.ExpressionStatement{Expression: &ast.Identifier{Value: "notHTML"}}))
 
 	parts = nil
@@ -1579,7 +1584,7 @@ func Test_Bytecode_Feature_Flags(t *testing.T) {
 	}
 }
 
-func Test_Fast_Render_Rejects_Block_Helper_Assignment(t *testing.T) {
+func Test_Fast_Render_Plans_Block_Helper_Assignment(t *testing.T) {
 	program, err := parser.Parse(`<% let value = "before" %><%= run() { value = "after" } %><%= value %>`)
 	require.NoError(t, err)
 
@@ -1587,8 +1592,12 @@ func Test_Fast_Render_Rejects_Block_Helper_Assignment(t *testing.T) {
 	require.NoError(t, compiler.Compile(program))
 
 	bytecode := compiler.Bytecode()
-	require.Nil(t, bytecode.FastRenderPlan)
-	require.NotEmpty(t, bytecode.FastReject)
+	require.NotNil(t, bytecode.FastRenderPlan, bytecode.FastReject)
+	require.Empty(t, bytecode.FastReject)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 3)
+	require.Equal(t, FastRenderSegmentBlockCall, bytecode.FastRenderPlan.Segments[1].Kind)
+	require.NotNil(t, bytecode.FastRenderPlan.Segments[1].BlockCall)
+	require.NotNil(t, bytecode.FastRenderPlan.Segments[1].BlockCall.BlockBytecode)
 }
 
 func Test_Mixed_Static_Runs_Are_Coalesced_Without_Marking_Template_Static(t *testing.T) {
@@ -2000,7 +2009,7 @@ func Test_Fast_Render_Plan_Includes_Script_Loop_Control(t *testing.T) {
 }
 
 func Test_Fast_Render_Plan_Includes_Loop_Block_Helper_Calls(t *testing.T) {
-	program, err := parser.Parse(`<%= for (_, product) in products { %><%= form({id: product.ID, path: cartPath()}) { %><span><%= product.Name %></span><% } %><% } %>`)
+	program, err := parser.Parse(`<%= for (_, item) in items { %><%= wrap({id: item.ID, path: itemPath()}) { %><span><%= item.Name %></span><% } %><% } %>`)
 	require.NoError(t, err)
 
 	compiler := New()
@@ -2016,7 +2025,7 @@ func Test_Fast_Render_Plan_Includes_Loop_Block_Helper_Calls(t *testing.T) {
 	require.Len(t, loop.Parts, 1)
 	require.Equal(t, FastLoopPartBlockCall, loop.Parts[0].Kind)
 	require.NotNil(t, loop.Parts[0].BlockCall)
-	require.Equal(t, "form", loop.Parts[0].BlockCall.Name)
+	require.Equal(t, "wrap", loop.Parts[0].BlockCall.Name)
 	require.Len(t, loop.Parts[0].BlockCall.Args, 1)
 	require.NotNil(t, loop.Parts[0].BlockCall.BlockBytecode)
 	require.NotEmpty(t, loop.Parts[0].BlockCall.BlockSource)
@@ -2392,7 +2401,7 @@ func Test_Fast_Render_Plan_Includes_Block_Helper_Call_With_Hash_Arguments(t *tes
 }
 
 func Test_Fast_Render_Plan_Block_Helper_Source_Preserves_Output_Tags(t *testing.T) {
-	program, err := parser.Parse(`<%= form({action: path}) { %><%= f.InputTag({name: "A"}) %><%= f.InputTag({name: "B"}) %><button>Go</button><% } %>`)
+	program, err := parser.Parse(`<%= wrap({action: path}) { %><%= builder.RenderControl({name: "A"}) %><%= builder.RenderControl({name: "B"}) %><button>Go</button><% } %>`)
 	require.NoError(t, err)
 
 	compiler := New()
@@ -2403,18 +2412,18 @@ func Test_Fast_Render_Plan_Block_Helper_Source_Preserves_Output_Tags(t *testing.
 	require.Empty(t, bytecode.FastReject)
 	block := bytecode.FastRenderPlan.Segments[0].BlockCall
 	require.NotNil(t, block)
-	require.Contains(t, block.BlockSource, `<%= f.InputTag`)
+	require.Contains(t, block.BlockSource, `<%= builder.RenderControl`)
 	require.Contains(t, block.BlockSource, `<button>Go</button>`)
 	require.NotNil(t, block.BlockBytecode)
 }
 
-func Test_Fast_Render_Plan_Block_Helper_Source_Preserves_Shipping_Form(t *testing.T) {
-	input := `<%= form({action: shippingEstimatorPath(), method: "POST", id: "shippingEstimate"}) { %>
-	<%= f.InputTag({name:"CartAdd[0].CartAddProductID", value: product.ProductId}) %>
-	<%= f.InputTag({name: "CartAdd[0].CartAddVariantID[]", value: product.ProductVariants[0].VariantId}) %>
-	<%= f.InputTag({name:"CartAdd[0].CartAddVariantAddQty", value: "1"}) %>
-	<%= f.InputTag({type:"text",label:"Shipping First Name", name:"Shipping.FirstName", value:"test"} ) %>
-<button class="btn btn-success" role="submit">Get ESTIMATED Rates</button>
+func Test_Fast_Render_Plan_Block_Helper_Source_Preserves_Form_Controls(t *testing.T) {
+	input := `<%= form({action: submitPath(), method: "POST", id: "sampleForm"}) { %>
+	<%= builder.RenderControl({name:"Record.ID", value: record.ID}) %>
+	<%= builder.RenderControl({name: "Record.OptionID[]", value: record.Options[0].ID}) %>
+	<%= builder.RenderControl({name:"Record.Quantity", value: "1"}) %>
+	<%= builder.RenderControl({type:"text", label:"Display Name", name:"Profile.DisplayName", value:"test"} ) %>
+<button class="btn btn-success" role="submit">Save</button>
 <% } %>`
 	program, err := parser.Parse(input)
 	require.NoError(t, err)
@@ -2426,6 +2435,24 @@ func Test_Fast_Render_Plan_Block_Helper_Source_Preserves_Shipping_Form(t *testin
 	require.NotNil(t, bytecode.FastRenderPlan, bytecode.FastReject)
 	require.Empty(t, bytecode.FastReject)
 	require.NotNil(t, bytecode.FastRenderPlan.Segments[0].BlockCall.BlockBytecode)
+}
+
+func Test_Fast_Render_Plan_Block_Helper_Allows_Local_Assignment_Setup(t *testing.T) {
+	input := `<%= wrap({}) { %><% let options = {} %><% for (_, item) in items { %><% options[item.Key] = item.Value %><% } %><%= builder.RenderControl({name: options[active], type: "hidden"}) %><% } %>`
+	program, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan, bytecode.FastReject)
+	require.Empty(t, bytecode.FastReject)
+
+	block := bytecode.FastRenderPlan.Segments[0].BlockCall
+	require.NotNil(t, block)
+	require.NotNil(t, block.BlockBytecode)
+	require.NotNil(t, block.BlockBytecode.FastRenderPlan)
 }
 
 func Test_Fast_Render_Plan_Includes_Top_Level_Let(t *testing.T) {
@@ -2648,14 +2675,19 @@ func Test_Fast_Render_Plan_Includes_Partial_Data_Helper_Call(t *testing.T) {
 	require.Equal(t, "prefix", value.Call.Args[1].Value)
 }
 
-func Test_Fast_Render_Plan_Skips_Partial_Data_Map_Layout(t *testing.T) {
+func Test_Fast_Render_Plan_Uses_Helper_Call_For_Partial_Data_Map_Layout(t *testing.T) {
 	program, err := parser.Parse(`<%= partial("row.plush", {name: name, layout: "shell"}) %>`)
 	require.NoError(t, err)
 
 	compiler := New()
 	require.NoError(t, compiler.Compile(program))
 
-	require.Nil(t, compiler.Bytecode().FastRenderPlan)
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan, bytecode.FastReject)
+	require.Empty(t, bytecode.FastReject)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+	require.Equal(t, FastRenderSegmentCall, bytecode.FastRenderPlan.Segments[0].Kind)
+	require.Equal(t, "partial", bytecode.FastRenderPlan.Segments[0].Call.Name)
 }
 
 func Test_Direct_Write_Call_Fusion_Chains(t *testing.T) {

--- a/vm/compiler/compiler_test.go
+++ b/vm/compiler/compiler_test.go
@@ -1522,6 +1522,10 @@ func Test_Static_Only_Bytecode_Fast_Path(t *testing.T) {
 	bytecode := compiler.Bytecode()
 	require.True(t, bytecode.Static)
 	require.Equal(t, `<section><p>Hello</p></section>`, bytecode.StaticOutput)
+	require.Equal(t, len(`<section><p>Hello</p></section>`), bytecode.StaticSize)
+	require.NotNil(t, bytecode.OutputSizeStats)
+	require.NotNil(t, bytecode.LayoutSizeStats)
+	require.NotNil(t, bytecode.PartialSizeStats)
 	require.Equal(t, 1, instructionOpcodeCount(bytecode.Instructions, code.OpWriteHTML))
 }
 
@@ -1535,6 +1539,7 @@ func Test_Static_Only_Bytecode_Escapes_String_Literal(t *testing.T) {
 	bytecode := compiler.Bytecode()
 	require.True(t, bytecode.Static)
 	require.Equal(t, `<strong>&lt;x&gt;</strong>`, bytecode.StaticOutput)
+	require.Equal(t, len(`<strong>&lt;x&gt;</strong>`), bytecode.StaticSize)
 	require.Equal(t, 1, instructionOpcodeCount(bytecode.Instructions, code.OpWriteHTML))
 }
 
@@ -1548,7 +1553,43 @@ func Test_Static_Only_Bytecode_Includes_Scalar_Constants(t *testing.T) {
 	bytecode := compiler.Bytecode()
 	require.True(t, bytecode.Static)
 	require.Equal(t, `10<span>items</span>`, bytecode.StaticOutput)
+	require.Equal(t, len(`10<span>items</span>`), bytecode.StaticSize)
 	require.Truef(t, instructionContainsOpcode(bytecode.Instructions, code.OpWriteConstant), "expected OpWriteConstant:\n%s", bytecode.Instructions.String())
+}
+
+func Test_Output_Size_StaticSize_Excludes_NonGuaranteed_Branch_And_Loop_Static(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		size  int
+	}{
+		{
+			name:  "conditional",
+			input: `A<%= if (show) { %>B<% } %>C`,
+			size:  len("AC"),
+		},
+		{
+			name:  "loop",
+			input: `<ul><%= for (i, item) in items { %><li><%= item %></li><% } %></ul>`,
+			size:  len("<ul></ul>"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			program, err := parser.Parse(tt.input)
+			require.NoError(t, err)
+
+			compiler := New()
+			require.NoError(t, compiler.Compile(program))
+
+			bytecode := compiler.Bytecode()
+			require.NotNil(t, bytecode.OutputSizeStats)
+			require.NotNil(t, bytecode.FastRenderPlan)
+			require.Equal(t, tt.size, bytecode.StaticSize)
+			require.Greater(t, bytecode.FastRenderPlan.StaticSize, bytecode.StaticSize)
+		})
+	}
 }
 
 func Test_Bytecode_Feature_Flags(t *testing.T) {

--- a/vm/compiler/fast_plan_ast.go
+++ b/vm/compiler/fast_plan_ast.go
@@ -174,9 +174,6 @@ func fastRenderBuildLoopStatementReject(plan *FastRenderPlan, loop *FastLoopPlan
 		}
 		return rejectFastRender(stmt, "fast render builder declined loop expression statement: "+fastExpressionSummary(stmt.Expression))
 	case *ast.ReturnStatement:
-		if stmt.Type != token.E_START {
-			return rejectFastRender(stmt, "fast render builder declined loop non-output return")
-		}
 		return fastRenderBuildLoopOutputReject(plan, loop, stmt.ReturnValue, lineForNode(stmt))
 	default:
 		return rejectFastRender(stmt, "fast render builder declined loop statement")
@@ -240,13 +237,46 @@ func firstFastRenderStatementReject(plan *FastRenderPlan, loop *FastLoopPlan, st
 func fastRenderStatementReject(plan *FastRenderPlan, loop *FastLoopPlan, stmt ast.Statement, inLoop bool) FastRenderReject {
 	switch stmt := stmt.(type) {
 	case *ast.ExpressionStatement:
+		if isFastCommentStatement(stmt) {
+			return FastRenderReject{}
+		}
 		if _, ok := stmt.Expression.(*ast.HTMLLiteral); ok {
 			return FastRenderReject{}
 		}
 		if inLoop {
-			switch stmt.Expression.(type) {
+			switch expr := stmt.Expression.(type) {
 			case *ast.BreakExpression, *ast.ContinueExpression:
 				return FastRenderReject{}
+			case *ast.CallExpression:
+				if expr.Block != nil {
+					if _, ok := fastSilentLoopBlockCallPlanFromExpression(plan, loop, expr, lineForNode(stmt)); ok {
+						return FastRenderReject{}
+					}
+					return fastRenderLoopBlockCallReject(plan, loop, expr, lineForNode(stmt))
+				}
+				if _, ok := fastSilentLoopCallPlanFromExpression(plan, loop, expr, lineForNode(stmt)); ok {
+					return FastRenderReject{}
+				}
+				return fastRenderCallReject(plan, expr, lineForNode(stmt))
+			case *ast.ForExpression:
+				if _, ok := fastSilentNestedLoopPlanFromExpression(plan, loop, expr, lineForNode(stmt)); ok {
+					return FastRenderReject{}
+				}
+				return fastRenderLoopReject(plan, loop, expr, lineForNode(stmt))
+			case *ast.AssignExpression:
+				parts := []FastLoopPart{}
+				if appendFastLoopAssignExpression(plan, loop, &parts, expr, lineForNode(stmt)) {
+					return FastRenderReject{}
+				}
+				return fastRenderValueReject(plan, expr.Value, "loop assignment value")
+			case *ast.IndexExpression:
+				if expr.Value != nil {
+					parts := []FastLoopPart{}
+					if appendFastLoopIndexAssignExpression(plan, loop, &parts, expr, lineForNode(stmt)) {
+						return FastRenderReject{}
+					}
+					return fastRenderIndexAssignReject(plan, loop, expr, lineForNode(stmt), true)
+				}
 			}
 		}
 		if ifExpression, ok := stmt.Expression.(*ast.IfExpression); ok {
@@ -271,14 +301,42 @@ func fastRenderStatementReject(plan *FastRenderPlan, loop *FastLoopPlan, stmt as
 				}
 				return fastRenderValueReject(plan, assign.Value, "assignment value")
 			}
+			if index, ok := stmt.Expression.(*ast.IndexExpression); ok && index.Value != nil {
+				segments := []FastRenderSegment{}
+				if appendFastIndexAssignExpression(plan, &segments, index, lineForNode(stmt)) {
+					return FastRenderReject{}
+				}
+				return fastRenderIndexAssignReject(plan, nil, index, lineForNode(stmt), false)
+			}
+			if forExpression, ok := stmt.Expression.(*ast.ForExpression); ok {
+				if _, ok := fastSilentLoopPlanFromExpression(plan, forExpression, lineForNode(stmt)); ok {
+					return FastRenderReject{}
+				}
+				return fastRenderLoopReject(plan, nil, forExpression, lineForNode(stmt))
+			}
+			if callExpression, ok := stmt.Expression.(*ast.CallExpression); ok && callExpression.Block != nil {
+				if _, ok := fastSilentBlockCallPlanFromExpression(plan, callExpression, lineForNode(stmt)); ok {
+					return FastRenderReject{}
+				}
+				return fastRenderBlockCallReject(plan, callExpression, lineForNode(stmt))
+			}
+			if callExpression, ok := stmt.Expression.(*ast.CallExpression); ok {
+				if _, ok := fastSilentCallPlanFromExpression(plan, callExpression, lineForNode(stmt)); ok {
+					return FastRenderReject{}
+				}
+				return fastRenderCallReject(plan, callExpression, lineForNode(stmt))
+			}
 		}
 		return rejectFastRender(stmt, "script expression statements are not fast-planned: "+fastExpressionSummary(stmt.Expression))
 	case *ast.ReturnStatement:
-		if stmt.Type != token.E_START {
-			return rejectFastRender(stmt, "non-output return statements are not fast-planned")
-		}
 		if inLoop {
 			return fastRenderLoopOutputReject(plan, loop, stmt.ReturnValue, lineForNode(stmt))
+		}
+		if stmt.Type != token.E_START {
+			if _, ok := fastValuePlanFromExpression(plan, stmt.ReturnValue, false, lineForNode(stmt.ReturnValue)); ok {
+				return FastRenderReject{}
+			}
+			return fastRenderValueReject(plan, stmt.ReturnValue, "return value")
 		}
 		return fastRenderOutputReject(plan, stmt.ReturnValue, lineForNode(stmt))
 	case *ast.LetStatement:
@@ -298,6 +356,17 @@ func fastRenderStatementReject(plan *FastRenderPlan, loop *FastLoopPlan, stmt as
 	default:
 		return rejectFastRender(stmt, "unsupported statement type for fast render")
 	}
+}
+
+func isFastCommentStatement(stmt *ast.ExpressionStatement) bool {
+	if stmt == nil {
+		return false
+	}
+	literal, ok := stmt.Expression.(*ast.StringLiteral)
+	if !ok || literal.Value != "" {
+		return false
+	}
+	return stmt.Token.Type == token.C_START || literal.Token.Type == token.E_END
 }
 
 func fastRenderOutputReject(plan *FastRenderPlan, expr ast.Expression, line int) FastRenderReject {
@@ -365,7 +434,7 @@ func fastRenderLoopReject(plan *FastRenderPlan, parent *FastLoopPlan, expr *ast.
 	if !ok {
 		return fastRenderValueReject(plan, expr.Iterable, "for iterable")
 	}
-	if iterable.Value == "nil" || !fastLoopIterableValueSupported(iterable) {
+	if !fastLoopIterableValueSupported(iterable) {
 		return FastRenderReject{Line: lineForNode(expr.Iterable), Reason: "unsupported for iterable for fast render: " + fastValuePlanSummary(iterable)}
 	}
 	loop := &FastLoopPlan{
@@ -403,7 +472,7 @@ func fastRenderLoopOutputReject(plan *FastRenderPlan, loop *FastLoopPlan, expr a
 		if _, ok := fastPartialPlanFromCall(plan, expr, line); ok {
 			return FastRenderReject{}
 		}
-		if _, ok := fastValuePlanFromLoopCall(loop, expr, line); ok {
+		if _, ok := fastValuePlanFromLoopCallWithPlan(plan, loop, expr, line); ok {
 			return FastRenderReject{}
 		}
 		if root, ok := fastLoopExpressionRootName(expr); ok && fastLoopHasOuterName(loop, root) {
@@ -419,7 +488,7 @@ func fastRenderLoopOutputReject(plan *FastRenderPlan, loop *FastLoopPlan, expr a
 		if _, ok := fastValuePlanFromLoopOperand(plan, loop, expr, false, line); ok {
 			return FastRenderReject{}
 		}
-		if _, ok := fastValuePlanFromLoopIndex(loop, expr, line); ok {
+		if _, ok := fastValuePlanFromLoopIndexWithPlan(plan, loop, expr, line); ok {
 			return FastRenderReject{}
 		}
 		return fastRenderValueReject(plan, expr, "loop output expression")
@@ -539,8 +608,8 @@ func fastRenderValueReject(plan *FastRenderPlan, expr ast.Expression, role strin
 			})
 		}
 		for _, key := range keys {
-			if _, ok := fastPartialDataKey(key); !ok {
-				return FastRenderReject{Line: lineForNode(key), Reason: role + ": hash literal keys must be identifiers or strings"}
+			if _, _, ok := fastHashLiteralKeyPlan(plan, key, lineForNode(key)); !ok {
+				return FastRenderReject{Line: lineForNode(key), Reason: role + ": unsupported hash literal key for fast render"}
 			}
 			value := expr.Pairs[key]
 			if _, ok := fastValuePlanFromExpression(plan, value, false, lineForNode(value)); !ok {
@@ -713,6 +782,22 @@ func appendFastStatements(plan *FastRenderPlan, segments *[]FastRenderSegment, s
 	return true
 }
 
+func appendFastOutputBlockStatements(plan *FastRenderPlan, segments *[]FastRenderSegment, statements []ast.Statement) bool {
+	for _, stmt := range statements {
+		if !appendFastOutputBlockStatement(plan, segments, stmt) {
+			return false
+		}
+	}
+	return true
+}
+
+func appendFastOutputBlockStatement(plan *FastRenderPlan, segments *[]FastRenderSegment, stmt ast.Statement) bool {
+	if ret, ok := stmt.(*ast.ReturnStatement); ok {
+		return appendFastOutputExpression(plan, segments, ret.ReturnValue, lineForNode(ret))
+	}
+	return appendFastStatement(plan, segments, stmt)
+}
+
 func appendFastSilentStatements(plan *FastRenderPlan, segments *[]FastRenderSegment, statements []ast.Statement) bool {
 	for _, stmt := range statements {
 		if !appendFastSilentStatement(plan, segments, stmt) {
@@ -725,12 +810,59 @@ func appendFastSilentStatements(plan *FastRenderPlan, segments *[]FastRenderSegm
 func appendFastSilentStatement(plan *FastRenderPlan, segments *[]FastRenderSegment, stmt ast.Statement) bool {
 	switch stmt := stmt.(type) {
 	case *ast.ExpressionStatement:
+		if isFastCommentStatement(stmt) {
+			return true
+		}
 		if html, ok := stmt.Expression.(*ast.HTMLLiteral); ok {
 			appendFastStatic(plan, segments, html.Value)
 			return true
 		}
 		if assign, ok := stmt.Expression.(*ast.AssignExpression); ok {
 			return appendFastAssignExpression(plan, segments, assign, lineForNode(stmt))
+		}
+		if index, ok := stmt.Expression.(*ast.IndexExpression); ok && index.Value != nil {
+			return appendFastIndexAssignExpression(plan, segments, index, lineForNode(stmt))
+		}
+		if forExpression, ok := stmt.Expression.(*ast.ForExpression); ok {
+			loop, ok := fastSilentLoopPlanFromExpression(plan, forExpression, lineForNode(stmt))
+			if !ok {
+				return false
+			}
+			*segments = append(*segments, FastRenderSegment{
+				Kind: FastRenderSegmentLoop,
+				Loop: loop,
+				Line: lineForNode(stmt),
+			})
+			plan.NameCount++
+			return true
+		}
+		if callExpression, ok := stmt.Expression.(*ast.CallExpression); ok {
+			if callExpression.Block != nil {
+				call, ok := fastSilentBlockCallPlanFromExpression(plan, callExpression, lineForNode(stmt))
+				if !ok {
+					return false
+				}
+				*segments = append(*segments, FastRenderSegment{
+					Kind:      FastRenderSegmentBlockCall,
+					Value:     call.Name,
+					BlockCall: call,
+					Line:      lineForNode(stmt),
+				})
+				plan.NameCount++
+				return true
+			}
+			call, ok := fastSilentCallPlanFromExpression(plan, callExpression, lineForNode(stmt))
+			if !ok {
+				return false
+			}
+			*segments = append(*segments, FastRenderSegment{
+				Kind:  FastRenderSegmentCall,
+				Value: call.Name,
+				Call:  call,
+				Line:  lineForNode(stmt),
+			})
+			plan.NameCount++
+			return true
 		}
 		if ifExpression, ok := stmt.Expression.(*ast.IfExpression); ok {
 			conditional, ok := fastSilentConditionalPlanFromExpression(plan, ifExpression, lineForNode(stmt))
@@ -748,6 +880,8 @@ func appendFastSilentStatement(plan *FastRenderPlan, segments *[]FastRenderSegme
 		return false
 	case *ast.ReturnStatement:
 		return appendFastOutputExpression(plan, segments, stmt.ReturnValue, lineForNode(stmt))
+	case *ast.LetStatement:
+		return appendFastLetStatement(plan, segments, stmt)
 	default:
 		return false
 	}
@@ -756,12 +890,59 @@ func appendFastSilentStatement(plan *FastRenderPlan, segments *[]FastRenderSegme
 func appendFastStatement(plan *FastRenderPlan, segments *[]FastRenderSegment, stmt ast.Statement) bool {
 	switch stmt := stmt.(type) {
 	case *ast.ExpressionStatement:
+		if isFastCommentStatement(stmt) {
+			return true
+		}
 		if html, ok := stmt.Expression.(*ast.HTMLLiteral); ok {
 			appendFastStatic(plan, segments, html.Value)
 			return true
 		}
 		if assign, ok := stmt.Expression.(*ast.AssignExpression); ok {
 			return appendFastAssignExpression(plan, segments, assign, lineForNode(stmt))
+		}
+		if index, ok := stmt.Expression.(*ast.IndexExpression); ok && index.Value != nil {
+			return appendFastIndexAssignExpression(plan, segments, index, lineForNode(stmt))
+		}
+		if forExpression, ok := stmt.Expression.(*ast.ForExpression); ok {
+			loop, ok := fastSilentLoopPlanFromExpression(plan, forExpression, lineForNode(stmt))
+			if !ok {
+				return false
+			}
+			*segments = append(*segments, FastRenderSegment{
+				Kind: FastRenderSegmentLoop,
+				Loop: loop,
+				Line: lineForNode(stmt),
+			})
+			plan.NameCount++
+			return true
+		}
+		if callExpression, ok := stmt.Expression.(*ast.CallExpression); ok {
+			if callExpression.Block != nil {
+				call, ok := fastSilentBlockCallPlanFromExpression(plan, callExpression, lineForNode(stmt))
+				if !ok {
+					return false
+				}
+				*segments = append(*segments, FastRenderSegment{
+					Kind:      FastRenderSegmentBlockCall,
+					Value:     call.Name,
+					BlockCall: call,
+					Line:      lineForNode(stmt),
+				})
+				plan.NameCount++
+				return true
+			}
+			call, ok := fastSilentCallPlanFromExpression(plan, callExpression, lineForNode(stmt))
+			if !ok {
+				return false
+			}
+			*segments = append(*segments, FastRenderSegment{
+				Kind:  FastRenderSegmentCall,
+				Value: call.Name,
+				Call:  call,
+				Line:  lineForNode(stmt),
+			})
+			plan.NameCount++
+			return true
 		}
 		if ifExpression, ok := stmt.Expression.(*ast.IfExpression); ok {
 			conditional, ok := fastSilentConditionalPlanFromExpression(plan, ifExpression, lineForNode(stmt))
@@ -778,15 +959,32 @@ func appendFastStatement(plan *FastRenderPlan, segments *[]FastRenderSegment, st
 		}
 		return false
 	case *ast.ReturnStatement:
-		if stmt.Type != token.E_START {
-			return false
+		if stmt.Type == token.E_START {
+			return appendFastOutputExpression(plan, segments, stmt.ReturnValue, lineForNode(stmt))
 		}
-		return appendFastOutputExpression(plan, segments, stmt.ReturnValue, lineForNode(stmt))
+		return appendFastReturnStatement(plan, segments, stmt)
 	case *ast.LetStatement:
 		return appendFastLetStatement(plan, segments, stmt)
 	default:
 		return false
 	}
+}
+
+func appendFastReturnStatement(plan *FastRenderPlan, segments *[]FastRenderSegment, stmt *ast.ReturnStatement) bool {
+	if stmt == nil {
+		return false
+	}
+	value, ok := fastValuePlanFromExpression(plan, stmt.ReturnValue, false, lineForNode(stmt.ReturnValue))
+	if !ok {
+		return false
+	}
+	*segments = append(*segments, FastRenderSegment{
+		Kind:      FastRenderSegmentReturn,
+		ValuePlan: value,
+		Line:      lineForNode(stmt),
+	})
+	plan.NameCount++
+	return true
 }
 
 func appendFastLetStatement(plan *FastRenderPlan, segments *[]FastRenderSegment, stmt *ast.LetStatement) bool {
@@ -821,7 +1019,32 @@ func appendFastAssignExpression(plan *FastRenderPlan, segments *[]FastRenderSegm
 		Value:     expr.Name.Value,
 		NameIndex: plan.bindName(expr.Name.Value),
 		ValuePlan: value,
-		Line:      line,
+		AssignTarget: &FastAssignTarget{
+			Kind:      FastAssignTargetName,
+			Name:      expr.Name.Value,
+			NameIndex: plan.bindName(expr.Name.Value),
+			Line:      line,
+		},
+		Line: line,
+	})
+	plan.NameCount++
+	return true
+}
+
+func appendFastIndexAssignExpression(plan *FastRenderPlan, segments *[]FastRenderSegment, expr *ast.IndexExpression, line int) bool {
+	target, ok := fastAssignIndexTargetFromExpression(plan, nil, expr, line, false)
+	if !ok {
+		return false
+	}
+	value, ok := fastValuePlanFromExpression(plan, expr.Value, false, lineForNode(expr.Value))
+	if !ok || !fastAssignValueSupported(value) {
+		return false
+	}
+	*segments = append(*segments, FastRenderSegment{
+		Kind:         FastRenderSegmentAssign,
+		ValuePlan:    value,
+		AssignTarget: &target,
+		Line:         line,
 	})
 	plan.NameCount++
 	return true
@@ -829,11 +1052,77 @@ func appendFastAssignExpression(plan *FastRenderPlan, segments *[]FastRenderSegm
 
 func fastAssignValueSupported(value FastValuePlan) bool {
 	switch value.Kind {
-	case FastValueName, FastValueString, FastValueInteger, FastValueFloat, FastValueBool, FastValuePath, FastValueCall, FastValuePrefix:
+	case FastValueName, FastValueString, FastValueInteger, FastValueFloat, FastValueBool, FastValuePath, FastValueCall, FastValuePrefix, FastValueInfix, FastValueConcat, FastValueArray, FastValueHash, FastValueIndex:
 		return true
 	default:
 		return false
 	}
+}
+
+func fastAssignIndexTargetFromExpression(plan *FastRenderPlan, loop *FastLoopPlan, expr *ast.IndexExpression, line int, inLoop bool) (FastAssignTarget, bool) {
+	if expr == nil || expr.Left == nil || expr.Index == nil || expr.Value == nil || expr.Callee != nil {
+		return FastAssignTarget{}, false
+	}
+	container, ok := fastValuePlanForAssignOperand(plan, loop, expr.Left, false, lineForNode(expr.Left), inLoop)
+	if !ok {
+		return FastAssignTarget{}, false
+	}
+	index, ok := fastValuePlanForAssignOperand(plan, loop, expr.Index, false, lineForNode(expr.Index), inLoop)
+	if !ok || !fastIndexOperandSupported(index) {
+		return FastAssignTarget{}, false
+	}
+	return FastAssignTarget{
+		Kind:      FastAssignTargetIndex,
+		Container: container,
+		Index:     index,
+		Line:      line,
+	}, true
+}
+
+func fastValuePlanForAssignOperand(plan *FastRenderPlan, loop *FastLoopPlan, expr ast.Expression, nullOnMissing bool, line int, inLoop bool) (FastValuePlan, bool) {
+	if inLoop {
+		return fastValuePlanFromLoopOperand(plan, loop, expr, nullOnMissing, line)
+	}
+	return fastValuePlanFromExpression(plan, expr, nullOnMissing, line)
+}
+
+func fastIndexOperandSupported(value FastValuePlan) bool {
+	switch value.Kind {
+	case FastValueName, FastValueString, FastValueInteger, FastValueFloat, FastValueBool, FastValuePath, FastValueCall, FastValuePrefix, FastValueInfix, FastValueConcat, FastValueIndex, FastValueLoopKey:
+		return true
+	default:
+		return false
+	}
+}
+
+func fastIndexContainerSupported(value FastValuePlan) bool {
+	switch value.Kind {
+	case FastValueName, FastValuePath, FastValueCall, FastValueArray, FastValueHash, FastValueIndex:
+		return true
+	default:
+		return false
+	}
+}
+
+func fastRenderIndexAssignReject(plan *FastRenderPlan, loop *FastLoopPlan, expr *ast.IndexExpression, line int, inLoop bool) FastRenderReject {
+	if expr == nil {
+		return FastRenderReject{Line: line, Reason: "nil index assignment is not fast-planned"}
+	}
+	if expr.Callee != nil {
+		return rejectFastRender(expr, "assignment target: chained index assignments are not fast-planned")
+	}
+	if _, ok := fastValuePlanForAssignOperand(plan, loop, expr.Left, false, lineForNode(expr.Left), inLoop); !ok {
+		return fastRenderValueReject(plan, expr.Left, "assignment target")
+	}
+	index, ok := fastValuePlanForAssignOperand(plan, loop, expr.Index, false, lineForNode(expr.Index), inLoop)
+	if !ok || !fastIndexOperandSupported(index) {
+		return fastRenderValueReject(plan, expr.Index, "assignment index")
+	}
+	value, ok := fastValuePlanForAssignOperand(plan, loop, expr.Value, false, lineForNode(expr.Value), inLoop)
+	if !ok || !fastAssignValueSupported(value) {
+		return fastRenderValueReject(plan, expr.Value, "assignment value")
+	}
+	return rejectFastRender(expr, "unsupported index assignment target for fast render")
 }
 
 func appendFastOutputExpression(plan *FastRenderPlan, segments *[]FastRenderSegment, expr ast.Expression, line int) bool {
@@ -1036,7 +1325,7 @@ func fastValuePlanFromHashLiteral(plan *FastRenderPlan, expr *ast.HashLiteral, l
 	}
 	pairs := make([]FastValuePair, 0, len(keys))
 	for _, keyExpr := range keys {
-		key, ok := fastPartialDataKey(keyExpr)
+		key, keyPlan, ok := fastHashLiteralKeyPlan(plan, keyExpr, lineForNode(keyExpr))
 		if !ok {
 			return FastValuePlan{}, false
 		}
@@ -1046,9 +1335,10 @@ func fastValuePlanFromHashLiteral(plan *FastRenderPlan, expr *ast.HashLiteral, l
 			return FastValuePlan{}, false
 		}
 		pairs = append(pairs, FastValuePair{
-			Key:   key,
-			Value: value,
-			Line:  lineForNode(valueExpr),
+			Key:     key,
+			KeyPlan: keyPlan,
+			Value:   value,
+			Line:    lineForNode(valueExpr),
 		})
 	}
 	return FastValuePlan{
@@ -1056,6 +1346,26 @@ func fastValuePlanFromHashLiteral(plan *FastRenderPlan, expr *ast.HashLiteral, l
 		Pairs: pairs,
 		Line:  line,
 	}, true
+}
+
+func fastHashLiteralKeyPlan(plan *FastRenderPlan, expr ast.Expression, line int) (string, *FastValuePlan, bool) {
+	if key, ok := fastPartialDataKey(expr); ok {
+		return key, nil, true
+	}
+	value, ok := fastValuePlanFromExpression(plan, expr, false, line)
+	if !ok || !fastHashLiteralKeySupported(value) {
+		return "", nil, false
+	}
+	return "", &value, true
+}
+
+func fastHashLiteralKeySupported(value FastValuePlan) bool {
+	switch value.Kind {
+	case FastValueString, FastValueInteger, FastValueBool:
+		return true
+	default:
+		return false
+	}
 }
 
 func fastValuePlanFromInfixExpression(plan *FastRenderPlan, expr *ast.InfixExpression, line int) (FastValuePlan, bool) {
@@ -1086,7 +1396,12 @@ func fastValuePlanFromInfixExpression(plan *FastRenderPlan, expr *ast.InfixExpre
 }
 
 func fastValuePlanFromPrefixExpression(plan *FastRenderPlan, expr *ast.PrefixExpression, line int) (FastValuePlan, bool) {
-	if expr == nil || expr.Operator != "!" || expr.Right == nil {
+	if expr == nil || expr.Right == nil {
+		return FastValuePlan{}, false
+	}
+	switch expr.Operator {
+	case "!", "-":
+	default:
 		return FastValuePlan{}, false
 	}
 	right, ok := fastValuePlanFromExpression(plan, expr.Right, true, lineForNode(expr.Right))
@@ -1156,16 +1471,46 @@ func fastValuePlanFromIdentifier(plan *FastRenderPlan, ident *ast.Identifier, nu
 func fastValuePlanFromIndexExpression(plan *FastRenderPlan, exp *ast.IndexExpression, nullOnMissing bool, line int) (FastValuePlan, bool) {
 	value, ok := fastValuePlanFromExpression(plan, exp.Left, nullOnMissing, line)
 	if !ok || !value.canUsePath() {
-		return FastValuePlan{}, false
+		return fastValuePlanFromDynamicIndexExpression(plan, exp, nullOnMissing, line)
 	}
 	indexStep, ok := fastIndexStepFromExpression(exp.Index, line)
 	if !ok {
+		return fastValuePlanFromDynamicIndexExpression(plan, exp, nullOnMissing, line)
+	}
+	appendFastValuePathStep(&value, indexStep)
+	if exp.Callee != nil {
+		if !appendFastReceiverCalleeWithArgumentPlanner(&value, exp.Callee, lastChainPart(exp.Left), line, func(arg ast.Expression, argLine int) (FastValuePlan, bool) {
+			return fastValuePlanFromExpression(plan, arg, false, argLine)
+		}) {
+			return FastValuePlan{}, false
+		}
+	}
+	return value, true
+}
+
+func fastValuePlanFromDynamicIndexExpression(plan *FastRenderPlan, exp *ast.IndexExpression, nullOnMissing bool, line int) (FastValuePlan, bool) {
+	if exp == nil || exp.Left == nil || exp.Index == nil {
 		return FastValuePlan{}, false
 	}
-	value.Kind = FastValuePath
-	value.Path = append(value.Path, indexStep)
+	left, ok := fastValuePlanFromExpression(plan, exp.Left, nullOnMissing, lineForNode(exp.Left))
+	if !ok || !fastIndexContainerSupported(left) {
+		return FastValuePlan{}, false
+	}
+	index, ok := fastValuePlanFromExpression(plan, exp.Index, false, lineForNode(exp.Index))
+	if !ok || !fastIndexOperandSupported(index) {
+		return FastValuePlan{}, false
+	}
+	value := FastValuePlan{
+		Kind:          FastValueIndex,
+		Left:          &left,
+		Right:         &index,
+		NullOnMissing: nullOnMissing,
+		Line:          line,
+	}
 	if exp.Callee != nil {
-		if !appendFastReceiverCallee(&value, exp.Callee, lastChainPart(exp.Left), line) {
+		if !appendFastReceiverCalleeWithArgumentPlanner(&value, exp.Callee, lastChainPart(exp.Left), line, func(arg ast.Expression, argLine int) (FastValuePlan, bool) {
+			return fastValuePlanFromExpression(plan, arg, false, argLine)
+		}) {
 			return FastValuePlan{}, false
 		}
 	}
@@ -1176,8 +1521,28 @@ func fastValuePlanFromCallExpression(plan *FastRenderPlan, exp *ast.CallExpressi
 	if exp.Block != nil {
 		return FastValuePlan{}, false
 	}
+	if exp.ChainCallee != nil {
+		root := *exp
+		root.ChainCallee = nil
+		if call, ok := fastCallPlanFromExpression(plan, &root, line); ok {
+			value := FastValuePlan{
+				Kind: FastValueCall,
+				Call: call,
+				Line: line,
+			}
+			if !appendFastReceiverCalleeWithArgumentPlanner(&value, exp.ChainCallee, lastChainPart(exp.Function), line, func(arg ast.Expression, argLine int) (FastValuePlan, bool) {
+				return fastValuePlanFromExpression(plan, arg, false, argLine)
+			}) {
+				return FastValuePlan{}, false
+			}
+			return value, true
+		}
+	}
 	if ident, ok := exp.Function.(*ast.Identifier); ok {
 		parts := identifierParts(ident)
+		if len(parts) > 1 && len(exp.Arguments) > 0 {
+			return fastValuePlanFromReceiverCallExpression(plan, exp, parts, nullOnMissing, line)
+		}
 		if len(parts) > 1 && len(exp.Arguments) == 0 {
 			value := FastValuePlan{
 				Kind:          FastValuePath,
@@ -1194,16 +1559,15 @@ func fastValuePlanFromCallExpression(plan *FastRenderPlan, exp *ast.CallExpressi
 				Value: callExpressionName(exp),
 				Line:  line,
 			})
-			if exp.ChainCallee != nil && !appendFastReceiverCallee(&value, exp.ChainCallee, lastChainPart(exp.Function), line) {
+			if exp.ChainCallee != nil && !appendFastReceiverCalleeWithArgumentPlanner(&value, exp.ChainCallee, lastChainPart(exp.Function), line, func(arg ast.Expression, argLine int) (FastValuePlan, bool) {
+				return fastValuePlanFromExpression(plan, arg, false, argLine)
+			}) {
 				return FastValuePlan{}, false
 			}
 			return value, true
 		}
 	}
 	if call, ok := fastCallPlanFromExpression(plan, exp, line); ok {
-		if call.Name == "partial" {
-			return FastValuePlan{}, false
-		}
 		return FastValuePlan{
 			Kind: FastValueCall,
 			Call: call,
@@ -1215,25 +1579,44 @@ func fastValuePlanFromCallExpression(plan *FastRenderPlan, exp *ast.CallExpressi
 		if !ok || !value.canUsePath() {
 			return FastValuePlan{}, false
 		}
-		value.Kind = FastValuePath
-		value.Path = append(value.Path, FastPathStep{
+		appendFastValuePathStep(&value, FastPathStep{
 			Kind:  FastPathStepCall,
 			Value: callExpressionName(exp),
 			Line:  line,
 		})
-		if exp.ChainCallee != nil && !appendFastReceiverCallee(&value, exp.ChainCallee, lastChainPart(exp.Function), line) {
+		if exp.ChainCallee != nil && !appendFastReceiverCalleeWithArgumentPlanner(&value, exp.ChainCallee, lastChainPart(exp.Function), line, func(arg ast.Expression, argLine int) (FastValuePlan, bool) {
+			return fastValuePlanFromExpression(plan, arg, false, argLine)
+		}) {
 			return FastValuePlan{}, false
 		}
 		return value, true
 	}
-	return FastValuePlan{}, false
+	value, ok := fastValuePlanFromExpression(plan, exp.Function, nullOnMissing, line)
+	if !ok || !value.canUsePath() {
+		return FastValuePlan{}, false
+	}
+	callStep := FastPathStep{
+		Kind:  FastPathStepCall,
+		Value: callExpressionName(exp),
+		Line:  line,
+	}
+	for _, arg := range exp.Arguments {
+		argPlan, ok := fastValuePlanFromExpression(plan, arg, false, lineForNode(arg))
+		if !ok {
+			return FastValuePlan{}, false
+		}
+		callStep.Args = append(callStep.Args, argPlan)
+	}
+	appendFastValuePathStep(&value, callStep)
+	if exp.ChainCallee != nil && !appendFastReceiverCalleeWithArgumentPlanner(&value, exp.ChainCallee, lastChainPart(exp.Function), line, func(arg ast.Expression, argLine int) (FastValuePlan, bool) {
+		return fastValuePlanFromExpression(plan, arg, false, argLine)
+	}) {
+		return FastValuePlan{}, false
+	}
+	return value, true
 }
 
-func (v FastValuePlan) canUsePath() bool {
-	return v.Kind == FastValueName || v.Kind == FastValuePath
-}
-
-func appendFastReceiverCallee(value *FastValuePlan, exp ast.Expression, base string, line int) bool {
+func appendFastReceiverCalleeWithArgumentPlanner(value *FastValuePlan, exp ast.Expression, base string, line int, argPlan func(ast.Expression, int) (FastValuePlan, bool)) bool {
 	switch exp := exp.(type) {
 	case *ast.Identifier:
 		receiver := base
@@ -1247,7 +1630,7 @@ func appendFastReceiverCallee(value *FastValuePlan, exp ast.Expression, base str
 		}
 		return true
 	case *ast.IndexExpression:
-		if !appendFastReceiverCallee(value, exp.Left, base, line) {
+		if !appendFastReceiverCalleeWithArgumentPlanner(value, exp.Left, base, line, argPlan) {
 			return false
 		}
 		indexStep, ok := fastIndexStepFromExpression(exp.Index, line)
@@ -1256,11 +1639,11 @@ func appendFastReceiverCallee(value *FastValuePlan, exp ast.Expression, base str
 		}
 		value.Path = append(value.Path, indexStep)
 		if exp.Callee != nil {
-			return appendFastReceiverCallee(value, exp.Callee, lastChainPart(exp.Left), line)
+			return appendFastReceiverCalleeWithArgumentPlanner(value, exp.Callee, lastChainPart(exp.Left), line, argPlan)
 		}
 		return true
 	case *ast.CallExpression:
-		if exp.Block != nil || len(exp.Arguments) != 0 {
+		if exp.Block != nil {
 			return false
 		}
 		if ident, ok := exp.Function.(*ast.Identifier); ok {
@@ -1274,21 +1657,88 @@ func appendFastReceiverCallee(value *FastValuePlan, exp ast.Expression, base str
 				value.Path = append(value.Path, fastPropertyStep(property, receiver, full, line, i == len(parts)-1))
 				receiver = full
 			}
-		} else if !appendFastReceiverCallee(value, exp.Function, base, line) {
+		} else if !appendFastReceiverCalleeWithArgumentPlanner(value, exp.Function, base, line, argPlan) {
 			return false
 		}
-		value.Path = append(value.Path, FastPathStep{
+		callStep := FastPathStep{
 			Kind:  FastPathStepCall,
 			Value: callExpressionName(exp),
 			Line:  line,
-		})
+		}
+		for _, arg := range exp.Arguments {
+			if argPlan == nil {
+				return false
+			}
+			planned, ok := argPlan(arg, lineForNode(arg))
+			if !ok {
+				return false
+			}
+			callStep.Args = append(callStep.Args, planned)
+		}
+		value.Path = append(value.Path, callStep)
 		if exp.ChainCallee != nil {
-			return appendFastReceiverCallee(value, exp.ChainCallee, lastChainPart(exp.Function), line)
+			return appendFastReceiverCalleeWithArgumentPlanner(value, exp.ChainCallee, lastChainPart(exp.Function), line, argPlan)
 		}
 		return true
 	default:
 		return false
 	}
+}
+
+func appendFastReceiverCallee(value *FastValuePlan, exp ast.Expression, base string, line int) bool {
+	return appendFastReceiverCalleeWithArgumentPlanner(value, exp, base, line, nil)
+}
+
+func fastValuePlanFromReceiverCallExpression(plan *FastRenderPlan, exp *ast.CallExpression, parts []string, nullOnMissing bool, line int) (FastValuePlan, bool) {
+	if exp == nil || exp.Block != nil || len(parts) < 2 || parts[0] == "" {
+		return FastValuePlan{}, false
+	}
+	value := FastValuePlan{
+		Kind:          FastValuePath,
+		Value:         parts[0],
+		NameIndex:     plan.bindName(parts[0]),
+		NullOnMissing: nullOnMissing,
+		Line:          line,
+	}
+	receiver := parts[0]
+	for i, property := range parts[1:] {
+		full := receiver + "." + property
+		value.Path = append(value.Path, fastPropertyStep(property, receiver, full, line, i == len(parts[1:])-1))
+		receiver = full
+	}
+	callStep := FastPathStep{
+		Kind:  FastPathStepCall,
+		Value: callExpressionName(exp),
+		Line:  line,
+	}
+	for _, arg := range exp.Arguments {
+		argPlan, ok := fastValuePlanFromExpression(plan, arg, false, lineForNode(arg))
+		if !ok {
+			return FastValuePlan{}, false
+		}
+		callStep.Args = append(callStep.Args, argPlan)
+	}
+	value.Path = append(value.Path, callStep)
+	if exp.ChainCallee != nil && !appendFastReceiverCalleeWithArgumentPlanner(&value, exp.ChainCallee, lastChainPart(exp.Function), line, func(arg ast.Expression, argLine int) (FastValuePlan, bool) {
+		return fastValuePlanFromExpression(plan, arg, false, argLine)
+	}) {
+		return FastValuePlan{}, false
+	}
+	return value, true
+}
+
+func (v FastValuePlan) canUsePath() bool {
+	return v.Kind == FastValueName || v.Kind == FastValuePath || v.Kind == FastValueIndex || v.Kind == FastValueCall
+}
+
+func appendFastValuePathStep(value *FastValuePlan, step FastPathStep) {
+	if value == nil {
+		return
+	}
+	if value.Kind == FastValueName {
+		value.Kind = FastValuePath
+	}
+	value.Path = append(value.Path, step)
 }
 
 func fastPropertyStep(property, receiver, full string, line int, method bool) FastPathStep {
@@ -1335,7 +1785,7 @@ func fastCallPlanFromExpression(plan *FastRenderPlan, exp *ast.CallExpression, l
 		return nil, false
 	}
 	ident, ok := exp.Function.(*ast.Identifier)
-	if !ok || ident.Callee != nil || ident.Value == "" || ident.Value == "nil" || ident.Value == "partial" {
+	if !ok || !fastPlainHelperIdentifier(ident) || ident.Value == "nil" {
 		return nil, false
 	}
 	call := &FastCallPlan{
@@ -1350,6 +1800,15 @@ func fastCallPlanFromExpression(plan *FastRenderPlan, exp *ast.CallExpression, l
 		}
 		call.Args = append(call.Args, value)
 	}
+	return call, true
+}
+
+func fastSilentCallPlanFromExpression(plan *FastRenderPlan, exp *ast.CallExpression, line int) (*FastCallPlan, bool) {
+	call, ok := fastCallPlanFromExpression(plan, exp, line)
+	if !ok {
+		return nil, false
+	}
+	call.Silent = true
 	return call, true
 }
 
@@ -1381,86 +1840,190 @@ func fastBlockCallPlanFromExpression(plan *FastRenderPlan, exp *ast.CallExpressi
 	return call, true
 }
 
-func fastBlockCanRenderFromSource(block *ast.BlockStatement) bool {
-	return block != nil && !fastBlockStatementsHaveAssignment(block.Statements)
+func fastSilentBlockCallPlanFromExpression(plan *FastRenderPlan, exp *ast.CallExpression, line int) (*FastBlockCallPlan, bool) {
+	call, ok := fastBlockCallPlanFromExpression(plan, exp, line)
+	if !ok {
+		return nil, false
+	}
+	call.Silent = true
+	return call, true
 }
 
-func fastBlockStatementsHaveAssignment(statements []ast.Statement) bool {
+func fastBlockCanRenderFromSource(block *ast.BlockStatement) bool {
+	if block == nil {
+		return false
+	}
+	return true
+}
+
+func fastBlockStatementsAllowScopedAssignments(statements []ast.Statement, locals map[string]struct{}) (map[string]struct{}, bool) {
+	scoped := cloneFastBlockLocals(locals)
 	for _, stmt := range statements {
-		if fastBlockStatementHasAssignment(stmt) {
-			return true
+		var ok bool
+		scoped, ok = fastBlockStatementAllowScopedAssignments(stmt, scoped)
+		if !ok {
+			return nil, false
 		}
 	}
-	return false
+	return scoped, true
 }
 
-func fastBlockStatementHasAssignment(stmt ast.Statement) bool {
+func fastBlockStatementAllowScopedAssignments(stmt ast.Statement, locals map[string]struct{}) (map[string]struct{}, bool) {
 	switch stmt := stmt.(type) {
 	case nil:
-		return false
+		return locals, true
 	case *ast.ExpressionStatement:
-		return fastBlockExpressionHasAssignment(stmt.Expression)
+		return locals, fastBlockExpressionAssignmentsAreScoped(stmt.Expression, locals)
 	case *ast.ReturnStatement:
-		return fastBlockExpressionHasAssignment(stmt.ReturnValue)
+		return locals, fastBlockExpressionAssignmentsAreScoped(stmt.ReturnValue, locals)
 	case *ast.LetStatement:
-		return fastBlockExpressionHasAssignment(stmt.Value)
+		if !fastBlockExpressionAssignmentsAreScoped(stmt.Value, locals) {
+			return nil, false
+		}
+		if stmt.Name != nil && stmt.Name.Value != "" && stmt.Name.Callee == nil {
+			locals = cloneFastBlockLocals(locals)
+			locals[stmt.Name.Value] = struct{}{}
+		}
+		return locals, true
 	case *ast.BlockStatement:
-		return fastBlockStatementsHaveAssignment(stmt.Statements)
+		_, ok := fastBlockStatementsAllowScopedAssignments(stmt.Statements, locals)
+		return locals, ok
 	default:
-		return false
+		return locals, true
 	}
 }
 
-func fastBlockExpressionHasAssignment(expr ast.Expression) bool {
+func fastBlockExpressionAssignmentsAreScoped(expr ast.Expression, locals map[string]struct{}) bool {
 	switch expr := expr.(type) {
 	case nil:
-		return false
-	case *ast.AssignExpression:
 		return true
+	case *ast.AssignExpression:
+		if expr.Name == nil || !fastBlockLocalExists(locals, expr.Name.Value) {
+			return false
+		}
+		return fastBlockExpressionAssignmentsAreScoped(expr.Value, locals)
 	case *ast.PrefixExpression:
-		return fastBlockExpressionHasAssignment(expr.Right)
+		return fastBlockExpressionAssignmentsAreScoped(expr.Right, locals)
 	case *ast.InfixExpression:
-		return fastBlockExpressionHasAssignment(expr.Left) || fastBlockExpressionHasAssignment(expr.Right)
+		return fastBlockExpressionAssignmentsAreScoped(expr.Left, locals) && fastBlockExpressionAssignmentsAreScoped(expr.Right, locals)
 	case *ast.IndexExpression:
-		return fastBlockExpressionHasAssignment(expr.Left) || fastBlockExpressionHasAssignment(expr.Index) || fastBlockExpressionHasAssignment(expr.Callee)
+		if expr.Value != nil {
+			root, ok := fastBlockAssignmentRoot(expr.Left)
+			if !ok || !fastBlockLocalExists(locals, root) {
+				return false
+			}
+			return fastBlockExpressionAssignmentsAreScoped(expr.Left, locals) &&
+				fastBlockExpressionAssignmentsAreScoped(expr.Index, locals) &&
+				fastBlockExpressionAssignmentsAreScoped(expr.Value, locals) &&
+				fastBlockExpressionAssignmentsAreScoped(expr.Callee, locals)
+		}
+		return fastBlockExpressionAssignmentsAreScoped(expr.Left, locals) &&
+			fastBlockExpressionAssignmentsAreScoped(expr.Index, locals) &&
+			fastBlockExpressionAssignmentsAreScoped(expr.Callee, locals)
 	case *ast.CallExpression:
-		if fastBlockExpressionHasAssignment(expr.Function) || fastBlockExpressionHasAssignment(expr.ChainCallee) {
-			return true
+		if !fastBlockExpressionAssignmentsAreScoped(expr.Function, locals) || !fastBlockExpressionAssignmentsAreScoped(expr.ChainCallee, locals) {
+			return false
 		}
 		for _, arg := range expr.Arguments {
-			if fastBlockExpressionHasAssignment(arg) {
-				return true
+			if !fastBlockExpressionAssignmentsAreScoped(arg, locals) {
+				return false
 			}
 		}
-		return expr.Block != nil && fastBlockStatementsHaveAssignment(expr.Block.Statements)
+		if expr.Block != nil {
+			_, ok := fastBlockStatementsAllowScopedAssignments(expr.Block.Statements, locals)
+			return ok
+		}
+		return true
 	case *ast.IfExpression:
-		if fastBlockExpressionHasAssignment(expr.Condition) || (expr.Block != nil && fastBlockStatementsHaveAssignment(expr.Block.Statements)) {
-			return true
+		if !fastBlockExpressionAssignmentsAreScoped(expr.Condition, locals) {
+			return false
+		}
+		if expr.Block != nil {
+			if _, ok := fastBlockStatementsAllowScopedAssignments(expr.Block.Statements, locals); !ok {
+				return false
+			}
 		}
 		for _, elseIf := range expr.ElseIf {
-			if elseIf != nil && (fastBlockExpressionHasAssignment(elseIf.Condition) || (elseIf.Block != nil && fastBlockStatementsHaveAssignment(elseIf.Block.Statements))) {
-				return true
+			if elseIf == nil {
+				continue
+			}
+			if !fastBlockExpressionAssignmentsAreScoped(elseIf.Condition, locals) {
+				return false
+			}
+			if elseIf.Block != nil {
+				if _, ok := fastBlockStatementsAllowScopedAssignments(elseIf.Block.Statements, locals); !ok {
+					return false
+				}
 			}
 		}
-		return expr.ElseBlock != nil && fastBlockStatementsHaveAssignment(expr.ElseBlock.Statements)
+		if expr.ElseBlock != nil {
+			_, ok := fastBlockStatementsAllowScopedAssignments(expr.ElseBlock.Statements, locals)
+			return ok
+		}
+		return true
 	case *ast.ForExpression:
-		return fastBlockExpressionHasAssignment(expr.Iterable) || (expr.Block != nil && fastBlockStatementsHaveAssignment(expr.Block.Statements))
+		if !fastBlockExpressionAssignmentsAreScoped(expr.Iterable, locals) {
+			return false
+		}
+		if expr.Block == nil {
+			return true
+		}
+		loopLocals := cloneFastBlockLocals(locals)
+		if expr.KeyName != "" && expr.KeyName != "_" {
+			loopLocals[expr.KeyName] = struct{}{}
+		}
+		if expr.ValueName != "" && expr.ValueName != "_" {
+			loopLocals[expr.ValueName] = struct{}{}
+		}
+		_, ok := fastBlockStatementsAllowScopedAssignments(expr.Block.Statements, loopLocals)
+		return ok
 	case *ast.ArrayLiteral:
 		for _, element := range expr.Elements {
-			if fastBlockExpressionHasAssignment(element) {
-				return true
+			if !fastBlockExpressionAssignmentsAreScoped(element, locals) {
+				return false
 			}
 		}
-		return false
+		return true
 	case *ast.HashLiteral:
 		for key, value := range expr.Pairs {
-			if fastBlockExpressionHasAssignment(key) || fastBlockExpressionHasAssignment(value) {
-				return true
+			if !fastBlockExpressionAssignmentsAreScoped(key, locals) || !fastBlockExpressionAssignmentsAreScoped(value, locals) {
+				return false
 			}
 		}
-		return false
+		return true
 	default:
+		return true
+	}
+}
+
+func cloneFastBlockLocals(locals map[string]struct{}) map[string]struct{} {
+	clone := make(map[string]struct{}, len(locals)+1)
+	for name := range locals {
+		clone[name] = struct{}{}
+	}
+	return clone
+}
+
+func fastBlockLocalExists(locals map[string]struct{}, name string) bool {
+	if name == "" {
 		return false
+	}
+	_, ok := locals[name]
+	return ok
+}
+
+func fastBlockAssignmentRoot(expr ast.Expression) (string, bool) {
+	switch expr := expr.(type) {
+	case *ast.Identifier:
+		parts := identifierParts(expr)
+		if len(parts) == 0 {
+			return "", false
+		}
+		return parts[0], true
+	case *ast.IndexExpression:
+		return fastBlockAssignmentRoot(expr.Left)
+	default:
+		return "", false
 	}
 }
 
@@ -1583,7 +2146,7 @@ func fastConditionalPlanFromExpression(plan *FastRenderPlan, expr *ast.IfExpress
 		return nil, false
 	}
 	firstSegments := []FastRenderSegment{}
-	if !appendFastStatements(plan, &firstSegments, expr.Block.Statements) {
+	if !appendFastOutputBlockStatements(plan, &firstSegments, expr.Block.Statements) {
 		return nil, false
 	}
 	conditional.Branches = append(conditional.Branches, FastConditionalBranch{
@@ -1600,7 +2163,7 @@ func fastConditionalPlanFromExpression(plan *FastRenderPlan, expr *ast.IfExpress
 			return nil, false
 		}
 		segments := []FastRenderSegment{}
-		if !appendFastStatements(plan, &segments, elseIf.Block.Statements) {
+		if !appendFastOutputBlockStatements(plan, &segments, elseIf.Block.Statements) {
 			return nil, false
 		}
 		conditional.Branches = append(conditional.Branches, FastConditionalBranch{
@@ -1611,7 +2174,7 @@ func fastConditionalPlanFromExpression(plan *FastRenderPlan, expr *ast.IfExpress
 	}
 	if expr.ElseBlock != nil {
 		segments := []FastRenderSegment{}
-		if !appendFastStatements(plan, &segments, expr.ElseBlock.Statements) {
+		if !appendFastOutputBlockStatements(plan, &segments, expr.ElseBlock.Statements) {
 			return nil, false
 		}
 		conditional.ElseSegments = segments
@@ -1675,6 +2238,9 @@ func firstFastSilentStatementReject(plan *FastRenderPlan, statements []ast.State
 func fastSilentStatementReject(plan *FastRenderPlan, stmt ast.Statement) FastRenderReject {
 	switch stmt := stmt.(type) {
 	case *ast.ExpressionStatement:
+		if isFastCommentStatement(stmt) {
+			return FastRenderReject{}
+		}
 		if _, ok := stmt.Expression.(*ast.HTMLLiteral); ok {
 			return FastRenderReject{}
 		}
@@ -1684,6 +2250,31 @@ func fastSilentStatementReject(plan *FastRenderPlan, stmt ast.Statement) FastRen
 				return FastRenderReject{}
 			}
 			return fastRenderValueReject(plan, assign.Value, "script assignment value")
+		}
+		if index, ok := stmt.Expression.(*ast.IndexExpression); ok && index.Value != nil {
+			segments := []FastRenderSegment{}
+			if appendFastIndexAssignExpression(plan, &segments, index, lineForNode(stmt)) {
+				return FastRenderReject{}
+			}
+			return fastRenderIndexAssignReject(plan, nil, index, lineForNode(stmt), false)
+		}
+		if forExpression, ok := stmt.Expression.(*ast.ForExpression); ok {
+			if _, ok := fastSilentLoopPlanFromExpression(plan, forExpression, lineForNode(stmt)); ok {
+				return FastRenderReject{}
+			}
+			return fastRenderLoopReject(plan, nil, forExpression, lineForNode(stmt))
+		}
+		if callExpression, ok := stmt.Expression.(*ast.CallExpression); ok && callExpression.Block != nil {
+			if _, ok := fastSilentBlockCallPlanFromExpression(plan, callExpression, lineForNode(stmt)); ok {
+				return FastRenderReject{}
+			}
+			return fastRenderBlockCallReject(plan, callExpression, lineForNode(stmt))
+		}
+		if callExpression, ok := stmt.Expression.(*ast.CallExpression); ok {
+			if _, ok := fastSilentCallPlanFromExpression(plan, callExpression, lineForNode(stmt)); ok {
+				return FastRenderReject{}
+			}
+			return fastRenderCallReject(plan, callExpression, lineForNode(stmt))
 		}
 		if ifExpression, ok := stmt.Expression.(*ast.IfExpression); ok {
 			return fastSilentConditionalReject(plan, ifExpression, lineForNode(stmt))
@@ -1695,7 +2286,11 @@ func fastSilentStatementReject(plan *FastRenderPlan, stmt ast.Statement) FastRen
 		}
 		return fastRenderOutputReject(plan, stmt.ReturnValue, lineForNode(stmt))
 	case *ast.LetStatement:
-		return rejectFastRender(stmt, "let statements inside script if bodies are not fast-planned")
+		segments := []FastRenderSegment{}
+		if appendFastLetStatement(plan, &segments, stmt) {
+			return FastRenderReject{}
+		}
+		return fastRenderValueReject(plan, stmt.Value, "script if let value")
 	default:
 		return rejectFastRender(stmt, "unsupported script if body statement type for fast render")
 	}
@@ -1759,16 +2354,28 @@ func fastLoopPlanFromExpression(plan *FastRenderPlan, expr *ast.ForExpression, l
 	return fastLoopPlanFromExpressionWithOuterNames(plan, nil, expr, line)
 }
 
+func fastSilentLoopPlanFromExpression(plan *FastRenderPlan, expr *ast.ForExpression, line int) (*FastLoopPlan, bool) {
+	return fastLoopPlanFromExpressionWithOuterNamesAndSilent(plan, nil, expr, line, true)
+}
+
 func fastNestedLoopPlanFromExpression(plan *FastRenderPlan, parent *FastLoopPlan, expr *ast.ForExpression, line int) (*FastLoopPlan, bool) {
 	return fastLoopPlanFromExpressionWithOuterNames(plan, fastLoopOuterNames(parent), expr, line)
 }
 
+func fastSilentNestedLoopPlanFromExpression(plan *FastRenderPlan, parent *FastLoopPlan, expr *ast.ForExpression, line int) (*FastLoopPlan, bool) {
+	return fastLoopPlanFromExpressionWithOuterNamesAndSilent(plan, fastLoopOuterNames(parent), expr, line, true)
+}
+
 func fastLoopPlanFromExpressionWithOuterNames(plan *FastRenderPlan, outerNames []string, expr *ast.ForExpression, line int) (*FastLoopPlan, bool) {
+	return fastLoopPlanFromExpressionWithOuterNamesAndSilent(plan, outerNames, expr, line, false)
+}
+
+func fastLoopPlanFromExpressionWithOuterNamesAndSilent(plan *FastRenderPlan, outerNames []string, expr *ast.ForExpression, line int, silent bool) (*FastLoopPlan, bool) {
 	if expr == nil || expr.Block == nil {
 		return nil, false
 	}
 	iterable, ok := fastValuePlanFromExpression(plan, expr.Iterable, false, lineForNode(expr.Iterable))
-	if !ok || iterable.Value == "nil" || !fastLoopIterableValueSupported(iterable) {
+	if !ok || !fastLoopIterableValueSupported(iterable) {
 		return nil, false
 	}
 	loop := &FastLoopPlan{
@@ -1778,11 +2385,13 @@ func fastLoopPlanFromExpressionWithOuterNames(plan *FastRenderPlan, outerNames [
 		KeyName:           expr.KeyName,
 		ValueName:         expr.ValueName,
 		OuterNames:        append([]string(nil), outerNames...),
+		Silent:            silent,
 		Line:              line,
 	}
 	if !appendFastLoopStatements(plan, loop, &loop.Parts, expr.Block.Statements) {
 		return nil, false
 	}
+	loop.PartFlagsSet = true
 	return loop, true
 }
 
@@ -1807,6 +2416,9 @@ func appendFastLoopStatements(plan *FastRenderPlan, loop *FastLoopPlan, parts *[
 func appendFastLoopStatement(plan *FastRenderPlan, loop *FastLoopPlan, parts *[]FastLoopPart, stmt ast.Statement) bool {
 	switch stmt := stmt.(type) {
 	case *ast.ExpressionStatement:
+		if isFastCommentStatement(stmt) {
+			return true
+		}
 		switch expr := stmt.Expression.(type) {
 		case *ast.HTMLLiteral:
 			appendFastLoopStatic(plan, loop, parts, expr.Value)
@@ -1816,6 +2428,49 @@ func appendFastLoopStatement(plan *FastRenderPlan, loop *FastLoopPlan, parts *[]
 			return true
 		case *ast.ContinueExpression:
 			appendFastLoopControlPart(parts, FastLoopPartContinue, lineForNode(stmt))
+			return true
+		case *ast.AssignExpression:
+			return appendFastLoopAssignExpression(plan, loop, parts, expr, lineForNode(stmt))
+		case *ast.IndexExpression:
+			if expr.Value != nil {
+				return appendFastLoopIndexAssignExpression(plan, loop, parts, expr, lineForNode(stmt))
+			}
+			return false
+		case *ast.CallExpression:
+			if expr.Block == nil {
+				call, ok := fastSilentLoopCallPlanFromExpression(plan, loop, expr, lineForNode(stmt))
+				if !ok {
+					return false
+				}
+				*parts = append(*parts, FastLoopPart{
+					Kind:  FastLoopPartCall,
+					Value: call.Name,
+					Call:  call,
+					Line:  lineForNode(stmt),
+				})
+				return true
+			}
+			blockCall, ok := fastSilentLoopBlockCallPlanFromExpression(plan, loop, expr, lineForNode(stmt))
+			if !ok {
+				return false
+			}
+			*parts = append(*parts, FastLoopPart{
+				Kind:      FastLoopPartBlockCall,
+				Value:     blockCall.Name,
+				BlockCall: blockCall,
+				Line:      lineForNode(stmt),
+			})
+			return true
+		case *ast.ForExpression:
+			nested, ok := fastSilentNestedLoopPlanFromExpression(plan, loop, expr, lineForNode(stmt))
+			if !ok {
+				return false
+			}
+			*parts = append(*parts, FastLoopPart{
+				Kind: FastLoopPartLoop,
+				Loop: nested,
+				Line: lineForNode(stmt),
+			})
 			return true
 		case *ast.IfExpression:
 			conditional, ok := fastSilentLoopConditionalPlanFromExpression(plan, loop, expr, lineForNode(stmt))
@@ -1833,7 +2488,7 @@ func appendFastLoopStatement(plan *FastRenderPlan, loop *FastLoopPlan, parts *[]
 		}
 	case *ast.ReturnStatement:
 		if stmt.Type != token.E_START {
-			return false
+			return appendFastLoopReturnStatement(plan, loop, parts, stmt)
 		}
 		return appendFastLoopOutputParts(plan, loop, parts, stmt.ReturnValue, lineForNode(stmt))
 	case *ast.LetStatement:
@@ -1841,6 +2496,82 @@ func appendFastLoopStatement(plan *FastRenderPlan, loop *FastLoopPlan, parts *[]
 	default:
 		return false
 	}
+}
+
+func appendFastLoopReturnStatement(plan *FastRenderPlan, loop *FastLoopPlan, parts *[]FastLoopPart, stmt *ast.ReturnStatement) bool {
+	if stmt == nil {
+		return false
+	}
+	value, ok := fastValuePlanFromLoopOperand(plan, loop, stmt.ReturnValue, false, lineForNode(stmt.ReturnValue))
+	if !ok {
+		return false
+	}
+	*parts = append(*parts, FastLoopPart{
+		Kind:      FastLoopPartReturn,
+		ValuePlan: value,
+		Line:      lineForNode(stmt),
+	})
+	plan.NameCount++
+	return true
+}
+
+func appendFastLoopAssignExpression(plan *FastRenderPlan, loop *FastLoopPlan, parts *[]FastLoopPart, expr *ast.AssignExpression, line int) bool {
+	if expr == nil || expr.Name == nil || expr.Name.Callee != nil || expr.Name.Value == "" || expr.Value == nil {
+		return false
+	}
+	if !fastLoopAssignTargetSupported(loop, expr.Name.Value) {
+		return false
+	}
+	value, ok := fastValuePlanFromLoopOperand(plan, loop, expr.Value, false, lineForNode(expr.Value))
+	if !ok || !fastAssignValueSupported(value) {
+		return false
+	}
+	*parts = append(*parts, FastLoopPart{
+		Kind:      FastLoopPartAssign,
+		Value:     expr.Name.Value,
+		NameIndex: plan.bindName(expr.Name.Value),
+		ValuePlan: value,
+		AssignTarget: &FastAssignTarget{
+			Kind:      FastAssignTargetName,
+			Name:      expr.Name.Value,
+			NameIndex: plan.bindName(expr.Name.Value),
+			Line:      line,
+		},
+		Line: line,
+	})
+	loop.HasAssign = true
+	plan.NameCount++
+	return true
+}
+
+func appendFastLoopIndexAssignExpression(plan *FastRenderPlan, loop *FastLoopPlan, parts *[]FastLoopPart, expr *ast.IndexExpression, line int) bool {
+	target, ok := fastAssignIndexTargetFromExpression(plan, loop, expr, line, true)
+	if !ok {
+		return false
+	}
+	value, ok := fastValuePlanFromLoopOperand(plan, loop, expr.Value, false, lineForNode(expr.Value))
+	if !ok || !fastAssignValueSupported(value) {
+		return false
+	}
+	*parts = append(*parts, FastLoopPart{
+		Kind:         FastLoopPartAssign,
+		ValuePlan:    value,
+		AssignTarget: &target,
+		Line:         line,
+	})
+	loop.HasAssign = true
+	plan.NameCount++
+	return true
+}
+
+func fastLoopAssignTargetSupported(loop *FastLoopPlan, name string) bool {
+	if loop == nil || name == "" || name == "_" {
+		return false
+	}
+	if fastLoopHasOuterName(loop, name) {
+		return false
+	}
+	return true
 }
 
 func appendFastLoopLetStatement(plan *FastRenderPlan, loop *FastLoopPlan, parts *[]FastLoopPart, stmt *ast.LetStatement) bool {
@@ -1858,6 +2589,7 @@ func appendFastLoopLetStatement(plan *FastRenderPlan, loop *FastLoopPlan, parts 
 		ValuePlan: value,
 		Line:      lineForNode(stmt),
 	})
+	loop.HasLet = true
 	plan.NameCount++
 	return true
 }
@@ -1969,7 +2701,7 @@ func appendFastLoopOutputParts(plan *FastRenderPlan, loop *FastLoopPlan, parts *
 			})
 			return true
 		}
-		if value, ok := fastValuePlanFromLoopCall(loop, expr, line); ok {
+		if value, ok := fastValuePlanFromLoopCallWithPlan(plan, loop, expr, line); ok {
 			*parts = append(*parts, FastLoopPart{Kind: FastLoopPartValuePath, ValuePlan: value, Line: line})
 			return true
 		}
@@ -1988,6 +2720,10 @@ func appendFastLoopOutputParts(plan *FastRenderPlan, loop *FastLoopPlan, parts *
 				Call:  call,
 				Line:  line,
 			})
+			return true
+		}
+		if value, ok := fastValuePlanFromLoopOperand(plan, loop, expr, false, line); ok {
+			*parts = append(*parts, FastLoopPart{Kind: FastLoopPartValuePath, ValuePlan: value, Line: line})
 			return true
 		}
 		return false
@@ -2087,6 +2823,52 @@ func fastSilentLoopConditionalPlanFromExpression(plan *FastRenderPlan, loop *Fas
 	return conditional, true
 }
 
+func fastLoopPartsHaveAssignmentLetConflict(parts []FastLoopPart, inheritedLets map[string]struct{}) bool {
+	letNames := inheritedLets
+	for i := range parts {
+		part := &parts[i]
+		switch part.Kind {
+		case FastLoopPartLet:
+			if letNames == nil {
+				letNames = make(map[string]struct{}, 1)
+			}
+			letNames[part.Value] = struct{}{}
+		case FastLoopPartAssign:
+			if _, ok := letNames[part.Value]; ok {
+				return true
+			}
+		case FastLoopPartConditional:
+			if part.Conditional == nil {
+				continue
+			}
+			for branchIndex := range part.Conditional.Branches {
+				if fastLoopPartsHaveAssignmentLetConflict(part.Conditional.Branches[branchIndex].Parts, cloneFastLoopLetNames(letNames)) {
+					return true
+				}
+			}
+			if fastLoopPartsHaveAssignmentLetConflict(part.Conditional.ElseParts, cloneFastLoopLetNames(letNames)) {
+				return true
+			}
+		case FastLoopPartLoop:
+			if part.Loop != nil && fastLoopPartsHaveAssignmentLetConflict(part.Loop.Parts, nil) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func cloneFastLoopLetNames(names map[string]struct{}) map[string]struct{} {
+	if len(names) == 0 {
+		return nil
+	}
+	clone := make(map[string]struct{}, len(names))
+	for name := range names {
+		clone[name] = struct{}{}
+	}
+	return clone
+}
+
 func fastValuePlanFromLoopCondition(plan *FastRenderPlan, loop *FastLoopPlan, expr ast.Expression, line int) (FastValuePlan, bool) {
 	if prefix, ok := expr.(*ast.PrefixExpression); ok {
 		return fastValuePlanFromLoopPrefix(plan, loop, prefix, line)
@@ -2125,7 +2907,12 @@ func fastValuePlanFromLoopInfix(plan *FastRenderPlan, loop *FastLoopPlan, expr *
 }
 
 func fastValuePlanFromLoopPrefix(plan *FastRenderPlan, loop *FastLoopPlan, expr *ast.PrefixExpression, line int) (FastValuePlan, bool) {
-	if expr == nil || expr.Operator != "!" || expr.Right == nil {
+	if expr == nil || expr.Right == nil {
+		return FastValuePlan{}, false
+	}
+	switch expr.Operator {
+	case "!", "-":
+	default:
 		return FastValuePlan{}, false
 	}
 	right, ok := fastValuePlanFromLoopOperand(plan, loop, expr.Right, true, lineForNode(expr.Right))
@@ -2163,7 +2950,7 @@ func fastValuePlanFromLoopConcat(plan *FastRenderPlan, loop *FastLoopPlan, expr 
 
 func fastInfixOperator(operator string) bool {
 	switch operator {
-	case "-", "*", "/", "==", "!=", "<", ">", "<=", ">=", "&&", "||":
+	case "-", "*", "/", "==", "!=", "~=", "<", ">", "<=", ">=", "&&", "||":
 		return true
 	default:
 		return false
@@ -2179,9 +2966,19 @@ func fastValuePlanFromLoopOperand(plan *FastRenderPlan, loop *FastLoopPlan, expr
 		return fastValuePlanFromLoopArrayLiteral(plan, loop, expr, line)
 	case *ast.HashLiteral:
 		return fastValuePlanFromLoopHashLiteral(plan, loop, expr, line)
+	case *ast.IndexExpression:
+		return fastValuePlanFromLoopIndexWithPlan(plan, loop, expr, line)
+	case *ast.StringLiteral:
+		return FastValuePlan{Kind: FastValueString, Value: expr.Value, Line: line}, true
+	case *ast.IntegerLiteral:
+		return FastValuePlan{Kind: FastValueInteger, IntValue: int64(expr.Value), Line: line}, true
+	case *ast.FloatLiteral:
+		return FastValuePlan{Kind: FastValueFloat, FloatValue: expr.Value, Line: line}, true
+	case *ast.Boolean:
+		return FastValuePlan{Kind: FastValueBool, BoolValue: expr.Value, Line: line}, true
 	}
 	if call, ok := expr.(*ast.CallExpression); ok {
-		if value, ok := fastValuePlanFromLoopCall(loop, call, line); ok {
+		if value, ok := fastValuePlanFromLoopCallWithPlan(plan, loop, call, line); ok {
 			return value, true
 		}
 		if planned, ok := fastLoopCallPlanFromExpression(plan, loop, call, line); ok {
@@ -2206,7 +3003,7 @@ func fastValuePlanFromLoopOperand(plan *FastRenderPlan, loop *FastLoopPlan, expr
 			return FastValuePlan{}, false
 		}
 		if root == loop.ValueName {
-			return fastValuePlanFromLoopExpression(loop, expr, line)
+			return fastValuePlanFromLoopExpression(plan, loop, expr, line)
 		}
 		if fastLoopHasOuterName(loop, root) {
 			return fastValuePlanFromExpression(plan, expr, nullOnMissing, line)
@@ -2249,7 +3046,7 @@ func fastValuePlanFromLoopHashLiteral(plan *FastRenderPlan, loop *FastLoopPlan, 
 	}
 	pairs := make([]FastValuePair, 0, len(keys))
 	for _, keyExpr := range keys {
-		key, ok := fastPartialDataKey(keyExpr)
+		key, keyPlan, ok := fastLoopHashLiteralKeyPlan(plan, loop, keyExpr, lineForNode(keyExpr))
 		if !ok {
 			return FastValuePlan{}, false
 		}
@@ -2259,9 +3056,10 @@ func fastValuePlanFromLoopHashLiteral(plan *FastRenderPlan, loop *FastLoopPlan, 
 			return FastValuePlan{}, false
 		}
 		pairs = append(pairs, FastValuePair{
-			Key:   key,
-			Value: value,
-			Line:  lineForNode(valueExpr),
+			Key:     key,
+			KeyPlan: keyPlan,
+			Value:   value,
+			Line:    lineForNode(valueExpr),
 		})
 	}
 	return FastValuePlan{
@@ -2271,12 +3069,23 @@ func fastValuePlanFromLoopHashLiteral(plan *FastRenderPlan, loop *FastLoopPlan, 
 	}, true
 }
 
+func fastLoopHashLiteralKeyPlan(plan *FastRenderPlan, loop *FastLoopPlan, expr ast.Expression, line int) (string, *FastValuePlan, bool) {
+	if key, ok := fastPartialDataKey(expr); ok {
+		return key, nil, true
+	}
+	value, ok := fastValuePlanFromLoopOperand(plan, loop, expr, false, line)
+	if !ok || !fastHashLiteralKeySupported(value) {
+		return "", nil, false
+	}
+	return "", &value, true
+}
+
 func fastLoopCallPlanFromExpression(plan *FastRenderPlan, loop *FastLoopPlan, exp *ast.CallExpression, line int) (*FastCallPlan, bool) {
 	if plan == nil || loop == nil || exp == nil || exp.Block != nil || exp.ChainCallee != nil {
 		return nil, false
 	}
 	ident, ok := exp.Function.(*ast.Identifier)
-	if !ok || ident.Callee != nil || ident.Value == "" || ident.Value == "nil" || ident.Value == "partial" {
+	if !ok || !fastPlainHelperIdentifier(ident) || ident.Value == "nil" {
 		return nil, false
 	}
 	call := &FastCallPlan{
@@ -2291,6 +3100,15 @@ func fastLoopCallPlanFromExpression(plan *FastRenderPlan, loop *FastLoopPlan, ex
 		}
 		call.Args = append(call.Args, value)
 	}
+	return call, true
+}
+
+func fastSilentLoopCallPlanFromExpression(plan *FastRenderPlan, loop *FastLoopPlan, exp *ast.CallExpression, line int) (*FastCallPlan, bool) {
+	call, ok := fastLoopCallPlanFromExpression(plan, loop, exp, line)
+	if !ok {
+		return nil, false
+	}
+	call.Silent = true
 	return call, true
 }
 
@@ -2319,6 +3137,15 @@ func fastLoopBlockCallPlanFromExpression(plan *FastRenderPlan, loop *FastLoopPla
 		}
 		call.Args = append(call.Args, value)
 	}
+	return call, true
+}
+
+func fastSilentLoopBlockCallPlanFromExpression(plan *FastRenderPlan, loop *FastLoopPlan, exp *ast.CallExpression, line int) (*FastBlockCallPlan, bool) {
+	call, ok := fastLoopBlockCallPlanFromExpression(plan, loop, exp, line)
+	if !ok {
+		return nil, false
+	}
+	call.Silent = true
 	return call, true
 }
 
@@ -2394,45 +3221,118 @@ func isFastLoopKeyIdentifier(loop *FastLoopPlan, expr ast.Expression) bool {
 }
 
 func fastValuePlanFromLoopIndex(loop *FastLoopPlan, expr ast.Expression, line int) (FastValuePlan, bool) {
+	return fastValuePlanFromLoopIndexWithPlan(&FastRenderPlan{}, loop, expr, line)
+}
+
+func fastValuePlanFromLoopIndexWithPlan(plan *FastRenderPlan, loop *FastLoopPlan, expr ast.Expression, line int) (FastValuePlan, bool) {
 	index, ok := expr.(*ast.IndexExpression)
 	if !ok {
 		return FastValuePlan{}, false
 	}
-	value, ok := fastValuePlanFromLoopExpressionWithMethod(loop, index.Left, line, false)
+	value, ok := fastValuePlanFromLoopExpressionWithMethodWithPlan(plan, loop, index.Left, line, false)
 	if !ok {
-		return FastValuePlan{}, false
+		return fastValuePlanFromLoopDynamicIndex(plan, loop, index, line)
 	}
 	indexStep, ok := fastIndexStepFromExpression(index.Index, line)
 	if !ok {
-		return FastValuePlan{}, false
+		return fastValuePlanFromLoopDynamicIndex(plan, loop, index, line)
 	}
 	value.Path = append(value.Path, indexStep)
-	if index.Callee != nil && !appendFastReceiverCallee(&value, index.Callee, lastChainPart(index.Left), line) {
+	if index.Callee != nil {
+		if !appendFastReceiverCalleeWithArgumentPlanner(&value, index.Callee, lastChainPart(index.Left), line, func(arg ast.Expression, argLine int) (FastValuePlan, bool) {
+			return fastValuePlanFromLoopCallArgument(plan, loop, arg, argLine)
+		}) {
+			return FastValuePlan{}, false
+		}
+	}
+	return value, true
+}
+
+func fastValuePlanFromLoopDynamicIndex(plan *FastRenderPlan, loop *FastLoopPlan, expr *ast.IndexExpression, line int) (FastValuePlan, bool) {
+	if expr == nil || expr.Left == nil || expr.Index == nil {
 		return FastValuePlan{}, false
+	}
+	left, ok := fastValuePlanFromLoopOperand(plan, loop, expr.Left, false, lineForNode(expr.Left))
+	if !ok {
+		return FastValuePlan{}, false
+	}
+	index, ok := fastValuePlanFromLoopOperand(plan, loop, expr.Index, false, lineForNode(expr.Index))
+	if !ok || !fastIndexOperandSupported(index) {
+		return FastValuePlan{}, false
+	}
+	value := FastValuePlan{
+		Kind:  FastValueIndex,
+		Left:  &left,
+		Right: &index,
+		Line:  line,
+	}
+	if expr.Callee != nil {
+		if !appendFastReceiverCalleeWithArgumentPlanner(&value, expr.Callee, lastChainPart(expr.Left), line, func(arg ast.Expression, argLine int) (FastValuePlan, bool) {
+			return fastValuePlanFromLoopCallArgument(plan, loop, arg, argLine)
+		}) {
+			return FastValuePlan{}, false
+		}
 	}
 	return value, true
 }
 
 func fastValuePlanFromLoopCall(loop *FastLoopPlan, exp *ast.CallExpression, line int) (FastValuePlan, bool) {
-	if exp == nil || exp.Block != nil || len(exp.Arguments) != 0 {
+	return fastValuePlanFromLoopCallWithPlan(&FastRenderPlan{}, loop, exp, line)
+}
+
+func fastValuePlanFromLoopCallWithPlan(plan *FastRenderPlan, loop *FastLoopPlan, exp *ast.CallExpression, line int) (FastValuePlan, bool) {
+	if exp == nil || exp.Block != nil {
 		return FastValuePlan{}, false
 	}
-	value, ok := fastValuePlanFromLoopExpressionWithMethod(loop, exp.Function, line, true)
+	if exp.ChainCallee != nil {
+		root := *exp
+		root.ChainCallee = nil
+		if call, ok := fastLoopCallPlanFromExpression(plan, loop, &root, line); ok {
+			value := FastValuePlan{
+				Kind: FastValueCall,
+				Call: call,
+				Line: line,
+			}
+			if !appendFastReceiverCalleeWithArgumentPlanner(&value, exp.ChainCallee, lastChainPart(exp.Function), line, func(arg ast.Expression, argLine int) (FastValuePlan, bool) {
+				return fastValuePlanFromLoopCallArgument(plan, loop, arg, argLine)
+			}) {
+				return FastValuePlan{}, false
+			}
+			return value, true
+		}
+	}
+	value, ok := fastValuePlanFromLoopExpressionWithMethodWithPlan(plan, loop, exp.Function, line, true)
 	if !ok {
 		return FastValuePlan{}, false
 	}
-	value.Path = append(value.Path, FastPathStep{Kind: FastPathStepCall, Value: callExpressionName(exp), Line: line})
-	if exp.ChainCallee != nil && !appendFastReceiverCallee(&value, exp.ChainCallee, lastChainPart(exp.Function), line) {
-		return FastValuePlan{}, false
+	callStep := FastPathStep{Kind: FastPathStepCall, Value: callExpressionName(exp), Line: line}
+	for _, arg := range exp.Arguments {
+		argPlan, ok := fastValuePlanFromLoopCallArgument(plan, loop, arg, lineForNode(arg))
+		if !ok {
+			return FastValuePlan{}, false
+		}
+		callStep.Args = append(callStep.Args, argPlan)
+	}
+	appendFastValuePathStep(&value, callStep)
+	if exp.ChainCallee != nil {
+		if !appendFastReceiverCalleeWithArgumentPlanner(&value, exp.ChainCallee, lastChainPart(exp.Function), line, func(arg ast.Expression, argLine int) (FastValuePlan, bool) {
+			return fastValuePlanFromLoopCallArgument(plan, loop, arg, argLine)
+		}) {
+			return FastValuePlan{}, false
+		}
 	}
 	return value, true
 }
 
-func fastValuePlanFromLoopExpression(loop *FastLoopPlan, expr ast.Expression, line int) (FastValuePlan, bool) {
-	return fastValuePlanFromLoopExpressionWithMethod(loop, expr, line, false)
+func fastValuePlanFromLoopExpression(plan *FastRenderPlan, loop *FastLoopPlan, expr ast.Expression, line int) (FastValuePlan, bool) {
+	return fastValuePlanFromLoopExpressionWithMethodWithPlan(plan, loop, expr, line, false)
 }
 
 func fastValuePlanFromLoopExpressionWithMethod(loop *FastLoopPlan, expr ast.Expression, line int, markLastPropertyAsMethod bool) (FastValuePlan, bool) {
+	return fastValuePlanFromLoopExpressionWithMethodWithPlan(&FastRenderPlan{}, loop, expr, line, markLastPropertyAsMethod)
+}
+
+func fastValuePlanFromLoopExpressionWithMethodWithPlan(plan *FastRenderPlan, loop *FastLoopPlan, expr ast.Expression, line int, markLastPropertyAsMethod bool) (FastValuePlan, bool) {
 	switch expr := expr.(type) {
 	case *ast.Identifier:
 		parts := identifierParts(expr)
@@ -2449,9 +3349,9 @@ func fastValuePlanFromLoopExpressionWithMethod(loop *FastLoopPlan, expr ast.Expr
 		}
 		return value, true
 	case *ast.IndexExpression:
-		return fastValuePlanFromLoopIndex(loop, expr, line)
+		return fastValuePlanFromLoopIndexWithPlan(plan, loop, expr, line)
 	case *ast.CallExpression:
-		return fastValuePlanFromLoopCall(loop, expr, line)
+		return fastValuePlanFromLoopCallWithPlan(plan, loop, expr, line)
 	default:
 		return FastValuePlan{}, false
 	}

--- a/vm/compiler/fast_plan_ast.go
+++ b/vm/compiler/fast_plan_ast.go
@@ -2387,6 +2387,7 @@ func fastLoopPlanFromExpressionWithOuterNamesAndSilent(plan *FastRenderPlan, out
 		OuterNames:        append([]string(nil), outerNames...),
 		Silent:            silent,
 		Line:              line,
+		SizeStats:         &LoopSizeStats{},
 	}
 	if !appendFastLoopStatements(plan, loop, &loop.Parts, expr.Block.Statements) {
 		return nil, false

--- a/vm/compiler/fast_plan_ast.go
+++ b/vm/compiler/fast_plan_ast.go
@@ -739,7 +739,7 @@ func scanInstructionFeatures(instructions code.Instructions, constants []object.
 			features.HasContextWrites = true
 		}
 		switch op {
-		case code.OpGetName, code.OpGetNameOrNull, code.OpSetName, code.OpAssignName,
+		case code.OpGetName, code.OpGetNameOrNull, code.OpGetNameOrJumpMissing, code.OpSetName, code.OpAssignName,
 			code.OpWriteName, code.OpWriteNameOrNull:
 			if len(operands) > 0 && stringConstantEquals(constants, operands[0], "partial") {
 				features.HasPartials = true

--- a/vm/compiler/fast_plan_ast.go
+++ b/vm/compiler/fast_plan_ast.go
@@ -36,7 +36,7 @@ func fastRenderPlanAnalysisFromProgram(program *ast.Program) (*FastRenderPlan, F
 		}
 		return nil, reject
 	}
-	if plan.NameCount == 0 {
+	if len(plan.Segments) == 0 {
 		return nil, FastRenderReject{}
 	}
 	return plan, FastRenderReject{}
@@ -384,7 +384,7 @@ func fastRenderOutputReject(plan *FastRenderPlan, expr ast.Expression, line int)
 		if _, ok := fastPartialPlanFromCall(plan, expr, line); ok {
 			return FastRenderReject{}
 		}
-		if _, ok := fastCallPlanFromExpression(plan, expr, line); ok {
+		if _, ok := fastCallPlanFromExpression(plan, expr, line, false); ok {
 			return FastRenderReject{}
 		}
 		if _, ok := fastValuePlanFromExpression(plan, expr, false, line); ok {
@@ -472,7 +472,7 @@ func fastRenderLoopOutputReject(plan *FastRenderPlan, loop *FastLoopPlan, expr a
 		if _, ok := fastPartialPlanFromCall(plan, expr, line); ok {
 			return FastRenderReject{}
 		}
-		if _, ok := fastValuePlanFromLoopCallWithPlan(plan, loop, expr, line); ok {
+		if _, ok := fastValuePlanFromLoopCallWithPlan(plan, loop, expr, line, false); ok {
 			return FastRenderReject{}
 		}
 		if root, ok := fastLoopExpressionRootName(expr); ok && fastLoopHasOuterName(loop, root) {
@@ -480,7 +480,7 @@ func fastRenderLoopOutputReject(plan *FastRenderPlan, loop *FastLoopPlan, expr a
 				return FastRenderReject{}
 			}
 		}
-		if _, ok := fastLoopCallPlanFromExpression(plan, loop, expr, line); ok {
+		if _, ok := fastLoopCallPlanFromExpression(plan, loop, expr, line, false); ok {
 			return FastRenderReject{}
 		}
 		return fastRenderCallReject(plan, expr, line)
@@ -488,7 +488,7 @@ func fastRenderLoopOutputReject(plan *FastRenderPlan, loop *FastLoopPlan, expr a
 		if _, ok := fastValuePlanFromLoopOperand(plan, loop, expr, false, line); ok {
 			return FastRenderReject{}
 		}
-		if _, ok := fastValuePlanFromLoopIndexWithPlan(plan, loop, expr, line); ok {
+		if _, ok := fastValuePlanFromLoopIndexWithPlan(plan, loop, expr, line, false); ok {
 			return FastRenderReject{}
 		}
 		return fastRenderValueReject(plan, expr, "loop output expression")
@@ -513,7 +513,7 @@ func fastRenderLoopBlockCallReject(plan *FastRenderPlan, loop *FastLoopPlan, exp
 		return rejectFastRender(expr.Block, "loop block helper body contains statements that cannot be source-rendered")
 	}
 	for _, arg := range expr.Arguments {
-		if _, ok := fastValuePlanFromLoopCallArgument(plan, loop, arg, lineForNode(arg)); !ok {
+		if _, ok := fastValuePlanFromLoopCallArgument(plan, loop, arg, lineForNode(arg), false); !ok {
 			return fastRenderValueReject(plan, arg, "loop block helper argument")
 		}
 	}
@@ -1186,7 +1186,7 @@ func appendFastOutputExpression(plan *FastRenderPlan, segments *[]FastRenderSegm
 			plan.NameCount++
 			return true
 		}
-		if call, ok := fastCallPlanFromExpression(plan, expr, line); ok {
+		if call, ok := fastCallPlanFromExpression(plan, expr, line, false); ok {
 			*segments = append(*segments, FastRenderSegment{
 				Kind:  FastRenderSegmentCall,
 				Call:  call,
@@ -1480,7 +1480,7 @@ func fastValuePlanFromIndexExpression(plan *FastRenderPlan, exp *ast.IndexExpres
 	appendFastValuePathStep(&value, indexStep)
 	if exp.Callee != nil {
 		if !appendFastReceiverCalleeWithArgumentPlanner(&value, exp.Callee, lastChainPart(exp.Left), line, func(arg ast.Expression, argLine int) (FastValuePlan, bool) {
-			return fastValuePlanFromExpression(plan, arg, false, argLine)
+			return fastValuePlanFromExpression(plan, arg, nullOnMissing, argLine)
 		}) {
 			return FastValuePlan{}, false
 		}
@@ -1509,7 +1509,7 @@ func fastValuePlanFromDynamicIndexExpression(plan *FastRenderPlan, exp *ast.Inde
 	}
 	if exp.Callee != nil {
 		if !appendFastReceiverCalleeWithArgumentPlanner(&value, exp.Callee, lastChainPart(exp.Left), line, func(arg ast.Expression, argLine int) (FastValuePlan, bool) {
-			return fastValuePlanFromExpression(plan, arg, false, argLine)
+			return fastValuePlanFromExpression(plan, arg, nullOnMissing, argLine)
 		}) {
 			return FastValuePlan{}, false
 		}
@@ -1524,14 +1524,14 @@ func fastValuePlanFromCallExpression(plan *FastRenderPlan, exp *ast.CallExpressi
 	if exp.ChainCallee != nil {
 		root := *exp
 		root.ChainCallee = nil
-		if call, ok := fastCallPlanFromExpression(plan, &root, line); ok {
+		if call, ok := fastCallPlanFromExpression(plan, &root, line, nullOnMissing); ok {
 			value := FastValuePlan{
 				Kind: FastValueCall,
 				Call: call,
 				Line: line,
 			}
 			if !appendFastReceiverCalleeWithArgumentPlanner(&value, exp.ChainCallee, lastChainPart(exp.Function), line, func(arg ast.Expression, argLine int) (FastValuePlan, bool) {
-				return fastValuePlanFromExpression(plan, arg, false, argLine)
+				return fastValuePlanFromExpression(plan, arg, nullOnMissing, argLine)
 			}) {
 				return FastValuePlan{}, false
 			}
@@ -1560,14 +1560,14 @@ func fastValuePlanFromCallExpression(plan *FastRenderPlan, exp *ast.CallExpressi
 				Line:  line,
 			})
 			if exp.ChainCallee != nil && !appendFastReceiverCalleeWithArgumentPlanner(&value, exp.ChainCallee, lastChainPart(exp.Function), line, func(arg ast.Expression, argLine int) (FastValuePlan, bool) {
-				return fastValuePlanFromExpression(plan, arg, false, argLine)
+				return fastValuePlanFromExpression(plan, arg, nullOnMissing, argLine)
 			}) {
 				return FastValuePlan{}, false
 			}
 			return value, true
 		}
 	}
-	if call, ok := fastCallPlanFromExpression(plan, exp, line); ok {
+	if call, ok := fastCallPlanFromExpression(plan, exp, line, nullOnMissing); ok {
 		return FastValuePlan{
 			Kind: FastValueCall,
 			Call: call,
@@ -1585,7 +1585,7 @@ func fastValuePlanFromCallExpression(plan *FastRenderPlan, exp *ast.CallExpressi
 			Line:  line,
 		})
 		if exp.ChainCallee != nil && !appendFastReceiverCalleeWithArgumentPlanner(&value, exp.ChainCallee, lastChainPart(exp.Function), line, func(arg ast.Expression, argLine int) (FastValuePlan, bool) {
-			return fastValuePlanFromExpression(plan, arg, false, argLine)
+			return fastValuePlanFromExpression(plan, arg, nullOnMissing, argLine)
 		}) {
 			return FastValuePlan{}, false
 		}
@@ -1601,7 +1601,7 @@ func fastValuePlanFromCallExpression(plan *FastRenderPlan, exp *ast.CallExpressi
 		Line:  line,
 	}
 	for _, arg := range exp.Arguments {
-		argPlan, ok := fastValuePlanFromExpression(plan, arg, false, lineForNode(arg))
+		argPlan, ok := fastValuePlanFromExpression(plan, arg, nullOnMissing, lineForNode(arg))
 		if !ok {
 			return FastValuePlan{}, false
 		}
@@ -1609,7 +1609,7 @@ func fastValuePlanFromCallExpression(plan *FastRenderPlan, exp *ast.CallExpressi
 	}
 	appendFastValuePathStep(&value, callStep)
 	if exp.ChainCallee != nil && !appendFastReceiverCalleeWithArgumentPlanner(&value, exp.ChainCallee, lastChainPart(exp.Function), line, func(arg ast.Expression, argLine int) (FastValuePlan, bool) {
-		return fastValuePlanFromExpression(plan, arg, false, argLine)
+		return fastValuePlanFromExpression(plan, arg, nullOnMissing, argLine)
 	}) {
 		return FastValuePlan{}, false
 	}
@@ -1712,7 +1712,7 @@ func fastValuePlanFromReceiverCallExpression(plan *FastRenderPlan, exp *ast.Call
 		Line:  line,
 	}
 	for _, arg := range exp.Arguments {
-		argPlan, ok := fastValuePlanFromExpression(plan, arg, false, lineForNode(arg))
+		argPlan, ok := fastValuePlanFromExpression(plan, arg, nullOnMissing, lineForNode(arg))
 		if !ok {
 			return FastValuePlan{}, false
 		}
@@ -1720,7 +1720,7 @@ func fastValuePlanFromReceiverCallExpression(plan *FastRenderPlan, exp *ast.Call
 	}
 	value.Path = append(value.Path, callStep)
 	if exp.ChainCallee != nil && !appendFastReceiverCalleeWithArgumentPlanner(&value, exp.ChainCallee, lastChainPart(exp.Function), line, func(arg ast.Expression, argLine int) (FastValuePlan, bool) {
-		return fastValuePlanFromExpression(plan, arg, false, argLine)
+		return fastValuePlanFromExpression(plan, arg, nullOnMissing, argLine)
 	}) {
 		return FastValuePlan{}, false
 	}
@@ -1780,7 +1780,7 @@ func fastIndexStepFromExpression(expr ast.Expression, line int) (FastPathStep, b
 	return FastPathStep{}, false
 }
 
-func fastCallPlanFromExpression(plan *FastRenderPlan, exp *ast.CallExpression, line int) (*FastCallPlan, bool) {
+func fastCallPlanFromExpression(plan *FastRenderPlan, exp *ast.CallExpression, line int, nullOnMissing bool) (*FastCallPlan, bool) {
 	if exp == nil || exp.Block != nil || exp.ChainCallee != nil {
 		return nil, false
 	}
@@ -1794,7 +1794,7 @@ func fastCallPlanFromExpression(plan *FastRenderPlan, exp *ast.CallExpression, l
 		Line:      line,
 	}
 	for _, arg := range exp.Arguments {
-		value, ok := fastValuePlanFromExpression(plan, arg, false, line)
+		value, ok := fastValuePlanFromExpression(plan, arg, nullOnMissing, line)
 		if !ok {
 			return nil, false
 		}
@@ -1804,7 +1804,7 @@ func fastCallPlanFromExpression(plan *FastRenderPlan, exp *ast.CallExpression, l
 }
 
 func fastSilentCallPlanFromExpression(plan *FastRenderPlan, exp *ast.CallExpression, line int) (*FastCallPlan, bool) {
-	call, ok := fastCallPlanFromExpression(plan, exp, line)
+	call, ok := fastCallPlanFromExpression(plan, exp, line, false)
 	if !ok {
 		return nil, false
 	}
@@ -2701,7 +2701,7 @@ func appendFastLoopOutputParts(plan *FastRenderPlan, loop *FastLoopPlan, parts *
 			})
 			return true
 		}
-		if value, ok := fastValuePlanFromLoopCallWithPlan(plan, loop, expr, line); ok {
+		if value, ok := fastValuePlanFromLoopCallWithPlan(plan, loop, expr, line, false); ok {
 			*parts = append(*parts, FastLoopPart{Kind: FastLoopPartValuePath, ValuePlan: value, Line: line})
 			return true
 		}
@@ -2713,7 +2713,7 @@ func appendFastLoopOutputParts(plan *FastRenderPlan, loop *FastLoopPlan, parts *
 			*parts = append(*parts, FastLoopPart{Kind: FastLoopPartValuePath, ValuePlan: value, Line: line})
 			return true
 		}
-		if call, ok := fastLoopCallPlanFromExpression(plan, loop, expr, line); ok {
+		if call, ok := fastLoopCallPlanFromExpression(plan, loop, expr, line, false); ok {
 			*parts = append(*parts, FastLoopPart{
 				Kind:  FastLoopPartCall,
 				Value: call.Name,
@@ -2967,7 +2967,7 @@ func fastValuePlanFromLoopOperand(plan *FastRenderPlan, loop *FastLoopPlan, expr
 	case *ast.HashLiteral:
 		return fastValuePlanFromLoopHashLiteral(plan, loop, expr, line)
 	case *ast.IndexExpression:
-		return fastValuePlanFromLoopIndexWithPlan(plan, loop, expr, line)
+		return fastValuePlanFromLoopIndexWithPlan(plan, loop, expr, line, nullOnMissing)
 	case *ast.StringLiteral:
 		return FastValuePlan{Kind: FastValueString, Value: expr.Value, Line: line}, true
 	case *ast.IntegerLiteral:
@@ -2978,10 +2978,10 @@ func fastValuePlanFromLoopOperand(plan *FastRenderPlan, loop *FastLoopPlan, expr
 		return FastValuePlan{Kind: FastValueBool, BoolValue: expr.Value, Line: line}, true
 	}
 	if call, ok := expr.(*ast.CallExpression); ok {
-		if value, ok := fastValuePlanFromLoopCallWithPlan(plan, loop, call, line); ok {
+		if value, ok := fastValuePlanFromLoopCallWithPlan(plan, loop, call, line, nullOnMissing); ok {
 			return value, true
 		}
-		if planned, ok := fastLoopCallPlanFromExpression(plan, loop, call, line); ok {
+		if planned, ok := fastLoopCallPlanFromExpression(plan, loop, call, line, nullOnMissing); ok {
 			return FastValuePlan{
 				Kind: FastValueCall,
 				Call: planned,
@@ -3080,7 +3080,7 @@ func fastLoopHashLiteralKeyPlan(plan *FastRenderPlan, loop *FastLoopPlan, expr a
 	return "", &value, true
 }
 
-func fastLoopCallPlanFromExpression(plan *FastRenderPlan, loop *FastLoopPlan, exp *ast.CallExpression, line int) (*FastCallPlan, bool) {
+func fastLoopCallPlanFromExpression(plan *FastRenderPlan, loop *FastLoopPlan, exp *ast.CallExpression, line int, nullOnMissing bool) (*FastCallPlan, bool) {
 	if plan == nil || loop == nil || exp == nil || exp.Block != nil || exp.ChainCallee != nil {
 		return nil, false
 	}
@@ -3094,7 +3094,7 @@ func fastLoopCallPlanFromExpression(plan *FastRenderPlan, loop *FastLoopPlan, ex
 		Line:      line,
 	}
 	for _, arg := range exp.Arguments {
-		value, ok := fastValuePlanFromLoopCallArgument(plan, loop, arg, line)
+		value, ok := fastValuePlanFromLoopCallArgument(plan, loop, arg, line, nullOnMissing)
 		if !ok {
 			return nil, false
 		}
@@ -3104,7 +3104,7 @@ func fastLoopCallPlanFromExpression(plan *FastRenderPlan, loop *FastLoopPlan, ex
 }
 
 func fastSilentLoopCallPlanFromExpression(plan *FastRenderPlan, loop *FastLoopPlan, exp *ast.CallExpression, line int) (*FastCallPlan, bool) {
-	call, ok := fastLoopCallPlanFromExpression(plan, loop, exp, line)
+	call, ok := fastLoopCallPlanFromExpression(plan, loop, exp, line, false)
 	if !ok {
 		return nil, false
 	}
@@ -3131,7 +3131,7 @@ func fastLoopBlockCallPlanFromExpression(plan *FastRenderPlan, loop *FastLoopPla
 		Line:        line,
 	}
 	for _, arg := range exp.Arguments {
-		value, ok := fastValuePlanFromLoopCallArgument(plan, loop, arg, lineForNode(arg))
+		value, ok := fastValuePlanFromLoopCallArgument(plan, loop, arg, lineForNode(arg), false)
 		if !ok {
 			return nil, false
 		}
@@ -3156,8 +3156,8 @@ func fastPlainHelperIdentifier(ident *ast.Identifier) bool {
 	return len(identifierParts(ident)) == 1
 }
 
-func fastValuePlanFromLoopCallArgument(plan *FastRenderPlan, loop *FastLoopPlan, expr ast.Expression, line int) (FastValuePlan, bool) {
-	return fastValuePlanFromLoopOperand(plan, loop, expr, false, line)
+func fastValuePlanFromLoopCallArgument(plan *FastRenderPlan, loop *FastLoopPlan, expr ast.Expression, line int, nullOnMissing bool) (FastValuePlan, bool) {
+	return fastValuePlanFromLoopOperand(plan, loop, expr, nullOnMissing, line)
 }
 
 func fastLoopOuterNames(parent *FastLoopPlan) []string {
@@ -3221,26 +3221,26 @@ func isFastLoopKeyIdentifier(loop *FastLoopPlan, expr ast.Expression) bool {
 }
 
 func fastValuePlanFromLoopIndex(loop *FastLoopPlan, expr ast.Expression, line int) (FastValuePlan, bool) {
-	return fastValuePlanFromLoopIndexWithPlan(&FastRenderPlan{}, loop, expr, line)
+	return fastValuePlanFromLoopIndexWithPlan(&FastRenderPlan{}, loop, expr, line, false)
 }
 
-func fastValuePlanFromLoopIndexWithPlan(plan *FastRenderPlan, loop *FastLoopPlan, expr ast.Expression, line int) (FastValuePlan, bool) {
+func fastValuePlanFromLoopIndexWithPlan(plan *FastRenderPlan, loop *FastLoopPlan, expr ast.Expression, line int, nullOnMissing bool) (FastValuePlan, bool) {
 	index, ok := expr.(*ast.IndexExpression)
 	if !ok {
 		return FastValuePlan{}, false
 	}
 	value, ok := fastValuePlanFromLoopExpressionWithMethodWithPlan(plan, loop, index.Left, line, false)
 	if !ok {
-		return fastValuePlanFromLoopDynamicIndex(plan, loop, index, line)
+		return fastValuePlanFromLoopDynamicIndex(plan, loop, index, line, nullOnMissing)
 	}
 	indexStep, ok := fastIndexStepFromExpression(index.Index, line)
 	if !ok {
-		return fastValuePlanFromLoopDynamicIndex(plan, loop, index, line)
+		return fastValuePlanFromLoopDynamicIndex(plan, loop, index, line, nullOnMissing)
 	}
 	value.Path = append(value.Path, indexStep)
 	if index.Callee != nil {
 		if !appendFastReceiverCalleeWithArgumentPlanner(&value, index.Callee, lastChainPart(index.Left), line, func(arg ast.Expression, argLine int) (FastValuePlan, bool) {
-			return fastValuePlanFromLoopCallArgument(plan, loop, arg, argLine)
+			return fastValuePlanFromLoopCallArgument(plan, loop, arg, argLine, nullOnMissing)
 		}) {
 			return FastValuePlan{}, false
 		}
@@ -3248,15 +3248,15 @@ func fastValuePlanFromLoopIndexWithPlan(plan *FastRenderPlan, loop *FastLoopPlan
 	return value, true
 }
 
-func fastValuePlanFromLoopDynamicIndex(plan *FastRenderPlan, loop *FastLoopPlan, expr *ast.IndexExpression, line int) (FastValuePlan, bool) {
+func fastValuePlanFromLoopDynamicIndex(plan *FastRenderPlan, loop *FastLoopPlan, expr *ast.IndexExpression, line int, nullOnMissing bool) (FastValuePlan, bool) {
 	if expr == nil || expr.Left == nil || expr.Index == nil {
 		return FastValuePlan{}, false
 	}
-	left, ok := fastValuePlanFromLoopOperand(plan, loop, expr.Left, false, lineForNode(expr.Left))
+	left, ok := fastValuePlanFromLoopOperand(plan, loop, expr.Left, nullOnMissing, lineForNode(expr.Left))
 	if !ok {
 		return FastValuePlan{}, false
 	}
-	index, ok := fastValuePlanFromLoopOperand(plan, loop, expr.Index, false, lineForNode(expr.Index))
+	index, ok := fastValuePlanFromLoopOperand(plan, loop, expr.Index, nullOnMissing, lineForNode(expr.Index))
 	if !ok || !fastIndexOperandSupported(index) {
 		return FastValuePlan{}, false
 	}
@@ -3268,7 +3268,7 @@ func fastValuePlanFromLoopDynamicIndex(plan *FastRenderPlan, loop *FastLoopPlan,
 	}
 	if expr.Callee != nil {
 		if !appendFastReceiverCalleeWithArgumentPlanner(&value, expr.Callee, lastChainPart(expr.Left), line, func(arg ast.Expression, argLine int) (FastValuePlan, bool) {
-			return fastValuePlanFromLoopCallArgument(plan, loop, arg, argLine)
+			return fastValuePlanFromLoopCallArgument(plan, loop, arg, argLine, nullOnMissing)
 		}) {
 			return FastValuePlan{}, false
 		}
@@ -3277,24 +3277,24 @@ func fastValuePlanFromLoopDynamicIndex(plan *FastRenderPlan, loop *FastLoopPlan,
 }
 
 func fastValuePlanFromLoopCall(loop *FastLoopPlan, exp *ast.CallExpression, line int) (FastValuePlan, bool) {
-	return fastValuePlanFromLoopCallWithPlan(&FastRenderPlan{}, loop, exp, line)
+	return fastValuePlanFromLoopCallWithPlan(&FastRenderPlan{}, loop, exp, line, false)
 }
 
-func fastValuePlanFromLoopCallWithPlan(plan *FastRenderPlan, loop *FastLoopPlan, exp *ast.CallExpression, line int) (FastValuePlan, bool) {
+func fastValuePlanFromLoopCallWithPlan(plan *FastRenderPlan, loop *FastLoopPlan, exp *ast.CallExpression, line int, nullOnMissing bool) (FastValuePlan, bool) {
 	if exp == nil || exp.Block != nil {
 		return FastValuePlan{}, false
 	}
 	if exp.ChainCallee != nil {
 		root := *exp
 		root.ChainCallee = nil
-		if call, ok := fastLoopCallPlanFromExpression(plan, loop, &root, line); ok {
+		if call, ok := fastLoopCallPlanFromExpression(plan, loop, &root, line, nullOnMissing); ok {
 			value := FastValuePlan{
 				Kind: FastValueCall,
 				Call: call,
 				Line: line,
 			}
 			if !appendFastReceiverCalleeWithArgumentPlanner(&value, exp.ChainCallee, lastChainPart(exp.Function), line, func(arg ast.Expression, argLine int) (FastValuePlan, bool) {
-				return fastValuePlanFromLoopCallArgument(plan, loop, arg, argLine)
+				return fastValuePlanFromLoopCallArgument(plan, loop, arg, argLine, nullOnMissing)
 			}) {
 				return FastValuePlan{}, false
 			}
@@ -3307,7 +3307,7 @@ func fastValuePlanFromLoopCallWithPlan(plan *FastRenderPlan, loop *FastLoopPlan,
 	}
 	callStep := FastPathStep{Kind: FastPathStepCall, Value: callExpressionName(exp), Line: line}
 	for _, arg := range exp.Arguments {
-		argPlan, ok := fastValuePlanFromLoopCallArgument(plan, loop, arg, lineForNode(arg))
+		argPlan, ok := fastValuePlanFromLoopCallArgument(plan, loop, arg, lineForNode(arg), nullOnMissing)
 		if !ok {
 			return FastValuePlan{}, false
 		}
@@ -3316,7 +3316,7 @@ func fastValuePlanFromLoopCallWithPlan(plan *FastRenderPlan, loop *FastLoopPlan,
 	appendFastValuePathStep(&value, callStep)
 	if exp.ChainCallee != nil {
 		if !appendFastReceiverCalleeWithArgumentPlanner(&value, exp.ChainCallee, lastChainPart(exp.Function), line, func(arg ast.Expression, argLine int) (FastValuePlan, bool) {
-			return fastValuePlanFromLoopCallArgument(plan, loop, arg, argLine)
+			return fastValuePlanFromLoopCallArgument(plan, loop, arg, argLine, nullOnMissing)
 		}) {
 			return FastValuePlan{}, false
 		}
@@ -3349,9 +3349,9 @@ func fastValuePlanFromLoopExpressionWithMethodWithPlan(plan *FastRenderPlan, loo
 		}
 		return value, true
 	case *ast.IndexExpression:
-		return fastValuePlanFromLoopIndexWithPlan(plan, loop, expr, line)
+		return fastValuePlanFromLoopIndexWithPlan(plan, loop, expr, line, false)
 	case *ast.CallExpression:
-		return fastValuePlanFromLoopCallWithPlan(plan, loop, expr, line)
+		return fastValuePlanFromLoopCallWithPlan(plan, loop, expr, line, false)
 	default:
 		return FastValuePlan{}, false
 	}

--- a/vm/compiler/fast_plan_ast_edges_test.go
+++ b/vm/compiler/fast_plan_ast_edges_test.go
@@ -28,9 +28,14 @@ func compilerFast_Test_Return(expr ast.Expression) *ast.ReturnStatement {
 
 func Test_Fast_Render_AST_Program_And_Static_Edges(t *testing.T) {
 	require.Nil(t, fastRenderPlanFromProgram(nil))
-	require.Nil(t, fastRenderPlanFromProgram(&ast.Program{Statements: []ast.Statement{
+	staticPlan := fastRenderPlanFromProgram(&ast.Program{Statements: []ast.Statement{
 		&ast.ExpressionStatement{Expression: &ast.HTMLLiteral{Value: "static"}},
-	}}))
+	}})
+	require.NotNil(t, staticPlan)
+	require.Empty(t, staticPlan.Bindings)
+	require.Len(t, staticPlan.Segments, 1)
+	require.Equal(t, FastRenderSegmentStatic, staticPlan.Segments[0].Kind)
+	require.Equal(t, "static", staticPlan.Segments[0].Value)
 
 	plan := &FastRenderPlan{}
 	segments := []FastRenderSegment{}
@@ -115,6 +120,19 @@ func Test_Fast_Render_AST_Value_Plan_Edges(t *testing.T) {
 	}, false, 3)
 	require.True(t, ok)
 	require.Equal(t, FastValueIndex, value.Kind)
+
+	value, ok = fastValuePlanFromExpression(plan, parseFast_Test_Expression(t, `custom(missing.Value)`), true, 4)
+	require.True(t, ok)
+	require.Equal(t, FastValueCall, value.Kind)
+	require.Len(t, value.Call.Args, 1)
+	require.True(t, value.Call.Args[0].NullOnMissing)
+
+	value, ok = fastValuePlanFromExpression(plan, parseFast_Test_Expression(t, `custom(missing.Value)`), false, 4)
+	require.True(t, ok)
+	require.Equal(t, FastValueCall, value.Kind)
+	require.Len(t, value.Call.Args, 1)
+	require.False(t, value.Call.Args[0].NullOnMissing)
+
 	_, ok = fastValuePlanFromIndexExpression(plan, &ast.IndexExpression{
 		Left:   &ast.Identifier{Value: "items"},
 		Index:  &ast.IntegerLiteral{Value: 0},
@@ -394,7 +412,7 @@ func Test_Fast_Render_AST_Loop_Edge_Branches(t *testing.T) {
 	loopCallPlan, ok := fastLoopCallPlanFromExpression(plan, loop, &ast.CallExpression{
 		Function:  &ast.Identifier{Value: "label"},
 		Arguments: []ast.Expression{&ast.HashLiteral{}},
-	}, 1)
+	}, 1, false)
 	require.True(t, ok)
 	require.NotNil(t, loopCallPlan)
 	require.Len(t, loopCallPlan.Args, 1)
@@ -407,7 +425,8 @@ func Test_Fast_Render_AST_Loop_Edge_Branches(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "product", root)
 
-	value, ok = fastValuePlanFromLoopIndex(loop, &ast.IndexExpression{Left: &ast.Identifier{Value: "product.Name"}, Index: &ast.Identifier{Value: "bad"}}, 1)
+	itemLoop := &FastLoopPlan{KeyName: "i", ValueName: "item"}
+	value, ok = fastValuePlanFromLoopIndex(itemLoop, &ast.IndexExpression{Left: &ast.Identifier{Value: "item.Name"}, Index: &ast.Identifier{Value: "bad"}}, 1)
 	require.True(t, ok)
 	require.Equal(t, FastValueIndex, value.Kind)
 	_, ok = fastValuePlanFromLoopIndex(loop, &ast.IndexExpression{

--- a/vm/compiler/fast_plan_ast_edges_test.go
+++ b/vm/compiler/fast_plan_ast_edges_test.go
@@ -34,10 +34,14 @@ func Test_Fast_Render_AST_Program_And_Static_Edges(t *testing.T) {
 
 	plan := &FastRenderPlan{}
 	segments := []FastRenderSegment{}
-	require.False(t, appendFastStatement(plan, &segments, &ast.ReturnStatement{
+	require.True(t, appendFastStatement(plan, &segments, &ast.ReturnStatement{
 		Type:        token.RETURN,
-		ReturnValue: &ast.StringLiteral{Value: "nope"},
+		ReturnValue: &ast.StringLiteral{Value: "done"},
 	}))
+	require.Len(t, segments, 1)
+	require.Equal(t, FastRenderSegmentReturn, segments[0].Kind)
+
+	segments = nil
 	require.False(t, appendFastStatement(plan, &segments, &ast.ExpressionStatement{
 		Expression: &ast.IntegerLiteral{Value: 7},
 	}))
@@ -105,11 +109,12 @@ func Test_Fast_Render_AST_Value_Plan_Edges(t *testing.T) {
 	}, false, 3)
 	require.False(t, ok)
 
-	_, ok = fastValuePlanFromIndexExpression(plan, &ast.IndexExpression{
+	value, ok = fastValuePlanFromIndexExpression(plan, &ast.IndexExpression{
 		Left:  &ast.Identifier{Value: "items"},
 		Index: &ast.Identifier{Value: "dynamic"},
 	}, false, 3)
-	require.False(t, ok)
+	require.True(t, ok)
+	require.Equal(t, FastValueIndex, value.Kind)
 	_, ok = fastValuePlanFromIndexExpression(plan, &ast.IndexExpression{
 		Left:   &ast.Identifier{Value: "items"},
 		Index:  &ast.IntegerLiteral{Value: 0},
@@ -123,25 +128,31 @@ func Test_Fast_Render_AST_Value_Plan_Edges(t *testing.T) {
 	}, false, 4)
 	require.False(t, ok)
 
-	_, ok = fastValuePlanFromCallExpression(plan, &ast.CallExpression{
+	value, ok = fastValuePlanFromCallExpression(plan, &ast.CallExpression{
 		Function:  &ast.Identifier{Value: "partial"},
 		Arguments: []ast.Expression{&ast.StringLiteral{Value: "row"}},
 	}, false, 4)
-	require.False(t, ok)
+	require.True(t, ok)
+	require.Equal(t, FastValueCall, value.Kind)
+	require.Equal(t, "partial", value.Call.Name)
 
 	_, ok = fastValuePlanFromCallExpression(plan, &ast.CallExpression{
 		Function: &ast.StringLiteral{Value: "not-path"},
 	}, false, 4)
 	require.False(t, ok)
 
-	_, ok = fastValuePlanFromCallExpression(plan, &ast.CallExpression{
+	value, ok = fastValuePlanFromCallExpression(plan, &ast.CallExpression{
 		Function: &ast.Identifier{Value: "robot.Name"},
 		ChainCallee: &ast.CallExpression{
 			Function:  &ast.Identifier{Value: "Echo"},
 			Arguments: []ast.Expression{&ast.StringLiteral{Value: "bad"}},
 		},
 	}, false, 4)
-	require.False(t, ok)
+	require.True(t, ok)
+	require.Equal(t, FastValuePath, value.Kind)
+	require.Len(t, value.Path, 4)
+	require.Equal(t, FastPathStepCall, value.Path[3].Kind)
+	require.Len(t, value.Path[3].Args, 1)
 
 	_, ok = fastValuePlanFromCallExpression(plan, &ast.CallExpression{
 		Function:    &ast.Identifier{Value: "robot"},
@@ -269,8 +280,9 @@ func Test_Fast_Render_AST_Loop_Edge_Branches(t *testing.T) {
 	require.False(t, ok)
 	require.Nil(t, gotLoop)
 	gotLoop, ok = fastLoopPlanFromExpression(plan, &ast.ForExpression{Iterable: &ast.Identifier{Value: "nil"}, Block: &ast.BlockStatement{}}, 1)
-	require.False(t, ok)
-	require.Nil(t, gotLoop)
+	require.True(t, ok)
+	require.NotNil(t, gotLoop)
+	require.Equal(t, "nil", gotLoop.Iterable.Value)
 	gotLoop, ok = fastLoopPlanFromExpression(plan, &ast.ForExpression{
 		Iterable: &ast.Identifier{Value: "items"},
 		Block: &ast.BlockStatement{Statements: []ast.Statement{
@@ -281,10 +293,12 @@ func Test_Fast_Render_AST_Loop_Edge_Branches(t *testing.T) {
 	require.Nil(t, gotLoop)
 
 	parts := []FastLoopPart{}
-	require.False(t, appendFastLoopStatement(plan, loop, &parts, &ast.ReturnStatement{
+	require.True(t, appendFastLoopStatement(plan, loop, &parts, &ast.ReturnStatement{
 		Type:        token.RETURN,
-		ReturnValue: &ast.StringLiteral{Value: "bad"},
+		ReturnValue: &ast.StringLiteral{Value: "done"},
 	}))
+	require.Len(t, parts, 1)
+	require.Equal(t, FastLoopPartReturn, parts[0].Kind)
 	require.False(t, appendFastLoopOutputParts(plan, loop, &parts, &ast.CallExpression{
 		Function: &ast.Identifier{Value: "product.Name"},
 		Block:    &ast.BlockStatement{},
@@ -393,8 +407,9 @@ func Test_Fast_Render_AST_Loop_Edge_Branches(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "product", root)
 
-	_, ok = fastValuePlanFromLoopIndex(loop, &ast.IndexExpression{Left: &ast.Identifier{Value: "product.Name"}, Index: &ast.Identifier{Value: "bad"}}, 1)
-	require.False(t, ok)
+	value, ok = fastValuePlanFromLoopIndex(loop, &ast.IndexExpression{Left: &ast.Identifier{Value: "product.Name"}, Index: &ast.Identifier{Value: "bad"}}, 1)
+	require.True(t, ok)
+	require.Equal(t, FastValueIndex, value.Kind)
 	_, ok = fastValuePlanFromLoopIndex(loop, &ast.IndexExpression{
 		Left:   &ast.Identifier{Value: "product.Name"},
 		Index:  &ast.IntegerLiteral{Value: 0},
@@ -403,11 +418,15 @@ func Test_Fast_Render_AST_Loop_Edge_Branches(t *testing.T) {
 	require.False(t, ok)
 	_, ok = fastValuePlanFromLoopCall(loop, &ast.CallExpression{Block: &ast.BlockStatement{}}, 1)
 	require.False(t, ok)
-	_, ok = fastValuePlanFromLoopCall(loop, &ast.CallExpression{
+	value, ok = fastValuePlanFromLoopCall(loop, &ast.CallExpression{
 		Function:  &ast.Identifier{Value: "product.Name"},
 		Arguments: []ast.Expression{&ast.StringLiteral{Value: "bad"}},
 	}, 1)
-	require.False(t, ok)
+	require.True(t, ok)
+	require.Equal(t, FastValuePath, value.Kind)
+	require.Len(t, value.Path, 2)
+	require.Equal(t, FastPathStepCall, value.Path[1].Kind)
+	require.Len(t, value.Path[1].Args, 1)
 	_, ok = fastValuePlanFromLoopCall(loop, &ast.CallExpression{Function: &ast.StringLiteral{Value: "bad"}}, 1)
 	require.False(t, ok)
 	_, ok = fastValuePlanFromLoopCall(loop, &ast.CallExpression{

--- a/vm/compiler/fast_plan_bytecode.go
+++ b/vm/compiler/fast_plan_bytecode.go
@@ -178,6 +178,7 @@ func fastLoopPlanFromFunction(fn *object.CompiledFunction, constants []object.Ob
 
 		switch op {
 		case code.OpReturn:
+			loop.PartFlagsSet = true
 			return loop, true
 		case code.OpWriteHTML:
 			value, ok := htmlConstantValue(constants, operands[0])

--- a/vm/compiler/fast_plan_bytecode.go
+++ b/vm/compiler/fast_plan_bytecode.go
@@ -169,7 +169,11 @@ func fastLoopPlanFromFunction(fn *object.CompiledFunction, constants []object.Ob
 		return nil, false
 	}
 
-	loop := &FastLoopPlan{KeyName: keyName, ValueName: valueName}
+	loop := &FastLoopPlan{
+		KeyName:   keyName,
+		ValueName: valueName,
+		SizeStats: &LoopSizeStats{},
+	}
 	for i := 0; i < len(fn.Instructions); {
 		op, operands, read, ok := instructionAt(fn.Instructions, i)
 		if !ok {

--- a/vm/compiler/fast_script_plan_test.go
+++ b/vm/compiler/fast_script_plan_test.go
@@ -28,7 +28,7 @@ func Test_Fast_Render_Plan_Literal_Lets_And_Path_Loops(t *testing.T) {
 }
 
 func Test_Fast_Render_Plan_Loop_Let_With_Helper_And_Arithmetic_Arg(t *testing.T) {
-	input := `<%= for (_, product) in products { %><% let categorySeo = replace(category.CategorySeoUrl, "-outofstock", "", 0 - 1) %><%= categorySeo %>:<%= product.Name %>;<% } %>`
+	input := `<%= for (_, item) in items { %><% let normalizedPath = replace(document.Path, "-draft", "", 0 - 1) %><%= normalizedPath %>:<%= item.Name %>;<% } %>`
 	program, err := parser.Parse(input)
 	require.NoError(t, err)
 
@@ -44,7 +44,7 @@ func Test_Fast_Render_Plan_Loop_Let_With_Helper_And_Arithmetic_Arg(t *testing.T)
 	require.NotNil(t, loop)
 	require.GreaterOrEqual(t, len(loop.Parts), 4)
 	require.Equal(t, FastLoopPartLet, loop.Parts[0].Kind)
-	require.Equal(t, "categorySeo", loop.Parts[0].Value)
+	require.Equal(t, "normalizedPath", loop.Parts[0].Value)
 	require.Equal(t, FastValueCall, loop.Parts[0].ValuePlan.Kind)
 	require.NotNil(t, loop.Parts[0].ValuePlan.Call)
 	require.Equal(t, "replace", loop.Parts[0].ValuePlan.Call.Name)
@@ -54,7 +54,7 @@ func Test_Fast_Render_Plan_Loop_Let_With_Helper_And_Arithmetic_Arg(t *testing.T)
 
 	require.Equal(t, FastLoopPartValuePath, loop.Parts[1].Kind)
 	require.Equal(t, FastValueName, loop.Parts[1].ValuePlan.Kind)
-	require.Equal(t, "categorySeo", loop.Parts[1].ValuePlan.Value)
+	require.Equal(t, "normalizedPath", loop.Parts[1].ValuePlan.Value)
 }
 
 func Test_Fast_Render_Plan_Loop_Assignment_Updates_Outer_Binding(t *testing.T) {
@@ -97,6 +97,22 @@ func Test_Fast_Render_Plan_Ignores_Comment_Blocks(t *testing.T) {
 	require.Len(t, bytecode.FastRenderPlan.Segments, 1)
 	require.Equal(t, FastRenderSegmentName, bytecode.FastRenderPlan.Segments[0].Kind)
 	require.Equal(t, "title", bytecode.FastRenderPlan.Segments[0].Value)
+}
+
+func Test_Fast_Render_Plan_Comment_With_Static_Output_Has_Zero_Binding_Plan(t *testing.T) {
+	program, err := parser.Parse(`<%# metadata %>Ready`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan, bytecode.FastReject)
+	require.Empty(t, bytecode.FastReject)
+	require.Empty(t, bytecode.FastRenderPlan.Bindings)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+	require.Equal(t, FastRenderSegmentStatic, bytecode.FastRenderPlan.Segments[0].Kind)
+	require.Equal(t, "Ready", bytecode.FastRenderPlan.Segments[0].Value)
 }
 
 func Test_Fast_Render_Plan_Assignment_Scalar_Expressions_And_Index_Targets(t *testing.T) {
@@ -523,7 +539,7 @@ func Test_Fast_Render_Plan_Extended_Syntax_Does_Not_Fallback(t *testing.T) {
 	}
 }
 
-func Test_Fast_Render_Plan_Unsupported_Syntax_Uses_Generic_VM_Except_Holes(t *testing.T) {
+func Test_Fast_Render_Plan_Unsupported_Syntax_Uses_Generic_VM(t *testing.T) {
 	program, err := parser.Parse(`<% let add = fn(x) { return x + 1 } %><%= add(2) %>`)
 	require.NoError(t, err)
 
@@ -544,6 +560,8 @@ func Test_Fast_Render_Plan_Unsupported_Syntax_Uses_Generic_VM_Except_Holes(t *te
 
 	bytecode = compiler.Bytecode()
 	require.True(t, bytecode.HasHoles)
-	require.Nil(t, bytecode.FastRenderPlan)
-	require.NotEmpty(t, bytecode.FastReject)
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Empty(t, bytecode.FastReject)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+	require.Equal(t, FastRenderSegmentGeneric, bytecode.FastRenderPlan.Segments[0].Kind)
 }

--- a/vm/compiler/fast_script_plan_test.go
+++ b/vm/compiler/fast_script_plan_test.go
@@ -57,6 +57,219 @@ func Test_Fast_Render_Plan_Loop_Let_With_Helper_And_Arithmetic_Arg(t *testing.T)
 	require.Equal(t, "categorySeo", loop.Parts[1].ValuePlan.Value)
 }
 
+func Test_Fast_Render_Plan_Loop_Assignment_Updates_Outer_Binding(t *testing.T) {
+	input := `<% let last = "" %><%= for (_, item) in items { %><% let label = item %><% last = label %><%= label %><% } %><%= last %>`
+	program, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan, bytecode.FastReject)
+	require.Empty(t, bytecode.FastReject)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 3)
+
+	loop := bytecode.FastRenderPlan.Segments[1].Loop
+	require.NotNil(t, loop)
+	require.Len(t, loop.Parts, 3)
+	require.Equal(t, FastLoopPartLet, loop.Parts[0].Kind)
+	require.Equal(t, FastLoopPartAssign, loop.Parts[1].Kind)
+	require.Equal(t, "last", loop.Parts[1].Value)
+	require.Equal(t, FastValueName, loop.Parts[1].ValuePlan.Kind)
+	require.Equal(t, "label", loop.Parts[1].ValuePlan.Value)
+
+	require.Equal(t, FastRenderSegmentName, bytecode.FastRenderPlan.Segments[2].Kind)
+	require.Equal(t, "last", bytecode.FastRenderPlan.Segments[2].Value)
+}
+
+func Test_Fast_Render_Plan_Ignores_Comment_Blocks(t *testing.T) {
+	input := `<%# editor metadata lives here %><%= title %>`
+	program, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan, bytecode.FastReject)
+	require.Empty(t, bytecode.FastReject)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+	require.Equal(t, FastRenderSegmentName, bytecode.FastRenderPlan.Segments[0].Kind)
+	require.Equal(t, "title", bytecode.FastRenderPlan.Segments[0].Value)
+}
+
+func Test_Fast_Render_Plan_Assignment_Scalar_Expressions_And_Index_Targets(t *testing.T) {
+	input := `<% let count = 0 %><% let data = {} %><%= for (_, item) in items { %><% count = count + 1 %><% data[item.Key] = item.Value %><% } %><%= data[active] %><%= count %>`
+	program, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan, bytecode.FastReject)
+	require.Empty(t, bytecode.FastReject)
+
+	loop := bytecode.FastRenderPlan.Segments[2].Loop
+	require.NotNil(t, loop)
+	require.Len(t, loop.Parts, 2)
+	require.Equal(t, FastLoopPartAssign, loop.Parts[0].Kind)
+	require.Equal(t, FastValueConcat, loop.Parts[0].ValuePlan.Kind)
+	require.Equal(t, FastLoopPartAssign, loop.Parts[1].Kind)
+	require.NotNil(t, loop.Parts[1].AssignTarget)
+	require.Equal(t, FastAssignTargetIndex, loop.Parts[1].AssignTarget.Kind)
+
+	require.Equal(t, FastRenderSegmentValue, bytecode.FastRenderPlan.Segments[3].Kind)
+	require.Equal(t, FastValueIndex, bytecode.FastRenderPlan.Segments[3].ValuePlan.Kind)
+}
+
+func Test_Fast_Render_Plan_Receiver_Call_With_Arguments(t *testing.T) {
+	input := `<%= builder.RenderControl({name: "Email", type: inputType}) %>`
+	program, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan, bytecode.FastReject)
+	require.Empty(t, bytecode.FastReject)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+
+	segment := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentValue, segment.Kind)
+	require.Equal(t, FastValuePath, segment.ValuePlan.Kind)
+	require.Len(t, segment.ValuePlan.Path, 2)
+	require.Equal(t, FastPathStepProperty, segment.ValuePlan.Path[0].Kind)
+	require.True(t, segment.ValuePlan.Path[0].Method)
+	require.Equal(t, FastPathStepCall, segment.ValuePlan.Path[1].Kind)
+	require.Len(t, segment.ValuePlan.Path[1].Args, 1)
+	require.Equal(t, FastValueHash, segment.ValuePlan.Path[1].Args[0].Kind)
+}
+
+func Test_Fast_Render_Plan_Receiver_Call_With_Scalar_And_Hash_Arguments(t *testing.T) {
+	input := `<%= builder.RenderSelect("Level", {options: ["one", "two"], value: selected}) %>`
+	program, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan, bytecode.FastReject)
+	require.Empty(t, bytecode.FastReject)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+
+	segment := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentValue, segment.Kind)
+	require.Equal(t, FastValuePath, segment.ValuePlan.Kind)
+	require.Len(t, segment.ValuePlan.Path, 2)
+	require.Equal(t, FastPathStepCall, segment.ValuePlan.Path[1].Kind)
+	require.Len(t, segment.ValuePlan.Path[1].Args, 2)
+	require.Equal(t, FastValueString, segment.ValuePlan.Path[1].Args[0].Kind)
+	require.Equal(t, FastValueHash, segment.ValuePlan.Path[1].Args[1].Kind)
+}
+
+func Test_Fast_Render_Plan_FormFor_Doc_Syntax(t *testing.T) {
+	input := `<%= form_for(record, {action: recordPath({id: record.ID}), method: "PUT"}) { %><%= f.InputTag("Title") %><%= f.SelectTag("Level", {options: ["one", "two"], value: selected}) %><%= f.CheckboxTag("Enabled", {unchecked: false}) %><% } %>`
+	program, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan, bytecode.FastReject)
+	require.Empty(t, bytecode.FastReject)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+
+	blockCall := bytecode.FastRenderPlan.Segments[0].BlockCall
+	require.NotNil(t, blockCall)
+	require.Equal(t, "form_for", blockCall.Name)
+	require.Len(t, blockCall.Args, 2)
+	require.Equal(t, FastValueName, blockCall.Args[0].Kind)
+	require.Equal(t, "record", blockCall.Args[0].Value)
+
+	options := blockCall.Args[1]
+	require.Equal(t, FastValueHash, options.Kind)
+	require.Len(t, options.Pairs, 2)
+	require.Equal(t, "action", options.Pairs[0].Key)
+	require.Equal(t, FastValueCall, options.Pairs[0].Value.Kind)
+	require.Equal(t, "recordPath", options.Pairs[0].Value.Call.Name)
+	require.Len(t, options.Pairs[0].Value.Call.Args, 1)
+	require.Equal(t, FastValueHash, options.Pairs[0].Value.Call.Args[0].Kind)
+	require.Equal(t, "method", options.Pairs[1].Key)
+	require.Equal(t, FastValueString, options.Pairs[1].Value.Kind)
+
+	require.NotNil(t, blockCall.BlockBytecode)
+	require.NotNil(t, blockCall.BlockBytecode.FastRenderPlan)
+}
+
+func Test_Fast_Render_Plan_Silent_Block_Helper_Call(t *testing.T) {
+	input := `<% capture("extra") { %><style><%= klass %></style><% } %><%= readCapture("extra") %>`
+	program, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan, bytecode.FastReject)
+	require.Empty(t, bytecode.FastReject)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 2)
+
+	segment := bytecode.FastRenderPlan.Segments[0]
+	require.Equal(t, FastRenderSegmentBlockCall, segment.Kind)
+	require.NotNil(t, segment.BlockCall)
+	require.Equal(t, "capture", segment.BlockCall.Name)
+	require.True(t, segment.BlockCall.Silent)
+	require.NotNil(t, segment.BlockCall.BlockBytecode)
+}
+
+func Test_Fast_Render_Plan_Silent_Script_For_Allows_Assignments(t *testing.T) {
+	input := `<% let collected = [] %><% for (_, item) in items { %>ignored<%= item.Value %><% collected = collected + item.Value %><% } %><%= collected[1] %>`
+	program, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan, bytecode.FastReject)
+	require.Empty(t, bytecode.FastReject)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 3)
+
+	loop := bytecode.FastRenderPlan.Segments[1].Loop
+	require.NotNil(t, loop)
+	require.True(t, loop.Silent)
+	require.GreaterOrEqual(t, len(loop.Parts), 3)
+	require.Equal(t, FastLoopPartAssign, loop.Parts[len(loop.Parts)-1].Kind)
+	require.Equal(t, FastValueConcat, loop.Parts[len(loop.Parts)-1].ValuePlan.Kind)
+}
+
+func Test_Fast_Render_Plan_Loop_Local_Assignment_After_Let(t *testing.T) {
+	input := `<% let out = "" %><%= for (_, item) in items { %><% let label = "" %><% label = item %><% out = out + label %><% } %><%= out %><%= if (label) { %>leak<% } %>`
+	program, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan, bytecode.FastReject)
+	require.Empty(t, bytecode.FastReject)
+
+	loop := bytecode.FastRenderPlan.Segments[1].Loop
+	require.NotNil(t, loop)
+	require.Len(t, loop.Parts, 3)
+	require.Equal(t, FastLoopPartLet, loop.Parts[0].Kind)
+	require.Equal(t, FastLoopPartAssign, loop.Parts[1].Kind)
+	require.Equal(t, "label", loop.Parts[1].Value)
+	require.Equal(t, FastLoopPartAssign, loop.Parts[2].Kind)
+	require.Equal(t, "out", loop.Parts[2].Value)
+}
+
 func Test_Fast_Render_Plan_Prefix_Condition_And_Loop_Concat(t *testing.T) {
 	input := `<%= if (!userSignedIn) { %>Guest<% } else { %>User<% } %><%= for (item) in menu.Items { %><%= item.Name + " x " + item.Count %>;<% } %>`
 	program, err := parser.Parse(input)
@@ -179,4 +392,158 @@ func Test_Fast_Render_Plan_Silent_Script_If_Allows_Assignments(t *testing.T) {
 	require.Len(t, conditional.Conditional.Branches, 1)
 	require.Len(t, conditional.Conditional.Branches[0].Segments, 1)
 	require.Equal(t, FastRenderSegmentAssign, conditional.Conditional.Branches[0].Segments[0].Kind)
+}
+
+func Test_Fast_Render_Plan_Extended_Syntax_Does_Not_Fallback(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		assert func(*testing.T, *Bytecode)
+	}{
+		{
+			name:  "regex match",
+			input: `<%= name ~= "^Mi" %>`,
+			assert: func(t *testing.T, bytecode *Bytecode) {
+				require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+				require.Equal(t, FastValueInfix, bytecode.FastRenderPlan.Segments[0].ValuePlan.Kind)
+				require.Equal(t, "~=", bytecode.FastRenderPlan.Segments[0].ValuePlan.Operator)
+			},
+		},
+		{
+			name:  "unary minus digit identifier arithmetic",
+			input: `<%= -my123greet %>|<%= -my123greet + my123greet2 %>`,
+			assert: func(t *testing.T, bytecode *Bytecode) {
+				require.Equal(t, []string{"my123greet", "my123greet2"}, bytecode.FastRenderPlan.Bindings)
+				require.Len(t, bytecode.FastRenderPlan.Segments, 3)
+				require.Equal(t, FastValuePrefix, bytecode.FastRenderPlan.Segments[0].ValuePlan.Kind)
+				require.Equal(t, "-", bytecode.FastRenderPlan.Segments[0].ValuePlan.Operator)
+				require.Equal(t, FastValueConcat, bytecode.FastRenderPlan.Segments[2].ValuePlan.Kind)
+				require.Equal(t, FastValuePrefix, bytecode.FastRenderPlan.Segments[2].ValuePlan.Left.Kind)
+				require.Equal(t, FastValueName, bytecode.FastRenderPlan.Segments[2].ValuePlan.Right.Kind)
+			},
+		},
+		{
+			name:  "silent plain helper call",
+			input: `<% touch(name) %><%= done %>`,
+			assert: func(t *testing.T, bytecode *Bytecode) {
+				require.Len(t, bytecode.FastRenderPlan.Segments, 2)
+				require.Equal(t, FastRenderSegmentCall, bytecode.FastRenderPlan.Segments[0].Kind)
+				require.True(t, bytecode.FastRenderPlan.Segments[0].Call.Silent)
+			},
+		},
+		{
+			name:  "dynamic partial name and layout",
+			input: `<%= partial(templateName, {name: name, layout: layoutName}) %>`,
+			assert: func(t *testing.T, bytecode *Bytecode) {
+				require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+				segment := bytecode.FastRenderPlan.Segments[0]
+				require.Equal(t, FastRenderSegmentCall, segment.Kind)
+				require.Equal(t, "partial", segment.Call.Name)
+				require.Len(t, segment.Call.Args, 2)
+				require.Equal(t, FastValueName, segment.Call.Args[0].Kind)
+				require.Equal(t, FastValueHash, segment.Call.Args[1].Kind)
+			},
+		},
+		{
+			name:  "dynamic callee and chained receiver call",
+			input: `<%= helpers[name]("x") %>|<%= makeUser(name).Render("short") %>`,
+			assert: func(t *testing.T, bytecode *Bytecode) {
+				require.Len(t, bytecode.FastRenderPlan.Segments, 3)
+				require.Equal(t, FastRenderSegmentValue, bytecode.FastRenderPlan.Segments[0].Kind)
+				require.Equal(t, FastValueIndex, bytecode.FastRenderPlan.Segments[0].ValuePlan.Kind)
+				require.Equal(t, FastRenderSegmentValue, bytecode.FastRenderPlan.Segments[2].Kind)
+				require.Equal(t, FastValueCall, bytecode.FastRenderPlan.Segments[2].ValuePlan.Kind)
+				require.NotEmpty(t, bytecode.FastRenderPlan.Segments[2].ValuePlan.Path)
+			},
+		},
+		{
+			name:  "top-level return",
+			input: `<% return done %><%= after %>`,
+			assert: func(t *testing.T, bytecode *Bytecode) {
+				require.Len(t, bytecode.FastRenderPlan.Segments, 2)
+				require.Equal(t, FastRenderSegmentReturn, bytecode.FastRenderPlan.Segments[0].Kind)
+			},
+		},
+		{
+			name:  "return inside output if and loop",
+			input: `<%= if (enabled) { return label } else { return fallback } %><%= for (_, item) in items { return item } %>`,
+			assert: func(t *testing.T, bytecode *Bytecode) {
+				require.Len(t, bytecode.FastRenderPlan.Segments, 2)
+				conditional := bytecode.FastRenderPlan.Segments[0].Conditional
+				require.NotNil(t, conditional)
+				require.Len(t, conditional.Branches[0].Segments, 1)
+				require.NotEqual(t, FastRenderSegmentReturn, conditional.Branches[0].Segments[0].Kind)
+				loop := bytecode.FastRenderPlan.Segments[1].Loop
+				require.NotNil(t, loop)
+				require.Len(t, loop.Parts, 1)
+				require.Equal(t, FastLoopPartReturn, loop.Parts[0].Kind)
+			},
+		},
+		{
+			name:  "nil loop and loop iterator assignment",
+			input: `<%= for (_, item) in nil { item = "x" } %><%= for (_, item) in items { item = "x"; return item } %>`,
+			assert: func(t *testing.T, bytecode *Bytecode) {
+				require.Len(t, bytecode.FastRenderPlan.Segments, 2)
+				require.Equal(t, "nil", bytecode.FastRenderPlan.Segments[0].Loop.Iterable.Value)
+				loop := bytecode.FastRenderPlan.Segments[1].Loop
+				require.NotNil(t, loop)
+				require.Len(t, loop.Parts, 2)
+				require.Equal(t, FastLoopPartAssign, loop.Parts[0].Kind)
+				require.Equal(t, "item", loop.Parts[0].Value)
+				require.Equal(t, FastLoopPartReturn, loop.Parts[1].Kind)
+			},
+		},
+		{
+			name:  "non-string hash literal keys",
+			input: `<%= {true: "yes", 7: "lucky"}[true] %>`,
+			assert: func(t *testing.T, bytecode *Bytecode) {
+				require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+				require.Equal(t, FastValueIndex, bytecode.FastRenderPlan.Segments[0].ValuePlan.Kind)
+				hash := bytecode.FastRenderPlan.Segments[0].ValuePlan.Left
+				require.NotNil(t, hash)
+				require.Equal(t, FastValueHash, hash.Kind)
+				require.NotNil(t, hash.Pairs[0].KeyPlan)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			program, err := parser.Parse(tt.input)
+			require.NoError(t, err)
+
+			compiler := New()
+			require.NoError(t, compiler.Compile(program))
+
+			bytecode := compiler.Bytecode()
+			require.NotNil(t, bytecode.FastRenderPlan, bytecode.FastReject)
+			require.Empty(t, bytecode.FastReject)
+			tt.assert(t, bytecode)
+		})
+	}
+}
+
+func Test_Fast_Render_Plan_Unsupported_Syntax_Uses_Generic_VM_Except_Holes(t *testing.T) {
+	program, err := parser.Parse(`<% let add = fn(x) { return x + 1 } %><%= add(2) %>`)
+	require.NoError(t, err)
+
+	compiler := New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode := compiler.Bytecode()
+	require.NotNil(t, bytecode.FastRenderPlan, bytecode.FastReject)
+	require.Empty(t, bytecode.FastReject)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+	require.Equal(t, FastRenderSegmentGeneric, bytecode.FastRenderPlan.Segments[0].Kind)
+
+	program, err = parser.Parse(`<%H "hole" %><%= name %>`)
+	require.NoError(t, err)
+
+	compiler = New()
+	require.NoError(t, compiler.Compile(program))
+
+	bytecode = compiler.Bytecode()
+	require.True(t, bytecode.HasHoles)
+	require.Nil(t, bytecode.FastRenderPlan)
+	require.NotEmpty(t, bytecode.FastReject)
 }

--- a/vm/compiler/layout_output_size_profile.go
+++ b/vm/compiler/layout_output_size_profile.go
@@ -1,0 +1,51 @@
+package compiler
+
+import "sync/atomic"
+
+const layoutOutputSizeBucketCount = 8
+
+type LayoutOutputSizeProfile struct {
+	buckets atomic.Pointer[layoutOutputSizeBuckets]
+}
+
+type layoutOutputSizeBuckets struct {
+	stats [layoutOutputSizeBucketCount]OutputSizeStats
+}
+
+func (p *LayoutOutputSizeProfile) Stats(yieldSize int) (*OutputSizeStats, string) {
+	if p == nil {
+		return nil, ""
+	}
+	buckets := p.buckets.Load()
+	if buckets == nil {
+		candidate := &layoutOutputSizeBuckets{}
+		if p.buckets.CompareAndSwap(nil, candidate) {
+			buckets = candidate
+		} else {
+			buckets = p.buckets.Load()
+		}
+	}
+	index, name := layoutOutputSizeBucket(yieldSize)
+	return &buckets.stats[index], name
+}
+
+func layoutOutputSizeBucket(yieldSize int) (int, string) {
+	switch {
+	case yieldSize <= 4<<10:
+		return 0, "0-4k"
+	case yieldSize <= 16<<10:
+		return 1, "4k-16k"
+	case yieldSize <= 32<<10:
+		return 2, "16k-32k"
+	case yieldSize <= 64<<10:
+		return 3, "32k-64k"
+	case yieldSize <= 256<<10:
+		return 4, "64k-256k"
+	case yieldSize <= 1<<20:
+		return 5, "256k-1m"
+	case yieldSize <= 4<<20:
+		return 6, "1m-4m"
+	default:
+		return 7, "4m+"
+	}
+}

--- a/vm/compiler/layout_output_size_profile_test.go
+++ b/vm/compiler/layout_output_size_profile_test.go
@@ -1,0 +1,67 @@
+package compiler
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_LayoutOutputSizeProfile_Isolates_Yield_Size_Bands(t *testing.T) {
+	var profile LayoutOutputSizeProfile
+
+	small, smallBand := profile.Stats(31_694)
+	medium, mediumBand := profile.Stats(35_179)
+	require.Equal(t, "16k-32k", smallBand)
+	require.Equal(t, "32k-64k", mediumBand)
+	require.NotSame(t, small, medium)
+
+	small.Observe(293_089)
+	medium.Observe(358_432)
+	require.Equal(t, 293_089, small.Estimate())
+	require.Equal(t, 358_432, medium.Estimate())
+
+	sameSmall, sameSmallBand := profile.Stats(20_000)
+	require.Same(t, small, sameSmall)
+	require.Equal(t, smallBand, sameSmallBand)
+}
+
+func Test_LayoutOutputSizeProfile_Bands(t *testing.T) {
+	tests := []struct {
+		yieldSize int
+		band      string
+	}{
+		{yieldSize: 0, band: "0-4k"},
+		{yieldSize: 4 << 10, band: "0-4k"},
+		{yieldSize: (4 << 10) + 1, band: "4k-16k"},
+		{yieldSize: 32 << 10, band: "16k-32k"},
+		{yieldSize: (32 << 10) + 1, band: "32k-64k"},
+		{yieldSize: 4 << 20, band: "1m-4m"},
+		{yieldSize: (4 << 20) + 1, band: "4m+"},
+	}
+
+	var profile LayoutOutputSizeProfile
+	for _, test := range tests {
+		_, band := profile.Stats(test.yieldSize)
+		require.Equal(t, test.band, band)
+	}
+}
+
+func Test_LayoutOutputSizeProfile_ConcurrentStats(t *testing.T) {
+	var profile LayoutOutputSizeProfile
+	const workers = 32
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			stats, _ := profile.Stats(50_796)
+			stats.Observe(379_151)
+		}()
+	}
+	wg.Wait()
+
+	stats, _ := profile.Stats(50_796)
+	require.Equal(t, uint64(workers), stats.Samples())
+	require.Equal(t, 379_151, stats.Estimate())
+}

--- a/vm/compiler/loop_size_stats.go
+++ b/vm/compiler/loop_size_stats.go
@@ -1,0 +1,37 @@
+package compiler
+
+import "sync/atomic"
+
+type LoopSizeStats struct {
+	bytesPerItem atomic.Uint64
+	samples      atomic.Uint64
+}
+
+func (s *LoopSizeStats) Observe(bytesPerItem int) {
+	if s == nil || bytesPerItem < 0 {
+		return
+	}
+	actual := outputSizeHintUint64(uint64(bytesPerItem))
+	for {
+		current := s.bytesPerItem.Load()
+		next := nextOutputSizeEstimate(current, actual, s.samples.Load())
+		if s.bytesPerItem.CompareAndSwap(current, next) {
+			s.samples.Add(1)
+			return
+		}
+	}
+}
+
+func (s *LoopSizeStats) BytesPerItem() int {
+	if s == nil {
+		return 0
+	}
+	return outputSizeHintInt(s.bytesPerItem.Load())
+}
+
+func (s *LoopSizeStats) Samples() uint64 {
+	if s == nil {
+		return 0
+	}
+	return s.samples.Load()
+}

--- a/vm/compiler/loop_size_stats_test.go
+++ b/vm/compiler/loop_size_stats_test.go
@@ -1,0 +1,50 @@
+package compiler
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_LoopSizeStats_Learn_And_Adapt(t *testing.T) {
+	var stats LoopSizeStats
+
+	require.Zero(t, stats.BytesPerItem())
+	require.Zero(t, stats.Samples())
+
+	stats.Observe(100)
+	require.Equal(t, 100, stats.BytesPerItem())
+	require.Equal(t, uint64(1), stats.Samples())
+
+	stats.Observe(300)
+	require.Equal(t, 200, stats.BytesPerItem())
+
+	stats.Observe(120)
+	require.Equal(t, 190, stats.BytesPerItem())
+	require.Equal(t, uint64(3), stats.Samples())
+
+	stats.Observe(-1)
+	require.Equal(t, uint64(3), stats.Samples())
+}
+
+func Test_LoopSizeStats_ConcurrentObserve(t *testing.T) {
+	var stats LoopSizeStats
+	var wg sync.WaitGroup
+
+	const workers = 16
+	const observations = 128
+	wg.Add(workers)
+	for worker := 0; worker < workers; worker++ {
+		go func(offset int) {
+			defer wg.Done()
+			for i := 0; i < observations; i++ {
+				stats.Observe(80 + offset + i%8)
+			}
+		}(worker)
+	}
+	wg.Wait()
+
+	require.Equal(t, uint64(workers*observations), stats.Samples())
+	require.Positive(t, stats.BytesPerItem())
+}

--- a/vm/compiler/optimizer.go
+++ b/vm/compiler/optimizer.go
@@ -46,6 +46,10 @@ func optimizeScope(
 			if len(ins.operands) > 0 {
 				jumpTargets[ins.operands[0]] = true
 			}
+		case code.OpGetNameOrJumpMissing:
+			if len(ins.operands) > 1 {
+				jumpTargets[ins.operands[1]] = true
+			}
 		}
 	}
 
@@ -126,6 +130,11 @@ func optimizeScope(
 		case code.OpJump, code.OpJumpNotTruthy:
 			copied := append([]int(nil), operands...)
 			copied[0] = mapTarget(copied[0])
+			replacement := code.Make(op, copied...)
+			copy(out[i:i+len(replacement)], replacement)
+		case code.OpGetNameOrJumpMissing:
+			copied := append([]int(nil), operands...)
+			copied[1] = mapTarget(copied[1])
 			replacement := code.Make(op, copied...)
 			copy(out[i:i+len(replacement)], replacement)
 		}

--- a/vm/compiler/output_size_stats.go
+++ b/vm/compiler/output_size_stats.go
@@ -1,0 +1,185 @@
+package compiler
+
+import (
+	"math"
+	"sync/atomic"
+)
+
+const outputSizeStatsMaxGrowHint = 4 << 20
+
+type OutputSizeStats struct {
+	estimate atomic.Uint64
+	samples  atomic.Uint64
+	minimum  atomic.Uint64
+	maximum  atomic.Uint64
+}
+
+func (s *OutputSizeStats) GrowHint(staticSize int) int {
+	if staticSize < 0 {
+		staticSize = 0
+	}
+	hint := uint64(staticSize)
+	if s != nil {
+		if estimate := s.estimate.Load(); estimate > hint {
+			hint = estimate
+		}
+	}
+	return outputSizeHintInt(hint)
+}
+
+func (s *OutputSizeStats) Observe(actualSize int) {
+	if s == nil || actualSize <= 0 {
+		return
+	}
+	actual := outputSizeHintUint64(uint64(actualSize))
+	s.observeRange(actual)
+	for {
+		current := s.estimate.Load()
+		next := nextOutputSizeEstimate(current, actual, s.samples.Load())
+		if s.estimate.CompareAndSwap(current, next) {
+			s.samples.Add(1)
+			return
+		}
+	}
+}
+
+func (s *OutputSizeStats) Range() (int, int) {
+	if s == nil {
+		return 0, 0
+	}
+	return outputSizeHintInt(s.minimum.Load()), outputSizeHintInt(s.maximum.Load())
+}
+
+func (s *OutputSizeStats) Unstable() bool {
+	if s == nil || s.samples.Load() < 2 {
+		return false
+	}
+	minimum := s.minimum.Load()
+	maximum := s.maximum.Load()
+	return minimum > 0 && maximum/minimum >= 4
+}
+
+func (s *OutputSizeStats) observeRange(actual uint64) {
+	for {
+		minimum := s.minimum.Load()
+		if minimum != 0 && minimum <= actual {
+			break
+		}
+		if s.minimum.CompareAndSwap(minimum, actual) {
+			break
+		}
+	}
+	for {
+		maximum := s.maximum.Load()
+		if maximum >= actual {
+			break
+		}
+		if s.maximum.CompareAndSwap(maximum, actual) {
+			break
+		}
+	}
+}
+
+func (s *OutputSizeStats) Estimate() int {
+	if s == nil {
+		return 0
+	}
+	return outputSizeHintInt(s.estimate.Load())
+}
+
+func (s *OutputSizeStats) Samples() uint64 {
+	if s == nil {
+		return 0
+	}
+	return s.samples.Load()
+}
+
+func (b *Bytecode) OutputGrowHint() int {
+	if b == nil {
+		return 0
+	}
+	if b.OutputSizeStats == nil {
+		return outputSizeHintInt(uint64(b.StaticSize))
+	}
+	return b.OutputSizeStats.GrowHint(b.StaticSize)
+}
+
+func (b *Bytecode) ObserveOutputSize(actualSize int) {
+	if b == nil || b.OutputSizeStats == nil {
+		return
+	}
+	b.OutputSizeStats.Observe(actualSize)
+}
+
+func (b *Bytecode) LayoutOverheadGrowHint() int {
+	if b == nil {
+		return 0
+	}
+	if b.LayoutSizeStats == nil {
+		return outputSizeHintInt(uint64(b.StaticSize))
+	}
+	return b.LayoutSizeStats.GrowHint(b.StaticSize)
+}
+
+func (b *Bytecode) PartialOutputGrowHint() int {
+	if b == nil {
+		return 0
+	}
+	if b.PartialSizeStats == nil {
+		return outputSizeHintInt(uint64(b.StaticSize))
+	}
+	return b.PartialSizeStats.GrowHint(b.StaticSize)
+}
+
+func nextOutputSizeEstimate(current, actual, samples uint64) uint64 {
+	if samples == 0 {
+		return actual
+	}
+	if current == actual {
+		return current
+	}
+	if current == 0 {
+		return actual
+	}
+	if actual > current {
+		limit := current * 4
+		if limit < current {
+			limit = math.MaxUint64
+		}
+		if actual > limit {
+			actual = limit
+		}
+		delta := actual - current
+		step := delta / 2
+		if step == 0 {
+			step = 1
+		}
+		return outputSizeHintUint64(current + step)
+	}
+
+	delta := current - actual
+	step := delta / 8
+	if step == 0 {
+		step = 1
+	}
+	return outputSizeHintUint64(current - step)
+}
+
+func outputSizeHintInt(value uint64) int {
+	value = outputSizeHintUint64(value)
+	if value > uint64(maxInt()) {
+		return maxInt()
+	}
+	return int(value)
+}
+
+func outputSizeHintUint64(value uint64) uint64 {
+	if value > outputSizeStatsMaxGrowHint {
+		return outputSizeStatsMaxGrowHint
+	}
+	return value
+}
+
+func maxInt() int {
+	return int(^uint(0) >> 1)
+}

--- a/vm/compiler/output_size_stats_test.go
+++ b/vm/compiler/output_size_stats_test.go
@@ -1,0 +1,87 @@
+package compiler
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_OutputSizeStats_GrowHint_Observe_And_Slow_Decay(t *testing.T) {
+	var stats OutputSizeStats
+
+	require.Equal(t, 12, stats.GrowHint(12))
+	require.Zero(t, stats.Estimate())
+	require.Zero(t, stats.Samples())
+	stats.Observe(0)
+	stats.Observe(-1)
+	require.Zero(t, stats.Estimate())
+	require.Zero(t, stats.Samples())
+
+	stats.Observe(100)
+	require.Equal(t, 100, stats.Estimate())
+	require.Equal(t, uint64(1), stats.Samples())
+	require.Equal(t, 100, stats.GrowHint(12))
+
+	stats.Observe(300)
+	require.Equal(t, 200, stats.Estimate())
+	require.Equal(t, uint64(2), stats.Samples())
+
+	stats.Observe(120)
+	require.Equal(t, 190, stats.Estimate())
+	require.Equal(t, uint64(3), stats.Samples())
+}
+
+func Test_OutputSizeStats_Outlier_And_Hint_Caps(t *testing.T) {
+	var stats OutputSizeStats
+
+	stats.Observe(100)
+	stats.Observe(100_000)
+	require.Equal(t, 250, stats.Estimate())
+	require.Equal(t, uint64(2), stats.Samples())
+
+	stats.Observe(outputSizeStatsMaxGrowHint * 2)
+	require.LessOrEqual(t, stats.Estimate(), outputSizeStatsMaxGrowHint)
+	require.Equal(t, outputSizeStatsMaxGrowHint, stats.GrowHint(outputSizeStatsMaxGrowHint*2))
+}
+
+func Test_OutputSizeStats_ConcurrentObserve(t *testing.T) {
+	var stats OutputSizeStats
+	var wg sync.WaitGroup
+
+	const workers = 16
+	const observations = 128
+	wg.Add(workers)
+	for worker := 0; worker < workers; worker++ {
+		go func(offset int) {
+			defer wg.Done()
+			for i := 0; i < observations; i++ {
+				stats.Observe(100 + offset + i%8)
+			}
+		}(worker)
+	}
+	wg.Wait()
+
+	require.Equal(t, uint64(workers*observations), stats.Samples())
+	require.Positive(t, stats.Estimate())
+	require.LessOrEqual(t, stats.Estimate(), outputSizeStatsMaxGrowHint)
+	minimum, maximum := stats.Range()
+	require.Equal(t, 100, minimum)
+	require.Equal(t, 122, maximum)
+	require.False(t, stats.Unstable())
+}
+
+func Test_OutputSizeStats_Detects_Unstable_Output_Range(t *testing.T) {
+	var stats OutputSizeStats
+
+	stats.Observe(100)
+	require.False(t, stats.Unstable())
+	stats.Observe(399)
+	require.False(t, stats.Unstable())
+	stats.Observe(400)
+	require.True(t, stats.Unstable())
+	require.Equal(t, 324, stats.Estimate())
+	minimum, maximum := stats.Range()
+	require.Equal(t, 100, minimum)
+	require.Equal(t, 400, maximum)
+}

--- a/vm/compiler/types.go
+++ b/vm/compiler/types.go
@@ -9,26 +9,31 @@ import (
 )
 
 type Bytecode struct {
-	Instructions     code.Instructions
-	CallNames        map[int]string
-	LocalNames       map[int]string
-	LineNumbers      map[int]int
-	Properties       map[int]object.PropertyAccess
-	PropertyCaches   []object.InlineCacheSlot
-	CallCaches       []object.InlineCacheSlot
-	NumLocals        int
-	NumGlobals       int
-	Constants        []object.Object
-	GlobalNames      map[int]string
-	Static           bool
-	StaticOutput     string
-	FastRenderPlan   *FastRenderPlan
-	FastRejectLine   int
-	FastReject       string
-	FastDiagnostics  atomic.Value
-	HasHoles         bool
-	HasPartials      bool
-	HasContextWrites bool
+	Instructions      code.Instructions
+	CallNames         map[int]string
+	LocalNames        map[int]string
+	LineNumbers       map[int]int
+	Properties        map[int]object.PropertyAccess
+	PropertyCaches    []object.InlineCacheSlot
+	CallCaches        []object.InlineCacheSlot
+	NumLocals         int
+	NumGlobals        int
+	Constants         []object.Object
+	GlobalNames       map[int]string
+	Static            bool
+	StaticOutput      string
+	StaticSize        int
+	FastRenderPlan    *FastRenderPlan
+	FastRejectLine    int
+	FastReject        string
+	FastDiagnostics   atomic.Value
+	OutputSizeStats   *OutputSizeStats
+	LayoutSizeStats   *OutputSizeStats
+	LayoutSizeProfile LayoutOutputSizeProfile
+	PartialSizeStats  *OutputSizeStats
+	HasHoles          bool
+	HasPartials       bool
+	HasContextWrites  bool
 }
 
 func (b *Bytecode) ContextWrites() bool {
@@ -143,6 +148,7 @@ type FastLoopPlan struct {
 	HasAssign         bool
 	PartFlagsSet      bool
 	Line              int
+	SizeStats         *LoopSizeStats
 }
 
 type FastValueKind uint8

--- a/vm/compiler/types.go
+++ b/vm/compiler/types.go
@@ -54,6 +54,8 @@ const (
 	FastRenderSegmentPartial
 	FastRenderSegmentLet
 	FastRenderSegmentAssign
+	FastRenderSegmentReturn
+	FastRenderSegmentGeneric
 )
 
 type FastRenderSegment struct {
@@ -71,6 +73,8 @@ type FastRenderSegment struct {
 	BlockCall     *FastBlockCallPlan
 	Conditional   *FastConditionalPlan
 	Partial       *FastPartialPlan
+	Generic       *FastGenericPlan
+	AssignTarget  *FastAssignTarget
 	PropertyCache object.InlineCacheSlot
 	CallCache     object.InlineCacheSlot
 	OutputCache   object.InlineCacheSlot
@@ -104,6 +108,8 @@ const (
 	FastLoopPartBlockCall
 	FastLoopPartPartial
 	FastLoopPartLet
+	FastLoopPartAssign
+	FastLoopPartReturn
 )
 
 type FastLoopPart struct {
@@ -117,6 +123,7 @@ type FastLoopPart struct {
 	Call          *FastCallPlan
 	BlockCall     *FastBlockCallPlan
 	Partial       *FastPartialPlan
+	AssignTarget  *FastAssignTarget
 	Conditional   *FastLoopConditionalPlan
 	Loop          *FastLoopPlan
 	PropertyCache object.InlineCacheSlot
@@ -131,6 +138,10 @@ type FastLoopPlan struct {
 	OuterNames        []string
 	Parts             []FastLoopPart
 	StaticSize        int
+	Silent            bool
+	HasLet            bool
+	HasAssign         bool
+	PartFlagsSet      bool
 	Line              int
 }
 
@@ -151,6 +162,7 @@ const (
 	FastValueConcat
 	FastValueArray
 	FastValueHash
+	FastValueIndex
 )
 
 type FastPathStepKind uint8
@@ -181,9 +193,10 @@ type FastValuePlan struct {
 }
 
 type FastValuePair struct {
-	Key   string
-	Value FastValuePlan
-	Line  int
+	Key     string
+	KeyPlan *FastValuePlan
+	Value   FastValuePlan
+	Line    int
 }
 
 type FastPathStep struct {
@@ -194,14 +207,32 @@ type FastPathStep struct {
 	Full          string
 	Method        bool
 	Line          int
+	Args          []FastValuePlan
 	PropertyCache object.InlineCacheSlot
 	CallCache     object.InlineCacheSlot
+}
+
+type FastAssignTargetKind uint8
+
+const (
+	FastAssignTargetName FastAssignTargetKind = iota
+	FastAssignTargetIndex
+)
+
+type FastAssignTarget struct {
+	Kind      FastAssignTargetKind
+	Name      string
+	NameIndex int
+	Container FastValuePlan
+	Index     FastValuePlan
+	Line      int
 }
 
 type FastCallPlan struct {
 	Name      string
 	NameIndex int
 	Args      []FastValuePlan
+	Silent    bool
 	Line      int
 	Cache     object.InlineCacheSlot
 }
@@ -213,6 +244,7 @@ type FastBlockCallPlan struct {
 	Block         *ast.BlockStatement
 	BlockSource   string
 	BlockBytecode *Bytecode
+	Silent        bool
 	Line          int
 	Cache         object.InlineCacheSlot
 }
@@ -227,6 +259,12 @@ type FastPartialDataPair struct {
 	Key   string
 	Value FastValuePlan
 	Line  int
+}
+
+type FastGenericPlan struct {
+	WholeTemplate bool
+	Reason        string
+	Line          int
 }
 
 type FastConditionalBranch struct {

--- a/vm/plush/parity_budget_test.go
+++ b/vm/plush/parity_budget_test.go
@@ -6,7 +6,6 @@ import (
 
 	rootplush "github.com/gobuffalo/plush/v5"
 	"github.com/gobuffalo/plush/v5/helpers/hctx"
-	vmplush "github.com/gobuffalo/plush/v5/vm/plush"
 	"github.com/stretchr/testify/require"
 )
 
@@ -149,7 +148,7 @@ func compareBudgetRender(t *testing.T, input string, limit int64, costs rootplus
 	t.Helper()
 
 	interpreterOut, interpreterErr, interpreterStats := renderInterpreterWithBudget(input, limit, costs, data)
-	vmOut, vmErr, vmStats := renderVMWithBudget(input, limit, costs, data)
+	vmOut, vmErr, vmStats := renderVMWithBudget(t, input, limit, costs, data)
 
 	if errors.Is(interpreterErr, rootplush.ErrBudgetExceeded) || errors.Is(vmErr, rootplush.ErrBudgetExceeded) {
 		require.ErrorIs(t, interpreterErr, rootplush.ErrBudgetExceeded)
@@ -178,10 +177,12 @@ func renderInterpreterWithBudget(input string, limit int64, costs rootplush.Budg
 	return out, err, budget.Stats()
 }
 
-func renderVMWithBudget(input string, limit int64, costs rootplush.BudgetCosts, data func() map[string]interface{}) (string, error, rootplush.BudgetStats) {
+func renderVMWithBudget(t *testing.T, input string, limit int64, costs rootplush.BudgetCosts, data func() map[string]interface{}) (string, error, rootplush.BudgetStats) {
+	t.Helper()
+
 	budget := rootplush.NewBudgetWithCosts(limit, costs)
 	ctx := rootplush.NewContextWith(data())
 	ctx.WithBudget(budget)
-	out, err := vmplush.Render(input, ctx)
+	out, err := renderVMContext(t, input, ctx)
 	return out, err, budget.Stats()
 }

--- a/vm/plush/parity_conditions_test.go
+++ b/vm/plush/parity_conditions_test.go
@@ -7,6 +7,14 @@ type parityTruthUser struct {
 	Image *string
 }
 
+type parityNodeSet struct {
+	Nodes []parityNode
+}
+
+type parityNode struct {
+	Label string
+}
+
 func Test_Parity_Conditions_Unknown_As_Nil(t *testing.T) {
 	compareRender(t, `<%= paths == nil %>`, emptyContext)
 	compareRender(t, `<%= nil == paths %>`, emptyContext)
@@ -71,6 +79,12 @@ func Test_Parity_Conditions_Nil_Pointer_Truthiness(t *testing.T) {
 	}))
 }
 
+func Test_Parity_Conditions_Len_Nil_Collection_Short_Circuits_Index(t *testing.T) {
+	compareRender(t, `<%= if (len(record.Nodes) > 0 && record.Nodes[0].Label) { %>present<% } else { %>empty<% } %>`, contextWith(map[string]interface{}{
+		"record": parityNodeSet{},
+	}))
+}
+
 func Test_Parity_Conditions_Logical_Unknown_Short_Circuit(t *testing.T) {
 	compareRender(t, `<%= if (names && len(names) >= 1) { %>yes<% } else { %>no<% } %>`, emptyContext)
 	compareRender(t, `<%= paths || pages %>`, contextWith(map[string]interface{}{
@@ -93,7 +107,7 @@ func Test_Parity_Conditions_Complex_Or_With_Unknown_Middle(t *testing.T) {
 
 func Test_Parity_Conditions_Direct_Unknown_Still_Errors(t *testing.T) {
 	_, interpreterErr := renderInterpreter(`<%= pages %>`, emptyContext)
-	_, vmErr := renderVM(`<%= pages %>`, emptyContext)
+	_, vmErr := renderVM(t, `<%= pages %>`, emptyContext)
 
 	if interpreterErr == nil {
 		t.Fatal("expected interpreter error")
@@ -105,7 +119,7 @@ func Test_Parity_Conditions_Direct_Unknown_Still_Errors(t *testing.T) {
 
 func Test_Parity_Conditions_Invalid_Int_Bool_Comparison_Errors(t *testing.T) {
 	_, interpreterErr := renderInterpreter(`<% let test = 1 %><%= if (test != true) { return "good"} %>`, emptyContext)
-	_, vmErr := renderVM(`<% let test = 1 %><%= if (test != true) { return "good"} %>`, emptyContext)
+	_, vmErr := renderVM(t, `<% let test = 1 %><%= if (test != true) { return "good"} %>`, emptyContext)
 
 	if interpreterErr == nil {
 		t.Fatal("expected interpreter error")

--- a/vm/plush/parity_errors_test.go
+++ b/vm/plush/parity_errors_test.go
@@ -108,7 +108,7 @@ func Test_Parity_Phase_13_Line_Numbers(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, interpreterErr := renderInterpreter(tt.input, contextWith(tt.data))
-			_, vmErr := renderVM(tt.input, contextWith(tt.data))
+			_, vmErr := renderVM(t, tt.input, contextWith(tt.data))
 			require.Error(t, interpreterErr)
 			require.Error(t, vmErr)
 			require.Equal(t, interpreterErr.Error(), vmErr.Error())
@@ -139,7 +139,7 @@ func compareExactRenderError(t *testing.T, input string, factory func() hctx.Con
 	t.Helper()
 
 	interpreterOut, interpreterErr := renderInterpreter(input, factory)
-	vmOut, vmErr := renderVM(input, factory)
+	vmOut, vmErr := renderVM(t, input, factory)
 
 	require.Error(t, interpreterErr, "expected interpreter error, got output %q", interpreterOut)
 	require.Error(t, vmErr, "expected VM error, got output %q", vmOut)

--- a/vm/plush/parity_functions_test.go
+++ b/vm/plush/parity_functions_test.go
@@ -140,7 +140,7 @@ func Test_Parity_Functions_Dash_In_Helper(t *testing.T) {
 
 func Test_Parity_Functions_Closure(t *testing.T) {
 	input := `<% let newAdder = fn(x) { return fn(y) { return x + y } } %><% let addTwo = newAdder(2) %><%= addTwo(3) %>`
-	out, err := renderVM(input, emptyContext)
+	out, err := renderVM(t, input, emptyContext)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vm/plush/parity_harness_test.go
+++ b/vm/plush/parity_harness_test.go
@@ -25,17 +25,35 @@ func compareRender(t *testing.T, input string, factory contextFactory) {
 	t.Helper()
 
 	interpreterOut, interpreterErr := renderInterpreter(input, factory)
-	vmOut, vmErr := renderVM(input, factory)
+	vmOut, vmErr := renderVM(t, input, factory)
 
 	require.Equalf(t, errorString(interpreterErr), errorString(vmErr), "error mismatch\ninterpreter: %q\nvm:          %q", errorString(interpreterErr), errorString(vmErr))
 	require.Equalf(t, interpreterOut, vmOut, "output mismatch\ninterpreter: %q\nvm:          %q", interpreterOut, vmOut)
+}
+
+func comparePlannedRender(t *testing.T, input string, factory contextFactory, expected string) {
+	t.Helper()
+
+	interpreterOut, interpreterErr := rootplush.Render(input, factory())
+	vmCtx := factory()
+	vmOut, vmErr := renderVMContext(t, input, vmCtx)
+
+	require.NoError(t, interpreterErr)
+	require.NoError(t, vmErr)
+	require.Equal(t, expected, interpreterOut)
+	require.Equal(t, expected, vmOut)
+
+	diagnostics, ok := rootplush.RenderDiagnosticsFromContext(vmCtx)
+	require.True(t, ok, "expected VM render diagnostics")
+	require.NotEqual(t, rootplush.RenderFastPathInterpreterFallback, diagnostics.FastPath, "template fell back to the interpreter: %s", diagnostics.FastReject)
+	require.Empty(t, diagnostics.FastReject)
 }
 
 func compareRenderError(t *testing.T, input string, factory contextFactory) {
 	t.Helper()
 
 	interpreterOut, interpreterErr := renderInterpreter(input, factory)
-	vmOut, vmErr := renderVM(input, factory)
+	vmOut, vmErr := renderVM(t, input, factory)
 
 	require.Error(t, interpreterErr, "expected interpreter error, got output %q", interpreterOut)
 	require.Error(t, vmErr, "expected VM error, got output %q", vmOut)
@@ -47,7 +65,7 @@ func compareBothRenderError(t *testing.T, input string, factory contextFactory) 
 	t.Helper()
 
 	interpreterOut, interpreterErr := renderInterpreter(input, factory)
-	vmOut, vmErr := renderVM(input, factory)
+	vmOut, vmErr := renderVM(t, input, factory)
 
 	require.Error(t, interpreterErr, "expected interpreter error, got output %q", interpreterOut)
 	require.Error(t, vmErr, "expected VM error, got output %q", vmOut)
@@ -57,8 +75,33 @@ func renderInterpreter(input string, factory contextFactory) (string, error) {
 	return rootplush.Render(input, factory())
 }
 
-func renderVM(input string, factory contextFactory) (string, error) {
-	return vmplush.Render(input, factory())
+func renderVM(t *testing.T, input string, factory contextFactory) (string, error) {
+	t.Helper()
+
+	return renderVMContext(t, input, factory())
+}
+
+func renderVMContext(t *testing.T, input string, ctx hctx.Context) (string, error) {
+	t.Helper()
+
+	previousFallback := rootplush.SetVMGenericFallback(true)
+	defer rootplush.SetVMGenericFallback(previousFallback)
+
+	out, err := vmplush.Render(input, ctx)
+	requireNoInterpreterFallback(t, ctx, err)
+	return out, err
+}
+
+func requireNoInterpreterFallback(t *testing.T, ctx hctx.Context, renderErr error) {
+	t.Helper()
+
+	diagnostics, ok := rootplush.RenderDiagnosticsFromContext(ctx)
+	if renderErr == nil {
+		require.True(t, ok, "expected VM render diagnostics")
+	}
+	if ok {
+		require.NotEqual(t, rootplush.RenderFastPathInterpreterFallback, diagnostics.FastPath, "parity render fell back to the interpreter: %s", diagnostics.FastReject)
+	}
 }
 
 func errorString(err error) string {

--- a/vm/plush/parity_helpers_test.go
+++ b/vm/plush/parity_helpers_test.go
@@ -185,6 +185,51 @@ func Test_Parity_Phase_6_Helper_Context_Block_With_And_Render(t *testing.T) {
 	})
 }
 
+func Test_Parity_Helper_Context_Set_Bindings_After_Native_Helper_Calls(t *testing.T) {
+	type widget struct {
+		Label string
+	}
+
+	t.Run("silent call", func(t *testing.T) {
+		compareRender(t, `<% seed() %><%= label %>|<%= widget.Label %>`, contextWith(map[string]interface{}{
+			"seed": func(help rootplush.HelperContext) {
+				help.Set("label", "ready")
+				help.Set("widget", widget{Label: "visible"})
+			},
+		}))
+	})
+
+	t.Run("block call", func(t *testing.T) {
+		compareRender(t, `<%= seed() { %><%= label %>|<%= widget.Label %><% } %>-><%= label %>|<%= widget.Label %>`, contextWith(map[string]interface{}{
+			"seed": func(help rootplush.HelperContext) (template.HTML, error) {
+				help.Set("label", "before")
+				help.Set("widget", widget{Label: "before"})
+				body, err := help.Block()
+				if err != nil {
+					return "", err
+				}
+				help.Set("label", "after")
+				help.Set("widget", widget{Label: "after"})
+				return template.HTML(body), nil
+			},
+		}))
+	})
+
+	t.Run("block with child assignment", func(t *testing.T) {
+		compareRender(t, `<%= scope() { %><%= label %><% label = "updated" %>|<%= label %><% } %>`, contextWith(map[string]interface{}{
+			"scope": func(help rootplush.HelperContext) (template.HTML, error) {
+				child := help.New()
+				child.Set("label", "initial")
+				body, err := help.BlockWith(child)
+				if err != nil {
+					return "", err
+				}
+				return template.HTML(body + "|child:" + child.Value("label").(string)), nil
+			},
+		}))
+	})
+}
+
 func Test_Parity_Helper_Context_Includes_Loop_Binding_For_Render_Like_Helper(t *testing.T) {
 	type renderBlock struct {
 		Type    string
@@ -192,7 +237,7 @@ func Test_Parity_Helper_Context_Includes_Loop_Binding_For_Render_Like_Helper(t *
 	}
 
 	compareRender(t, `<%= for (_, block) in blocks { %><%= render(block.Type + ".plush.html", {settings: block}) %><% } %>`, contextWith(map[string]interface{}{
-		"blocks": []renderBlock{{Type: "product-option", BlockID: "test-1234"}},
+		"blocks": []renderBlock{{Type: "settings-panel", BlockID: "test-1234"}},
 		"render": func(fileName string, data map[string]interface{}, help rootplush.HelperContext) (template.HTML, error) {
 			block, ok := help.Value("block").(renderBlock)
 			if !ok {
@@ -256,7 +301,7 @@ func Test_Parity_Phase_6_Unknown_Helper_Errors(t *testing.T) {
 }
 
 func Test_Parity_Phase_6_Helper_Error_Contains_Returned_Error(t *testing.T) {
-	_, err := renderVM(`<%= fail() %>`, contextWith(map[string]interface{}{
+	_, err := renderVM(t, `<%= fail() %>`, contextWith(map[string]interface{}{
 		"fail": func() (string, error) {
 			return "", errors.New("phase6 returned error")
 		},

--- a/vm/plush/parity_helpers_test.go
+++ b/vm/plush/parity_helpers_test.go
@@ -185,6 +185,28 @@ func Test_Parity_Phase_6_Helper_Context_Block_With_And_Render(t *testing.T) {
 	})
 }
 
+func Test_Parity_Helper_Context_Includes_Loop_Binding_For_Render_Like_Helper(t *testing.T) {
+	type renderBlock struct {
+		Type    string
+		BlockID string
+	}
+
+	compareRender(t, `<%= for (_, block) in blocks { %><%= render(block.Type + ".plush.html", {settings: block}) %><% } %>`, contextWith(map[string]interface{}{
+		"blocks": []renderBlock{{Type: "product-option", BlockID: "test-1234"}},
+		"render": func(fileName string, data map[string]interface{}, help rootplush.HelperContext) (template.HTML, error) {
+			block, ok := help.Value("block").(renderBlock)
+			if !ok {
+				return "", fmt.Errorf("%q: unknown identifier", "block")
+			}
+			settings, ok := data["settings"].(renderBlock)
+			if !ok {
+				return "", fmt.Errorf("%q: unknown identifier", "settings")
+			}
+			return template.HTML(fileName + "|" + settings.BlockID + "|" + block.BlockID), nil
+		},
+	}))
+}
+
 func Test_Parity_Phase_6_Helper_Block_Scope_Behavior(t *testing.T) {
 	t.Run("assignment updates outer scope", func(t *testing.T) {
 		compareRender(t, `<% let value = "before" %><%= run() { value = "after" } %><%= value %>`, contextWith(map[string]interface{}{

--- a/vm/plush/parity_loops_test.go
+++ b/vm/plush/parity_loops_test.go
@@ -1,6 +1,9 @@
 package plush_test
 
 import (
+	"encoding/json"
+	"html/template"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -12,6 +15,19 @@ type parityLoopMenu struct {
 type parityLoopItem struct {
 	Name  string
 	Count int
+}
+
+type paritySelectableEntry struct {
+	ID string
+}
+
+type parityMediaRecord struct {
+	Assets []parityMediaAsset
+}
+
+type parityMediaAsset struct {
+	URL string
+	Alt string
 }
 
 func Test_Parity_Loops_Array_Return(t *testing.T) {
@@ -35,6 +51,250 @@ func Test_Parity_Loops_Key_Value_And_Outer_Same_Identifier(t *testing.T) {
 
 func Test_Parity_Loops_Update_Outer_Binding(t *testing.T) {
 	compareRender(t, `<% let varTest = "" %><% for (i,v) in ["a", "b", "c"] {varTest = v} %><%= varTest %>`, emptyContext)
+}
+
+func Test_Parity_Loops_Nested_Output_Branches_Update_Outer_Binding(t *testing.T) {
+	input := `<% let selected = entries[0] %>
+<%= if (input["target_id"] != "" && count(entries) > 0) { %>
+	<%= for (i, entry) in entries { %>
+		<%= if (entry.ID == input["target_id"]) { %>
+			<% selected = entry %>
+		<% } %>
+	<% } %>
+<% } %>
+<%= selected.ID %>`
+	for _, tt := range []struct {
+		name     string
+		form     map[string]string
+		expected string
+	}{
+		{name: "updates selected value", form: map[string]string{"target_id": "second"}, expected: "second"},
+		{name: "keeps initial value when branch skips", form: map[string]string{"target_id": ""}, expected: "first"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			factory := contextWith(map[string]interface{}{
+				"input": tt.form,
+				"entries": []paritySelectableEntry{
+					{ID: "first"},
+					{ID: "second"},
+				},
+				"count": func(values []paritySelectableEntry) int {
+					return len(values)
+				},
+			})
+			compareRender(t, input, factory)
+
+			vmOut, vmErr := renderVM(t, input, factory)
+			if vmErr != nil {
+				t.Fatalf("unexpected VM error: %v", vmErr)
+			}
+			if actual := strings.TrimSpace(vmOut); actual != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, actual)
+			}
+		})
+	}
+}
+
+func Test_Parity_Loops_Nested_If_Appends_Local_String_To_Outer_Array(t *testing.T) {
+	input := `<% let handlers = [] %>
+<% let items = [1,2,3,4,5,6,7,8,9,0,10] %>
+<%= for (index, item) in items { %>
+	<%= if(true) { %>
+		<% let handle = "test" + to_string(index) %>
+		<% handlers = handlers + handle %>
+		<script>console.log(<%= json_encode(handlers) %>)</script>
+	<% } %>
+<% } %>
+<%= json_encode(handlers) %>`
+	compareRender(t, input, contextWith(map[string]interface{}{
+		"to_string": strconv.Itoa,
+		"json_encode": func(value interface{}) template.HTML {
+			data, _ := json.Marshal(value)
+			return template.HTML(data)
+		},
+	}))
+}
+
+func Test_Parity_Loops_Scoped_Assignment_Combinations(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "silent conditional syncs an outer assignment",
+			input:    `<% let result = [] %><% if (true) { %>discarded<% let local = "A" %><% result = result + local %><% } %><%= result[0] %>`,
+			expected: "A",
+		},
+		{
+			name:     "else branch syncs an outer assignment",
+			input:    `<% let result = [] %><%= if (false) { %><% let local = "wrong" %><% result = result + local %><% } else { %><% let local = "B" %><% result = result + local %><% } %><%= result[0] %>`,
+			expected: "B",
+		},
+		{
+			name:     "nested conditionals sync an outer assignment",
+			input:    `<% let result = [] %><%= if (true) { %><% let prefix = "A" %><%= if (true) { %><% let suffix = "B" %><% result = result + (prefix + suffix) %><% } %><% } %><%= result[0] %>`,
+			expected: "AB",
+		},
+		{
+			name:     "else if branch syncs an outer assignment",
+			input:    `<% let result = "start" %><%= if (false) { %><% result = "wrong" %><% } else if (true) { %><% let local = "selected" %><% result = local %><% } else { %><% result = "also-wrong" %><% } %><%= result %>`,
+			expected: "selected",
+		},
+		{
+			name:     "silent loop conditional syncs between iterations",
+			input:    `<% let result = [] %><%= for (_, item) in [1,2,3] { %><% if (item > 1) { %>discarded<% let local = item %><% result = result + local %><% } %><% } %><%= result[0] %><%= result[1] %>`,
+			expected: "23",
+		},
+		{
+			name:     "nested loops sync an outer assignment",
+			input:    `<% let result = [] %><%= for (_, row) in [[1,2],[3]] { %><%= for (_, item) in row { %><%= if (true) { %><% let local = item %><% result = result + local %><% } %><% } %><% } %><%= result[0] %><%= result[1] %><%= result[2] %>`,
+			expected: "123",
+		},
+		{
+			name:     "nested loop assignment is visible before the parent iteration ends",
+			input:    `<% let result = "" %><%= for (_, row) in [["A","B"],["C"]] { %><%= for (_, item) in row { %><% let local = item %><% result = result + local %><% } %><% result = result + "|" %><% } %><%= result %>`,
+			expected: "AB|C|",
+		},
+		{
+			name:     "loop inside a scoped conditional syncs an outer assignment",
+			input:    `<% let result = "" %><%= if (true) { %><% let prefix = "x" %><%= for (_, item) in ["A","B"] { %><% let local = prefix + item %><% result = result + local %><% } %><% } %><%= result %>`,
+			expected: "xAxB",
+		},
+		{
+			name:     "nested loop local shadow does not leak while outer assignment syncs",
+			input:    `<% let label = "outer" %><% let result = "" %><%= for (_, row) in [["A","B"]] { %><%= for (_, item) in row { %><% let label = item %><% label = label + "!" %><% result = result + label %><% } %><% } %><%= result %>|<%= label %>`,
+			expected: "A!B!|outer",
+		},
+		{
+			name:     "continue preserves an outer assignment",
+			input:    `<% let result = [] %><%= for (_, item) in [1,2,3] { if (item == 2) { let local = item; result = result + local; continue }; result = result + item } %><%= result[0] %><%= result[1] %><%= result[2] %>`,
+			expected: "123",
+		},
+		{
+			name:     "break preserves an outer assignment",
+			input:    `<% let result = [] %><%= for (_, item) in [1,2,3] { if (item == 2) { let local = item; result = result + local; break }; result = result + item } %><%= result[0] %><%= result[1] %>`,
+			expected: "12",
+		},
+		{
+			name:     "multiple outer assignments sync independently",
+			input:    `<% let left = "" %><% let right = "" %><%= for (_, item) in ["A","B"] { %><%= if (true) { %><% let local = item %><% left = left + local %><% right = local + right %><% } %><% } %><%= left %>|<%= right %>`,
+			expected: "AB|BA",
+		},
+		{
+			name:     "branch local assignment does not replace shadowed outer binding",
+			input:    `<% let label = "outer" %><%= if (true) { %><% let label = "inner" %><% label = label + "!" %><%= label %><% } %>|<%= label %>`,
+			expected: "inner!|outer",
+		},
+		{
+			name:     "local shadow in an unselected branch does not hide selected assignment",
+			input:    `<% let result = "start" %><%= if (false) { %><% let result = "shadow" %><% result = "wrong" %><% } else { %><% result = "selected" %><% } %><%= result %>`,
+			expected: "selected",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			comparePlannedRender(t, tt.input, emptyContext, tt.expected)
+		})
+	}
+}
+
+func Test_Parity_Loops_Scoped_Assignment_Iterable_Matrix(t *testing.T) {
+	stringPointer := []string{"A", "B"}
+	tests := []struct {
+		name     string
+		input    string
+		factory  contextFactory
+		expected string
+	}{
+		{
+			name:     "native string slice",
+			input:    `<% let result = "" %><%= for (_, item) in items { %><%= if (true) { %><% let local = item %><% result = result + local %><% } %><% } %><%= result %>`,
+			factory:  contextWith(map[string]interface{}{"items": []string{"A", "B"}}),
+			expected: "AB",
+		},
+		{
+			name:     "native interface slice",
+			input:    `<% let result = "" %><%= for (_, item) in items { %><%= if (true) { %><% let local = item %><% result = result + local %><% } %><% } %><%= result %>`,
+			factory:  contextWith(map[string]interface{}{"items": []interface{}{"A", "B"}}),
+			expected: "AB",
+		},
+		{
+			name:     "typed struct slice",
+			input:    `<% let result = "" %><%= for (_, item) in items { %><%= if (true) { %><% let local = item.Name %><% result = result + local %><% } %><% } %><%= result %>`,
+			factory:  contextWith(map[string]interface{}{"items": []parityLoopItem{{Name: "A"}, {Name: "B"}}}),
+			expected: "AB",
+		},
+		{
+			name:     "native array",
+			input:    `<% let result = "" %><%= for (_, item) in items { %><%= if (true) { %><% let local = item %><% result = result + local %><% } %><% } %><%= result %>`,
+			factory:  contextWith(map[string]interface{}{"items": [2]string{"A", "B"}}),
+			expected: "AB",
+		},
+		{
+			name:     "pointer to native slice",
+			input:    `<% let result = "" %><%= for (_, item) in items { %><%= if (true) { %><% let local = item %><% result = result + local %><% } %><% } %><%= result %>`,
+			factory:  contextWith(map[string]interface{}{"items": &stringPointer}),
+			expected: "AB",
+		},
+		{
+			name:     "native map",
+			input:    `<% let result = 0 %><%= for (_, item) in items { %><%= if (true) { %><% let local = item %><% result = result + local %><% } %><% } %><%= result %>`,
+			factory:  contextWith(map[string]interface{}{"items": map[string]int{"a": 1, "b": 2}}),
+			expected: "3",
+		},
+		{
+			name:     "existing context binding",
+			input:    `<%= for (_, item) in ["A","B"] { %><%= if (true) { %><% let local = item %><% result = result + local %><% } %><% } %><%= result %>`,
+			factory:  contextWith(map[string]interface{}{"result": ""}),
+			expected: "AB",
+		},
+		{
+			name:     "indexed outer mutation",
+			input:    `<% let result = {} %><%= for (_, item) in ["A","B"] { %><%= if (true) { %><% let local = item %><% result[item] = local %><% } %><% } %><%= result["A"] %><%= result["B"] %>`,
+			factory:  emptyContext,
+			expected: "AB",
+		},
+		{
+			name:     "assigned iterator does not replace shadowed outer binding",
+			input:    `<% let item = "outer" %><%= for (_, item) in ["A"] { %><% item = item + "!" %><%= item %><% } %>|<%= item %>`,
+			factory:  emptyContext,
+			expected: "A!|outer",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			comparePlannedRender(t, tt.input, tt.factory, tt.expected)
+		})
+	}
+}
+
+func Test_Parity_Loops_Guarded_Collection_Loop_Reads_Value_Property(t *testing.T) {
+	input := `<%= if (len(record.Assets) > 0 && record.Assets[0].URL) { %>
+	<%= for (index, asset) in record.Assets { %>
+		<link href="<%= asset.URL %>" data-alt="<%= asset.Alt %>" data-index="<%= index %>" />
+	<% } %>
+<% } %>`
+	compareRender(t, input, contextWith(map[string]interface{}{
+		"record": parityMediaRecord{Assets: []parityMediaAsset{
+			{URL: "/first.png", Alt: "First"},
+			{URL: "/second.png", Alt: "Second"},
+		}},
+	}))
+	vmOut, vmErr := renderVM(t, input, contextWith(map[string]interface{}{
+		"record": parityMediaRecord{Assets: []parityMediaAsset{
+			{URL: "/first.png", Alt: "First"},
+			{URL: "/second.png", Alt: "Second"},
+		}},
+	}))
+	if vmErr != nil {
+		t.Fatalf("unexpected VM error: %v", vmErr)
+	}
+	if !strings.Contains(vmOut, `href="/first.png"`) || !strings.Contains(vmOut, `href="/second.png"`) {
+		t.Fatalf("expected VM output to include both loop values, got %q", vmOut)
+	}
 }
 
 func Test_Parity_Loops_Continue(t *testing.T) {
@@ -102,7 +362,7 @@ func Test_Parity_Loops_Map_Contains_Entries(t *testing.T) {
 	})
 
 	interpreterOut, interpreterErr := renderInterpreter(input, factory)
-	vmOut, vmErr := renderVM(input, factory)
+	vmOut, vmErr := renderVM(t, input, factory)
 	if interpreterErr != nil || vmErr != nil {
 		t.Fatalf("unexpected errors\ninterpreter: %v\nvm: %v", interpreterErr, vmErr)
 	}

--- a/vm/plush/parity_math_test.go
+++ b/vm/plush/parity_math_test.go
@@ -242,7 +242,7 @@ func requireBothRender(t *testing.T, input, expected string, factory contextFact
 	require.NoError(t, interpreterErr)
 	require.Equal(t, expected, interpreterOut)
 
-	vmOut, vmErr := renderVM(input, factory)
+	vmOut, vmErr := renderVM(t, input, factory)
 	require.NoError(t, vmErr)
 	require.Equal(t, expected, vmOut)
 }

--- a/vm/plush/parity_math_test.go
+++ b/vm/plush/parity_math_test.go
@@ -113,6 +113,72 @@ func Test_Parity_Math_Renders_Many_Numeric_Types(t *testing.T) {
 	}))
 }
 
+func Test_Parity_Math_Unary_Minus_Identifier_With_Digits(t *testing.T) {
+	tests := []struct {
+		input    string
+		values   map[string]interface{}
+		expected string
+	}{
+		{
+			input: `<%= -my123greet %>`,
+			values: map[string]interface{}{
+				"my123greet": float64(5.5),
+			},
+			expected: "-5.5",
+		},
+		{
+			input: `<%= -my123greet + 10 %>`,
+			values: map[string]interface{}{
+				"my123greet": float64(5.5),
+			},
+			expected: "4.5",
+		},
+		{
+			input: `<%= -my123greet - 10 %>`,
+			values: map[string]interface{}{
+				"my123greet": float64(5.5),
+			},
+			expected: "-15.5",
+		},
+		{
+			input: `<%= -my123greet + my123greet2 %>`,
+			values: map[string]interface{}{
+				"my123greet":  float64(5.5),
+				"my123greet2": int64(-10),
+			},
+			expected: "-15.5",
+		},
+		{
+			input: `<%= -my123greet + my123greet2 %>`,
+			values: map[string]interface{}{
+				"my123greet":  int64(10),
+				"my123greet2": float64(5.5),
+			},
+			expected: "-4.5",
+		},
+		{
+			input: `<%= -my123int %>`,
+			values: map[string]interface{}{
+				"my123int": int(4),
+			},
+			expected: "-4",
+		},
+		{
+			input: `<%= -my123count + 1 %>`,
+			values: map[string]interface{}{
+				"my123count": int64(6),
+			},
+			expected: "-5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			requireBothRender(t, tt.input, tt.expected, contextWith(tt.values))
+		})
+	}
+}
+
 func Test_Parity_Math_Safe_Mixed_Numeric_Comparisons(t *testing.T) {
 	ctx := contextWith(map[string]interface{}{
 		"i32":     int32(0),

--- a/vm/plush/parity_optional_if_test.go
+++ b/vm/plush/parity_optional_if_test.go
@@ -6,6 +6,10 @@ type phase9Robot struct {
 	Name string
 }
 
+type phase9Record struct {
+	Limit int
+}
+
 func Test_Parity_Phase_9_Optional_If_Parentheses(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -111,6 +115,14 @@ func Test_Parity_Phase_9_Optional_If_Parentheses(t *testing.T) {
 			input:    `<%= if (false) { %>no<% } else if (true) { %>yes<% } %>`,
 			expected: "yes",
 			factory:  emptyContext,
+		},
+		{
+			name:     "missing helper call uses else",
+			input:    `<%= if(optional(record.Limit)) { %>set<% } else { %>fallback<% } %>`,
+			expected: "fallback",
+			factory: contextWith(map[string]interface{}{
+				"record": phase9Record{Limit: 5},
+			}),
 		},
 	}
 

--- a/vm/plush/parity_partials_test.go
+++ b/vm/plush/parity_partials_test.go
@@ -1,6 +1,7 @@
 package plush_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"html/template"
 	"strings"
@@ -10,9 +11,14 @@ import (
 	"github.com/gobuffalo/plush/v5/helpers/hctx"
 	"github.com/gobuffalo/plush/v5/helpers/meta"
 	"github.com/gobuffalo/plush/v5/templatecache/inmemory"
-	vmplush "github.com/gobuffalo/plush/v5/vm/plush"
 	"github.com/stretchr/testify/require"
 )
+
+type parityPartialNode struct {
+	Label    string
+	Enabled  bool
+	Children []parityPartialNode
+}
 
 func Test_Parity_Partials_Simple(t *testing.T) {
 	compareRender(t, `<%= partial("hello.plush") %>`, contextWith(map[string]interface{}{
@@ -58,6 +64,66 @@ func Test_Parity_Phase_12_Partials_Data_Recursion_Layout_And_Yield(t *testing.T)
 			return `<%= if (number > 0) { %><% let number = number - 1 %><%= partial("count") %><%= number %>, <% } %>`, nil
 		},
 	}))
+}
+
+func Test_Parity_Partials_Four_Level_Recursive_Loops_Update_Main_Array(t *testing.T) {
+	partialSource := `<%= for (_, node) in nodes { %>` +
+		`<%= if (node.Enabled) { %>` +
+		`<% let entry = "enter:" + node.Label %>` +
+		`<% collected = collected + entry %>` +
+		`<%= if (len(node.Children) > 0) { %>` +
+		`<%= partial("tree.plush.html", {nodes: node.Children}) %>` +
+		`<% } %>` +
+		`<% let exit = "exit:" + node.Label %>` +
+		`<% collected = collected + exit %>` +
+		`<% } %>` +
+		`<% } %>`
+
+	input := `<% let collected = [] %><%= partial("tree.plush.html", {nodes: nodes}) %><%= json_encode(collected) %>`
+	expected := `["enter:root","enter:branch","enter:leaf","enter:tip","exit:tip","exit:leaf","exit:branch","enter:sibling","exit:sibling","exit:root"]`
+
+	comparePlannedRender(t, input, contextWith(map[string]interface{}{
+		"nodes": []parityPartialNode{
+			{
+				Label:   "root",
+				Enabled: true,
+				Children: []parityPartialNode{
+					{
+						Label:   "branch",
+						Enabled: true,
+						Children: []parityPartialNode{
+							{
+								Label:   "leaf",
+								Enabled: true,
+								Children: []parityPartialNode{
+									{Label: "tip", Enabled: true},
+								},
+							},
+							{
+								Label:   "disabled",
+								Enabled: false,
+								Children: []parityPartialNode{
+									{Label: "never-rendered", Enabled: true},
+								},
+							},
+						},
+					},
+					{Label: "sibling", Enabled: true},
+				},
+			},
+			{Label: "disabled-root", Enabled: false},
+		},
+		"json_encode": func(value interface{}) template.HTML {
+			encoded, _ := json.Marshal(value)
+			return template.HTML(encoded)
+		},
+		"partialFeeder": func(name string) (string, error) {
+			if name != "tree.plush.html" {
+				return "", fmt.Errorf("unexpected partial %q", name)
+			}
+			return partialSource, nil
+		},
+	}), expected)
 }
 
 func Test_Parity_Partials_Data_Map_Values(t *testing.T) {
@@ -169,14 +235,14 @@ func Test_Phase_12_VM_Plush_Cache_Hole_Skeleton_For_Plush_Filenames(t *testing.T
 			ctx.Set(meta.TemplateFileKey, filename)
 
 			input := `<%= items[0] %><%H suffix %><%= items[1] %>`
-			out, err := vmplush.Render(input, ctx)
+			out, err := renderVMContext(t, input, ctx)
 			require.NoError(t, err)
 			require.Equal(t, "a1b", out)
 			requireCacheKey(t, cache, rootplush.GenerateASTKey(filename))
 			requireCacheKey(t, cache, "full:"+filename)
 
 			ctx.Set("suffix", "2")
-			out, err = vmplush.Render(input, ctx)
+			out, err = renderVMContext(t, input, ctx)
 			require.NoError(t, err)
 			require.Equal(t, "a2b", out)
 		})
@@ -191,11 +257,11 @@ func Test_Phase_12_VM_Plush_Non_Plush_Filename_Does_Not_Use_Hole_Cache(t *testin
 	ctx := rootplush.NewContext()
 	ctx.Set(meta.TemplateFileKey, "phase12.txt")
 
-	out, err := vmplush.Render(`<%= "a" %><%H "hole" %>`, ctx)
+	out, err := renderVMContext(t, `<%= "a" %><%H "hole" %>`, ctx)
 	require.NoError(t, err)
 	require.Equal(t, "a<PLUSH_HOLE_0>", out)
 
-	out, err = vmplush.Render(`<%= "b" %><%H "hole" %>`, ctx)
+	out, err = renderVMContext(t, `<%= "b" %><%H "hole" %>`, ctx)
 	require.NoError(t, err)
 	require.Equal(t, "b<PLUSH_HOLE_0>", out)
 }
@@ -212,12 +278,12 @@ func Test_VM_Bytecode_Caches_HTML_Template_Filenames(t *testing.T) {
 	ctx := rootplush.NewContext()
 	ctx.Set(meta.TemplateFileKey, filename)
 
-	out, err := vmplush.Render(`<%= "old" %>`, ctx)
+	out, err := renderVMContext(t, `<%= "old" %>`, ctx)
 	require.NoError(t, err)
 	require.Equal(t, "old", out)
 	requireCacheKey(t, cache, rootplush.GenerateASTKey(filename))
 
-	out, err = vmplush.Render(`<%= "new" %>`, ctx)
+	out, err = renderVMContext(t, `<%= "new" %>`, ctx)
 	require.NoError(t, err)
 	require.Equal(t, "new", out)
 }
@@ -231,7 +297,7 @@ func Test_Phase_12_VM_Plush_Cache_Uses_Current_URL_In_Full_Key(t *testing.T) {
 	ctx.Set(meta.TemplateFileKey, "phase12-url.plush")
 	ctx.Set(meta.TemplateCurrentUrlKey, "/products/123?ignored=true")
 
-	out, err := vmplush.Render(`<%= "x" %><%H "hole" %>`, ctx)
+	out, err := renderVMContext(t, `<%= "x" %><%H "hole" %>`, ctx)
 	require.NoError(t, err)
 	require.Equal(t, "xhole", out)
 	requireCacheKey(t, cache, "full:phase12-url.plush|url:products_123")
@@ -246,17 +312,17 @@ func Test_Phase_12_VM_Plush_Caches_Bytecode_By_AST_Key(t *testing.T) {
 	ctx := rootplush.NewContext()
 	ctx.Set(meta.TemplateFileKey, filename)
 
-	out, err := vmplush.Render(`<%= "old" %>`, ctx)
+	out, err := renderVMContext(t, `<%= "old" %>`, ctx)
 	require.NoError(t, err)
 	require.Equal(t, "old", out)
 	requireCacheKey(t, cache, rootplush.GenerateASTKey(filename))
 
-	out, err = vmplush.Render(`<%= "new" %>`, ctx)
+	out, err = renderVMContext(t, `<%= "new" %>`, ctx)
 	require.NoError(t, err)
 	require.Equal(t, "new", out)
 
 	cache.Delete(rootplush.GenerateASTKey(filename))
-	out, err = vmplush.Render(`<%= "new" %>`, ctx)
+	out, err = renderVMContext(t, `<%= "new" %>`, ctx)
 	require.NoError(t, err)
 	require.Equal(t, "new", out)
 }
@@ -270,7 +336,7 @@ func Test_Phase_12_VM_Plush_Caches_Bytecode_Without_AST_Or_Source(t *testing.T) 
 	ctx := rootplush.NewContext()
 	ctx.Set(meta.TemplateFileKey, filename)
 
-	out, err := vmplush.Render(`<%= "old" %>`, ctx)
+	out, err := renderVMContext(t, `<%= "old" %>`, ctx)
 	require.NoError(t, err)
 	require.Equal(t, "old", out)
 
@@ -281,7 +347,7 @@ func Test_Phase_12_VM_Plush_Caches_Bytecode_Without_AST_Or_Source(t *testing.T) 
 	require.Nil(t, entry.Program)
 	require.Empty(t, entry.Input)
 
-	out, err = vmplush.Render(`<%= "new" %>`, ctx)
+	out, err = renderVMContext(t, `<%= "new" %>`, ctx)
 	require.NoError(t, err)
 	require.Equal(t, "new", out)
 	entry, ok = cache.Get(key)
@@ -318,7 +384,7 @@ func Test_Phase_12_VM_Plush_Uses_Existing_Interpreter_AST_Cache(t *testing.T) {
 	require.Nil(t, entry.VMBytecode)
 	require.Empty(t, entry.Input)
 
-	out, err = vmplush.Render(`<%= "new" %>`, ctx)
+	out, err = renderVMContext(t, `<%= "new" %>`, ctx)
 	require.NoError(t, err)
 	require.Equal(t, "new", out)
 

--- a/vm/plush/parity_recursive_partials_test.go
+++ b/vm/plush/parity_recursive_partials_test.go
@@ -1,0 +1,517 @@
+package plush_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html/template"
+	"sync"
+	"testing"
+
+	rootplush "github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+	"github.com/gobuffalo/plush/v5/helpers/meta"
+	"github.com/gobuffalo/plush/v5/templatecache/inmemory"
+	vmplush "github.com/gobuffalo/plush/v5/vm/plush"
+	"github.com/stretchr/testify/require"
+)
+
+type parityRecursiveNode struct {
+	Label    string
+	Action   string
+	Enabled  bool
+	Children []parityRecursiveNode
+}
+
+func parityRecursiveJSON(value interface{}) template.HTML {
+	encoded, _ := json.Marshal(value)
+	return template.HTML(encoded)
+}
+
+func parityRecursivePartialFeeder(partials map[string]string) func(string) (string, error) {
+	return func(name string) (string, error) {
+		partial, ok := partials[name]
+		if !ok {
+			return "", fmt.Errorf("unexpected partial %q", name)
+		}
+		return partial, nil
+	}
+}
+
+func parityRecursiveArrayPartial(next string) string {
+	recurse := ""
+	if next != "" {
+		recurse = `<%= if (len(node.Children) > 0) { %>` +
+			fmt.Sprintf(`<%%= partial(%q, {nodes: node.Children}) %%>`, next) +
+			`<% } %>`
+	}
+	return `<%= for (_, node) in nodes { %>` +
+		`<%= if (node.Enabled) { %>` +
+		`<% let entry = "enter:" + node.Label %>` +
+		`<% collected = collected + entry %>` +
+		recurse +
+		`<% let exit = "exit:" + node.Label %>` +
+		`<% collected = collected + exit %>` +
+		`<% } %>` +
+		`<% } %>`
+}
+
+func parityRecursiveContext(nodes interface{}, partials map[string]string) hctx.Context {
+	return rootplush.NewContextWith(map[string]interface{}{
+		"nodes":         nodes,
+		"json_encode":   parityRecursiveJSON,
+		"partialFeeder": parityRecursivePartialFeeder(partials),
+	})
+}
+
+func Test_Parity_Partials_Unique_Filename_Chain_Updates_Main_Array(t *testing.T) {
+	partials := map[string]string{
+		"level-one.plush.html":   parityRecursiveArrayPartial("level-two.plush.html"),
+		"level-two.plush.html":   parityRecursiveArrayPartial("level-three.plush.html"),
+		"level-three.plush.html": parityRecursiveArrayPartial("level-four.plush.html"),
+		"level-four.plush.html":  parityRecursiveArrayPartial(""),
+	}
+	nodes := []parityRecursiveNode{
+		{
+			Label:   "root",
+			Enabled: true,
+			Children: []parityRecursiveNode{
+				{
+					Label:   "branch",
+					Enabled: true,
+					Children: []parityRecursiveNode{
+						{
+							Label:   "leaf",
+							Enabled: true,
+							Children: []parityRecursiveNode{
+								{Label: "tip", Enabled: true},
+							},
+						},
+					},
+				},
+				{Label: "sibling", Enabled: true},
+			},
+		},
+	}
+	input := `<% let collected = [] %><%= partial("level-one.plush.html", {nodes: nodes}) %><%= json_encode(collected) %>`
+	expected := `["enter:root","enter:branch","enter:leaf","enter:tip","exit:tip","exit:leaf","exit:branch","enter:sibling","exit:sibling","exit:root"]`
+
+	comparePlannedRender(t, input, func() hctx.Context {
+		return parityRecursiveContext(nodes, partials)
+	}, expected)
+}
+
+func Test_Parity_Partials_Cached_Recursive_Renders_Isolate_Sequential_Contexts(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	rootplush.PlushCacheSetup(cache)
+	defer rootplush.ClearTemplateCache()
+
+	partialName := "cached-tree.plush.html"
+	partials := map[string]string{partialName: parityRecursiveArrayPartial(partialName)}
+	input := `<% let collected = [] %><%= partial("cached-tree.plush.html", {nodes: nodes}) %><%= json_encode(collected) %>`
+
+	newContext := func(nodes []parityRecursiveNode) hctx.Context {
+		ctx := parityRecursiveContext(nodes, partials)
+		ctx.Set(meta.TemplateFileKey, "recursive-cache-root.plush.html")
+		return ctx
+	}
+
+	firstNodes := []parityRecursiveNode{{
+		Label:   "first",
+		Enabled: true,
+		Children: []parityRecursiveNode{
+			{Label: "first-child", Enabled: true},
+		},
+	}}
+	firstOut, firstErr := renderVMContext(t, input, newContext(firstNodes))
+	require.NoError(t, firstErr)
+	require.Equal(t, `["enter:first","enter:first-child","exit:first-child","exit:first"]`, firstOut)
+
+	secondNodes := []parityRecursiveNode{{
+		Label:   "second",
+		Enabled: true,
+		Children: []parityRecursiveNode{
+			{Label: "second-child", Enabled: true},
+		},
+	}}
+	secondCtx := newContext(secondNodes)
+	secondOut, secondErr := renderVMContext(t, input, secondCtx)
+	require.NoError(t, secondErr)
+	require.Equal(t, `["enter:second","enter:second-child","exit:second-child","exit:second"]`, secondOut)
+	require.NotContains(t, secondOut, "first")
+
+	diagnostics, ok := rootplush.RenderDiagnosticsFromContext(secondCtx)
+	require.True(t, ok)
+	require.Equal(t, rootplush.VMBytecodeCacheHit, diagnostics.VMBytecodeCache)
+}
+
+func Test_Parity_Partials_Cached_Recursive_Renders_Isolate_Concurrent_Contexts(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	rootplush.PlushCacheSetup(cache)
+	defer rootplush.ClearTemplateCache()
+
+	partialName := "concurrent-tree.plush.html"
+	partials := map[string]string{partialName: parityRecursiveArrayPartial(partialName)}
+	input := `<% let collected = [] %><%= partial("concurrent-tree.plush.html", {nodes: nodes}) %><%= json_encode(collected) %>`
+	tmpl, err := vmplush.Compile(input)
+	require.NoError(t, err)
+
+	previousFallback := rootplush.SetVMGenericFallback(true)
+	defer rootplush.SetVMGenericFallback(previousFallback)
+
+	type result struct {
+		index       int
+		output      string
+		err         error
+		diagnostics rootplush.RenderDiagnostics
+		hasDiag     bool
+	}
+	const renders = 16
+	results := make(chan result, renders)
+	var wg sync.WaitGroup
+	for index := 0; index < renders; index++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			label := fmt.Sprintf("render-%02d", index)
+			child := label + "-child"
+			ctx := parityRecursiveContext([]parityRecursiveNode{{
+				Label:   label,
+				Enabled: true,
+				Children: []parityRecursiveNode{
+					{Label: child, Enabled: true},
+				},
+			}}, partials)
+			ctx.Set(meta.TemplateFileKey, "recursive-concurrent-root.plush.html")
+			output, renderErr := tmpl.Render(ctx)
+			diagnostics, hasDiag := rootplush.RenderDiagnosticsFromContext(ctx)
+			results <- result{index: index, output: output, err: renderErr, diagnostics: diagnostics, hasDiag: hasDiag}
+		}(index)
+	}
+	wg.Wait()
+	close(results)
+
+	for renderResult := range results {
+		label := fmt.Sprintf("render-%02d", renderResult.index)
+		child := label + "-child"
+		expected := fmt.Sprintf(`["enter:%s","enter:%s","exit:%s","exit:%s"]`, label, child, child, label)
+		require.NoError(t, renderResult.err)
+		require.Equal(t, expected, renderResult.output)
+		require.True(t, renderResult.hasDiag)
+		require.NotEqual(t, rootplush.RenderFastPathInterpreterFallback, renderResult.diagnostics.FastPath)
+	}
+}
+
+func Test_Parity_Partials_Shadowed_Accumulator_Is_Isolated(t *testing.T) {
+	partialName := "append.plush.html"
+	partials := map[string]string{
+		partialName: `<% collected = collected + label %><%= json_encode(collected) %>`,
+	}
+	input := `<% let collected = ["main"] %>` +
+		`<%= partial("append.plush.html", {label: "inherited"}) %>|` +
+		`<%= partial("append.plush.html", {label: "local", collected: []}) %>|` +
+		`<%= json_encode(collected) %>`
+	expected := `["main","inherited"]|["local"]|["main","inherited"]`
+
+	comparePlannedRender(t, input, func() hctx.Context {
+		return parityRecursiveContext(nil, partials)
+	}, expected)
+}
+
+func Test_Parity_Partials_Recursive_Update_Survives_Continue_And_Break(t *testing.T) {
+	partialName := "control-tree.plush.html"
+	partialSource := `<%= for (_, node) in nodes { %>` +
+		`<%= if (node.Enabled) { %>` +
+		`<% let entry = "enter:" + node.Label %>` +
+		`<% collected = collected + entry %>` +
+		`<%= if (len(node.Children) > 0) { %>` +
+		`<%= partial("control-tree.plush.html", {nodes: node.Children}) %>` +
+		`<% } %>` +
+		`<%= if (node.Action == "continue") { %><%= continue %><% } %>` +
+		`<%= if (node.Action == "break") { %><%= break %><% } %>` +
+		`<% let after = "after:" + node.Label %>` +
+		`<% collected = collected + after %>` +
+		`<% } %>` +
+		`<% } %>`
+	partials := map[string]string{partialName: partialSource}
+	nodes := []parityRecursiveNode{
+		{
+			Label:   "continue",
+			Action:  "continue",
+			Enabled: true,
+			Children: []parityRecursiveNode{
+				{Label: "continue-child", Enabled: true},
+			},
+		},
+		{Label: "normal", Enabled: true},
+		{
+			Label:   "break",
+			Action:  "break",
+			Enabled: true,
+			Children: []parityRecursiveNode{
+				{Label: "break-child", Enabled: true},
+			},
+		},
+		{Label: "after-break", Enabled: true},
+	}
+	input := `<% let collected = [] %><%= partial("control-tree.plush.html", {nodes: nodes}) %><%= json_encode(collected) %>`
+	expected := `["enter:continue","enter:continue-child","after:continue-child","enter:normal","after:normal","enter:break","enter:break-child","after:break-child"]`
+
+	comparePlannedRender(t, input, func() hctx.Context {
+		return parityRecursiveContext(nodes, partials)
+	}, expected)
+}
+
+func Test_Parity_Partials_Recursive_Error_Trace_Recovers_With_Cached_Bytecode(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	rootplush.PlushCacheSetup(cache)
+	defer rootplush.ClearTemplateCache()
+
+	partials := map[string]string{
+		"error-one.plush.html":   `<%= partial("error-two.plush.html") %>`,
+		"error-two.plush.html":   `<%= partial("error-three.plush.html") %>`,
+		"error-three.plush.html": `<%= partial("error-four.plush.html") %>`,
+		"error-four.plush.html":  `<%= fail_deep() %>`,
+	}
+	input := `<%= partial("error-one.plush.html") %>`
+	newContext := func(fail bool) hctx.Context {
+		ctx := rootplush.NewContextWith(map[string]interface{}{
+			"partialFeeder": parityRecursivePartialFeeder(partials),
+			"fail_deep": func() (string, error) {
+				if fail {
+					return "", errors.New("deep recursive failure")
+				}
+				return "recovered", nil
+			},
+		})
+		ctx.Set(meta.TemplateFileKey, "recursive-error-root.plush.html")
+		return ctx
+	}
+
+	_, interpreterErr := rootplush.Render(input, newContext(true))
+	_, vmErr := renderVMContext(t, input, newContext(true))
+	require.Error(t, interpreterErr)
+	require.Error(t, vmErr)
+	for _, fragment := range []string{
+		"deep recursive failure",
+		"error-one.plush.html",
+		"error-two.plush.html",
+		"error-three.plush.html",
+		"error-four.plush.html",
+	} {
+		require.Contains(t, interpreterErr.Error(), fragment)
+		require.Contains(t, vmErr.Error(), fragment)
+	}
+
+	recoveryCtx := newContext(false)
+	recovered, recoveryErr := renderVMContext(t, input, recoveryCtx)
+	require.NoError(t, recoveryErr)
+	require.Equal(t, "recovered", recovered)
+	diagnostics, ok := rootplush.RenderDiagnosticsFromContext(recoveryCtx)
+	require.True(t, ok)
+	require.Equal(t, rootplush.VMBytecodeCacheHit, diagnostics.VMBytecodeCache)
+}
+
+func Test_Parity_Partials_Recursive_Indexed_Mutation_Updates_Main_Map(t *testing.T) {
+	partialName := "indexed-tree.plush.html"
+	partialSource := `<%= for (_, node) in nodes { %>` +
+		`<%= if (node.Enabled) { %>` +
+		`<% collected[node.Label] = "seen:" + node.Label %>` +
+		`<%= if (len(node.Children) > 0) { %>` +
+		`<%= partial("indexed-tree.plush.html", {nodes: node.Children}) %>` +
+		`<% } %>` +
+		`<% } %>` +
+		`<% } %>`
+	partials := map[string]string{partialName: partialSource}
+	nodes := []parityRecursiveNode{{
+		Label:   "root",
+		Enabled: true,
+		Children: []parityRecursiveNode{
+			{
+				Label:   "branch",
+				Enabled: true,
+				Children: []parityRecursiveNode{
+					{Label: "leaf", Enabled: true},
+				},
+			},
+		},
+	}}
+	input := `<% let collected = {} %><%= partial("indexed-tree.plush.html", {nodes: nodes}) %><%= json_encode(collected) %>`
+	expected := `{"branch":"seen:branch","leaf":"seen:leaf","root":"seen:root"}`
+
+	comparePlannedRender(t, input, func() hctx.Context {
+		return parityRecursiveContext(nodes, partials)
+	}, expected)
+}
+
+func Test_Parity_Partials_Recursive_Update_Syncs_Multiple_Accumulators(t *testing.T) {
+	partialName := "multi-tree.plush.html"
+	partialSource := `<%= for (_, node) in nodes { %>` +
+		`<%= if (node.Enabled) { %>` +
+		`<% let entry = "enter:" + node.Label %>` +
+		`<% collected = collected + entry %>` +
+		`<% count = count + 1 %>` +
+		`<% lookup[entry] = count %>` +
+		`<%= if (len(node.Children) > 0) { %>` +
+		`<%= partial("multi-tree.plush.html", {nodes: node.Children}) %>` +
+		`<% } %>` +
+		`<% let exit = "exit:" + node.Label %>` +
+		`<% collected = collected + exit %>` +
+		`<% count = count + 1 %>` +
+		`<% lookup[exit] = count %>` +
+		`<% } %>` +
+		`<% } %>`
+	partials := map[string]string{partialName: partialSource}
+	nodes := []parityRecursiveNode{{
+		Label:   "root",
+		Enabled: true,
+		Children: []parityRecursiveNode{
+			{
+				Label:   "branch",
+				Enabled: true,
+				Children: []parityRecursiveNode{
+					{
+						Label:   "leaf",
+						Enabled: true,
+						Children: []parityRecursiveNode{
+							{Label: "tip", Enabled: true},
+						},
+					},
+				},
+			},
+		},
+	}}
+	input := `<% let collected = [] %><% let count = 0 %><% let lookup = {} %>` +
+		`<%= partial("multi-tree.plush.html", {nodes: nodes}) %>` +
+		`<%= json_encode(collected) %>|<%= count %>|` +
+		`<%= lookup["enter:root"] %>|<%= lookup["enter:tip"] %>|` +
+		`<%= lookup["exit:tip"] %>|<%= lookup["exit:root"] %>`
+	expected := `["enter:root","enter:branch","enter:leaf","enter:tip","exit:tip","exit:leaf","exit:branch","exit:root"]|8|1|4|5|8`
+
+	comparePlannedRender(t, input, func() hctx.Context {
+		return parityRecursiveContext(nodes, partials)
+	}, expected)
+}
+
+func Test_Parity_Partials_Recursive_Children_Edge_Matrix(t *testing.T) {
+	partialName := "children-tree.plush.html"
+	partialSource := `<% calls = calls + 1 %>` +
+		`<%= for (_, node) in nodes { %>` +
+		`<%= if (node.Enabled) { %>` +
+		`<% let entry = "enter:" + node.Label %>` +
+		`<% collected = collected + entry %>` +
+		`<%= if (len(node.Children) > 0) { %>` +
+		`<%= partial("children-tree.plush.html", {nodes: node.Children}) %>` +
+		`<% } %>` +
+		`<% let exit = "exit:" + node.Label %>` +
+		`<% collected = collected + exit %>` +
+		`<% } %>` +
+		`<% } %>`
+	mapPartialSource := `<% calls = calls + 1 %>` +
+		`<%= for (_, node) in nodes { %>` +
+		`<%= if (node["Enabled"]) { %>` +
+		`<% let entry = "enter:" + node["Label"] %>` +
+		`<% collected = collected + entry %>` +
+		`<%= if (len(node["Children"]) > 0) { %>` +
+		`<%= partial("children-tree.plush.html", {nodes: node["Children"]}) %>` +
+		`<% } %>` +
+		`<% let exit = "exit:" + node["Label"] %>` +
+		`<% collected = collected + exit %>` +
+		`<% } %>` +
+		`<% } %>`
+	input := `<% let collected = [] %><% let calls = 0 %>` +
+		`<%= partial("children-tree.plush.html", {nodes: nodes}) %>` +
+		`<%= json_encode(collected) %>|<%= calls %>`
+
+	tests := []struct {
+		name     string
+		nodes    interface{}
+		source   string
+		expected string
+	}{
+		{
+			name:     "nil typed children",
+			nodes:    []parityRecursiveNode{{Label: "nil", Enabled: true, Children: nil}},
+			expected: `["enter:nil","exit:nil"]|1`,
+		},
+		{
+			name:     "empty typed children",
+			nodes:    []parityRecursiveNode{{Label: "empty", Enabled: true, Children: []parityRecursiveNode{}}},
+			expected: `["enter:empty","exit:empty"]|1`,
+		},
+		{
+			name: "missing map children key",
+			nodes: []map[string]interface{}{
+				{"Label": "missing", "Enabled": true},
+			},
+			source:   mapPartialSource,
+			expected: `["enter:missing","exit:missing"]|1`,
+		},
+		{
+			name: "disabled child does not recurse into its children",
+			nodes: []parityRecursiveNode{{
+				Label:   "root",
+				Enabled: true,
+				Children: []parityRecursiveNode{{
+					Label:   "disabled",
+					Enabled: false,
+					Children: []parityRecursiveNode{
+						{Label: "never", Enabled: true},
+					},
+				}},
+			}},
+			expected: `["enter:root","exit:root"]|2`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := partialSource
+			if tt.source != "" {
+				source = tt.source
+			}
+			partials := map[string]string{partialName: source}
+			comparePlannedRender(t, input, func() hctx.Context {
+				return parityRecursiveContext(tt.nodes, partials)
+			}, tt.expected)
+		})
+	}
+}
+
+func Test_Parity_Partials_Recursive_Update_Escapes_Helper_Block(t *testing.T) {
+	partialName := "helper-tree.plush.html"
+	partialSource := `<%= for (_, node) in nodes { %>` +
+		`<%= if (node.Enabled) { %>` +
+		`<% let item = helperLabel + ":" + node.Label %>` +
+		`<% collected = collected + item %>` +
+		`<%= if (len(node.Children) > 0) { %>` +
+		`<%= partial("helper-tree.plush.html", {nodes: node.Children}) %>` +
+		`<% } %>` +
+		`<% } %>` +
+		`<% } %>`
+	partials := map[string]string{partialName: partialSource}
+	nodes := []parityRecursiveNode{{
+		Label:   "root",
+		Enabled: true,
+		Children: []parityRecursiveNode{
+			{Label: "child", Enabled: true},
+		},
+	}}
+	input := `<% let collected = [] %>` +
+		`<%= scope() { %>` +
+		`<%= partial("helper-tree.plush.html", {nodes: nodes}) %>` +
+		`<%= helperLabel %>:<%= json_encode(collected) %>` +
+		`<% } %>|<%= json_encode(collected) %>`
+	expected := `[scope:["scope:root","scope:child"]]|["scope:root","scope:child"]`
+
+	comparePlannedRender(t, input, contextWith(map[string]interface{}{
+		"nodes":         nodes,
+		"json_encode":   parityRecursiveJSON,
+		"partialFeeder": parityRecursivePartialFeeder(partials),
+		"scope": func(help rootplush.HelperContext) (template.HTML, error) {
+			help.Set("helperLabel", "scope")
+			rendered, err := help.Block()
+			return template.HTML("[" + rendered + "]"), err
+		},
+	}), expected)
+}

--- a/vm/plush/parity_root_tests_test.go
+++ b/vm/plush/parity_root_tests_test.go
@@ -390,7 +390,7 @@ func Test_Parity_Root_For_Cases(t *testing.T) {
 		"myMap": map[string]string{"a": "A", "b": "B"},
 	})
 	interpreterOut, interpreterErr := renderInterpreter(mapLoop, factory)
-	vmOut, vmErr := renderVM(mapLoop, factory)
+	vmOut, vmErr := renderVM(t, mapLoop, factory)
 	require.NoError(t, interpreterErr)
 	require.NoError(t, vmErr)
 	for _, fragment := range []string{"a:A", "b:B"} {
@@ -519,7 +519,7 @@ func Test_Parity_Root_Quote_And_Error_Type_Cases(t *testing.T) {
 		},
 	})
 	_, interpreterErr := renderInterpreter(`<%= sqlError() %>`, ctxFactory)
-	_, vmErr := renderVM(`<%= sqlError() %>`, ctxFactory)
+	_, vmErr := renderVM(t, `<%= sqlError() %>`, ctxFactory)
 	require.True(t, errors.Is(interpreterErr, sql.ErrNoRows))
 	require.True(t, errors.Is(vmErr, sql.ErrNoRows))
 }

--- a/vm/plush/parity_struct_access_test.go
+++ b/vm/plush/parity_struct_access_test.go
@@ -360,7 +360,7 @@ func Test_Parity_Struct_Access_Errors(t *testing.T) {
 func compareVMRender(t *testing.T, input, expected string, factory contextFactory) {
 	t.Helper()
 
-	out, err := renderVM(input, factory)
+	out, err := renderVM(t, input, factory)
 	require.NoError(t, err)
 	require.Equal(t, expected, out)
 }

--- a/vm/plush/parity_variables_test.go
+++ b/vm/plush/parity_variables_test.go
@@ -10,8 +10,46 @@ type parityProduct struct {
 	Name []string
 }
 
+type parityRecordWithFields struct {
+	Fields map[string]string
+}
+
 func Test_Parity_Variables_Let_And_Assign(t *testing.T) {
 	compareRender(t, `<% let message = "hello" %><% message = "bye" %><%= message %>`, emptyContext)
+}
+
+func Test_Parity_Variables_Let_And_Assign_In_Same_Script_Block(t *testing.T) {
+	compareRender(t, `<% let value = "fallback"; value = record.Fields["shade"]; %><%= value %>`, contextWith(map[string]interface{}{
+		"record": parityRecordWithFields{
+			Fields: map[string]string{
+				"shade": "blue",
+			},
+		},
+	}))
+}
+
+func Test_Parity_Variables_Let_And_Assign_In_Partial_Script_Block(t *testing.T) {
+	compareRender(t, `<%= partial("details.plush.html") %>`, contextWith(map[string]interface{}{
+		"record": parityRecordWithFields{
+			Fields: map[string]string{
+				"shade": "blue",
+			},
+		},
+		"partialFeeder": func(name string) (string, error) {
+			return `<% let value = "fallback"; value = record.Fields["shade"]; %><%= value %>`, nil
+		},
+	}))
+}
+
+func Test_Parity_Variables_Partial_Assignment_To_Missing_Map_Value(t *testing.T) {
+	compareRender(t, `<%= partial("details.plush.html", {record: record}) %>`, contextWith(map[string]interface{}{
+		"record": parityRecordWithFields{
+			Fields: map[string]string{},
+		},
+		"partialFeeder": func(name string) (string, error) {
+			return `<% let value = "fallback"; value = record.Fields["missing"]; %><%= value %>`, nil
+		},
+	}))
 }
 
 func Test_Parity_Variables_Fast_Local_Let_Helper_Call(t *testing.T) {

--- a/vm/plush/plush_test.go
+++ b/vm/plush/plush_test.go
@@ -232,6 +232,74 @@ func Test_Buffalo_Renderer_VM_Cached_Layout_Partial_Sees_Top_Level_Let_Alias_Fro
 	}
 }
 
+func Test_Buffalo_Renderer_VM_Cached_Branch_Partial_Assigns_Parent_Binding(t *testing.T) {
+	previous := rootplush.SetRenderMode(rootplush.RenderModeVM)
+	defer rootplush.SetRenderMode(previous)
+	previousFallback := rootplush.SetVMGenericFallback(true)
+	defer rootplush.SetVMGenericFallback(previousFallback)
+
+	cache := inmemory.NewMemoryCache()
+	rootplush.PlushCacheSetup(cache)
+	defer rootplush.ClearTemplateCache()
+
+	input := `<%= if (currentRoute.PathName == "target") { %><% let registry = {} %><%= partial("partials/registry-file.html") %><%= registry["primary"] %><% } %>`
+	helpers := map[string]interface{}{
+		"partialFeeder": func(name string) (string, error) {
+			require.Equal(t, "partials/registry-file.html", name)
+			return `<% registry = {"primary": entryID} %>`, nil
+		},
+	}
+
+	for _, id := range []string{"first-id", "second-id"} {
+		data := map[string]interface{}{
+			"currentRoute": struct {
+				PathName string
+			}{PathName: "target"},
+			"entryID": id,
+		}
+		out, err := rootplush.BuffaloRendererWithContext(input, data, helpers, func(ctx *rootplush.Context) {
+			ctx.Set(meta.TemplateFileKey, "templates/application.plush.html")
+		})
+		require.NoError(t, err)
+		require.Equal(t, id, out)
+	}
+}
+
+func Test_Buffalo_Renderer_VM_Interpreter_Fallback_Partial_Sees_Branch_Let(t *testing.T) {
+	previous := rootplush.SetRenderMode(rootplush.RenderModeVM)
+	defer rootplush.SetRenderMode(previous)
+	previousFallback := rootplush.SetVMGenericFallback(true)
+	defer rootplush.SetVMGenericFallback(previousFallback)
+
+	cache := inmemory.NewMemoryCache()
+	rootplush.PlushCacheSetup(cache)
+	defer rootplush.ClearTemplateCache()
+
+	input := `<% let done = false %><% done = {"value": true} %><%= if (currentRoute.PathName == "target") { %><% let registry = {} %><%= partial("partials/registry-file.html") %><%= registry["primary"] %><% } %>`
+	helpers := map[string]interface{}{
+		"partialFeeder": func(name string) (string, error) {
+			require.Equal(t, "partials/registry-file.html", name)
+			return `<% registry = {"primary": entryID} %>`, nil
+		},
+	}
+
+	data := map[string]interface{}{
+		"currentRoute": struct {
+			PathName string
+		}{PathName: "target"},
+		"entryID": "current-id",
+	}
+	out, err := rootplush.BuffaloRendererWithContext(input, data, helpers, func(ctx *rootplush.Context) {
+		ctx.Set(meta.TemplateFileKey, "templates/application.plush.html")
+	})
+	require.NoError(t, err)
+	require.Equal(t, "current-id", out)
+	diagnostics, ok := rootplush.RenderDiagnosticsFromData(data)
+	require.True(t, ok)
+	require.Equal(t, rootplush.RenderFastPathInterpreterFallback, diagnostics.FastPath)
+	require.Contains(t, diagnostics.FastReject, `assignment value`)
+}
+
 func Test_Clear_Fast_Helper_Removes_Custom_Fast_Render(t *testing.T) {
 	fastCalls := 0
 	fallbackCalls := 0

--- a/vm/plush/plush_test.go
+++ b/vm/plush/plush_test.go
@@ -265,7 +265,7 @@ func Test_Buffalo_Renderer_VM_Cached_Branch_Partial_Assigns_Parent_Binding(t *te
 	}
 }
 
-func Test_Buffalo_Renderer_VM_Interpreter_Fallback_Partial_Sees_Branch_Let(t *testing.T) {
+func Test_Buffalo_Renderer_VM_Generic_Partial_Sees_Branch_Let(t *testing.T) {
 	previous := rootplush.SetRenderMode(rootplush.RenderModeVM)
 	defer rootplush.SetRenderMode(previous)
 	previousFallback := rootplush.SetVMGenericFallback(true)
@@ -296,8 +296,8 @@ func Test_Buffalo_Renderer_VM_Interpreter_Fallback_Partial_Sees_Branch_Let(t *te
 	require.Equal(t, "current-id", out)
 	diagnostics, ok := rootplush.RenderDiagnosticsFromData(data)
 	require.True(t, ok)
-	require.Equal(t, rootplush.RenderFastPathInterpreterFallback, diagnostics.FastPath)
-	require.Contains(t, diagnostics.FastReject, `assignment value`)
+	require.Equal(t, rootplush.RenderFastPathGeneric, diagnostics.FastPath)
+	require.Empty(t, diagnostics.FastReject)
 }
 
 func Test_Clear_Fast_Helper_Removes_Custom_Fast_Render(t *testing.T) {

--- a/vm/plush/plush_test.go
+++ b/vm/plush/plush_test.go
@@ -178,7 +178,7 @@ func Test_Buffalo_Renderer_VM_Cached_Layout_Partial_Sees_Top_Level_Let(t *testin
 			},
 		}
 		out, err := rootplush.BuffaloRendererWithContext(input, data, helpers, func(ctx *rootplush.Context) {
-			ctx.Set(meta.TemplateFileKey, "templates/application.plush.html")
+			ctx.Set(meta.TemplateFileKey, "templates/layout.plush.html")
 		})
 		require.NoError(t, err)
 		require.Contains(t, out, "color: "+color+";")
@@ -225,7 +225,7 @@ func Test_Buffalo_Renderer_VM_Cached_Layout_Partial_Sees_Top_Level_Let_Alias_Fro
 			},
 		}
 		out, err := rootplush.BuffaloRendererWithContext(input, data, helpers, func(ctx *rootplush.Context) {
-			ctx.Set(meta.TemplateFileKey, "templates/application.plush.html")
+			ctx.Set(meta.TemplateFileKey, "templates/layout.plush.html")
 		})
 		require.NoError(t, err)
 		require.Contains(t, out, "color: "+color+";")
@@ -258,7 +258,7 @@ func Test_Buffalo_Renderer_VM_Cached_Branch_Partial_Assigns_Parent_Binding(t *te
 			"entryID": id,
 		}
 		out, err := rootplush.BuffaloRendererWithContext(input, data, helpers, func(ctx *rootplush.Context) {
-			ctx.Set(meta.TemplateFileKey, "templates/application.plush.html")
+			ctx.Set(meta.TemplateFileKey, "templates/layout.plush.html")
 		})
 		require.NoError(t, err)
 		require.Equal(t, id, out)
@@ -290,7 +290,7 @@ func Test_Buffalo_Renderer_VM_Generic_Partial_Sees_Branch_Let(t *testing.T) {
 		"entryID": "current-id",
 	}
 	out, err := rootplush.BuffaloRendererWithContext(input, data, helpers, func(ctx *rootplush.Context) {
-		ctx.Set(meta.TemplateFileKey, "templates/application.plush.html")
+		ctx.Set(meta.TemplateFileKey, "templates/layout.plush.html")
 	})
 	require.NoError(t, err)
 	require.Equal(t, "current-id", out)

--- a/vm/plush/render_mode_test.go
+++ b/vm/plush/render_mode_test.go
@@ -1,15 +1,204 @@
 package plush_test
 
 import (
+	"html/template"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	rootplush "github.com/gobuffalo/plush/v5"
 	"github.com/gobuffalo/plush/v5/helpers/meta"
 	"github.com/gobuffalo/plush/v5/templatecache/inmemory"
+	"github.com/gobuffalo/plush/v5/vm/compiler"
 	_ "github.com/gobuffalo/plush/v5/vm/plush"
 	"github.com/stretchr/testify/require"
 )
+
+func Test_Buffalo_Render_Pass_File_Output_Tracks_Layout_Not_Nested_Renders(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	rootplush.PlushCacheSetup(cache)
+	defer rootplush.ClearTemplateCache()
+
+	previous := rootplush.SetRenderMode(rootplush.RenderModeVM)
+	defer rootplush.SetRenderMode(previous)
+
+	const pageFile = "templates/pages/detail.plush"
+	const layoutFile = "templates/application.plush"
+	pageSource := `<%= nested() %><%= name %>`
+	layoutSource := `<html><%= nestedBuffalo() %><%= yield %></html>`
+
+	renderRequest := func(name string) rootplush.RenderDiagnostics {
+		data := map[string]interface{}{
+			meta.TemplateFileKey: pageFile,
+			"name":               name,
+		}
+		helpers := map[string]interface{}{
+			"nested": func(help rootplush.HelperContext) (template.HTML, error) {
+				help.Set(meta.TemplateFileKey, "templates/sections/nested.plush")
+				defer help.Set(meta.TemplateFileKey, pageFile)
+				rendered, err := rootplush.Render(`<section>N</section>`, help.Context)
+				return template.HTML(rendered), err
+			},
+		}
+		helpers["nestedBuffalo"] = func() (template.HTML, error) {
+			originalFilename := data[meta.TemplateFileKey]
+			data[meta.TemplateFileKey] = "templates/sections/nested-buffalo.plush"
+			defer func() {
+				data[meta.TemplateFileKey] = originalFilename
+			}()
+			rendered, err := rootplush.BuffaloRenderer(`<aside>B</aside>`, data, helpers)
+			return template.HTML(rendered), err
+		}
+		body, err := rootplush.BuffaloRenderer(pageSource, data, helpers)
+		require.NoError(t, err)
+
+		data["yield"] = template.HTML(body)
+		data[meta.TemplateFileKey] = layoutFile
+		rendered, err := rootplush.BuffaloRenderer(layoutSource, data, helpers)
+		require.NoError(t, err)
+		require.Equal(t, "<html><aside>B</aside><section>N</section>"+name+"</html>", rendered)
+
+		diagnostics, ok := rootplush.RenderDiagnosticsFromData(data)
+		require.True(t, ok)
+		return diagnostics
+	}
+
+	first := renderRequest("Fry")
+	firstYield := "<section>N</section>Fry"
+	firstRendered := "<html><aside>B</aside>" + firstYield + "</html>"
+	require.Equal(t, "file", first.OutputSize.Scope)
+	require.True(t, first.OutputSize.Contextual)
+	require.Equal(t, len(firstYield), first.OutputSize.YieldSize)
+	require.Equal(t, len(firstRendered), first.OutputSize.Actual)
+	require.Equal(t, len(firstRendered)-len(firstYield), first.OutputSize.OverheadActual)
+	require.Equal(t, first.OutputSize.OverheadActual, first.OutputSize.OverheadAfter)
+	require.Equal(t, uint64(1), first.OutputSize.SamplesAfter)
+
+	second := renderRequest("Fry")
+	require.Equal(t, "file", second.OutputSize.Scope)
+	require.Equal(t, second.OutputSize.Actual, second.OutputSize.EstimateBefore)
+	require.Equal(t, second.OutputSize.OverheadActual, second.OutputSize.OverheadBefore)
+	require.Equal(t, uint64(2), second.OutputSize.SamplesAfter)
+
+	third := renderRequest("Philip J. Fry")
+	require.Greater(t, third.OutputSize.YieldSize, second.OutputSize.YieldSize)
+	require.Equal(t, third.OutputSize.Actual, third.OutputSize.EstimateBefore)
+	require.Equal(t, third.OutputSize.OverheadActual, third.OutputSize.OverheadBefore)
+	require.Equal(t, uint64(3), third.OutputSize.SamplesAfter)
+}
+
+func Test_Buffalo_Render_Pass_File_Output_Isolates_Yield_Size_Bands(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	rootplush.PlushCacheSetup(cache)
+	defer rootplush.ClearTemplateCache()
+
+	previous := rootplush.SetRenderMode(rootplush.RenderModeVM)
+	defer rootplush.SetRenderMode(previous)
+
+	const pageFile = "templates/pages/detail.plush"
+	const pageSource = `<%= body %>`
+	const layoutFile = "templates/application.plush"
+	const layoutSource = `<html><%= yield %></html>`
+
+	renderRequest := func(body string) rootplush.RenderDiagnostics {
+		data := map[string]interface{}{
+			meta.TemplateFileKey: pageFile,
+			"body":               body,
+		}
+		bodyOutput, err := rootplush.BuffaloRenderer(pageSource, data, nil)
+		require.NoError(t, err)
+		data["yield"] = template.HTML(bodyOutput)
+		data[meta.TemplateFileKey] = layoutFile
+		_, err = rootplush.BuffaloRenderer(layoutSource, data, nil)
+		require.NoError(t, err)
+		diagnostics, ok := rootplush.RenderDiagnosticsFromData(data)
+		require.True(t, ok)
+		return diagnostics
+	}
+
+	smallBody := strings.Repeat("s", 31_694)
+	mediumBody := strings.Repeat("m", 35_179)
+	smallFirst := renderRequest(smallBody)
+	mediumFirst := renderRequest(mediumBody)
+	smallSecond := renderRequest(smallBody)
+
+	require.Equal(t, "16k-32k", smallFirst.OutputSize.ProfileBand)
+	require.Zero(t, smallFirst.OutputSize.SamplesBefore)
+	require.Equal(t, "32k-64k", mediumFirst.OutputSize.ProfileBand)
+	require.Zero(t, mediumFirst.OutputSize.SamplesBefore)
+	require.Equal(t, "16k-32k", smallSecond.OutputSize.ProfileBand)
+	require.Equal(t, uint64(1), smallSecond.OutputSize.SamplesBefore)
+	require.Equal(t, smallSecond.OutputSize.Actual, smallSecond.OutputSize.EstimateBefore)
+}
+
+func Test_Buffalo_Render_Pass_Root_Layout_Overhead_Stats_Are_Concurrent(t *testing.T) {
+	cache := inmemory.NewMemoryCache()
+	rootplush.PlushCacheSetup(cache)
+	defer rootplush.ClearTemplateCache()
+
+	previous := rootplush.SetRenderMode(rootplush.RenderModeVM)
+	defer rootplush.SetRenderMode(previous)
+
+	const layoutFile = "templates/application.plush"
+	const pageSource = `<%= body %>`
+	const layoutSource = `<html><%= chrome %><%= yield %></html>`
+
+	renderRequest := func(pageFile, body, chrome string) error {
+		data := map[string]interface{}{
+			meta.TemplateFileKey: pageFile,
+			"body":               body,
+			"chrome":             chrome,
+		}
+		bodyOutput, err := rootplush.BuffaloRenderer(pageSource, data, nil)
+		if err != nil {
+			return err
+		}
+		data["yield"] = template.HTML(bodyOutput)
+		data[meta.TemplateFileKey] = layoutFile
+		_, err = rootplush.BuffaloRenderer(layoutSource, data, nil)
+		return err
+	}
+
+	pages := []struct {
+		filename string
+		body     string
+		chrome   string
+	}{
+		{filename: "templates/pages/alpha.plush", body: "alpha", chrome: "ALPHA-CHROME"},
+		{filename: "templates/pages/beta.plush", body: "beta", chrome: "BETA-CHROME"},
+	}
+	for _, page := range pages {
+		require.NoError(t, renderRequest(page.filename, page.body, page.chrome))
+	}
+
+	const rendersPerRoot = 16
+	errCh := make(chan error, len(pages)*rendersPerRoot)
+	var wg sync.WaitGroup
+	for _, page := range pages {
+		for i := 0; i < rendersPerRoot; i++ {
+			wg.Add(1)
+			go func(filename, body, chrome string) {
+				defer wg.Done()
+				errCh <- renderRequest(filename, body, chrome)
+			}(page.filename, page.body, page.chrome)
+		}
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+
+	for _, page := range pages {
+		entry, ok := cache.Get(rootplush.GenerateASTKey(page.filename))
+		require.True(t, ok)
+		bytecode, ok := entry.VMBytecode.(*compiler.Bytecode)
+		require.True(t, ok)
+		stats, _ := bytecode.LayoutSizeProfile.Stats(len(page.body))
+		require.Equal(t, uint64(rendersPerRoot+1), stats.Samples())
+	}
+}
 
 func Test_Root_Render_Mode_VM_Uses_Registered_VM_Renderer(t *testing.T) {
 	previous := rootplush.SetRenderMode(rootplush.RenderModeVM)

--- a/vm/plush/render_mode_test.go
+++ b/vm/plush/render_mode_test.go
@@ -161,7 +161,7 @@ func Test_Root_Render_Mode_VM_Writes_Diagnostics_To_Context(t *testing.T) {
 	require.NotZero(t, diagnostics.EngineDuration)
 }
 
-func Test_Root_Render_Mode_VM_Generic_Fallback_Uses_Interpreter(t *testing.T) {
+func Test_Root_Render_Mode_VM_Generic_Segment_Stays_In_VM(t *testing.T) {
 	previousMode := rootplush.SetRenderMode(rootplush.RenderModeVM)
 	defer rootplush.SetRenderMode(previousMode)
 	previousFallback := rootplush.SetVMGenericFallback(true)
@@ -175,10 +175,10 @@ func Test_Root_Render_Mode_VM_Generic_Fallback_Uses_Interpreter(t *testing.T) {
 	diagnostics, ok := rootplush.RenderDiagnosticsFromContext(ctx)
 	require.True(t, ok)
 	require.Equal(t, rootplush.RenderModeNameVM, diagnostics.Mode)
-	require.Equal(t, rootplush.RenderFastPathInterpreterFallback, diagnostics.FastPath)
+	require.Equal(t, rootplush.RenderFastPathGeneric, diagnostics.FastPath)
 }
 
-func Test_Root_Render_Mode_VM_Generic_Fallback_Keeps_Bytecode_Cache(t *testing.T) {
+func Test_Root_Render_Mode_VM_Generic_Segment_Keeps_Bytecode_Cache(t *testing.T) {
 	cache := inmemory.NewMemoryCache()
 	rootplush.PlushCacheSetup(cache)
 	defer rootplush.ClearTemplateCache()
@@ -188,7 +188,7 @@ func Test_Root_Render_Mode_VM_Generic_Fallback_Keeps_Bytecode_Cache(t *testing.T
 	previousFallback := rootplush.SetVMGenericFallback(true)
 	defer rootplush.SetVMGenericFallback(previousFallback)
 
-	filename := "render-mode-vm-fallback-cache.plush"
+	filename := "render-mode-vm-generic-cache.plush"
 	ctx := rootplush.NewContext()
 	ctx.Set(meta.TemplateFileKey, filename)
 
@@ -206,10 +206,10 @@ func Test_Root_Render_Mode_VM_Generic_Fallback_Keeps_Bytecode_Cache(t *testing.T
 	diagnostics, ok = rootplush.RenderDiagnosticsFromContext(ctx)
 	require.True(t, ok)
 	require.Equal(t, rootplush.VMBytecodeCacheHit, diagnostics.VMBytecodeCache)
-	require.Equal(t, rootplush.RenderFastPathInterpreterFallback, diagnostics.FastPath)
+	require.Equal(t, rootplush.RenderFastPathGeneric, diagnostics.FastPath)
 }
 
-func Test_Root_Render_Mode_VM_Generic_Fallback_Renders_Partials_With_Interpreter(t *testing.T) {
+func Test_Root_Render_Mode_VM_Generic_Segment_Renders_Partials_In_VM(t *testing.T) {
 	previousMode := rootplush.SetRenderMode(rootplush.RenderModeVM)
 	defer rootplush.SetRenderMode(previousMode)
 	previousFallback := rootplush.SetVMGenericFallback(true)
@@ -221,7 +221,7 @@ func Test_Root_Render_Mode_VM_Generic_Fallback_Renders_Partials_With_Interpreter
 		require.Equal(t, "row.plush", name)
 		return `<% let title = "Row" %><%= title %>`, nil
 	})
-	ctx.Set(meta.TemplateFileKey, "render-mode-vm-fallback-partial.plush")
+	ctx.Set(meta.TemplateFileKey, "render-mode-vm-generic-partial.plush")
 
 	out, err := rootplush.Render(`<% let forceBytecode = fn() { return "x" } %><%= partial("row.plush", {}) %>`, ctx)
 	require.NoError(t, err)
@@ -229,7 +229,7 @@ func Test_Root_Render_Mode_VM_Generic_Fallback_Renders_Partials_With_Interpreter
 
 	diagnostics, ok := rootplush.RenderDiagnosticsFromContext(ctx)
 	require.True(t, ok)
-	require.Equal(t, rootplush.RenderFastPathInterpreterFallback, diagnostics.FastPath)
+	require.Equal(t, rootplush.RenderFastPathGeneric, diagnostics.FastPath)
 	require.Zero(t, diagnostics.VMHotspots.PartialCalls)
 }
 

--- a/vm/vm/execution.go
+++ b/vm/vm/execution.go
@@ -492,6 +492,9 @@ func (vm *VM) wrapRuntimeError(err error) error {
 	if err == nil {
 		return nil
 	}
+	if plush.IsTemplateTraceError(err) {
+		return err
+	}
 	if strings.HasPrefix(err.Error(), "line ") {
 		return err
 	}

--- a/vm/vm/execution.go
+++ b/vm/vm/execution.go
@@ -300,6 +300,18 @@ func (vm *VM) Run() error {
 				return err
 			}
 
+		case code.OpGetNameOrJumpMissing:
+			nameIndex := int(code.ReadUint16(ins[ip+1:]))
+			missingPos := int(code.ReadUint16(ins[ip+3:]))
+			vm.currentFrame().ip += 4
+			if value, ok := vm.contextValue(vm.stringConstant(nameIndex)); ok {
+				if err := vm.push(object.Wrap(value)); err != nil {
+					return err
+				}
+			} else {
+				vm.currentFrame().ip = missingPos - 1
+			}
+
 		case code.OpSetName:
 			nameIndex := int(code.ReadUint16(ins[ip+1:]))
 			vm.currentFrame().ip += 2

--- a/vm/vm/execution.go
+++ b/vm/vm/execution.go
@@ -1190,6 +1190,9 @@ func (vm *VM) callNativeValue(name string, raw interface{}, numArgs int, block *
 
 	res := rv.Call(args)
 	if helperCtx != nil {
+		if name != "partial" {
+			vm.syncContextBindingsFromContext(vm.ctx, helperCtx)
+		}
 		vm.syncFrameBindingsFromContext(helperCtx)
 		vm.lastHelperContext = nil
 	}
@@ -1241,6 +1244,9 @@ func (vm *VM) writeNativeValueCall(name string, raw interface{}, numArgs int, ca
 
 	res := rv.Call(args)
 	if helperCtx != nil {
+		if name != "partial" {
+			vm.syncContextBindingsFromContext(vm.ctx, helperCtx)
+		}
 		vm.syncFrameBindingsFromContext(helperCtx)
 		vm.lastHelperContext = nil
 	}

--- a/vm/vm/fast_bindings.go
+++ b/vm/vm/fast_bindings.go
@@ -147,6 +147,27 @@ func (b *fastRenderBindings) setLocalAndContext(index int, value interface{}) {
 	b.ctx.Set(b.names[index], value)
 }
 
+func (b *fastRenderBindings) assignExistingLocalAndContext(index int, value interface{}) bool {
+	if b == nil || index < 0 || index >= len(b.names) {
+		return false
+	}
+	if b.ctx == nil {
+		b.setLocal(index, value)
+		return true
+	}
+	if id, ok := b.bindingID(index); ok {
+		if updater, ok := b.ctx.(interface{ UpdateID(int, interface{}) bool }); ok && updater.UpdateID(id, value) {
+			b.setLocal(index, value)
+			return true
+		}
+	}
+	if b.ctx.Update(b.names[index], value) {
+		b.setLocal(index, value)
+		return true
+	}
+	return false
+}
+
 func (b fastRenderBindings) syncLocalValuesFromContext() {
 	if b.ctx == nil || len(b.localOK) == 0 || len(b.localVals) == 0 {
 		return
@@ -238,6 +259,9 @@ func fastContextValue(ctx hctx.Context, name string) (interface{}, bool) {
 func fastLineError(line int, err error) error {
 	if err == nil {
 		return nil
+	}
+	if plush.IsTemplateTraceError(err) {
+		return err
 	}
 	if line <= 0 {
 		line = 1

--- a/vm/vm/fast_bindings.go
+++ b/vm/vm/fast_bindings.go
@@ -135,6 +135,10 @@ func (b *fastRenderBindings) setLocalAndContext(index int, value interface{}) {
 		return
 	}
 	if id, ok := b.bindingID(index); ok {
+		if overlay, ok := b.ctx.(*partialOverlayContext); ok {
+			overlay.setLocalWithID(b.names[index], id, value)
+			return
+		}
 		if setter, ok := b.ctx.(interface{ SetID(int, interface{}) }); ok {
 			setter.SetID(id, value)
 			return

--- a/vm/vm/fast_cache_partial_helpers_test.go
+++ b/vm/vm/fast_cache_partial_helpers_test.go
@@ -290,6 +290,63 @@ func Test_VM_Partial_Overlay_Render_Assigns_Missing_Map_Value_To_Existing_Local(
 	require.Empty(t, out)
 }
 
+func Test_VM_Partial_Overlay_Render_Nested_Output_Branches_Update_Outer_Binding(t *testing.T) {
+	type entry struct {
+		ID string
+	}
+
+	entries := []entry{{ID: "first"}, {ID: "second"}}
+	parent := plush.NewContextWith(map[string]interface{}{
+		"input":   map[string]string{"target_id": "second"},
+		"entries": entries,
+		"count": func(values []entry) int {
+			return len(values)
+		},
+	})
+	ctx := borrowPartialOverlayContext(parent)
+	defer releasePartialOverlayContext(ctx)
+
+	out, err := Render(`<% let selected = entries[0] %>
+<%= if (input["target_id"] != "" && count(entries) > 0) { %>
+	<%= for (i, entry) in entries { %>
+		<%= if (entry.ID == input["target_id"]) { %>
+			<% selected = entry %>
+		<% } %>
+	<% } %>
+<% } %>
+<%= selected.ID %>`, ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, "second")
+}
+
+func Test_VM_Partial_Overlay_Render_Guarded_Collection_Loop_Reads_Value_Property(t *testing.T) {
+	type asset struct {
+		URL string
+		Alt string
+	}
+	type record struct {
+		Assets []asset
+	}
+
+	parent := plush.NewContextWith(map[string]interface{}{
+		"record": record{Assets: []asset{
+			{URL: "/first.png", Alt: "First"},
+			{URL: "/second.png", Alt: "Second"},
+		}},
+	})
+	ctx := borrowPartialOverlayContext(parent)
+	defer releasePartialOverlayContext(ctx)
+
+	out, err := Render(`<%= if (len(record.Assets) > 0 && record.Assets[0].URL) { %>
+	<%= for (index, asset) in record.Assets { %>
+		<link href="<%= asset.URL %>" data-alt="<%= asset.Alt %>" data-index="<%= index %>" />
+	<% } %>
+<% } %>`, ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, `/first.png`)
+	require.Contains(t, out, `/second.png`)
+}
+
 func Test_VM_Partial_Overlay_Lookup_And_Context_Branches(t *testing.T) {
 	var nilOverlay *partialOverlayContext
 	nilOverlay.reset(nil)

--- a/vm/vm/fast_cache_partial_helpers_test.go
+++ b/vm/vm/fast_cache_partial_helpers_test.go
@@ -261,6 +261,10 @@ func Test_VM_Partial_Overlay_Update_ID_Branches(t *testing.T) {
 	value, ok := local.LookupID(localID)
 	require.True(t, ok)
 	require.Equal(t, "second", value)
+	require.True(t, local.UpdateID(localID, nil))
+	value, ok = local.LookupID(localID)
+	require.True(t, ok)
+	require.Nil(t, value)
 
 	require.True(t, local.UpdateID(parentID, "new"))
 	require.Equal(t, "new", parent.values["parent"])
@@ -268,6 +272,22 @@ func Test_VM_Partial_Overlay_Update_ID_Branches(t *testing.T) {
 	missingID := local.InternID("missing")
 	require.False(t, local.UpdateID(missingID, "value"))
 	require.False(t, local.UpdateID(missingID, nil))
+}
+
+func Test_VM_Partial_Overlay_Render_Assigns_Missing_Map_Value_To_Existing_Local(t *testing.T) {
+	type record struct {
+		Fields map[string]string
+	}
+
+	parent := plush.NewContextWith(map[string]interface{}{
+		"record": record{Fields: map[string]string{}},
+	})
+	ctx := borrowPartialOverlayContext(parent)
+	defer releasePartialOverlayContext(ctx)
+
+	out, err := Render(`<% let value = "fallback"; value = record.Fields["missing"]; %><%= value %>`, ctx)
+	require.NoError(t, err)
+	require.Empty(t, out)
 }
 
 func Test_VM_Partial_Overlay_Lookup_And_Context_Branches(t *testing.T) {

--- a/vm/vm/fast_calls.go
+++ b/vm/vm/fast_calls.go
@@ -73,6 +73,11 @@ func writeFastCallSegment(out *strings.Builder, ctx hctx.Context, bindings fastR
 	if call == nil {
 		return nil
 	}
+	writeOut := out
+	if call.Silent {
+		var discard strings.Builder
+		writeOut = &discard
+	}
 	raw, ok := bindings.value(call.NameIndex)
 	if !ok {
 		return fastLineError(call.Line, fmt.Errorf("%q: unknown identifier", call.Name))
@@ -86,14 +91,14 @@ func writeFastCallSegment(out *strings.Builder, ctx hctx.Context, bindings fastR
 		if err != nil {
 			return err
 		}
-		if handled, err := writeRegisteredFastHelperNamed(out, ctx, call.Name, helper, args); handled || err != nil {
+		if handled, err := writeRegisteredFastHelperNamed(writeOut, ctx, call.Name, helper, args); handled || err != nil {
 			if err != nil {
 				return fastLineError(call.Line, err)
 			}
 			return nil
 		}
 	}
-	if handled, err := writeFastDirectStringCallSegment(out, ctx, bindings, call, raw); handled || err != nil {
+	if handled, err := writeFastDirectStringCallSegment(writeOut, ctx, bindings, call, raw); handled || err != nil {
 		return err
 	}
 	var argStore fastCallArgs
@@ -101,7 +106,7 @@ func writeFastCallSegment(out *strings.Builder, ctx hctx.Context, bindings fastR
 	if err != nil {
 		return err
 	}
-	if err := writeFastCallValue(out, ctx, call.Name, raw, args, &call.Cache); err != nil {
+	if err := writeFastCallValue(writeOut, ctx, call.Name, raw, args, &call.Cache); err != nil {
 		return fastLineError(call.Line, err)
 	}
 	return nil
@@ -110,6 +115,11 @@ func writeFastCallSegment(out *strings.Builder, ctx hctx.Context, bindings fastR
 func writeFastBlockCallSegment(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, call *compiler.FastBlockCallPlan) error {
 	if call == nil {
 		return nil
+	}
+	writeOut := out
+	if call.Silent {
+		var discard strings.Builder
+		writeOut = &discard
 	}
 	raw, ok := bindings.value(call.NameIndex)
 	if !ok {
@@ -131,7 +141,7 @@ func writeFastBlockCallSegment(out *strings.Builder, ctx hctx.Context, bindings 
 		scopedBindings.syncLocalValuesFromContext()
 		return rendered, err
 	})
-	if err := writeFastBlockCallValue(out, ctx, call.Name, raw, args, helperCtx, &call.Cache); err != nil {
+	if err := writeFastBlockCallValue(writeOut, ctx, call.Name, raw, args, helperCtx, &call.Cache); err != nil {
 		return fastLineError(call.Line, err)
 	}
 	return nil
@@ -140,6 +150,11 @@ func writeFastBlockCallSegment(out *strings.Builder, ctx hctx.Context, bindings 
 func writeFastLoopBlockCallPart(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, loop *compiler.FastLoopPlan, call *compiler.FastBlockCallPlan, loopKey, loopValue interface{}) error {
 	if call == nil {
 		return nil
+	}
+	writeOut := out
+	if call.Silent {
+		var discard strings.Builder
+		writeOut = &discard
 	}
 	raw, ok := bindings.value(call.NameIndex)
 	if !ok {
@@ -161,7 +176,7 @@ func writeFastLoopBlockCallPart(out *strings.Builder, ctx hctx.Context, bindings
 		scopedBindings.syncLocalValuesFromContext()
 		return rendered, err
 	})
-	if err := writeFastBlockCallValue(out, ctx, call.Name, raw, args, helperCtx, &call.Cache); err != nil {
+	if err := writeFastBlockCallValue(writeOut, ctx, call.Name, raw, args, helperCtx, &call.Cache); err != nil {
 		return fastLineError(call.Line, err)
 	}
 	return nil
@@ -176,7 +191,7 @@ func renderFastBlockCallBytecode(call *compiler.FastBlockCallPlan, ctx hctx.Cont
 		return bytecode.StaticOutput, nil
 	}
 	if bytecode.FastRenderPlan != nil {
-		if rendered, ok, err := renderFastPlanWithBindingPlan(bytecode.FastRenderPlan, ctx, topLevelFastBindingPlan(bytecode.FastRenderPlan, ctx)); ok || err != nil {
+		if rendered, ok, err := renderFastPlanWithBindingPlan(bytecode, bytecode.FastRenderPlan, ctx, topLevelFastBindingPlan(bytecode.FastRenderPlan, ctx)); ok || err != nil {
 			return rendered, err
 		}
 	}

--- a/vm/vm/fast_calls.go
+++ b/vm/vm/fast_calls.go
@@ -391,6 +391,10 @@ func evalFastCallArgsInto(plans []compiler.FastValuePlan, ctx hctx.Context, bind
 			return nil, err
 		}
 		if !ok {
+			if plans[i].NullOnMissing {
+				args.Append(nil)
+				continue
+			}
 			return nil, fastLineError(plans[i].Line, fmt.Errorf("%q: unknown identifier", plans[i].Value))
 		}
 		args.Append(value)

--- a/vm/vm/fast_calls_helpers_test.go
+++ b/vm/vm/fast_calls_helpers_test.go
@@ -226,6 +226,11 @@ func Test_VM_Eval_Fast_Call_Args_Into_Branches(t *testing.T) {
 	_, err = evalFastCallArgsInto([]compiler.FastValuePlan{{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing", Line: 5}}, ctx, bindings, nil)
 	require.ErrorContains(t, err, `line 5: "missing": unknown identifier`)
 
+	args, err = evalFastCallArgsInto([]compiler.FastValuePlan{{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing", NullOnMissing: true, Line: 5}}, ctx, bindings, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, args.Len())
+	require.Nil(t, args.Raw(0))
+
 	_, err = evalFastCallArgsInto([]compiler.FastValuePlan{{
 		Kind: compiler.FastValueCall,
 		Call: &compiler.FastCallPlan{Name: "name", NameIndex: 0, Line: 6},

--- a/vm/vm/fast_loop_branch_edges_test.go
+++ b/vm/vm/fast_loop_branch_edges_test.go
@@ -208,17 +208,17 @@ func Test_VM_Write_Fast_Loop_Call_Part_Error_And_Fast_Helper_Branches(t *testing
 		Line:      1,
 	}
 	var out strings.Builder
-	require.NoError(t, writeFastLoopCallPart(&out, ctx, bindings, nil, 0, "item"))
+	require.NoError(t, writeFastLoopCallPart(&out, ctx, bindings, nil, nil, 0, "item"))
 	require.Empty(t, out.String())
 
-	require.NoError(t, writeFastLoopCallPart(&out, ctx, bindings, call, 0, "<item>"))
+	require.NoError(t, writeFastLoopCallPart(&out, ctx, bindings, nil, call, 0, "<item>"))
 	require.Equal(t, "fast:&lt;item&gt;", out.String())
 
 	missingCall := &compiler.FastCallPlan{Name: "missing", NameIndex: 99, Line: 7}
-	err := writeFastLoopCallPart(&strings.Builder{}, ctx, bindings, missingCall, 0, "item")
+	err := writeFastLoopCallPart(&strings.Builder{}, ctx, bindings, nil, missingCall, 0, "item")
 	require.ErrorContains(t, err, `line 7`)
 
-	err = writeFastLoopCallPart(&strings.Builder{}, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, call, 0, "item")
+	err = writeFastLoopCallPart(&strings.Builder{}, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, nil, call, 0, "item")
 	require.ErrorContains(t, err, `line 1`)
 
 	badArg := &compiler.FastCallPlan{
@@ -227,19 +227,19 @@ func Test_VM_Write_Fast_Loop_Call_Part_Error_And_Fast_Helper_Branches(t *testing
 		Args:      []compiler.FastValuePlan{{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing", Line: 8}},
 		Line:      8,
 	}
-	err = writeFastLoopCallPart(&strings.Builder{}, ctx, bindings, badArg, 0, "item")
+	err = writeFastLoopCallPart(&strings.Builder{}, ctx, bindings, nil, badArg, 0, "item")
 	require.ErrorContains(t, err, `line 8`)
 
 	slowCtx := plush.NewContextWith(map[string]interface{}{
 		"label": func(value string) string { return value },
 	})
 	slowBindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label"}}, slowCtx)
-	err = writeFastLoopCallPart(&strings.Builder{}, slowCtx, slowBindings, badArg, 0, "item")
+	err = writeFastLoopCallPart(&strings.Builder{}, slowCtx, slowBindings, nil, badArg, 0, "item")
 	require.ErrorContains(t, err, `line 8`)
 
 	SetFastHelper(ctx, "label", func(FastWriter, FastArgs) error {
 		return errors.New("boom")
 	})
-	err = writeFastLoopCallPart(&strings.Builder{}, ctx, bindings, call, 0, "item")
+	err = writeFastLoopCallPart(&strings.Builder{}, ctx, bindings, nil, call, 0, "item")
 	require.ErrorContains(t, err, `line 1`)
 }

--- a/vm/vm/fast_loops.go
+++ b/vm/vm/fast_loops.go
@@ -123,7 +123,7 @@ func renderFastPartialSegmentWithDataPlan(out *strings.Builder, ctx hctx.Context
 	return nil
 }
 
-func renderFastLoop(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, loop *compiler.FastLoopPlan) (bool, error) {
+func renderFastLoop(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, loop *compiler.FastLoopPlan) (handled bool, renderErr error) {
 	if loop == nil {
 		return false, nil
 	}
@@ -158,10 +158,22 @@ func renderFastLoop(out *strings.Builder, ctx hctx.Context, bindings fastRenderB
 	if iter == nil {
 		return true, nil
 	}
+	startLen := out.Len()
+	renderedItems := 0
+	itemCount, itemCountKnown := fastIterableLen(iter)
+	outputSizeObservation := beginFastLoopSizeObservation(out, loop, itemCount, itemCountKnown)
+	defer func() {
+		if handled && renderErr == nil {
+			observeFastLoopOutput(ctx, loop, out.Len()-startLen, renderedItems, outputSizeObservation)
+		}
+	}()
 
 	switch iter := iter.(type) {
 	case []string:
 		if handled, err := renderFastStringKeyValueLoop(out, ctx, loop, iter); handled || err != nil {
+			if handled && err == nil {
+				renderedItems = len(iter)
+			}
 			return true, err
 		}
 		for i, value := range iter {
@@ -169,6 +181,7 @@ func renderFastLoop(out *strings.Builder, ctx hctx.Context, bindings fastRenderB
 			if err != nil {
 				return true, err
 			}
+			renderedItems++
 			if stop {
 				break
 			}
@@ -180,6 +193,7 @@ func renderFastLoop(out *strings.Builder, ctx hctx.Context, bindings fastRenderB
 			if err != nil {
 				return true, err
 			}
+			renderedItems++
 			if stop {
 				break
 			}
@@ -191,6 +205,7 @@ func renderFastLoop(out *strings.Builder, ctx hctx.Context, bindings fastRenderB
 			if err != nil {
 				return true, err
 			}
+			renderedItems++
 			if stop {
 				break
 			}
@@ -208,6 +223,9 @@ func renderFastLoop(out *strings.Builder, ctx hctx.Context, bindings fastRenderB
 	switch rv.Kind() {
 	case reflect.Array, reflect.Slice:
 		if handled, err := renderFastStructFieldLoop(out, ctx, bindings, loop, rv); handled || err != nil {
+			if handled && err == nil {
+				renderedItems = rv.Len()
+			}
 			return true, err
 		}
 		for i := 0; i < rv.Len(); i++ {
@@ -215,6 +233,7 @@ func renderFastLoop(out *strings.Builder, ctx hctx.Context, bindings fastRenderB
 			if err != nil {
 				return true, err
 			}
+			renderedItems++
 			if stop {
 				break
 			}
@@ -226,6 +245,7 @@ func renderFastLoop(out *strings.Builder, ctx hctx.Context, bindings fastRenderB
 			if err != nil {
 				return true, err
 			}
+			renderedItems++
 			if stop {
 				break
 			}

--- a/vm/vm/fast_loops.go
+++ b/vm/vm/fast_loops.go
@@ -14,6 +14,7 @@ import (
 var (
 	errFastLoopBreak    = errors.New("fast loop break")
 	errFastLoopContinue = errors.New("fast loop continue")
+	errFastLoopReturn   = errors.New("fast loop return")
 )
 
 func renderFastConditional(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, conditional *compiler.FastConditionalPlan) (bool, error) {
@@ -71,12 +72,16 @@ func renderFastConditionalSilently(ctx hctx.Context, bindings fastRenderBindings
 		}
 		if isTruthyFastValue(value) {
 			var discard strings.Builder
-			return renderFastSegments(&discard, ctx, bindings, branch.Segments)
+			branchCtx, branchBindings, cleanup := fastRenderSegmentScopeForLet(ctx, bindings, branch.Segments)
+			defer cleanup()
+			return renderFastSegments(&discard, branchCtx, branchBindings, branch.Segments)
 		}
 	}
 	if len(conditional.ElseSegments) > 0 {
 		var discard strings.Builder
-		return renderFastSegments(&discard, ctx, bindings, conditional.ElseSegments)
+		branchCtx, branchBindings, cleanup := fastRenderSegmentScopeForLet(ctx, bindings, conditional.ElseSegments)
+		defer cleanup()
+		return renderFastSegments(&discard, branchCtx, branchBindings, conditional.ElseSegments)
 	}
 	return true, nil
 }
@@ -114,9 +119,18 @@ func renderFastLoop(out *strings.Builder, ctx hctx.Context, bindings fastRenderB
 	if loop == nil {
 		return false, nil
 	}
-	if fastLoopPartsHaveLet(loop.Parts) {
+	if loop.Silent {
+		var discard strings.Builder
+		out = &discard
+	}
+	hasLet, hasAssign := fastLoopPartFlags(loop)
+	if hasLet {
+		outerBindings := bindings
 		scopedCtx, scopedBindings, cleanup := fastRenderScopedBindings(ctx, bindings)
 		defer cleanup()
+		if hasAssign {
+			defer syncFastLoopAssignmentBindings(scopedCtx, &outerBindings, loop.Parts)
+		}
 		ctx = scopedCtx
 		bindings = scopedBindings
 		bindings = fastRenderBindingsWithLocalCopy(bindings)
@@ -234,6 +248,8 @@ func renderFastLoopIterationOrControl(out *strings.Builder, ctx hctx.Context, bi
 		return true, nil
 	case errFastLoopContinue:
 		return false, nil
+	case errFastLoopReturn:
+		return false, nil
 	default:
 		return false, err
 	}
@@ -248,27 +264,29 @@ func renderFastLoopIteration(out *strings.Builder, ctx hctx.Context, bindings fa
 }
 
 func renderFastLoopParts(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, loop *compiler.FastLoopPlan, parts []compiler.FastLoopPart, key, value interface{}) error {
+	currentKey := key
+	currentValue := value
 	for i := range parts {
 		part := &parts[i]
 		switch part.Kind {
 		case compiler.FastLoopPartStatic:
 			out.WriteString(part.Value)
 		case compiler.FastLoopPartKey:
-			writeFastGoValue(out, ctx, key)
+			writeFastGoValue(out, ctx, currentKey)
 		case compiler.FastLoopPartValue:
-			writeFastGoValue(out, ctx, value)
+			writeFastGoValue(out, ctx, currentValue)
 		case compiler.FastLoopPartValueProperty:
 			if err := spendFastTraversal(ctx, part.Line); err != nil {
 				return err
 			}
-			if err := writeFastPropertyOutput(out, ctx, value, part.Value, object.PropertyAccess{
+			if err := writeFastPropertyOutput(out, ctx, currentValue, part.Value, object.PropertyAccess{
 				Receiver: part.Receiver,
 				Full:     part.Full,
 			}, &part.PropertyCache); err != nil {
 				return fastLineError(part.Line, err)
 			}
 		case compiler.FastLoopPartValuePath:
-			property, ok, err := evalFastLoopValue(&part.ValuePlan, ctx, bindings, key, value)
+			property, ok, err := evalFastLoopValue(&part.ValuePlan, ctx, bindings, currentKey, currentValue)
 			if err != nil {
 				return err
 			}
@@ -277,19 +295,19 @@ func renderFastLoopParts(out *strings.Builder, ctx hctx.Context, bindings fastRe
 			}
 			writeFastGoValue(out, ctx, property)
 		case compiler.FastLoopPartCall:
-			if err := writeFastLoopCallPart(out, ctx, bindings, part.Call, key, value); err != nil {
+			if err := writeFastLoopCallPart(out, ctx, bindings, loop, part.Call, currentKey, currentValue); err != nil {
 				return err
 			}
 		case compiler.FastLoopPartBlockCall:
-			if err := writeFastLoopBlockCallPart(out, ctx, bindings, loop, part.BlockCall, key, value); err != nil {
+			if err := writeFastLoopBlockCallPart(out, ctx, bindings, loop, part.BlockCall, currentKey, currentValue); err != nil {
 				return err
 			}
 		case compiler.FastLoopPartPartial:
-			if err := renderFastLoopPartialPart(out, ctx, bindings, loop, part.Partial, key, value); err != nil {
+			if err := renderFastLoopPartialPart(out, ctx, bindings, loop, part.Partial, currentKey, currentValue); err != nil {
 				return err
 			}
 		case compiler.FastLoopPartLet:
-			local, ok, err := evalFastLoopValue(&part.ValuePlan, ctx, bindings, key, value)
+			local, ok, err := evalFastLoopValue(&part.ValuePlan, ctx, bindings, currentKey, currentValue)
 			if err != nil {
 				return err
 			}
@@ -300,12 +318,32 @@ func renderFastLoopParts(out *strings.Builder, ctx hctx.Context, bindings fastRe
 				return err
 			}
 			bindings.setLocalAndContext(part.NameIndex, local)
+		case compiler.FastLoopPartAssign:
+			assigned, err := assignFastLoopIteratorPartValue(ctx, bindings, loop, part, &currentKey, &currentValue)
+			if err != nil {
+				return err
+			}
+			if assigned {
+				continue
+			}
+			if err := assignFastLoopPartValue(ctx, &bindings, part, currentKey, currentValue); err != nil {
+				return err
+			}
+		case compiler.FastLoopPartReturn:
+			value, ok, err := evalFastLoopValue(&part.ValuePlan, ctx, bindings, currentKey, currentValue)
+			if err != nil {
+				return err
+			}
+			if ok {
+				writeFastGoValue(out, ctx, value)
+			}
+			return errFastLoopReturn
 		case compiler.FastLoopPartConditional:
-			if err := renderFastLoopConditional(out, ctx, bindings, loop, part.Conditional, key, value); err != nil {
+			if err := renderFastLoopConditional(out, ctx, bindings, loop, part.Conditional, currentKey, currentValue); err != nil {
 				return err
 			}
 		case compiler.FastLoopPartLoop:
-			nestedBindings := fastLoopBindingsWithCurrentLocals(bindings, loop, key, value)
+			nestedBindings := fastLoopBindingsWithCurrentLocals(bindings, loop, currentKey, currentValue)
 			ok, err := renderFastLoop(out, ctx, nestedBindings, part.Loop)
 			if err != nil {
 				return err
@@ -320,6 +358,99 @@ func renderFastLoopParts(out *strings.Builder, ctx hctx.Context, bindings fastRe
 		default:
 			return nil
 		}
+	}
+	return nil
+}
+
+func assignFastLoopIteratorPartValue(ctx hctx.Context, bindings fastRenderBindings, loop *compiler.FastLoopPlan, part *compiler.FastLoopPart, key, value *interface{}) (bool, error) {
+	if loop == nil || part == nil || part.AssignTarget == nil || part.AssignTarget.Kind != compiler.FastAssignTargetName {
+		return false, nil
+	}
+	target := part.AssignTarget.Name
+	if target != loop.KeyName && target != loop.ValueName {
+		return false, nil
+	}
+	next, ok, err := evalFastLoopValue(&part.ValuePlan, ctx, bindings, *key, *value)
+	if err != nil {
+		return true, err
+	}
+	if !ok {
+		return true, fastLineError(part.Line, fmt.Errorf("%q: unknown identifier", fastValueMissingName(&part.ValuePlan)))
+	}
+	if err := spendFastAssignment(ctx, part.Line); err != nil {
+		return true, err
+	}
+	if target == loop.KeyName {
+		*key = next
+		return true, nil
+	}
+	*value = next
+	return true, nil
+}
+
+func assignFastLoopPartValue(ctx hctx.Context, bindings *fastRenderBindings, part *compiler.FastLoopPart, key, loopValue interface{}) error {
+	if part == nil {
+		return nil
+	}
+	if part.AssignTarget == nil || part.AssignTarget.Kind == compiler.FastAssignTargetName {
+		return assignFastLoopValue(ctx, bindings, part.Value, part.NameIndex, &part.ValuePlan, part.Line, key, loopValue)
+	}
+	return assignFastLoopIndexValue(ctx, bindings, part.AssignTarget, &part.ValuePlan, part.Line, key, loopValue)
+}
+
+func assignFastLoopValue(ctx hctx.Context, bindings *fastRenderBindings, name string, nameIndex int, valuePlan *compiler.FastValuePlan, line int, key, loopValue interface{}) error {
+	if bindings == nil {
+		return fastLineError(line, fmt.Errorf("%q: unknown identifier", name))
+	}
+	if _, ok := bindings.value(nameIndex); !ok {
+		return fastLineError(line, fmt.Errorf("%q: unknown identifier", name))
+	}
+	value, ok, err := evalFastLoopValue(valuePlan, ctx, *bindings, key, loopValue)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fastLineError(line, fmt.Errorf("%q: unknown identifier", fastValueMissingName(valuePlan)))
+	}
+	if err := spendFastAssignment(ctx, line); err != nil {
+		return err
+	}
+	if !bindings.assignExistingLocalAndContext(nameIndex, value) {
+		return fastLineError(line, fmt.Errorf("%q: unknown identifier", name))
+	}
+	return nil
+}
+
+func assignFastLoopIndexValue(ctx hctx.Context, bindings *fastRenderBindings, target *compiler.FastAssignTarget, valuePlan *compiler.FastValuePlan, line int, key, loopValue interface{}) error {
+	if bindings == nil || target == nil || target.Kind != compiler.FastAssignTargetIndex {
+		return fastLineError(line, fmt.Errorf("unsupported assignment target"))
+	}
+	container, ok, err := evalFastLoopValue(&target.Container, ctx, *bindings, key, loopValue)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fastLineError(target.Line, fmt.Errorf("%q: unknown identifier", fastValueMissingName(&target.Container)))
+	}
+	index, ok, err := evalFastLoopValue(&target.Index, ctx, *bindings, key, loopValue)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fastLineError(target.Line, fmt.Errorf("%q: unknown identifier", fastValueMissingName(&target.Index)))
+	}
+	value, ok, err := evalFastLoopValue(valuePlan, ctx, *bindings, key, loopValue)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fastLineError(line, fmt.Errorf("%q: unknown identifier", fastValueMissingName(valuePlan)))
+	}
+	if err := spendFastAssignment(ctx, line); err != nil {
+		return err
+	}
+	if err := setFastIndexGoValue(container, index, value); err != nil {
+		return fastLineError(line, err)
 	}
 	return nil
 }
@@ -346,7 +477,7 @@ func renderFastLoopConditional(out *strings.Builder, ctx hctx.Context, bindings 
 		return nil
 	}
 	if conditional.Silent {
-		return renderFastLoopConditionalSilently(ctx, bindings, loop, conditional, key, value)
+		return renderFastLoopConditionalSilently(out, ctx, bindings, loop, conditional, key, value)
 	}
 	for i := range conditional.Branches {
 		branch := &conditional.Branches[i]
@@ -378,7 +509,7 @@ func renderFastLoopConditional(out *strings.Builder, ctx hctx.Context, bindings 
 	return nil
 }
 
-func renderFastLoopConditionalSilently(ctx hctx.Context, bindings fastRenderBindings, loop *compiler.FastLoopPlan, conditional *compiler.FastLoopConditionalPlan, key, value interface{}) error {
+func renderFastLoopConditionalSilently(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, loop *compiler.FastLoopPlan, conditional *compiler.FastLoopConditionalPlan, key, value interface{}) error {
 	if conditional == nil {
 		return nil
 	}
@@ -395,15 +526,77 @@ func renderFastLoopConditionalSilently(ctx hctx.Context, bindings fastRenderBind
 			result = nil
 		}
 		if isTruthyFastValue(result) {
-			var discard strings.Builder
-			return renderFastLoopParts(&discard, ctx, bindings, loop, branch.Parts, key, value)
+			var rendered strings.Builder
+			branchCtx, branchBindings, cleanup := fastRenderLoopPartScopeForLet(ctx, bindings, branch.Parts)
+			defer cleanup()
+			err := renderFastLoopParts(&rendered, branchCtx, branchBindings, loop, branch.Parts, key, value)
+			if err == errFastLoopBreak || err == errFastLoopContinue || err == errFastLoopReturn {
+				out.WriteString(rendered.String())
+			}
+			return err
 		}
 	}
 	if len(conditional.ElseParts) > 0 {
-		var discard strings.Builder
-		return renderFastLoopParts(&discard, ctx, bindings, loop, conditional.ElseParts, key, value)
+		var rendered strings.Builder
+		branchCtx, branchBindings, cleanup := fastRenderLoopPartScopeForLet(ctx, bindings, conditional.ElseParts)
+		defer cleanup()
+		err := renderFastLoopParts(&rendered, branchCtx, branchBindings, loop, conditional.ElseParts, key, value)
+		if err == errFastLoopBreak || err == errFastLoopContinue || err == errFastLoopReturn {
+			out.WriteString(rendered.String())
+		}
+		return err
 	}
 	return nil
+}
+
+func syncFastLoopAssignmentBindings(ctx hctx.Context, bindings *fastRenderBindings, parts []compiler.FastLoopPart) {
+	syncFastLoopAssignmentBindingsWithLets(ctx, bindings, parts, nil)
+}
+
+func syncFastLoopAssignmentBindingsWithLets(ctx hctx.Context, bindings *fastRenderBindings, parts []compiler.FastLoopPart, localLets map[string]struct{}) {
+	if ctx == nil || bindings == nil {
+		return
+	}
+	letNames := cloneFastLoopSyncNames(localLets)
+	for i := range parts {
+		part := &parts[i]
+		switch part.Kind {
+		case compiler.FastLoopPartLet:
+			if part.Value != "" {
+				letNames[part.Value] = struct{}{}
+			}
+		case compiler.FastLoopPartAssign:
+			if part.AssignTarget != nil && part.AssignTarget.Kind != compiler.FastAssignTargetName {
+				continue
+			}
+			if _, local := letNames[part.Value]; local {
+				continue
+			}
+			if value, ok := fastContextValue(ctx, part.Value); ok {
+				bindings.setLocal(part.NameIndex, value)
+			}
+		case compiler.FastLoopPartConditional:
+			if part.Conditional == nil {
+				continue
+			}
+			for branchIndex := range part.Conditional.Branches {
+				syncFastLoopAssignmentBindingsWithLets(ctx, bindings, part.Conditional.Branches[branchIndex].Parts, letNames)
+			}
+			syncFastLoopAssignmentBindingsWithLets(ctx, bindings, part.Conditional.ElseParts, letNames)
+		case compiler.FastLoopPartLoop:
+			if part.Loop != nil {
+				syncFastLoopAssignmentBindingsWithLets(ctx, bindings, part.Loop.Parts, letNames)
+			}
+		}
+	}
+}
+
+func cloneFastLoopSyncNames(names map[string]struct{}) map[string]struct{} {
+	clone := make(map[string]struct{}, len(names)+1)
+	for name := range names {
+		clone[name] = struct{}{}
+	}
+	return clone
 }
 
 func fastLoopBindingsWithCurrentLocals(bindings fastRenderBindings, loop *compiler.FastLoopPlan, key, value interface{}) fastRenderBindings {
@@ -457,6 +650,43 @@ func fastLoopPartsHaveLet(parts []compiler.FastLoopPart) bool {
 		}
 	}
 	return false
+}
+
+func fastLoopPartsHaveAssign(parts []compiler.FastLoopPart) bool {
+	for i := range parts {
+		part := &parts[i]
+		switch part.Kind {
+		case compiler.FastLoopPartAssign:
+			return true
+		case compiler.FastLoopPartConditional:
+			if part.Conditional == nil {
+				continue
+			}
+			for branchIndex := range part.Conditional.Branches {
+				if fastLoopPartsHaveAssign(part.Conditional.Branches[branchIndex].Parts) {
+					return true
+				}
+			}
+			if fastLoopPartsHaveAssign(part.Conditional.ElseParts) {
+				return true
+			}
+		case compiler.FastLoopPartLoop:
+			if part.Loop != nil && fastLoopPartsHaveAssign(part.Loop.Parts) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func fastLoopPartFlags(loop *compiler.FastLoopPlan) (bool, bool) {
+	if loop == nil {
+		return false, false
+	}
+	if loop.PartFlagsSet {
+		return loop.HasLet, loop.HasAssign
+	}
+	return fastLoopPartsHaveLet(loop.Parts), fastLoopPartsHaveAssign(loop.Parts)
 }
 
 func fastRenderSegmentsHaveLet(segments []compiler.FastRenderSegment) bool {
@@ -519,9 +749,14 @@ func fastLoopBindingName(name string) bool {
 	return name != "" && name != "_"
 }
 
-func writeFastLoopCallPart(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, call *compiler.FastCallPlan, loopKey, loopValue interface{}) error {
+func writeFastLoopCallPart(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, loop *compiler.FastLoopPlan, call *compiler.FastCallPlan, loopKey, loopValue interface{}) error {
 	if call == nil {
 		return nil
+	}
+	writeOut := out
+	if call.Silent {
+		var discard strings.Builder
+		writeOut = &discard
 	}
 	raw, ok := bindings.value(call.NameIndex)
 	if !ok {
@@ -530,6 +765,7 @@ func writeFastLoopCallPart(out *strings.Builder, ctx hctx.Context, bindings fast
 	if err := spendFastFunctionCall(ctx, call.Name, call.Line); err != nil {
 		return err
 	}
+	callCtx := fastLoopBlockContext(ctx, bindings, loop, loopKey, loopValue)
 	var argStore fastCallArgs
 	var args *fastCallArgs
 	var err error
@@ -538,7 +774,7 @@ func writeFastLoopCallPart(out *strings.Builder, ctx hctx.Context, bindings fast
 		if err != nil {
 			return err
 		}
-		if handled, err := writeRegisteredFastHelperNamed(out, ctx, call.Name, helper, args); handled || err != nil {
+		if handled, err := writeRegisteredFastHelperNamed(writeOut, callCtx, call.Name, helper, args); handled || err != nil {
 			if err != nil {
 				return fastLineError(call.Line, err)
 			}
@@ -551,7 +787,7 @@ func writeFastLoopCallPart(out *strings.Builder, ctx hctx.Context, bindings fast
 			return err
 		}
 	}
-	if err := writeFastCallValue(out, ctx, call.Name, raw, args, &call.Cache); err != nil {
+	if err := writeFastCallValue(writeOut, callCtx, call.Name, raw, args, &call.Cache); err != nil {
 		return fastLineError(call.Line, err)
 	}
 	return nil

--- a/vm/vm/fast_loops.go
+++ b/vm/vm/fast_loops.go
@@ -37,16 +37,20 @@ func renderFastConditional(out *strings.Builder, ctx hctx.Context, bindings fast
 			value = nil
 		}
 		if isTruthyFastValue(value) {
+			outerBindings := bindings
 			branchCtx, branchBindings, cleanup := fastRenderSegmentScopeForLet(ctx, bindings, branch.Segments)
 			defer cleanup()
+			defer syncFastSegmentAssignmentBindings(branchCtx, &outerBindings, branch.Segments)
 			ctx = branchCtx
 			bindings = branchBindings
 			return renderFastSegments(out, ctx, bindings, branch.Segments)
 		}
 	}
 	if len(conditional.ElseSegments) > 0 {
+		outerBindings := bindings
 		branchCtx, branchBindings, cleanup := fastRenderSegmentScopeForLet(ctx, bindings, conditional.ElseSegments)
 		defer cleanup()
+		defer syncFastSegmentAssignmentBindings(branchCtx, &outerBindings, conditional.ElseSegments)
 		ctx = branchCtx
 		bindings = branchBindings
 		return renderFastSegments(out, ctx, bindings, conditional.ElseSegments)
@@ -72,15 +76,19 @@ func renderFastConditionalSilently(ctx hctx.Context, bindings fastRenderBindings
 		}
 		if isTruthyFastValue(value) {
 			var discard strings.Builder
+			outerBindings := bindings
 			branchCtx, branchBindings, cleanup := fastRenderSegmentScopeForLet(ctx, bindings, branch.Segments)
 			defer cleanup()
+			defer syncFastSegmentAssignmentBindings(branchCtx, &outerBindings, branch.Segments)
 			return renderFastSegments(&discard, branchCtx, branchBindings, branch.Segments)
 		}
 	}
 	if len(conditional.ElseSegments) > 0 {
 		var discard strings.Builder
+		outerBindings := bindings
 		branchCtx, branchBindings, cleanup := fastRenderSegmentScopeForLet(ctx, bindings, conditional.ElseSegments)
 		defer cleanup()
+		defer syncFastSegmentAssignmentBindings(branchCtx, &outerBindings, conditional.ElseSegments)
 		return renderFastSegments(&discard, branchCtx, branchBindings, conditional.ElseSegments)
 	}
 	return true, nil
@@ -303,7 +311,9 @@ func renderFastLoopParts(out *strings.Builder, ctx hctx.Context, bindings fastRe
 				return err
 			}
 		case compiler.FastLoopPartPartial:
-			if err := renderFastLoopPartialPart(out, ctx, bindings, loop, part.Partial, currentKey, currentValue); err != nil {
+			err := renderFastLoopPartialPart(out, ctx, bindings, loop, part.Partial, currentKey, currentValue)
+			bindings.syncLocalValuesFromContext()
+			if err != nil {
 				return err
 			}
 		case compiler.FastLoopPartLet:
@@ -345,6 +355,7 @@ func renderFastLoopParts(out *strings.Builder, ctx hctx.Context, bindings fastRe
 		case compiler.FastLoopPartLoop:
 			nestedBindings := fastLoopBindingsWithCurrentLocals(bindings, loop, currentKey, currentValue)
 			ok, err := renderFastLoop(out, ctx, nestedBindings, part.Loop)
+			syncFastLoopAssignmentBindings(ctx, &bindings, part.Loop.Parts)
 			if err != nil {
 				return err
 			}
@@ -492,16 +503,20 @@ func renderFastLoopConditional(out *strings.Builder, ctx hctx.Context, bindings 
 			result = nil
 		}
 		if isTruthyFastValue(result) {
+			outerBindings := bindings
 			branchCtx, branchBindings, cleanup := fastRenderLoopPartScopeForLet(ctx, bindings, branch.Parts)
 			defer cleanup()
+			defer syncFastLoopAssignmentBindings(branchCtx, &outerBindings, branch.Parts)
 			ctx = branchCtx
 			bindings = branchBindings
 			return renderFastLoopParts(out, ctx, bindings, loop, branch.Parts, key, value)
 		}
 	}
 	if len(conditional.ElseParts) > 0 {
+		outerBindings := bindings
 		branchCtx, branchBindings, cleanup := fastRenderLoopPartScopeForLet(ctx, bindings, conditional.ElseParts)
 		defer cleanup()
+		defer syncFastLoopAssignmentBindings(branchCtx, &outerBindings, conditional.ElseParts)
 		ctx = branchCtx
 		bindings = branchBindings
 		return renderFastLoopParts(out, ctx, bindings, loop, conditional.ElseParts, key, value)
@@ -527,8 +542,10 @@ func renderFastLoopConditionalSilently(out *strings.Builder, ctx hctx.Context, b
 		}
 		if isTruthyFastValue(result) {
 			var rendered strings.Builder
+			outerBindings := bindings
 			branchCtx, branchBindings, cleanup := fastRenderLoopPartScopeForLet(ctx, bindings, branch.Parts)
 			defer cleanup()
+			defer syncFastLoopAssignmentBindings(branchCtx, &outerBindings, branch.Parts)
 			err := renderFastLoopParts(&rendered, branchCtx, branchBindings, loop, branch.Parts, key, value)
 			if err == errFastLoopBreak || err == errFastLoopContinue || err == errFastLoopReturn {
 				out.WriteString(rendered.String())
@@ -538,8 +555,10 @@ func renderFastLoopConditionalSilently(out *strings.Builder, ctx hctx.Context, b
 	}
 	if len(conditional.ElseParts) > 0 {
 		var rendered strings.Builder
+		outerBindings := bindings
 		branchCtx, branchBindings, cleanup := fastRenderLoopPartScopeForLet(ctx, bindings, conditional.ElseParts)
 		defer cleanup()
+		defer syncFastLoopAssignmentBindings(branchCtx, &outerBindings, conditional.ElseParts)
 		err := renderFastLoopParts(&rendered, branchCtx, branchBindings, loop, conditional.ElseParts, key, value)
 		if err == errFastLoopBreak || err == errFastLoopContinue || err == errFastLoopReturn {
 			out.WriteString(rendered.String())
@@ -551,6 +570,48 @@ func renderFastLoopConditionalSilently(out *strings.Builder, ctx hctx.Context, b
 
 func syncFastLoopAssignmentBindings(ctx hctx.Context, bindings *fastRenderBindings, parts []compiler.FastLoopPart) {
 	syncFastLoopAssignmentBindingsWithLets(ctx, bindings, parts, nil)
+}
+
+func syncFastSegmentAssignmentBindings(ctx hctx.Context, bindings *fastRenderBindings, segments []compiler.FastRenderSegment) {
+	syncFastSegmentAssignmentBindingsWithLets(ctx, bindings, segments, nil)
+}
+
+func syncFastSegmentAssignmentBindingsWithLets(ctx hctx.Context, bindings *fastRenderBindings, segments []compiler.FastRenderSegment, localLets map[string]struct{}) {
+	if ctx == nil || bindings == nil {
+		return
+	}
+	letNames := cloneFastLoopSyncNames(localLets)
+	for i := range segments {
+		segment := &segments[i]
+		switch segment.Kind {
+		case compiler.FastRenderSegmentLet:
+			if segment.Value != "" {
+				letNames[segment.Value] = struct{}{}
+			}
+		case compiler.FastRenderSegmentAssign:
+			if segment.AssignTarget != nil && segment.AssignTarget.Kind != compiler.FastAssignTargetName {
+				continue
+			}
+			if _, local := letNames[segment.Value]; local {
+				continue
+			}
+			if value, ok := fastContextValue(ctx, segment.Value); ok {
+				bindings.setLocal(segment.NameIndex, value)
+			}
+		case compiler.FastRenderSegmentConditional:
+			if segment.Conditional == nil {
+				continue
+			}
+			for branchIndex := range segment.Conditional.Branches {
+				syncFastSegmentAssignmentBindingsWithLets(ctx, bindings, segment.Conditional.Branches[branchIndex].Segments, letNames)
+			}
+			syncFastSegmentAssignmentBindingsWithLets(ctx, bindings, segment.Conditional.ElseSegments, letNames)
+		case compiler.FastRenderSegmentLoop:
+			if segment.Loop != nil {
+				syncFastLoopAssignmentBindingsWithLets(ctx, bindings, segment.Loop.Parts, letNames)
+			}
+		}
+	}
 }
 
 func syncFastLoopAssignmentBindingsWithLets(ctx hctx.Context, bindings *fastRenderBindings, parts []compiler.FastLoopPart, localLets map[string]struct{}) {
@@ -807,6 +868,10 @@ func evalFastLoopCallArgsInto(plans []compiler.FastValuePlan, ctx hctx.Context, 
 			return nil, err
 		}
 		if !ok {
+			if plans[i].NullOnMissing {
+				args.Append(nil)
+				continue
+			}
 			return nil, fastLineError(plans[i].Line, fmt.Errorf("%q: unknown identifier", plans[i].Value))
 		}
 		args.Append(value)

--- a/vm/vm/fast_render.go
+++ b/vm/vm/fast_render.go
@@ -16,7 +16,7 @@ import (
 // tryRenderFastBytecode is the VM fast-render entry point. A false handled
 // result means the caller should run the normal bytecode VM path.
 func tryRenderFastBytecode(bytecode *compiler.Bytecode, ctx hctx.Context) (string, bool, error) {
-	if bytecode == nil || bytecode.FastRenderPlan == nil {
+	if bytecode == nil || bytecode.FastRenderPlan == nil || bytecode.HasHoles {
 		return "", false, nil
 	}
 	if restorePartial := installVMPartialHelperForBytecode(bytecode, ctx); restorePartial != nil {
@@ -1226,6 +1226,10 @@ func evalFastCallValuePlan(call *compiler.FastCallPlan, simpleArgs []*fastSimple
 				return nil, true, err
 			}
 			if !argOK {
+				if call.Args[i].NullOnMissing {
+					argStore.Append(nil)
+					continue
+				}
 				return nil, false, nil
 			}
 			argStore.Append(value)

--- a/vm/vm/fast_render.go
+++ b/vm/vm/fast_render.go
@@ -19,13 +19,103 @@ func tryRenderFastBytecode(bytecode *compiler.Bytecode, ctx hctx.Context) (strin
 	if bytecode == nil || bytecode.FastRenderPlan == nil {
 		return "", false, nil
 	}
-	return renderFastPlanWithBindingPlan(bytecode.FastRenderPlan, ctx, topLevelFastBindingPlan(bytecode.FastRenderPlan, ctx))
+	if restorePartial := installVMPartialHelperForBytecode(bytecode, ctx); restorePartial != nil {
+		defer restorePartial()
+	}
+	return renderFastPlanWithBindingPlan(bytecode, bytecode.FastRenderPlan, ctx, topLevelFastBindingPlan(bytecode.FastRenderPlan, ctx))
+}
+
+func fastRenderPlanUsesGenericVM(plan *compiler.FastRenderPlan) bool {
+	if plan == nil {
+		return false
+	}
+	return fastRenderSegmentsUseGenericVM(plan.Segments)
+}
+
+func fastRenderSegmentsUseGenericVM(segments []compiler.FastRenderSegment) bool {
+	for i := range segments {
+		segment := &segments[i]
+		switch segment.Kind {
+		case compiler.FastRenderSegmentGeneric:
+			return true
+		case compiler.FastRenderSegmentConditional:
+			if segment.Conditional == nil {
+				continue
+			}
+			for branchIndex := range segment.Conditional.Branches {
+				if fastRenderSegmentsUseGenericVM(segment.Conditional.Branches[branchIndex].Segments) {
+					return true
+				}
+			}
+			if fastRenderSegmentsUseGenericVM(segment.Conditional.ElseSegments) {
+				return true
+			}
+		case compiler.FastRenderSegmentLoop:
+			if fastLoopPartsUseGenericVM(segment.Loop) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func fastLoopPartsUseGenericVM(loop *compiler.FastLoopPlan) bool {
+	if loop == nil {
+		return false
+	}
+	for i := range loop.Parts {
+		part := &loop.Parts[i]
+		switch part.Kind {
+		case compiler.FastLoopPartConditional:
+			if part.Conditional == nil {
+				continue
+			}
+			for branchIndex := range part.Conditional.Branches {
+				if fastLoopPartSliceUsesGenericVM(part.Conditional.Branches[branchIndex].Parts) {
+					return true
+				}
+			}
+			if fastLoopPartSliceUsesGenericVM(part.Conditional.ElseParts) {
+				return true
+			}
+		case compiler.FastLoopPartLoop:
+			if fastLoopPartsUseGenericVM(part.Loop) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func fastLoopPartSliceUsesGenericVM(parts []compiler.FastLoopPart) bool {
+	for i := range parts {
+		part := &parts[i]
+		switch part.Kind {
+		case compiler.FastLoopPartConditional:
+			if part.Conditional == nil {
+				continue
+			}
+			for branchIndex := range part.Conditional.Branches {
+				if fastLoopPartSliceUsesGenericVM(part.Conditional.Branches[branchIndex].Parts) {
+					return true
+				}
+			}
+			if fastLoopPartSliceUsesGenericVM(part.Conditional.ElseParts) {
+				return true
+			}
+		case compiler.FastLoopPartLoop:
+			if fastLoopPartsUseGenericVM(part.Loop) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // renderFastPlanWithBindingPlan tries the prepared fast plan variants in order:
 // static-name, simple, mixed. Each variant must preserve Plush rendering
 // semantics or decline so the normal VM can handle the template.
-func renderFastPlanWithBindingPlan(plan *compiler.FastRenderPlan, ctx hctx.Context, bindingPlan *fastRenderBindingPlan) (string, bool, error) {
+func renderFastPlanWithBindingPlan(bytecode *compiler.Bytecode, plan *compiler.FastRenderPlan, ctx hctx.Context, bindingPlan *fastRenderBindingPlan) (string, bool, error) {
 	if plan == nil {
 		return "", false, nil
 	}
@@ -59,7 +149,7 @@ func renderFastPlanWithBindingPlan(plan *compiler.FastRenderPlan, ctx hctx.Conte
 		}
 	}
 
-	ok, err := renderFastMixedPlan(&out, ctx, bindings, mixed)
+	ok, err := renderFastMixedPlan(&out, ctx, bindings, mixed, bytecode)
 	if !ok || err != nil {
 		return "", ok, err
 	}
@@ -93,7 +183,7 @@ func renderFastPlanInlineWithBindings(out *strings.Builder, plan *compiler.FastR
 	if grow := fastOutputGrowSize(mixed, bindings); grow > 0 {
 		scratch.Grow(grow)
 	}
-	ok, err := renderFastMixedPlan(&scratch, ctx, bindings, mixed)
+	ok, err := renderFastMixedPlan(&scratch, ctx, bindings, mixed, nil)
 	if !ok || err != nil {
 		return ok, err
 	}
@@ -161,12 +251,15 @@ func fastLoopGrowSize(loop *compiler.FastLoopPlan) int {
 	if loop == nil {
 		return 0
 	}
+	if loop.Silent {
+		return 0
+	}
 	size := loop.StaticSize
 	for i := range loop.Parts {
 		switch loop.Parts[i].Kind {
 		case compiler.FastLoopPartKey:
 			size += 4
-		case compiler.FastLoopPartValue, compiler.FastLoopPartValueProperty, compiler.FastLoopPartValuePath, compiler.FastLoopPartCall, compiler.FastLoopPartPartial:
+		case compiler.FastLoopPartValue, compiler.FastLoopPartValueProperty, compiler.FastLoopPartValuePath, compiler.FastLoopPartCall, compiler.FastLoopPartPartial, compiler.FastLoopPartReturn:
 			size += 16
 		case compiler.FastLoopPartConditional:
 			size += fastLoopConditionalGrowSize(loop.Parts[i].Conditional)
@@ -201,7 +294,7 @@ func fastLoopPartsGrowSize(parts []compiler.FastLoopPart) int {
 			continue
 		case compiler.FastLoopPartKey:
 			size += 4
-		case compiler.FastLoopPartValue, compiler.FastLoopPartValueProperty, compiler.FastLoopPartValuePath, compiler.FastLoopPartCall, compiler.FastLoopPartPartial:
+		case compiler.FastLoopPartValue, compiler.FastLoopPartValueProperty, compiler.FastLoopPartValuePath, compiler.FastLoopPartCall, compiler.FastLoopPartPartial, compiler.FastLoopPartReturn:
 			size += 16
 		case compiler.FastLoopPartConditional:
 			size += fastLoopConditionalGrowSize(parts[i].Conditional)
@@ -284,6 +377,8 @@ func buildFastMixedPlan(plan *compiler.FastRenderPlan) *fastMixedPlan {
 			blockCall:     segment.BlockCall,
 			conditional:   segment.Conditional,
 			partial:       segment.Partial,
+			generic:       segment.Generic,
+			assignTarget:  segment.AssignTarget,
 			propertyCache: segment.PropertyCache,
 			outputCache:   segment.OutputCache,
 		}
@@ -315,6 +410,10 @@ func buildFastMixedPlan(plan *compiler.FastRenderPlan) *fastMixedPlan {
 			op.kind = fastMixedOpLet
 		case compiler.FastRenderSegmentAssign:
 			op.kind = fastMixedOpAssign
+		case compiler.FastRenderSegmentReturn:
+			op.kind = fastMixedOpReturn
+		case compiler.FastRenderSegmentGeneric:
+			op.kind = fastMixedOpGeneric
 		default:
 			op.kind = fastMixedOpStatic
 		}
@@ -507,6 +606,8 @@ func fastMixedOpsFromSegments(segments []compiler.FastRenderSegment) []fastMixed
 			blockCall:     segment.BlockCall,
 			conditional:   segment.Conditional,
 			partial:       segment.Partial,
+			generic:       segment.Generic,
+			assignTarget:  segment.AssignTarget,
 			propertyCache: segment.PropertyCache,
 			outputCache:   segment.OutputCache,
 		}
@@ -538,6 +639,10 @@ func fastMixedOpsFromSegments(segments []compiler.FastRenderSegment) []fastMixed
 			op.kind = fastMixedOpLet
 		case compiler.FastRenderSegmentAssign:
 			op.kind = fastMixedOpAssign
+		case compiler.FastRenderSegmentReturn:
+			op.kind = fastMixedOpReturn
+		case compiler.FastRenderSegmentGeneric:
+			op.kind = fastMixedOpGeneric
 		default:
 			op.kind = fastMixedOpStatic
 		}
@@ -563,6 +668,9 @@ func buildFastSimpleValuePlan(plan fastSimpleNameBinder, value *compiler.FastVal
 			prepared.lookupIndex = plan.bindNameIndex(value.NameIndex)
 		}
 	case compiler.FastValuePath:
+		if fastPathStepsNeedRuntimeBindings(value.Path) {
+			return nil
+		}
 		prepared.lookupIndex = plan.bindNameIndex(value.NameIndex)
 	case compiler.FastValueInfix:
 		if value.Left == nil || value.Right == nil {
@@ -594,6 +702,9 @@ func buildFastSimpleValuePlan(plan fastSimpleNameBinder, value *compiler.FastVal
 		if value.Call == nil {
 			return nil
 		}
+		if len(value.Path) > 0 {
+			return nil
+		}
 		prepared.lookupIndex = plan.bindNameIndex(value.Call.NameIndex)
 		if len(value.Call.Args) > 0 {
 			prepared.args = make([]*fastSimpleValuePlan, 0, len(value.Call.Args))
@@ -617,6 +728,9 @@ func buildFastSimpleValuePlan(plan fastSimpleNameBinder, value *compiler.FastVal
 			}
 		}
 	case compiler.FastValueHash:
+		if !fastValuePairsUseStaticStringKeys(value.Pairs) {
+			return nil
+		}
 		if len(value.Pairs) > 0 {
 			prepared.args = make([]*fastSimpleValuePlan, 0, len(value.Pairs))
 			for i := range value.Pairs {
@@ -627,6 +741,8 @@ func buildFastSimpleValuePlan(plan fastSimpleNameBinder, value *compiler.FastVal
 				prepared.args = append(prepared.args, pairValue)
 			}
 		}
+	case compiler.FastValueIndex:
+		return nil
 	case compiler.FastValueString, compiler.FastValueInteger, compiler.FastValueFloat, compiler.FastValueBool:
 		// Literal operands do not need binding slots.
 	default:
@@ -1007,6 +1123,9 @@ func evalFastSimpleValue(plan *fastSimpleValuePlan, ctx hctx.Context, bindings f
 	case compiler.FastValueHash:
 		return evalFastSimpleHashValue(plan, ctx, bindings, values, oks, base)
 	case compiler.FastValuePath:
+		if fastPathStepsNeedRuntimeBindings(value.Path) {
+			return evalFastPathValue(value, ctx, bindings, base, nil, nil, false)
+		}
 		raw := base
 		if value.NameIndex >= 0 {
 			var ok bool
@@ -1159,19 +1278,21 @@ func evalFastSimpleInfixValue(plan *fastSimpleValuePlan, ctx hctx.Context, bindi
 	if err != nil {
 		return nil, true, err
 	}
-	if !ok {
+	leftOK := ok
+	if !leftOK {
 		left = nil
 	}
 	right, ok, err := evalFastSimpleValue(plan.right, ctx, bindings, values, oks, base)
 	if err != nil {
 		return nil, true, err
 	}
-	if !ok {
+	rightOK := ok
+	if !rightOK {
 		right = nil
 	}
 	result, err := evalFastInfixOperator(value.Operator, left, right)
 	if err != nil {
-		return nil, true, fastLineError(value.Line, err)
+		return nil, true, fastLineError(value.Line, annotateFastInfixError(value, leftOK, rightOK, left, right, err))
 	}
 	return result, true, nil
 }
@@ -1180,14 +1301,25 @@ func evalFastSimplePrefixValue(plan *fastSimpleValuePlan, ctx hctx.Context, bind
 	if plan == nil || plan.value == nil || plan.value.Kind != compiler.FastValuePrefix || plan.right == nil {
 		return nil, false, nil
 	}
-	if plan.value.Operator != "!" {
-		return nil, true, fastLineError(plan.value.Line, fmt.Errorf("unknown fast prefix operator: %s", plan.value.Operator))
-	}
 	right, ok, err := evalFastSimpleValue(plan.right, ctx, bindings, values, oks, base)
 	if err != nil {
 		return nil, true, err
 	}
-	return !(ok && isTruthyFastValue(right)), true, nil
+	switch plan.value.Operator {
+	case "!":
+		return !(ok && isTruthyFastValue(right)), true, nil
+	case "-":
+		if !ok {
+			right = nil
+		}
+		result, err := evalFastMinusOperator(right)
+		if err != nil {
+			return nil, true, fastLineError(plan.value.Line, err)
+		}
+		return result, true, nil
+	default:
+		return nil, true, fastLineError(plan.value.Line, fmt.Errorf("unknown fast prefix operator: %s", plan.value.Operator))
+	}
 }
 
 func evalFastSimpleConcatValue(plan *fastSimpleValuePlan, ctx hctx.Context, bindings fastRenderBindings, values []interface{}, oks []bool, base interface{}) (interface{}, bool, error) {
@@ -1245,9 +1377,13 @@ func evalFastSimpleLogicalInfixValue(plan *fastSimpleValuePlan, ctx hctx.Context
 	return ok && isTruthyFastValue(right), true, nil
 }
 
-func renderFastMixedPlan(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, plan *fastMixedPlan) (bool, error) {
+func renderFastMixedPlan(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, plan *fastMixedPlan, bytecodes ...*compiler.Bytecode) (bool, error) {
 	if plan == nil {
 		return false, nil
+	}
+	var bytecode *compiler.Bytecode
+	if len(bytecodes) > 0 {
+		bytecode = bytecodes[0]
 	}
 	for i := range plan.ops {
 		op := &plan.ops[i]
@@ -1381,9 +1517,20 @@ func renderFastMixedPlan(out *strings.Builder, ctx hctx.Context, bindings fastRe
 			}
 			bindings.setLocalAndContext(op.nameIndex, value)
 		case fastMixedOpAssign:
-			if err := assignFastValue(ctx, &bindings, op.value, op.nameIndex, &op.valuePlan, op.line); err != nil {
+			if err := assignFastSegmentValue(ctx, &bindings, op.assignTarget, op.value, op.nameIndex, &op.valuePlan, op.line); err != nil {
 				return true, err
 			}
+		case fastMixedOpReturn:
+			if err := writeFastReturnSegment(out, ctx, bindings, &op.valuePlan, op.line); err != nil {
+				return true, err
+			}
+			return true, nil
+		case fastMixedOpGeneric:
+			ok, err := renderFastGenericSegment(out, ctx, bytecode, op.generic)
+			if !ok || err != nil {
+				return ok, err
+			}
+			return true, nil
 		default:
 			return false, nil
 		}
@@ -1477,15 +1624,55 @@ func renderFastSegments(out *strings.Builder, ctx hctx.Context, bindings fastRen
 			}
 			bindings.setLocalAndContext(segment.NameIndex, value)
 		case compiler.FastRenderSegmentAssign:
-			if err := assignFastValue(ctx, &bindings, segment.Value, segment.NameIndex, &segment.ValuePlan, segment.Line); err != nil {
+			if err := assignFastSegmentValue(ctx, &bindings, segment.AssignTarget, segment.Value, segment.NameIndex, &segment.ValuePlan, segment.Line); err != nil {
 				return true, err
 			}
+		case compiler.FastRenderSegmentReturn:
+			if err := writeFastReturnSegment(out, ctx, bindings, &segment.ValuePlan, segment.Line); err != nil {
+				return true, err
+			}
+			return true, nil
+		case compiler.FastRenderSegmentGeneric:
+			return false, nil
 		default:
 			return false, nil
 		}
 	}
 
 	return true, nil
+}
+
+func renderFastGenericSegment(out *strings.Builder, ctx hctx.Context, bytecode *compiler.Bytecode, generic *compiler.FastGenericPlan) (bool, error) {
+	if out == nil || bytecode == nil || generic == nil || !generic.WholeTemplate {
+		return false, nil
+	}
+	genericBytecode := *bytecode
+	genericBytecode.FastRenderPlan = nil
+	rendered, err := renderBytecodeVMWithState(&genericBytecode, ctx, "", false, "")
+	if err != nil {
+		return true, err
+	}
+	out.WriteString(rendered)
+	return true, nil
+}
+
+func writeFastReturnSegment(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, valuePlan *compiler.FastValuePlan, line int) error {
+	value, ok, err := evalFastValue(valuePlan, ctx, bindings, nil)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fastLineError(line, fmt.Errorf("%q: unknown identifier", fastValueMissingName(valuePlan)))
+	}
+	writeFastGoValue(out, ctx, value)
+	return nil
+}
+
+func assignFastSegmentValue(ctx hctx.Context, bindings *fastRenderBindings, target *compiler.FastAssignTarget, name string, nameIndex int, valuePlan *compiler.FastValuePlan, line int) error {
+	if target == nil || target.Kind == compiler.FastAssignTargetName {
+		return assignFastValue(ctx, bindings, name, nameIndex, valuePlan, line)
+	}
+	return assignFastIndexValue(ctx, bindings, target, valuePlan, line)
 }
 
 func assignFastValue(ctx hctx.Context, bindings *fastRenderBindings, name string, nameIndex int, valuePlan *compiler.FastValuePlan, line int) error {
@@ -1505,6 +1692,42 @@ func assignFastValue(ctx hctx.Context, bindings *fastRenderBindings, name string
 	if err := spendFastAssignment(ctx, line); err != nil {
 		return err
 	}
-	bindings.setLocalAndContext(nameIndex, value)
+	if !bindings.assignExistingLocalAndContext(nameIndex, value) {
+		return fastLineError(line, fmt.Errorf("%q: unknown identifier", name))
+	}
+	return nil
+}
+
+func assignFastIndexValue(ctx hctx.Context, bindings *fastRenderBindings, target *compiler.FastAssignTarget, valuePlan *compiler.FastValuePlan, line int) error {
+	if bindings == nil || target == nil || target.Kind != compiler.FastAssignTargetIndex {
+		return fastLineError(line, fmt.Errorf("unsupported assignment target"))
+	}
+	container, ok, err := evalFastValue(&target.Container, ctx, *bindings, nil)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fastLineError(target.Line, fmt.Errorf("%q: unknown identifier", fastValueMissingName(&target.Container)))
+	}
+	index, ok, err := evalFastValue(&target.Index, ctx, *bindings, nil)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fastLineError(target.Line, fmt.Errorf("%q: unknown identifier", fastValueMissingName(&target.Index)))
+	}
+	value, ok, err := evalFastValue(valuePlan, ctx, *bindings, nil)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fastLineError(line, fmt.Errorf("%q: unknown identifier", fastValueMissingName(valuePlan)))
+	}
+	if err := spendFastAssignment(ctx, line); err != nil {
+		return err
+	}
+	if err := setFastIndexGoValue(container, index, value); err != nil {
+		return fastLineError(line, err)
+	}
 	return nil
 }

--- a/vm/vm/fast_render.go
+++ b/vm/vm/fast_render.go
@@ -16,13 +16,21 @@ import (
 // tryRenderFastBytecode is the VM fast-render entry point. A false handled
 // result means the caller should run the normal bytecode VM path.
 func tryRenderFastBytecode(bytecode *compiler.Bytecode, ctx hctx.Context) (string, bool, error) {
+	return tryRenderFastBytecodeWithOptions(bytecode, ctx, outputSizeOptions{})
+}
+
+func tryRenderFastBytecodeTopLevel(bytecode *compiler.Bytecode, ctx hctx.Context) (string, bool, error) {
+	return tryRenderFastBytecodeWithOptions(bytecode, ctx, outputSizeOptions{topLevel: true})
+}
+
+func tryRenderFastBytecodeWithOptions(bytecode *compiler.Bytecode, ctx hctx.Context, options outputSizeOptions) (string, bool, error) {
 	if bytecode == nil || bytecode.FastRenderPlan == nil || bytecode.HasHoles {
 		return "", false, nil
 	}
 	if restorePartial := installVMPartialHelperForBytecode(bytecode, ctx); restorePartial != nil {
 		defer restorePartial()
 	}
-	return renderFastPlanWithBindingPlan(bytecode, bytecode.FastRenderPlan, ctx, topLevelFastBindingPlan(bytecode.FastRenderPlan, ctx))
+	return renderFastPlanWithBindingPlanOptions(bytecode, bytecode.FastRenderPlan, ctx, topLevelFastBindingPlan(bytecode.FastRenderPlan, ctx), options)
 }
 
 func fastRenderPlanUsesGenericVM(plan *compiler.FastRenderPlan) bool {
@@ -116,6 +124,10 @@ func fastLoopPartSliceUsesGenericVM(parts []compiler.FastLoopPart) bool {
 // static-name, simple, mixed. Each variant must preserve Plush rendering
 // semantics or decline so the normal VM can handle the template.
 func renderFastPlanWithBindingPlan(bytecode *compiler.Bytecode, plan *compiler.FastRenderPlan, ctx hctx.Context, bindingPlan *fastRenderBindingPlan) (string, bool, error) {
+	return renderFastPlanWithBindingPlanOptions(bytecode, plan, ctx, bindingPlan, outputSizeOptions{})
+}
+
+func renderFastPlanWithBindingPlanOptions(bytecode *compiler.Bytecode, plan *compiler.FastRenderPlan, ctx hctx.Context, bindingPlan *fastRenderBindingPlan, options outputSizeOptions) (string, bool, error) {
 	if plan == nil {
 		return "", false, nil
 	}
@@ -123,15 +135,15 @@ func renderFastPlanWithBindingPlan(bytecode *compiler.Bytecode, plan *compiler.F
 	mixed := prepareFastMixedPlan(plan)
 	bindings := newFastRenderBindingsWithPlan(plan, ctx, bindingPlan)
 	var out strings.Builder
-	if grow := fastOutputGrowSize(mixed, bindings); grow > 0 {
-		out.Grow(grow)
-	}
+	observation := beginOutputSizeObservation(bytecode, fastOutputGrowSize(mixed, bindings), ctx, options)
+	growEmptyOutputBuilder(&out, observation.growHint, &observation)
 
 	if mixed.staticName != nil {
 		ok, err := renderFastStaticNamePlan(&out, ctx, bindings, mixed.staticName)
 		if !ok || err != nil {
 			return "", ok, err
 		}
+		observeOutputBuilderSize(bytecode, ctx, options, &out, observation)
 		return out.String(), true, nil
 	}
 
@@ -141,12 +153,12 @@ func renderFastPlanWithBindingPlan(bytecode *compiler.Bytecode, plan *compiler.F
 			return "", true, err
 		}
 		if ok {
+			observeOutputBuilderSize(bytecode, ctx, options, &out, observation)
 			return out.String(), true, nil
 		}
 		out.Reset()
-		if grow := fastOutputGrowSize(mixed, bindings); grow > 0 {
-			out.Grow(grow)
-		}
+		observation = beginOutputSizeObservation(bytecode, fastOutputGrowSize(mixed, bindings), ctx, options)
+		growEmptyOutputBuilder(&out, observation.growHint, &observation)
 	}
 
 	ok, err := renderFastMixedPlan(&out, ctx, bindings, mixed, bytecode)
@@ -154,6 +166,7 @@ func renderFastPlanWithBindingPlan(bytecode *compiler.Bytecode, plan *compiler.F
 		return "", ok, err
 	}
 
+	observeOutputBuilderSize(bytecode, ctx, options, &out, observation)
 	return out.String(), true, nil
 }
 

--- a/vm/vm/fast_render_edge_helpers_test.go
+++ b/vm/vm/fast_render_edge_helpers_test.go
@@ -125,7 +125,7 @@ func Test_VM_Fast_Render_Mixed_And_Conditional_Remaining_Branches(t *testing.T) 
 			Line:     35,
 		},
 		line: 35,
-	}}})
+	}}}, nil)
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.Equal(t, "true", out.String())
@@ -141,7 +141,7 @@ func Test_VM_Fast_Render_Mixed_And_Conditional_Remaining_Branches(t *testing.T) 
 			Line:     36,
 		},
 		line: 36,
-	}}})
+	}}}, nil)
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.Equal(t, "true", out.String())
@@ -150,14 +150,14 @@ func Test_VM_Fast_Render_Mixed_And_Conditional_Remaining_Branches(t *testing.T) 
 		kind:      fastMixedOpAccessChain,
 		valuePlan: compiler.FastValuePlan{Kind: compiler.FastValuePath, NameIndex: 99, Value: "missing"},
 		line:      37,
-	}}})
+	}}}, nil)
 	require.ErrorContains(t, err, "line 37")
 
 	_, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{{
 		kind:      fastMixedOpAccessChain,
 		valuePlan: compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing"},
 		line:      38,
-	}}})
+	}}}, nil)
 	require.ErrorContains(t, err, "line 38")
 
 	_, err = renderFastMixedPlan(&out, plush.NewContext().WithBudget(plush.NewBudget(0)), bindings, &fastMixedPlan{ops: []fastMixedOp{{
@@ -168,7 +168,7 @@ func Test_VM_Fast_Render_Mixed_And_Conditional_Remaining_Branches(t *testing.T) 
 				line:      39,
 			}},
 		},
-	}}})
+	}}}, nil)
 	require.ErrorContains(t, err, "line 39")
 }
 
@@ -202,7 +202,7 @@ func Test_VM_Fast_Render_Inline_And_Simple_Value_Edges(t *testing.T) {
 	bindings := newFastRenderBindings(plan, ctx)
 	var out strings.Builder
 
-	rendered, handled, err := renderFastPlanWithBindingPlan(nil, ctx, nil)
+	rendered, handled, err := renderFastPlanWithBindingPlan(nil, nil, ctx, nil)
 	require.NoError(t, err)
 	require.False(t, handled)
 	require.Empty(t, rendered)

--- a/vm/vm/fast_render_segments_test.go
+++ b/vm/vm/fast_render_segments_test.go
@@ -156,7 +156,7 @@ func Test_VM_Render_Fast_Mixed_Plan_All_Optimized_Op_Kinds(t *testing.T) {
 				Line: 16,
 			},
 		},
-	}})
+	}}, nil)
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.Equal(t, ` access=&lt;Bender&gt;GO yes<span>Mido</span>ab`, out.String())
@@ -181,7 +181,7 @@ func Test_VM_Render_Fast_Mixed_Plan_Error_And_Fallback_Edges(t *testing.T) {
 		value:     "user",
 		property:  "Profile",
 		line:      21,
-	}}})
+	}}}, nil)
 	require.ErrorContains(t, err, "line 21")
 
 	_, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{{
@@ -194,7 +194,7 @@ func Test_VM_Render_Fast_Mixed_Plan_Error_And_Fallback_Edges(t *testing.T) {
 			Line:     22,
 		},
 		line: 22,
-	}}})
+	}}}, nil)
 	require.ErrorContains(t, err, "line 22")
 
 	_, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{{
@@ -206,7 +206,7 @@ func Test_VM_Render_Fast_Mixed_Plan_Error_And_Fallback_Edges(t *testing.T) {
 			Path:      []compiler.FastPathStep{{Kind: compiler.FastPathStepProperty, Value: "Name", Line: 23}},
 		},
 		line: 23,
-	}}})
+	}}}, nil)
 	require.ErrorContains(t, err, "line 23")
 
 	_, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{{
@@ -218,7 +218,7 @@ func Test_VM_Render_Fast_Mixed_Plan_Error_And_Fallback_Edges(t *testing.T) {
 			Path:      vmAccessProfileNamePlan(99).Path,
 		},
 		line: 24,
-	}}})
+	}}}, nil)
 	require.ErrorContains(t, err, "line 24")
 
 	out.Reset()
@@ -226,7 +226,7 @@ func Test_VM_Render_Fast_Mixed_Plan_Error_And_Fallback_Edges(t *testing.T) {
 		kind:      fastMixedOpAccessChain,
 		valuePlan: compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "fallback"},
 		line:      25,
-	}}})
+	}}}, nil)
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.Equal(t, "fallback", out.String())
@@ -234,7 +234,7 @@ func Test_VM_Render_Fast_Mixed_Plan_Error_And_Fallback_Edges(t *testing.T) {
 	_, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{{
 		kind: fastMixedOpCall,
 		call: &compiler.FastCallPlan{Name: "missing", NameIndex: 99, Line: 26},
-	}}})
+	}}}, nil)
 	require.ErrorContains(t, err, "line 26")
 
 	ok, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{{
@@ -246,20 +246,20 @@ func Test_VM_Render_Fast_Mixed_Plan_Error_And_Fallback_Edges(t *testing.T) {
 				line:      27,
 			}},
 		},
-	}}})
+	}}}, nil)
 	require.NoError(t, err)
 	require.True(t, ok)
 
 	_, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{{
 		kind:    fastMixedOpPartial,
 		partial: &compiler.FastPartialPlan{Name: "edge_mixed_missing_partial.plush", Line: 28},
-	}}})
+	}}}, nil)
 	require.ErrorContains(t, err, "line 28")
 
 	ok, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{{
 		kind: fastMixedOpLoop,
 		loop: &compiler.FastLoopPlan{IterableName: "scalar", IterableNameIndex: 3, Line: 29},
-	}}})
+	}}}, nil)
 	require.NoError(t, err)
 	require.False(t, ok)
 }
@@ -384,7 +384,7 @@ func Test_VM_Render_Fast_Segments_And_Mixed_Edge_Branches(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, ok)
 
-	ok, err = renderFastMixedPlan(&out, ctx, bindings, nil)
+	ok, err = renderFastMixedPlan(&out, ctx, bindings, nil, nil)
 	require.NoError(t, err)
 	require.False(t, ok)
 
@@ -393,38 +393,38 @@ func Test_VM_Render_Fast_Segments_And_Mixed_Edge_Branches(t *testing.T) {
 		{kind: fastMixedOpStatic, prefix: "prefix"},
 		{kind: fastMixedOpName, nameIndex: 99, value: "missing", nullOnMissing: true, line: 6},
 		{kind: fastMixedOpName, nameIndex: 0, value: "name", line: 6},
-	}})
+	}}, nil)
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.Equal(t, "prefixMido", out.String())
 
 	ok, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{
 		{kind: fastMixedOpName, nameIndex: 1, value: "unsupported", line: 7},
-	}})
+	}}, nil)
 	require.NoError(t, err)
 	require.False(t, ok)
 
 	_, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{
 		{kind: fastMixedOpName, nameIndex: 99, value: "missing", line: 8},
-	}})
+	}}, nil)
 	require.ErrorContains(t, err, "line 8")
 
 	_, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{
 		{kind: fastMixedOpProperty, nameIndex: 99, value: "missing", property: "Name", line: 9},
-	}})
+	}}, nil)
 	require.ErrorContains(t, err, "line 9")
 
 	_, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{
 		{kind: fastMixedOpProperty, nameIndex: 2, value: "user", property: "Missing", receiver: "user", full: "user.Missing", line: 10},
-	}})
+	}}, nil)
 	require.ErrorContains(t, err, "line 10")
 
 	_, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{
 		{kind: fastMixedOpValue, valuePlan: compiler.FastValuePlan{Kind: compiler.FastValueName, NameIndex: 99, Value: "missing"}, line: 11},
-	}})
+	}}, nil)
 	require.ErrorContains(t, err, "line 11")
 
-	ok, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{{kind: fastMixedOpKind(255)}}})
+	ok, err = renderFastMixedPlan(&out, ctx, bindings, &fastMixedPlan{ops: []fastMixedOp{{kind: fastMixedOpKind(255)}}}, nil)
 	require.NoError(t, err)
 	require.False(t, ok)
 }
@@ -467,7 +467,7 @@ func Test_VM_Render_Fast_Data_Partial_Slow_Branches(t *testing.T) {
 	out.Reset()
 	handled, err = renderFastDataPartialInto(&out, partial, ctx, fastRenderBindings{}, nil)
 	require.True(t, handled)
-	require.ErrorContains(t, err, "line 7: missing")
+	require.ErrorContains(t, err, "line 7:row.html: missing")
 }
 
 func Test_VM_Fast_Iterable_Len_And_Grow_Size_Branches(t *testing.T) {

--- a/vm/vm/fast_script_plan_test.go
+++ b/vm/vm/fast_script_plan_test.go
@@ -3,11 +3,14 @@ package vm
 import (
 	"fmt"
 	"html/template"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
 	"github.com/gobuffalo/plush/v5/vm/compiler"
+	"github.com/gobuffalo/tags/v3"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,7 +32,42 @@ type fastScriptPlanRecord struct {
 	ID int
 }
 
+type fastScriptPlanChoiceSet struct {
+	Entries []fastScriptPlanChoice
+}
+
+type fastScriptPlanChoice struct {
+	ID    string
+	Label string
+}
+
+type fastScriptPlanNodeSet struct {
+	Nodes []fastScriptPlanNode
+}
+
+type fastScriptPlanNode struct {
+	Label string
+}
+
+type fastScriptPlanRecursiveNode struct {
+	Label    string
+	Enabled  bool
+	Children []fastScriptPlanRecursiveNode
+}
+
+type fastScriptPlanAssetSet struct {
+	Assets []fastScriptPlanAsset
+}
+
+type fastScriptPlanAsset struct {
+	URL string
+}
+
 type fastScriptPlanBuilder struct{}
+
+type fastScriptPlanFormBuilder struct{}
+
+type fastScriptPlanTagFormBuilder struct{}
 
 type fastScriptPlanUser struct {
 	Name string
@@ -70,6 +108,40 @@ func (fastScriptPlanBuilder) CheckboxTag(name string, options map[string]interfa
 	return "check:" + name + ":" + fmt.Sprint(options["unchecked"])
 }
 
+func (fastScriptPlanFormBuilder) InputTag(options map[string]interface{}) string {
+	return fmt.Sprintf("input:%v:%v:%v", options["name"], options["value"], options["class"])
+}
+
+func (fastScriptPlanFormBuilder) SelectTag(options map[string]interface{}) string {
+	return fmt.Sprintf("select:%v:%v:%v", options["name"], options["value"], options["options"])
+}
+
+func (fastScriptPlanTagFormBuilder) InputTag(options tags.Options) *tags.Tag {
+	if options["type"] == nil {
+		options["type"] = "text"
+	}
+	return tags.New("input", options)
+}
+
+func (fastScriptPlanTagFormBuilder) SelectTag(options tags.Options) template.HTML {
+	return template.HTML(fmt.Sprintf(`<select name="%v"></select>`, options["name"]))
+}
+
+const fastScriptPlanNestedSelectionTemplate = `<% let selectedEntry = set.Entries[0] %><%= if(input["target_id"] != "" && count(set.Entries) > 0) { %><%= for (_, candidate) in set.Entries { %><%= if(candidate.ID == input["target_id"]) { %><% selectedEntry = candidate %><% } %><% } %><% } %><%= selectedEntry.Label %>`
+
+func fastScriptPlanNestedSelectionContext() *plush.Context {
+	return plush.NewContextWith(map[string]interface{}{
+		"set": fastScriptPlanChoiceSet{Entries: []fastScriptPlanChoice{
+			{ID: "first", Label: "First"},
+			{ID: "second", Label: "Second"},
+		}},
+		"input": map[string]interface{}{"target_id": "second"},
+		"count": func(values []fastScriptPlanChoice) int {
+			return len(values)
+		},
+	})
+}
+
 func Test_VM_Fast_Render_Literal_Lets_And_Path_Loops(t *testing.T) {
 	tmpl, err := Compile(`<% let title = "Default" %><title><%= title %></title><%= for (item) in menu.Items { %><%= item.Name %>;<% } %>`)
 	require.NoError(t, err)
@@ -86,16 +158,16 @@ func Test_VM_Fast_Render_Literal_Lets_And_Path_Loops(t *testing.T) {
 }
 
 func Test_VM_Fast_Render_Loop_Let_With_Helper_And_Arithmetic_Arg(t *testing.T) {
-	tmpl, err := Compile(`<%= for (_, product) in products { %><% let categorySeo = replace(category.CategorySeoUrl, "-outofstock", "", 0 - 1) %><%= categorySeo %>:<%= product.Name %>;<% } %>`)
+	tmpl, err := Compile(`<%= for (_, item) in items { %><% let normalizedPath = replace(document.Path, "-draft", "", 0 - 1) %><%= normalizedPath %>:<%= item.Name %>;<% } %>`)
 	require.NoError(t, err)
 	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
 	require.Empty(t, tmpl.bytecode.FastReject)
 
 	ctx := plush.NewContextWith(map[string]interface{}{
-		"category": struct {
-			CategorySeoUrl string
-		}{CategorySeoUrl: "pizza-outofstock"},
-		"products": []fastScriptPlanItem{
+		"document": struct {
+			Path string
+		}{Path: "guide-draft"},
+		"items": []fastScriptPlanItem{
 			{Name: "One"},
 			{Name: "Two"},
 		},
@@ -104,7 +176,7 @@ func Test_VM_Fast_Render_Loop_Let_With_Helper_And_Arithmetic_Arg(t *testing.T) {
 
 	out, err := tmpl.Render(ctx)
 	require.NoError(t, err)
-	require.Equal(t, `pizza:One;pizza:Two;`, out)
+	require.Equal(t, `guide:One;guide:Two;`, out)
 
 	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
 	require.True(t, ok)
@@ -152,6 +224,26 @@ func Test_VM_Fast_Render_Loop_Assignment_Updates_Outer_Binding(t *testing.T) {
 	}))
 	require.NoError(t, err)
 	require.Equal(t, "|", out)
+}
+
+func Test_VM_Fast_Render_Nested_Conditional_Loop_Assignment_Updates_Outer_Binding(t *testing.T) {
+	tmpl, err := Compile(fastScriptPlanNestedSelectionTemplate)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	out, err := tmpl.Render(fastScriptPlanNestedSelectionContext())
+	require.NoError(t, err)
+	require.Equal(t, "Second", out)
+}
+
+func Test_VM_Bytecode_Render_Nested_Conditional_Loop_Assignment_Updates_Outer_Binding(t *testing.T) {
+	tmpl, err := Compile(fastScriptPlanNestedSelectionTemplate)
+	require.NoError(t, err)
+
+	out, err := renderBytecodeVMWithState(tmpl.bytecode, fastScriptPlanNestedSelectionContext(), "", false, "")
+	require.NoError(t, err)
+	require.Equal(t, "Second", out)
 }
 
 func Test_VM_Fast_Render_Ignores_Comment_Blocks(t *testing.T) {
@@ -240,6 +332,679 @@ func Test_VM_Fast_Render_FormFor_Doc_Syntax_With_Helper_Block_Context(t *testing
 	require.Equal(t, `<form action="/records/7" method="PUT">input:Title|select:Level:2:two|check:Enabled:false</form>`, out)
 }
 
+func Test_VM_Fast_Render_Form_Helper_Context_Set_Survives_Option_Map_Script(t *testing.T) {
+	tmpl, err := Compile(`<%= form({action: submitPath(), method: "POST"}) { %><%= f.InputTag({name:"Fields[0].Value", value: row.Value, class:"field_input"}) %><% let options = {}; let selected = ""; if (row.Code == "") { selected = choices[0].ID } else { selected = row.Code }; for (candidate) in choices { options[candidate.Label] = candidate.ID } %><%= f.SelectTag({name:"Fields[0].Code", value: selected, options: options}) %><%= f.InputTag({name:"Fields[0].RecordID", value: record.ID, type:"hidden"}) %><% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"row": struct {
+			Value int
+			Code  string
+		}{Value: 1},
+		"record": fastScriptPlanRecord{ID: 7},
+		"choices": []fastScriptPlanChoice{
+			{ID: "first-id", Label: "First"},
+			{ID: "second-id", Label: "Second"},
+		},
+		"submitPath": func() string {
+			return "/records"
+		},
+		"form": func(data map[string]interface{}, help plush.HelperContext) (template.HTML, error) {
+			help.Set("f", fastScriptPlanFormBuilder{})
+			body, err := help.Block()
+			if err != nil {
+				return "", err
+			}
+			return template.HTML(fmt.Sprintf(`<form action="%s" method="%s">%s</form>`, data["action"], data["method"], body)), nil
+		},
+	})
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, "input:Fields[0].Value:1:field_input")
+	require.Contains(t, out, "select:Fields[0].Code:first-id:")
+	require.Contains(t, out, "input:Fields[0].RecordID:7:&lt;nil&gt;")
+}
+
+func Test_VM_Fast_Render_Hctx_Block_Helper_Set_Is_Visible_To_Receiver_Calls(t *testing.T) {
+	tmpl, err := Compile(`<%= if(record.Enabled) { %><%= form({action: submitPath(), method: "POST"}) { %><% let selected = record.Entries[0] %><%= if(input["target_id"] != "" && count(record.Entries) > 0) { %><%= for (_, candidate) in record.Entries { %><%= if(candidate.ID == input["target_id"]) { %><% selected = candidate %><% } %><% } %><% } %><%= f.InputTag({name:"Fields[0].EntryID", value: selected.ID, class:"field_input"}) %><% } %><% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	type entry struct {
+		ID string
+	}
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"record": struct {
+			Enabled bool
+			Entries []entry
+		}{
+			Enabled: true,
+			Entries: []entry{
+				{ID: "first"},
+				{ID: "second"},
+			},
+		},
+		"input": map[string]interface{}{"target_id": "second"},
+		"count": func(values []entry) int {
+			return len(values)
+		},
+		"submitPath": func() string {
+			return "/records"
+		},
+		"form": func(data tags.Options, help hctx.HelperContext) (template.HTML, error) {
+			help.Set("f", fastScriptPlanFormBuilder{})
+			body, err := help.Block()
+			if err != nil {
+				return "", err
+			}
+			return template.HTML(fmt.Sprintf(`<form action="%s" method="%s">%s</form>`, data["action"], data["method"], body)), nil
+		},
+	})
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `<form action="/records" method="POST">input:Fields[0].EntryID:second:field_input</form>`, out)
+}
+
+func Test_VM_Fast_Render_Hctx_Block_Helper_Set_Survives_Reused_Bytecode_With_New_Context(t *testing.T) {
+	tmpl, err := Compile(`<%= form({action: submitPath(), method: "POST"}) { %><%= f.InputTag({name:"Fields[0].Value", value: record.Value, class:"field_input"}) %><% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	type record struct {
+		Value int
+	}
+	newCtx := func(value int, extraKey string) *plush.Context {
+		ctx := plush.NewContextWith(map[string]interface{}{
+			extraKey: "extra",
+			"record": record{
+				Value: value,
+			},
+			"submitPath": func() string {
+				return "/records"
+			},
+			"form": func(data tags.Options, help hctx.HelperContext) (template.HTML, error) {
+				help.Set("f", fastScriptPlanFormBuilder{})
+				body, err := help.Block()
+				if err != nil {
+					return "", err
+				}
+				return template.HTML(fmt.Sprintf(`<form action="%s" method="%s">%s</form>`, data["action"], data["method"], body)), nil
+			},
+		})
+		return ctx
+	}
+
+	first, err := tmpl.Render(newCtx(1, "first_extra"))
+	require.NoError(t, err)
+	require.Equal(t, `<form action="/records" method="POST">input:Fields[0].Value:1:field_input</form>`, first)
+
+	second, err := tmpl.Render(newCtx(2, "second_extra"))
+	require.NoError(t, err)
+	require.Equal(t, `<form action="/records" method="POST">input:Fields[0].Value:2:field_input</form>`, second)
+}
+
+func Test_VM_Fast_Render_Hctx_Block_Helper_Set_Remains_Visible_After_Block_Call(t *testing.T) {
+	tmpl, err := Compile(`<%= form({action: submitPath(), method: "POST"}) { %>inside<% } %>|<%= f.InputTag({name:"Fields[0].Value", value: record.Value, class:"field_input"}) %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"record": struct {
+			Value int
+		}{Value: 7},
+		"submitPath": func() string {
+			return "/records"
+		},
+		"form": func(data tags.Options, help hctx.HelperContext) (template.HTML, error) {
+			help.Set("f", fastScriptPlanFormBuilder{})
+			body, err := help.Block()
+			if err != nil {
+				return "", err
+			}
+			return template.HTML(fmt.Sprintf(`<form action="%s" method="%s">%s</form>`, data["action"], data["method"], body)), nil
+		},
+	})
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `<form action="/records" method="POST">inside</form>|input:Fields[0].Value:7:field_input`, out)
+}
+
+func Test_VM_Fast_Render_Hctx_Block_Helper_Set_Is_Visible_Inside_Loop_Block_Call(t *testing.T) {
+	tmpl, err := Compile(`<%= for (_, record) in records { %><%= form({action: submitPath(record.ID), method: "POST"}) { %><%= f.InputTag({name:"Fields[0].Value", value: record.Value, class:"field_input"}) %><% } %><% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	type record struct {
+		ID    string
+		Value int
+	}
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"records": []record{
+			{ID: "first", Value: 1},
+			{ID: "second", Value: 2},
+		},
+		"submitPath": func(id string) string {
+			return "/records/" + id
+		},
+		"form": func(data tags.Options, help hctx.HelperContext) (template.HTML, error) {
+			help.Set("f", fastScriptPlanFormBuilder{})
+			body, err := help.Block()
+			if err != nil {
+				return "", err
+			}
+			return template.HTML(fmt.Sprintf(`<form action="%s" method="%s">%s</form>`, data["action"], data["method"], body)), nil
+		},
+	})
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `<form action="/records/first" method="POST">input:Fields[0].Value:1:field_input</form><form action="/records/second" method="POST">input:Fields[0].Value:2:field_input</form>`, out)
+}
+
+func Test_VM_Fast_Render_Hctx_Block_Helper_Set_Is_Visible_To_Repeated_Receiver_Calls(t *testing.T) {
+	tmpl, err := Compile(`<%= form({action: submitPath(), method: "POST", id: "control_set"}) { %>
+<%= f.InputTag({name:"entity_id", value: record.ID}) %>
+<%= f.InputTag({type:"text", name: "priority", value: 1}) %>
+<%= f.InputTag({type:"text", name: "heading", value: "HEADING"}) %>
+<%= f.InputTag({type:"text", name:"notes", value: "NOTES"}) %>
+<%= f.InputTag({type:"text", name:"label", value: "sample"}) %>
+<button role="submit">Save</button>
+<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"record": fastScriptPlanRecord{ID: 7},
+		"submitPath": func() string {
+			return "/records"
+		},
+		"form": func(data tags.Options, help hctx.HelperContext) (template.HTML, error) {
+			help.Set("f", fastScriptPlanFormBuilder{})
+			body, err := help.Block()
+			if err != nil {
+				return "", err
+			}
+			return template.HTML(fmt.Sprintf(`<form action="%s" method="%s">%s</form>`, data["action"], data["method"], body)), nil
+		},
+	})
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, "input:entity_id:7:&lt;nil&gt;")
+	require.Contains(t, out, "input:priority:1:&lt;nil&gt;")
+	require.Contains(t, out, "input:heading:HEADING:&lt;nil&gt;")
+	require.Contains(t, out, "input:notes:NOTES:&lt;nil&gt;")
+	require.Contains(t, out, "input:label:sample:&lt;nil&gt;")
+}
+
+func Test_VM_Fast_Render_Hctx_Block_Helper_Set_Is_Visible_To_Repeated_Tag_Calls(t *testing.T) {
+	const input = `<%= form({action: submitPath(), method: "POST", id: "control_set"}) { %>
+<%= f.InputTag({name:"entity_id", value: record.ID}) %>
+<%= f.InputTag({type:"text", name: "priority", value: 1}) %>
+<%= f.InputTag({type:"text", name: "heading", value: "HEADING"}) %>
+<%= f.InputTag({type:"text", name:"notes", value: "NOTES"}) %>
+<%= f.InputTag({type:"text", name:"label", value: "sample"}) %>
+<button role="submit">Save</button>
+<% } %>`
+	tmpl, err := Compile(input)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	ctx := fastScriptPlanRepeatedTagFormContext()
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, `<input name="entity_id" type="text" value="7" />`)
+	require.Contains(t, out, `<input name="priority" type="text" value="1" />`)
+	require.Contains(t, out, `<input name="heading" type="text" value="HEADING" />`)
+	require.Contains(t, out, `<input name="notes" type="text" value="NOTES" />`)
+	require.Contains(t, out, `<input name="label" type="text" value="sample" />`)
+}
+
+func Test_VM_Fast_Render_Hctx_Block_Helper_Set_Survives_Loop_Let_And_Break_Inside_Block(t *testing.T) {
+	const input = `<%= form({action: submitPath(), method: "POST", id: "form_editor"}) { %>
+<%= f.InputTag({name:"record_id", value: record.ID, type:"hidden"}) %>
+<%= for (i, entry) in record.Entries { %>
+	<%= if (i == 1) { break } %>
+	<% let is_active = "" %>
+	<%= if (input["entry_id"] != "" && entry.ID == input["entry_id"]) { %>
+		<% is_active = "active" %>
+	<% } %>
+	<span class="<%= is_active %>"><%= entry.ID %></span>
+<% } %>
+<%= if(record.Enabled) { %>
+	<%= f.InputTag({name:"count", value: 1, class:"child_count_input"}) %>
+<% } %>
+<% } %>`
+	tmpl, err := Compile(input)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	type entry struct {
+		ID string
+	}
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"record": struct {
+			ID      int
+			Enabled bool
+			Entries []entry
+		}{
+			ID:      7,
+			Enabled: true,
+			Entries: []entry{{ID: "first"}, {ID: "second"}, {ID: "third"}},
+		},
+		"input": map[string]interface{}{"entry_id": "first"},
+		"submitPath": func() string {
+			return "/records"
+		},
+		"form": func(data tags.Options, help hctx.HelperContext) (template.HTML, error) {
+			help.Set("f", fastScriptPlanTagFormBuilder{})
+			body, err := help.Block()
+			if err != nil {
+				return "", err
+			}
+			return template.HTML(fmt.Sprintf(`<form action="%s" method="%s">%s</form>`, data["action"], data["method"], body)), nil
+		},
+	})
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, `<form action="/records" method="POST">`)
+	require.Contains(t, out, `<input name="record_id" type="hidden" value="7" />`)
+	require.Contains(t, out, `<span class="active">first</span>`)
+	require.NotContains(t, out, `third`)
+	require.Contains(t, out, `<input class="child_count_input" name="count" type="text" value="1" />`)
+}
+
+func Test_VM_Fast_Render_Hctx_Block_Helper_Set_Survives_Long_Form_With_Break_And_Later_Let_Loop(t *testing.T) {
+	const input = `<%= form({action: submitPath(), method: "POST", id: "form_editor"}) { %>
+<%= f.SelectTag({name: "record_entry_id", value: selected, options: entryChoices, type:"hidden"}) %>
+<%= f.InputTag({name:"record_id", value: record.ID, type:"hidden"}) %>
+<%= for (index, entry) in record.Entries { %>
+	<%= if (index == 30) { break } %>
+	<%= if (entry.Asset) { %>
+		<span><%= entry.Asset.URL %></span>
+	<% } else { %>
+		<%= for (_, asset) in record.Assets { %>
+			<span><%= asset.URL %></span>
+		<% } %>
+	<% } %>
+<% } %>
+<%= for (fieldIndex, fieldName) in record.Fields { %>
+	<%= if (fieldName == "secondary") { %>
+		<%= for (i, entry) in record.Entries { %>
+			<% let is_active = "" %>
+			<%= if (input["entry_id"] != "" && entry.ID == input["entry_id"]) { %>
+				<% is_active = "active" %>
+			<% } %>
+			<div class="<%= is_active %>"><%= entry.FieldValues[fieldIndex] %></div>
+		<% } %>
+	<% } %>
+<% } %>
+<%= if(record.Enabled) { %>
+	<%= f.InputTag({name:"count", value: 1, class:"child_count_input"}) %>
+<% } %>
+<% } %>`
+	tmpl, err := Compile(input)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	type asset struct {
+		URL string
+	}
+	type entry struct {
+		ID          string
+		Asset       *asset
+		FieldValues []string
+	}
+	entries := make([]entry, 35)
+	for i := range entries {
+		entries[i] = entry{
+			ID:          fmt.Sprintf("entry-%d", i),
+			FieldValues: []string{"primary", fmt.Sprintf("secondary-%d", i)},
+		}
+	}
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"record": struct {
+			ID      int
+			Enabled bool
+			Entries []entry
+			Assets  []asset
+			Fields  []string
+		}{
+			ID:      7,
+			Enabled: true,
+			Entries: entries,
+			Assets:  []asset{{URL: "fallback.jpg"}},
+			Fields:  []string{"primary", "secondary"},
+		},
+		"selected":     "entry-0",
+		"entryChoices": map[string]interface{}{"primary secondary-0": "entry-0"},
+		"input":        map[string]interface{}{"entry_id": "entry-2"},
+		"submitPath": func() string {
+			return "/records"
+		},
+		"form": func(data tags.Options, help hctx.HelperContext) (template.HTML, error) {
+			help.Set("f", fastScriptPlanTagFormBuilder{})
+			body, err := help.Block()
+			if err != nil {
+				return "", err
+			}
+			return template.HTML(fmt.Sprintf(`<form action="%s" method="%s">%s</form>`, data["action"], data["method"], body)), nil
+		},
+	})
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, `<form action="/records" method="POST">`)
+	require.Contains(t, out, `<select name="record_entry_id">`)
+	require.Contains(t, out, `<input name="record_id" type="hidden" value="7" />`)
+	require.Contains(t, out, `<div class="active">secondary-2</div>`)
+	require.NotContains(t, out, `secondary-34</span>`)
+	require.Contains(t, out, `<input class="child_count_input" name="count" type="text" value="1" />`)
+}
+
+func Test_VM_Fast_Render_Hctx_BlockWith_Helper_Set_Survives_Long_Form_With_Break_And_Later_Let_Loop(t *testing.T) {
+	const input = `<%= form({action: submitPath(), method: "POST", id: "form_editor"}) { %>
+<%= f.SelectTag({name: "record_entry_id", value: selected, options: entryChoices, type:"hidden"}) %>
+<%= f.InputTag({name:"record_id", value: record.ID, type:"hidden"}) %>
+<%= for (index, entry) in record.Entries { %>
+	<%= if (index == 30) { break } %>
+	<%= if (entry.Asset) { %>
+		<span><%= entry.Asset.URL %></span>
+	<% } else { %>
+		<%= for (_, asset) in record.Assets { %>
+			<span><%= asset.URL %></span>
+		<% } %>
+	<% } %>
+<% } %>
+<%= for (fieldIndex, fieldName) in record.Fields { %>
+	<%= if (fieldName == "secondary") { %>
+		<%= for (i, entry) in record.Entries { %>
+			<% let is_active = "" %>
+			<%= if (input["entry_id"] != "" && entry.ID == input["entry_id"]) { %>
+				<% is_active = "active" %>
+			<% } %>
+			<div class="<%= is_active %>"><%= entry.FieldValues[fieldIndex] %></div>
+		<% } %>
+	<% } %>
+<% } %>
+<%= if(record.Enabled) { %>
+	<%= f.InputTag({name:"count", value: 1, class:"child_count_input"}) %>
+<% } %>
+<% } %>`
+	tmpl, err := Compile(input)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	type asset struct {
+		URL string
+	}
+	type entry struct {
+		ID          string
+		Asset       *asset
+		FieldValues []string
+	}
+	entries := make([]entry, 35)
+	for i := range entries {
+		entries[i] = entry{
+			ID:          fmt.Sprintf("entry-%d", i),
+			FieldValues: []string{"primary", fmt.Sprintf("secondary-%d", i)},
+		}
+	}
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"record": struct {
+			ID      int
+			Enabled bool
+			Entries []entry
+			Assets  []asset
+			Fields  []string
+		}{
+			ID:      7,
+			Enabled: true,
+			Entries: entries,
+			Assets:  []asset{{URL: "fallback.jpg"}},
+			Fields:  []string{"primary", "secondary"},
+		},
+		"selected":     "entry-0",
+		"entryChoices": map[string]interface{}{"primary secondary-0": "entry-0"},
+		"input":        map[string]interface{}{"entry_id": "entry-2"},
+		"submitPath": func() string {
+			return "/records"
+		},
+		"form": func(data tags.Options, help hctx.HelperContext) (template.HTML, error) {
+			child := help.New()
+			child.Set("f", fastScriptPlanTagFormBuilder{})
+			body, err := help.BlockWith(child)
+			if err != nil {
+				return "", err
+			}
+			return template.HTML(fmt.Sprintf(`<form action="%s" method="%s">%s</form>`, data["action"], data["method"], body)), nil
+		},
+	})
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, `<form action="/records" method="POST">`)
+	require.Contains(t, out, `<select name="record_entry_id">`)
+	require.Contains(t, out, `<input name="record_id" type="hidden" value="7" />`)
+	require.Contains(t, out, `<div class="active">secondary-2</div>`)
+	require.NotContains(t, out, `secondary-34</span>`)
+	require.Contains(t, out, `<input class="child_count_input" name="count" type="text" value="1" />`)
+}
+
+func Test_VM_Bytecode_Render_Hctx_Block_Helper_Set_Is_Visible_To_Repeated_Tag_Calls(t *testing.T) {
+	const input = `<%= form({action: submitPath(), method: "POST", id: "control_set"}) { %>
+<%= f.InputTag({name:"entity_id", value: record.ID}) %>
+<%= f.InputTag({type:"text", name: "priority", value: 1}) %>
+<%= f.InputTag({type:"text", name: "heading", value: "HEADING"}) %>
+<%= f.InputTag({type:"text", name:"notes", value: "NOTES"}) %>
+<%= f.InputTag({type:"text", name:"label", value: "sample"}) %>
+<button role="submit">Save</button>
+<% } %>`
+	tmpl, err := Compile(input)
+	require.NoError(t, err)
+
+	out, err := renderBytecodeVMWithState(tmpl.bytecode, fastScriptPlanRepeatedTagFormContext(), "", false, "")
+	require.NoError(t, err)
+	require.Contains(t, out, `<input name="entity_id" type="text" value="7" />`)
+	require.Contains(t, out, `<input name="priority" type="text" value="1" />`)
+	require.Contains(t, out, `<input name="heading" type="text" value="HEADING" />`)
+	require.Contains(t, out, `<input name="notes" type="text" value="NOTES" />`)
+	require.Contains(t, out, `<input name="label" type="text" value="sample" />`)
+}
+
+func fastScriptPlanRepeatedTagFormContext() *plush.Context {
+	return plush.NewContextWith(map[string]interface{}{
+		"record": fastScriptPlanRecord{ID: 7},
+		"submitPath": func() string {
+			return "/records"
+		},
+		"form": func(data tags.Options, help hctx.HelperContext) (template.HTML, error) {
+			builder := fastScriptPlanTagFormBuilder{}
+			help.Set("f", builder)
+			body, err := help.Block()
+			if err != nil {
+				return "", err
+			}
+			return template.HTML(fmt.Sprintf(`<form action="%s" method="%s">%s</form>`, data["action"], data["method"], body)), nil
+		},
+	})
+}
+
+func Test_VM_Fast_Render_Hctx_Block_Helper_Set_Is_Visible_After_Earlier_Form_And_Shadowing_Loop(t *testing.T) {
+	tmpl, err := Compile(`<%= if (record) { %>
+<%= form({action: firstPath(), method: "POST"}) { %>
+<%= f.InputTag({name:"first_id", value: record.ID}) %>
+<% } %>
+<%= if (related && related.Items) { %>
+<%= for (record) in related.Items { %>
+<%= form({action: itemPath(record.ID), method: "POST"}) { %>
+<%= f.InputTag({name:"item_id", value: record.ID}) %>
+<% } %>
+<% } %>
+<% } %>
+<%= form({action: submitPath(), method: "POST", id: "control_set"}) { %>
+<%= f.InputTag({name:"entity_id", value: record.ID}) %>
+<%= f.InputTag({type:"text", name: "priority", value: 1}) %>
+<%= f.InputTag({type:"text", name: "heading", value: "HEADING"}) %>
+<%= f.InputTag({type:"text", name:"notes", value: "NOTES"}) %>
+<%= f.InputTag({type:"text", name:"label", value: "sample"}) %>
+<% } %>
+<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	type record struct {
+		ID int
+	}
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"record": record{ID: 7},
+		"related": struct {
+			Items []record
+		}{Items: []record{{ID: 11}}},
+		"firstPath": func() string {
+			return "/first"
+		},
+		"itemPath": func(id int) string {
+			return fmt.Sprintf("/items/%d", id)
+		},
+		"submitPath": func() string {
+			return "/records"
+		},
+		"form": func(data tags.Options, help hctx.HelperContext) (template.HTML, error) {
+			help.Set("f", fastScriptPlanTagFormBuilder{})
+			body, err := help.Block()
+			if err != nil {
+				return "", err
+			}
+			return template.HTML(fmt.Sprintf(`<form action="%s" method="%s">%s</form>`, data["action"], data["method"], body)), nil
+		},
+	})
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, `<form action="/first" method="POST">`)
+	require.Contains(t, out, `<form action="/items/11" method="POST">`)
+	require.Contains(t, out, `<form action="/records" method="POST">`)
+	require.Contains(t, out, `<input name="entity_id" type="text" value="7" />`)
+	require.Contains(t, out, `<input name="notes" type="text" value="NOTES" />`)
+}
+
+func Test_VM_Fast_Render_Form_Helper_Context_Set_Is_Visible_To_Nested_Render_Helper(t *testing.T) {
+	tmpl, err := Compile(`<%= form({action: submitPath(), method: "POST"}) { %><%= for (_, block) in blocks { %><%= if(!block.Hidden) { %><%= render(block.Type + ".plush.html", {settings: block}) %><% } %><% } %><% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"blocks": []struct {
+			Type   string
+			Hidden bool
+		}{{Type: "panel", Hidden: false}},
+		"submitPath": func() string {
+			return "/records"
+		},
+		"form": func(data map[string]interface{}, help plush.HelperContext) (template.HTML, error) {
+			help.Set("f", fastScriptPlanFormBuilder{})
+			body, err := help.Block()
+			if err != nil {
+				return "", err
+			}
+			return template.HTML(fmt.Sprintf(`<form action="%s" method="%s">%s</form>`, data["action"], data["method"], body)), nil
+		},
+		"render": func(string, map[string]interface{}, plush.HelperContext) (template.HTML, error) {
+			return "", nil
+		},
+	})
+	SetFastHelper(ctx, "render", func(w FastWriter, args FastArgs) error {
+		fileName, ok := args.String(0)
+		if !ok || fileName != "panel.plush.html" {
+			return ErrFastUnsupported
+		}
+		data, ok := args.Raw(1)
+		if !ok {
+			return ErrFastUnsupported
+		}
+		values, ok := data.(map[string]interface{})
+		if !ok {
+			return ErrFastUnsupported
+		}
+		help := plush.NewHelperContext(w.Context(), nil)
+		child := help.New()
+		for k, v := range values {
+			child.Set(k, v)
+		}
+		rendered, err := plush.Render(`<%= f.InputTag({name:"Fields[0].Value", value: 1, class:"field_input"}) %>`, child)
+		if err != nil {
+			return err
+		}
+		w.WriteHTMLString(rendered)
+		return nil
+	})
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `<form action="/records" method="POST">input:Fields[0].Value:1:field_input</form>`, out)
+}
+
+func Test_VM_Fast_Render_Loop_Partial_Data_Can_Use_Current_Value(t *testing.T) {
+	tmpl, err := Compile(`<%= for (_, entry) in entries { %><%= partial("entry-card.plush", {entry: entry}) %><% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"entries": []fastScriptPlanChoice{
+			{ID: "first", Label: "First"},
+			{ID: "second", Label: "Second"},
+		},
+		"partialFeeder": func(name string) (string, error) {
+			require.Equal(t, "entry-card.plush", name)
+			return `<span><%= entry.Label %></span>`, nil
+		},
+	})
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `<span>First</span><span>Second</span>`, out)
+}
+
+func Test_VM_Fast_Render_Nested_Collection_Loop_Reads_Value_Field(t *testing.T) {
+	for name, entries := range map[string]interface{}{
+		"value slice":   fastScriptPlanAssetSet{Assets: []fastScriptPlanAsset{{URL: "/first.png"}, {URL: "/second.png"}}},
+		"pointer slice": struct{ Assets []*fastScriptPlanAsset }{Assets: []*fastScriptPlanAsset{{URL: "/first.png"}, {URL: "/second.png"}}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			tmpl, err := Compile(`<%= for (index, asset) in set.Assets { %><link data-index="<%= index %>" href="<%= asset.URL %>" /><% } %>`)
+			require.NoError(t, err)
+			require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+			require.Empty(t, tmpl.bytecode.FastReject)
+
+			out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+				"set": entries,
+			}))
+			require.NoError(t, err)
+			require.Equal(t, `<link data-index="0" href="/first.png" /><link data-index="1" href="/second.png" />`, out)
+		})
+	}
+}
+
 func Test_VM_Fast_Render_Silent_Block_Helper_Discards_Return_And_Renders_Block(t *testing.T) {
 	tmpl, err := Compile(`<% capture("extra") { %><style><%= klass %></style><% } %><%= readCapture("extra") %>`)
 	require.NoError(t, err)
@@ -285,6 +1050,144 @@ func Test_VM_Fast_Render_Silent_Script_For_Discards_Output_And_Assigns(t *testin
 	}))
 	require.NoError(t, err)
 	require.Equal(t, "second", out)
+}
+
+func Test_VM_Fast_Render_Loop_Branch_Appends_Local_Value_To_Outer_Array(t *testing.T) {
+	tmpl, err := Compile(`<% let handlers = [] %><% let items = [1,2,3] %><%= for (index, item) in items { %><%= if(true) { %><% let handle = "test" + to_string(index) %><% handlers = handlers + handle %><% } %><% } %><%= handlers[0] %>|<%= handlers[1] %>|<%= handlers[2] %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"to_string": strconv.Itoa,
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "test0|test1|test2", out)
+}
+
+func Test_VM_Fast_Render_Branch_Appends_Local_Value_To_Outer_Array(t *testing.T) {
+	tmpl, err := Compile(`<% let handlers = [] %><%= if(true) { %><% let handle = "test0" %><% handlers = handlers + handle %><% } %><%= handlers[0] %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	out, err := tmpl.Render(plush.NewContext())
+	require.NoError(t, err)
+	require.Equal(t, "test0", out)
+}
+
+func Test_VM_Fast_Render_Scoped_Assignment_Path_Matrix(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "output conditional else branch",
+			input:    `<% let result = "" %><%= if (false) { %><% let local = "wrong" %><% result = local %><% } else { %><% let local = "A" %><% result = local %><% } %><%= result %>`,
+			expected: "A",
+		},
+		{
+			name:     "silent conditional branch",
+			input:    `<% let result = "" %><% if (true) { %>discarded<% let local = "A" %><% result = local %><% } %><%= result %>`,
+			expected: "A",
+		},
+		{
+			name:     "output loop conditional branch",
+			input:    `<% let result = "" %><%= for (_, item) in ["A","B"] { %><%= if (true) { %><% let local = item %><% result = result + local %><% } %><% } %><%= result %>`,
+			expected: "AB",
+		},
+		{
+			name:     "silent loop conditional branch",
+			input:    `<% let result = "" %><%= for (_, item) in ["A","B"] { %><% if (true) { %>discarded<% let local = item %><% result = result + local %><% } %><% } %><%= result %>`,
+			expected: "AB",
+		},
+		{
+			name:     "nested loop assignment",
+			input:    `<% let result = "" %><%= for (_, row) in [["A","B"],["C"]] { %><%= for (_, item) in row { %><% let local = item %><% result = result + local %><% } %><% } %><%= result %>`,
+			expected: "ABC",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpl, err := Compile(tt.input)
+			require.NoError(t, err)
+			require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+			require.Empty(t, tmpl.bytecode.FastReject)
+
+			ctx := plush.NewContext()
+			out, err := tmpl.Render(ctx)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, out)
+
+			diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+			require.True(t, ok)
+			require.Equal(t, plush.RenderFastPathFast, diagnostics.FastPath)
+		})
+	}
+}
+
+func Test_VM_Fast_Render_Recursive_Loop_Partial_Syncs_Parent_Assignment(t *testing.T) {
+	partialSource := `<%= for (_, node) in nodes { %>` +
+		`<%= if (node.Enabled) { %>` +
+		`<% let entry = "enter:" + node.Label + "|" %>` +
+		`<% collected = collected + entry %>` +
+		`<%= if (len(node.Children) > 0) { %>` +
+		`<%= partial("tree.plush.html", {nodes: node.Children}) %>` +
+		`<% } %>` +
+		`<% let exit = "exit:" + node.Label + "|" %>` +
+		`<% collected = collected + exit %>` +
+		`<% } %>` +
+		`<% } %>`
+
+	partialTemplate, err := Compile(partialSource)
+	require.NoError(t, err)
+	require.NotNil(t, partialTemplate.bytecode.FastRenderPlan, partialTemplate.bytecode.FastReject)
+	require.Empty(t, partialTemplate.bytecode.FastReject)
+
+	rootTemplate, err := Compile(`<% let collected = "" %><%= partial("tree.plush.html", {nodes: nodes}) %><%= collected %>`)
+	require.NoError(t, err)
+	require.NotNil(t, rootTemplate.bytecode.FastRenderPlan, rootTemplate.bytecode.FastReject)
+	require.Empty(t, rootTemplate.bytecode.FastReject)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"nodes": []fastScriptPlanRecursiveNode{
+			{
+				Label:   "root",
+				Enabled: true,
+				Children: []fastScriptPlanRecursiveNode{
+					{
+						Label:   "branch",
+						Enabled: true,
+						Children: []fastScriptPlanRecursiveNode{
+							{
+								Label:   "leaf",
+								Enabled: true,
+								Children: []fastScriptPlanRecursiveNode{
+									{Label: "tip", Enabled: true},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"partialFeeder": func(name string) (string, error) {
+			if name != "tree.plush.html" {
+				return "", fmt.Errorf("unexpected partial %q", name)
+			}
+			return partialSource, nil
+		},
+	})
+
+	out, err := rootTemplate.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "enter:root|enter:branch|enter:leaf|enter:tip|exit:tip|exit:leaf|exit:branch|exit:root|", out)
+
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.NotEqual(t, plush.RenderFastPathInterpreterFallback, diagnostics.FastPath)
 }
 
 func Test_VM_Fast_Render_Block_Helper_Allows_Local_Assignment_Setup(t *testing.T) {
@@ -576,7 +1479,7 @@ func Test_VM_Fast_Render_Loop_Registered_Helper_Context_Includes_Loop_Binding(t 
 	require.Empty(t, tmpl.bytecode.FastReject)
 
 	ctx := plush.NewContextWith(map[string]interface{}{
-		"blocks": []fastScriptPlanRenderBlock{{Type: "product-option", BlockID: "test-1234"}},
+		"blocks": []fastScriptPlanRenderBlock{{Type: "panel-option", BlockID: "test-1234"}},
 		"render": func(string, map[string]interface{}, plush.HelperContext) (template.HTML, error) {
 			return "", nil
 		},
@@ -608,7 +1511,7 @@ func Test_VM_Fast_Render_Loop_Registered_Helper_Context_Includes_Loop_Binding(t 
 
 	out, err := tmpl.Render(ctx)
 	require.NoError(t, err)
-	require.Equal(t, "product-option.plush.html|test-1234|test-1234", out)
+	require.Equal(t, "panel-option.plush.html|test-1234|test-1234", out)
 
 	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
 	require.True(t, ok)
@@ -650,6 +1553,65 @@ func Test_VM_Fast_Render_Output_If_Return_Nil_Loop_And_Iterator_Assignment(t *te
 	out, err = tmpl.Render(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "PA2", out)
+}
+
+func Test_VM_Fast_Render_Len_Nil_Collection_Short_Circuits_Index(t *testing.T) {
+	for name, tt := range map[string]struct {
+		record   interface{}
+		template string
+	}{
+		"typed nil slice field": {
+			record:   fastScriptPlanNodeSet{},
+			template: `<%= if (len(record.Nodes) > 0 && record.Nodes[0].Label) { %>present<% } else { %>empty<% } %>`,
+		},
+		"nil map value": {
+			record:   map[string]interface{}{"Nodes": nil},
+			template: `<%= if (len(record.Nodes) > 0 && record.Nodes[0].Label) { %>present<% } else { %>empty<% } %>`,
+		},
+		"missing map value": {
+			record:   map[string]interface{}{},
+			template: `<%= if (len(record.Nodes) > 0 && record.Nodes[0].Label) { %>present<% } else { %>empty<% } %>`,
+		},
+		"assigned nil collection": {
+			record:   fastScriptPlanNodeSet{},
+			template: `<% let nodes = record.Nodes %><%= if (len(nodes) > 1) { %>present<% } else { %>empty<% } %>`,
+		},
+		"assigned nil map value": {
+			record:   map[string]interface{}{"Nodes": nil},
+			template: `<% let nodes = record.Nodes %><%= if (len(nodes) > 1) { %>present<% } else { %>empty<% } %>`,
+		},
+		"assigned missing map value": {
+			record:   map[string]interface{}{},
+			template: `<% let nodes = record.Nodes %><%= if (len(nodes) > 1) { %>present<% } else { %>empty<% } %>`,
+		},
+		"loop typed nil slice field": {
+			record:   []fastScriptPlanNodeSet{{}},
+			template: `<%= for (_, record) in record { %><%= if (len(record.Nodes) > 1) { %>present<% } else { %>empty<% } %><% } %>`,
+		},
+		"loop nil map value": {
+			record:   []map[string]interface{}{{"Nodes": nil}},
+			template: `<%= for (_, record) in record { %><%= if (len(record.Nodes) > 1) { %>present<% } else { %>empty<% } %><% } %>`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			tmpl, err := Compile(tt.template)
+			require.NoError(t, err)
+			require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+			require.Empty(t, tmpl.bytecode.FastReject)
+
+			ctx := plush.NewContextWith(map[string]interface{}{
+				"record": tt.record,
+			})
+			out, err := tmpl.Render(ctx)
+			require.NoError(t, err)
+			require.Equal(t, "empty", out)
+
+			diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+			require.True(t, ok)
+			require.Equal(t, plush.RenderFastPathFast, diagnostics.FastPath)
+			require.Empty(t, diagnostics.FastReject)
+		})
+	}
 }
 
 func Test_VM_Fast_Render_Function_Literal_Uses_Generic_VM_Not_Interpreter_Fallback(t *testing.T) {

--- a/vm/vm/fast_script_plan_test.go
+++ b/vm/vm/fast_script_plan_test.go
@@ -1,10 +1,13 @@
 package vm
 
 import (
+	"fmt"
+	"html/template"
 	"strings"
 	"testing"
 
 	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/vm/compiler"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,6 +18,56 @@ type fastScriptPlanMenu struct {
 type fastScriptPlanItem struct {
 	Name  string
 	Count int
+}
+
+type fastScriptPlanPair struct {
+	Key   string
+	Value string
+}
+
+type fastScriptPlanRecord struct {
+	ID int
+}
+
+type fastScriptPlanBuilder struct{}
+
+type fastScriptPlanUser struct {
+	Name string
+}
+
+type fastScriptPlanRenderBlock struct {
+	Type    string
+	BlockID string
+}
+
+func (u fastScriptPlanUser) Render(mode string) string {
+	return mode + ":" + u.Name
+}
+
+func (fastScriptPlanBuilder) RenderControl(options map[string]interface{}) string {
+	name, _ := options["name"].(string)
+	typ, _ := options["type"].(string)
+	return name + ":" + typ
+}
+
+func (fastScriptPlanBuilder) RenderSelect(name string, options map[string]interface{}) string {
+	values, _ := options["options"].([]interface{})
+	selected, _ := options["value"].(string)
+	return name + ":" + fmt.Sprint(len(values)) + ":" + selected
+}
+
+func (fastScriptPlanBuilder) InputTag(name string) string {
+	return "input:" + name
+}
+
+func (fastScriptPlanBuilder) SelectTag(name string, options map[string]interface{}) string {
+	values, _ := options["options"].([]interface{})
+	selected, _ := options["value"].(string)
+	return "select:" + name + ":" + fmt.Sprint(len(values)) + ":" + selected
+}
+
+func (fastScriptPlanBuilder) CheckboxTag(name string, options map[string]interface{}) string {
+	return "check:" + name + ":" + fmt.Sprint(options["unchecked"])
 }
 
 func Test_VM_Fast_Render_Literal_Lets_And_Path_Loops(t *testing.T) {
@@ -78,6 +131,196 @@ func Test_VM_Fast_Render_Loop_Let_Spends_Assignment_Budget(t *testing.T) {
 	_, err = tmpl.Render(ctx)
 	require.ErrorIs(t, err, plush.ErrBudgetExceeded)
 	require.Equal(t, int64(2), budget.Stats().Assignments)
+}
+
+func Test_VM_Fast_Render_Loop_Assignment_Updates_Outer_Binding(t *testing.T) {
+	tmpl, err := Compile(`<% let last = "" %><%= for (_, item) in items { %><% let label = item %><% last = label %><%= label %><% } %>|<%= last %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+	require.Len(t, tmpl.bytecode.FastRenderPlan.Segments, 4)
+	require.Equal(t, compiler.FastLoopPartAssign, tmpl.bytecode.FastRenderPlan.Segments[1].Loop.Parts[1].Kind)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"items": []string{"a", "b"},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "ab|b", out)
+
+	out, err = tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"items": []string{},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "|", out)
+}
+
+func Test_VM_Fast_Render_Ignores_Comment_Blocks(t *testing.T) {
+	tmpl, err := Compile(`<%# editor metadata lives here %><%= title %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"title": "Ready",
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "Ready", out)
+}
+
+func Test_VM_Fast_Render_Assignment_Scalar_Expressions_And_Index_Targets(t *testing.T) {
+	tmpl, err := Compile(`<% let count = 0 %><% let label = "" %><% let data = {} %><%= for (_, item) in items { %><% count = count + 1 %><% label = label + item.Key %><% data[item.Key] = item.Value %><% } %><%= data[active] %>|<%= count %>|<%= label %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"active": "second",
+		"items": []fastScriptPlanPair{
+			{Key: "first", Value: "A"},
+			{Key: "second", Value: "B"},
+		},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "B|2|firstsecond", out)
+}
+
+func Test_VM_Fast_Render_Receiver_Call_With_Arguments(t *testing.T) {
+	tmpl, err := Compile(`<%= builder.RenderControl({name: "Email", type: inputType}) %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"builder":   fastScriptPlanBuilder{},
+		"inputType": "text",
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "Email:text", out)
+}
+
+func Test_VM_Fast_Render_Receiver_Call_With_Scalar_And_Hash_Arguments(t *testing.T) {
+	tmpl, err := Compile(`<%= builder.RenderSelect("Level", {options: ["one", "two"], value: selected}) %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"builder":  fastScriptPlanBuilder{},
+		"selected": "two",
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "Level:2:two", out)
+}
+
+func Test_VM_Fast_Render_FormFor_Doc_Syntax_With_Helper_Block_Context(t *testing.T) {
+	tmpl, err := Compile(`<%= form_for(record, {action: recordPath({id: record.ID}), method: "PUT"}) { %><%= f.InputTag("Title") %>|<%= f.SelectTag("Level", {options: ["one", "two"], value: selected}) %>|<%= f.CheckboxTag("Enabled", {unchecked: false}) %><% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"record":   fastScriptPlanRecord{ID: 7},
+		"selected": "two",
+		"recordPath": func(data map[string]interface{}) string {
+			return fmt.Sprintf("/records/%v", data["id"])
+		},
+		"form_for": func(_ fastScriptPlanRecord, data map[string]interface{}, help plush.HelperContext) (template.HTML, error) {
+			child := help.New()
+			child.Set("f", fastScriptPlanBuilder{})
+			body, err := help.BlockWith(child)
+			if err != nil {
+				return "", err
+			}
+			return template.HTML(fmt.Sprintf(`<form action="%s" method="%s">%s</form>`, data["action"], data["method"], body)), nil
+		},
+	})
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `<form action="/records/7" method="PUT">input:Title|select:Level:2:two|check:Enabled:false</form>`, out)
+}
+
+func Test_VM_Fast_Render_Silent_Block_Helper_Discards_Return_And_Renders_Block(t *testing.T) {
+	tmpl, err := Compile(`<% capture("extra") { %><style><%= klass %></style><% } %><%= readCapture("extra") %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+	require.True(t, tmpl.bytecode.FastRenderPlan.Segments[0].BlockCall.Silent)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"klass": "online",
+		"capture": func(name string, help plush.HelperContext) (template.HTML, error) {
+			rendered, err := help.Block()
+			if err != nil {
+				return "", err
+			}
+			help.Set("capture:"+name, rendered)
+			return template.HTML("visible return should be discarded"), nil
+		},
+		"readCapture": func(name string, help plush.HelperContext) template.HTML {
+			value, _ := help.Value("capture:" + name).(string)
+			return template.HTML(value)
+		},
+	})
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "<style>online</style>", out)
+}
+
+func Test_VM_Fast_Render_Silent_Script_For_Discards_Output_And_Assigns(t *testing.T) {
+	tmpl, err := Compile(`<% let collected = [] %><% for (_, item) in items { %>ignored<%= item.Value %><% collected = collected + item.Value %><% } %><%= collected[1] %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+	require.True(t, tmpl.bytecode.FastRenderPlan.Segments[1].Loop.Silent)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"items": []struct {
+			Value string
+		}{
+			{Value: "first"},
+			{Value: "second"},
+		},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "second", out)
+}
+
+func Test_VM_Fast_Render_Block_Helper_Allows_Local_Assignment_Setup(t *testing.T) {
+	tmpl, err := Compile(`<%= wrap({}) { %><% let options = {} %><% for (_, item) in items { %><% options[item.Key] = item.Value %><% } %><%= builder.RenderControl({name: options[active], type: "hidden"}) %><% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan.Segments[0].BlockCall.BlockBytecode.FastRenderPlan)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"active":  "second",
+		"builder": fastScriptPlanBuilder{},
+		"items": []fastScriptPlanPair{
+			{Key: "first", Value: "A"},
+			{Key: "second", Value: "B"},
+		},
+		"wrap": func(_ map[string]interface{}, help plush.HelperContext) (template.HTML, error) {
+			rendered, err := help.Block()
+			return template.HTML("[" + rendered + "]"), err
+		},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "[B:hidden]", out)
+}
+
+func Test_VM_Fast_Render_Loop_Local_Assignment_Does_Not_Leak(t *testing.T) {
+	tmpl, err := Compile(`<% let out = "" %><%= for (_, item) in items { %><% let label = "" %><% label = item %><% out = out + label %><% } %><%= out %><%= if (label) { %>leak<% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	out, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"items": []string{"a", "b"},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "ab", out)
 }
 
 func Test_VM_Fast_Render_Prefix_Condition_And_Loop_Concat(t *testing.T) {
@@ -192,4 +435,237 @@ func Test_VM_Fast_Render_Silent_Script_If_Inside_Loop(t *testing.T) {
 	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
 	require.True(t, ok)
 	require.Equal(t, plush.RenderFastPathFast, diagnostics.FastPath)
+}
+
+func Test_VM_Fast_Render_Regex_And_NonString_Hash_Keys(t *testing.T) {
+	tmpl, err := Compile(`<%= name ~= "^Mi" %>|<%= {true: "yes", 7: "lucky"}[true] %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name": "Mido",
+	})
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "true|yes", out)
+
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, plush.RenderFastPathFast, diagnostics.FastPath)
+	require.Empty(t, diagnostics.FastReject)
+}
+
+func Test_VM_Fast_Render_Identifier_With_Digits_Unary_Minus(t *testing.T) {
+	tmpl, err := Compile(`<%= -my123greet %>|<%= -my123greet + 10 %>|<%= -my123greet - 10 %>|<%= -my123greet + my123greet2 %>|<%= -my123int64 + my123float64 %>|<%= -my123int %>|<%= -my123count + 1 %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+	require.Equal(t, []string{"my123greet", "my123greet2", "my123int64", "my123float64", "my123int", "my123count"}, tmpl.bytecode.FastRenderPlan.Bindings)
+	require.Equal(t, compiler.FastValuePrefix, tmpl.bytecode.FastRenderPlan.Segments[0].ValuePlan.Kind)
+	require.Equal(t, "-", tmpl.bytecode.FastRenderPlan.Segments[0].ValuePlan.Operator)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"my123greet":   float64(5.5),
+		"my123greet2":  int64(-10),
+		"my123int64":   int64(10),
+		"my123float64": float64(5.5),
+		"my123int":     int(4),
+		"my123count":   int64(6),
+	})
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "-5.5|4.5|-15.5|-15.5|-4.5|-4|-5", out)
+
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, plush.RenderFastPathFast, diagnostics.FastPath)
+	require.Empty(t, diagnostics.FastReject)
+}
+
+func Test_VM_Fast_Render_Silent_Plain_Helper_Call_Discards_Return(t *testing.T) {
+	tmpl, err := Compile(`<% touch(name) %><%= done %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+	require.True(t, tmpl.bytecode.FastRenderPlan.Segments[0].Call.Silent)
+
+	calls := []string{}
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name": "Mido",
+		"done": "ok",
+		"touch": func(value string) string {
+			calls = append(calls, value)
+			return "hidden"
+		},
+	})
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "ok", out)
+	require.Equal(t, []string{"Mido"}, calls)
+
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, plush.RenderFastPathFast, diagnostics.FastPath)
+}
+
+func Test_VM_Fast_Render_Dynamic_Partial_Name_And_Layout(t *testing.T) {
+	tmpl, err := Compile(`<%= partial(templateName, {name: name, layout: layoutName}) %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+	require.Equal(t, compiler.FastRenderSegmentCall, tmpl.bytecode.FastRenderPlan.Segments[0].Kind)
+	require.Equal(t, "partial", tmpl.bytecode.FastRenderPlan.Segments[0].Call.Name)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"templateName": "row.plush",
+		"layoutName":   "shell.plush",
+		"name":         "Mido",
+		"partialFeeder": func(name string) (string, error) {
+			switch name {
+			case "row.plush":
+				return `<span><%= name %></span>`, nil
+			case "shell.plush":
+				return `<section><%= yield %></section>`, nil
+			default:
+				return "", fmt.Errorf("missing partial %s", name)
+			}
+		},
+	})
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "<section><span>Mido</span></section>", out)
+
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, plush.RenderFastPathFast, diagnostics.FastPath)
+}
+
+func Test_VM_Fast_Render_Dynamic_Callee_And_Chained_Receiver_Call(t *testing.T) {
+	tmpl, err := Compile(`<%= helpers[name]("x") %>|<%= makeUser(name).Render("short") %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"name": "echo",
+		"helpers": map[string]interface{}{
+			"echo": func(value string) string {
+				return "dyn:" + value
+			},
+		},
+		"makeUser": func(name string) fastScriptPlanUser {
+			return fastScriptPlanUser{Name: name}
+		},
+	})
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "dyn:x|short:echo", out)
+
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, plush.RenderFastPathFast, diagnostics.FastPath)
+}
+
+func Test_VM_Fast_Render_Loop_Registered_Helper_Context_Includes_Loop_Binding(t *testing.T) {
+	tmpl, err := Compile(`<%= for (_, block) in blocks { %><%= render(block.Type + ".plush.html", {settings: block}) %><% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"blocks": []fastScriptPlanRenderBlock{{Type: "product-option", BlockID: "test-1234"}},
+		"render": func(string, map[string]interface{}, plush.HelperContext) (template.HTML, error) {
+			return "", nil
+		},
+	})
+	SetFastHelper(ctx, "render", func(w FastWriter, args FastArgs) error {
+		fileName, ok := args.String(0)
+		if !ok {
+			return ErrFastUnsupported
+		}
+		rawData, ok := args.Raw(1)
+		if !ok {
+			return ErrFastUnsupported
+		}
+		data, ok := rawData.(map[string]interface{})
+		if !ok {
+			return ErrFastUnsupported
+		}
+		settings, ok := data["settings"].(fastScriptPlanRenderBlock)
+		if !ok {
+			return fmt.Errorf("%q: unknown identifier", "settings")
+		}
+		block, ok := w.Context().Value("block").(fastScriptPlanRenderBlock)
+		if !ok {
+			return fmt.Errorf("%q: unknown identifier", "block")
+		}
+		w.WriteHTMLString(fileName + "|" + settings.BlockID + "|" + block.BlockID)
+		return nil
+	})
+
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "product-option.plush.html|test-1234|test-1234", out)
+
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, plush.RenderFastPathFast, diagnostics.FastPath)
+	require.Empty(t, diagnostics.FastReject)
+}
+
+func Test_VM_Fast_Render_Output_If_Return_Nil_Loop_And_Iterator_Assignment(t *testing.T) {
+	tmpl, err := Compile(`<%= if active { return "yes" } %>after`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+	ctx := plush.NewContextWith(map[string]interface{}{"active": true})
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "yesafter", out)
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, plush.RenderFastPathFast, diagnostics.FastPath)
+
+	tmpl, err = Compile(`<%= for (_, item) in nil { %>x<% } %><%= for (_, item) in items { %><% item = "x" %><%= item %><% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+	ctx = plush.NewContextWith(map[string]interface{}{
+		"items": []string{"a", "b"},
+	})
+	out, err = tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "xx", out)
+
+	tmpl, err = Compile(`<%= for (_, value) in items { %><% if (value == 1) { %>P<% return "A" } %><%= value %><% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+	ctx = plush.NewContextWith(map[string]interface{}{
+		"items": []int{1, 2},
+	})
+	out, err = tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "PA2", out)
+}
+
+func Test_VM_Fast_Render_Function_Literal_Uses_Generic_VM_Not_Interpreter_Fallback(t *testing.T) {
+	tmpl, err := Compile(`<% let add = fn(x) { return x + 1 } %><%= add(2) %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan, tmpl.bytecode.FastReject)
+	require.Empty(t, tmpl.bytecode.FastReject)
+
+	ctx := plush.NewContext()
+	out, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "3", out)
+
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, plush.RenderFastPathGeneric, diagnostics.FastPath)
+	require.NotEqual(t, plush.RenderFastPathInterpreterFallback, diagnostics.FastPath)
+	require.Empty(t, diagnostics.FastReject)
 }

--- a/vm/vm/fast_struct_loops.go
+++ b/vm/vm/fast_struct_loops.go
@@ -108,7 +108,7 @@ func renderFastStructLoopWriterOps(out *strings.Builder, ctx hctx.Context, bindi
 				return err
 			}
 		case fastStructLoopWriterCall:
-			if err := writeFastStructLoopCallPart(out, ctx, bindings, state, op.call, key, item); err != nil {
+			if err := writeFastStructLoopCallPartWithLoop(out, ctx, bindings, state, loop, op.call, key, item); err != nil {
 				return err
 			}
 		case fastStructLoopWriterConditional:
@@ -154,6 +154,10 @@ func isTruthyFastStructLoopCondition(branch *fastStructLoopConditionalWriterBran
 }
 
 func writeFastStructLoopCallPart(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, state *fastStructLoopRenderState, plan *fastStructLoopCallPlan, loopKey interface{}, item reflect.Value) error {
+	return writeFastStructLoopCallPartWithLoop(out, ctx, bindings, state, nil, plan, loopKey, item)
+}
+
+func writeFastStructLoopCallPartWithLoop(out *strings.Builder, ctx hctx.Context, bindings fastRenderBindings, state *fastStructLoopRenderState, loop *compiler.FastLoopPlan, plan *fastStructLoopCallPlan, loopKey interface{}, item reflect.Value) error {
 	if plan == nil || plan.call == nil {
 		return nil
 	}
@@ -169,6 +173,13 @@ func writeFastStructLoopCallPart(out *strings.Builder, ctx hctx.Context, binding
 
 	var args fastCallArgs
 	argsReady := false
+	var scopedCtx hctx.Context
+	callCtx := func() hctx.Context {
+		if scopedCtx == nil {
+			scopedCtx = fastLoopBlockContext(ctx, bindings, loop, loopKey, fastStructLoopItemValue(item))
+		}
+		return scopedCtx
+	}
 	if helper, ok := fastHelperForContext(ctx, call.Name); ok {
 		if len(plan.args) > 0 {
 			if err := evalFastStructLoopCallPlanArgs(plan, ctx, bindings, loopKey, item, &args); err != nil {
@@ -176,7 +187,7 @@ func writeFastStructLoopCallPart(out *strings.Builder, ctx hctx.Context, binding
 			}
 			argsReady = true
 		}
-		if handled, err := writeRegisteredFastHelperNamed(out, ctx, call.Name, helper, fastCallArgsOrNil(&args, len(plan.args))); handled || err != nil {
+		if handled, err := writeRegisteredFastHelperNamed(out, callCtx(), call.Name, helper, fastCallArgsOrNil(&args, len(plan.args))); handled || err != nil {
 			if err != nil {
 				return fastLineError(call.Line, err)
 			}
@@ -219,10 +230,42 @@ func writeFastStructLoopCallPart(out *strings.Builder, ctx hctx.Context, binding
 		}
 		argsReady = true
 	}
-	if err := writeFastCallValueWithEntry(out, ctx, call.Name, resolved.raw, fastCallArgsOrNil(&args, len(plan.args)), resolved.entry); err != nil {
+	if err := writeFastCallValueWithEntry(out, fastStructLoopHelperContext(ctx, callCtx, resolved.entry, len(plan.args)), call.Name, resolved.raw, fastCallArgsOrNil(&args, len(plan.args)), resolved.entry); err != nil {
 		return fastLineError(call.Line, err)
 	}
 	return nil
+}
+
+func fastStructLoopHelperContext(ctx hctx.Context, scoped func() hctx.Context, entry *fastBuilderCallCacheEntry, argCount int) hctx.Context {
+	if fastStructLoopCallNeedsHelperContext(entry, argCount) {
+		return scoped()
+	}
+	return ctx
+}
+
+func fastStructLoopCallNeedsHelperContext(entry *fastBuilderCallCacheEntry, argCount int) bool {
+	if entry == nil || entry.plan == nil || entry.plan.isVariadic || argCount >= entry.plan.numIn {
+		return false
+	}
+	for pos := argCount; pos < entry.plan.numIn; pos++ {
+		if entry.plan.optionalArgs[pos] == optionalArgHelperContext {
+			return true
+		}
+	}
+	return false
+}
+
+func fastStructLoopItemValue(item reflect.Value) interface{} {
+	if !item.IsValid() || isNilReflectValue(item) {
+		return nil
+	}
+	if item.Kind() == reflect.Interface {
+		item = item.Elem()
+	}
+	if !item.IsValid() || !item.CanInterface() {
+		return nil
+	}
+	return item.Interface()
 }
 
 func fastCallArgsOrNil(args *fastCallArgs, count int) *fastCallArgs {
@@ -704,6 +747,8 @@ func evalFastStructLoopValue(value *compiler.FastValuePlan, ctx hctx.Context, bi
 		return evalFastStructLoopPrefixValue(value, ctx, bindings, loopKey, item)
 	case compiler.FastValueConcat:
 		return evalFastStructLoopConcatValue(value, ctx, bindings, loopKey, item)
+	case compiler.FastValueCall, compiler.FastValueArray, compiler.FastValueHash, compiler.FastValueIndex:
+		return evalFastLoopValue(value, ctx, bindings, loopKey, fastStructLoopItemValue(item))
 	case compiler.FastValuePath:
 		if value.NameIndex >= 0 {
 			return evalFastValue(value, ctx, bindings, nil)
@@ -771,7 +816,7 @@ func evalFastStructLoopPathValue(value *compiler.FastValuePlan, ctx hctx.Context
 		return nil, true, nil
 	}
 	if len(value.Path) == 0 {
-		return fastReflectInterface(rv), true, nil
+		return fastStructLoopItemValue(item), true, nil
 	}
 	if chain, ok := fastAccessChainPlanFor(value, rv.Type()); ok {
 		return evalFastAccessChainPlanValue(chain, rv, ctx)

--- a/vm/vm/fast_struct_loops.go
+++ b/vm/vm/fast_struct_loops.go
@@ -414,6 +414,9 @@ func fastStructLoopCallArgStatic(kind fastStructLoopCallArgKind) bool {
 func evalFastStructLoopStaticCallArgReflect(plan *fastStructLoopCallArgPlan, bindings fastRenderBindings, expected reflect.Type, name string, pos int) (reflect.Value, error) {
 	value, ok := evalFastStructLoopStaticCallArgValue(plan, bindings)
 	if !ok {
+		if plan.value.NullOnMissing {
+			return reflect.Zero(expected), nil
+		}
 		return reflect.Value{}, fastLineError(plan.line, fmt.Errorf("%q: unknown identifier", plan.value.Value))
 	}
 	return fastReflectArgForCall(name, pos, value, expected)
@@ -509,6 +512,10 @@ func evalFastStructLoopCallPlanArgs(plan *fastStructLoopCallPlan, ctx hctx.Conte
 			return err
 		}
 		if !ok {
+			if plan.args[i].value.NullOnMissing {
+				args.Append(nil)
+				continue
+			}
 			return fastLineError(plan.args[i].line, fmt.Errorf("%q: unknown identifier", plan.args[i].value.Value))
 		}
 		args.Append(value)
@@ -709,6 +716,9 @@ func evalFastStructLoopCallArgReflect(plan *fastStructLoopCallArgPlan, ctx hctx.
 			return reflect.Value{}, err
 		}
 		if !ok {
+			if plan.value.NullOnMissing {
+				return reflect.Zero(expected), nil
+			}
 			return reflect.Value{}, fastLineError(plan.line, fmt.Errorf("%q: unknown identifier", plan.value.Value))
 		}
 		return fastReflectArgForCall(name, pos, value, expected)

--- a/vm/vm/fast_types.go
+++ b/vm/vm/fast_types.go
@@ -286,6 +286,8 @@ const (
 	fastMixedOpLoop
 	fastMixedOpLet
 	fastMixedOpAssign
+	fastMixedOpReturn
+	fastMixedOpGeneric
 )
 
 type fastMixedPlan struct {
@@ -312,6 +314,8 @@ type fastMixedOp struct {
 	blockCall     *compiler.FastBlockCallPlan
 	conditional   *compiler.FastConditionalPlan
 	partial       *compiler.FastPartialPlan
+	generic       *compiler.FastGenericPlan
+	assignTarget  *compiler.FastAssignTarget
 	partialData   *fastPartialDataBindingPlan
 	simpleCond    *fastSimpleConditionalPlan
 	accessCache   object.InlineCacheSlot

--- a/vm/vm/fast_values.go
+++ b/vm/vm/fast_values.go
@@ -1732,6 +1732,10 @@ func evalFastPathStepWithBindings(base interface{}, step *compiler.FastPathStep,
 					return nil, err
 				}
 				if !ok {
+					if step.Args[i].NullOnMissing {
+						argStore.Append(nil)
+						continue
+					}
 					return nil, fastLineError(step.Args[i].Line, fmt.Errorf("%q: unknown identifier", fastValueMissingName(&step.Args[i])))
 				}
 				argStore.Append(arg)

--- a/vm/vm/fast_values.go
+++ b/vm/vm/fast_values.go
@@ -46,38 +46,23 @@ func evalFastValue(value *compiler.FastValuePlan, ctx hctx.Context, bindings fas
 	case compiler.FastValueConcat:
 		return evalFastConcatValue(value, ctx, bindings, nil, nil, base, false)
 	case compiler.FastValueCall:
-		return evalFastCallValuePlan(value.Call, nil, ctx, bindings, nil, nil, nil)
+		result, ok, err := evalFastCallValuePlan(value.Call, nil, ctx, bindings, nil, nil, nil)
+		if err != nil || !ok || len(value.Path) == 0 {
+			return result, ok, err
+		}
+		result, err = evalFastPathSteps(result, value.Path, ctx, bindings, nil, nil, false)
+		if err != nil {
+			return nil, true, err
+		}
+		return result, true, nil
 	case compiler.FastValueArray:
 		return evalFastArrayValue(value.Elements, ctx, bindings, base)
 	case compiler.FastValueHash:
 		return evalFastHashValue(value.Pairs, ctx, bindings, base)
 	case compiler.FastValuePath:
-		raw := base
-		if value.NameIndex >= 0 {
-			var ok bool
-			raw, ok = bindings.value(value.NameIndex)
-			if !ok {
-				if value.NullOnMissing {
-					return nil, true, nil
-				}
-				return nil, false, nil
-			}
-		}
-		if result, handled, err := evalFastFieldChainValue(value, raw, ctx); handled || err != nil {
-			return result, true, err
-		}
-		if result, handled, err := evalFastAccessChainValue(value, raw, ctx); handled || err != nil {
-			return result, true, err
-		}
-		for i := range value.Path {
-			step := &value.Path[i]
-			var err error
-			raw, err = evalFastPathStep(raw, step, ctx)
-			if err != nil {
-				return nil, true, err
-			}
-		}
-		return raw, true, nil
+		return evalFastPathValue(value, ctx, bindings, base, nil, nil, false)
+	case compiler.FastValueIndex:
+		return evalFastIndexPlanValue(value, ctx, bindings, nil, nil, base, false)
 	default:
 		return nil, false, nil
 	}
@@ -95,16 +80,38 @@ func evalFastArrayValue(elements []compiler.FastValuePlan, ctx hctx.Context, bin
 	return out, true, nil
 }
 
-func evalFastHashValue(pairs []compiler.FastValuePair, ctx hctx.Context, bindings fastRenderBindings, base interface{}) (map[string]interface{}, bool, error) {
-	out := make(map[string]interface{}, len(pairs))
+func evalFastHashValue(pairs []compiler.FastValuePair, ctx hctx.Context, bindings fastRenderBindings, base interface{}) (interface{}, bool, error) {
+	if fastValuePairsUseStaticStringKeys(pairs) {
+		out := make(map[string]interface{}, len(pairs))
+		for i := range pairs {
+			value, ok, err := evalFastValue(&pairs[i].Value, ctx, bindings, base)
+			if err != nil || !ok {
+				return nil, ok, err
+			}
+			out[pairs[i].Key] = value
+		}
+		return out, true, nil
+	}
+	out := make(map[object.HashKey]object.HashPair, len(pairs))
 	for i := range pairs {
 		value, ok, err := evalFastValue(&pairs[i].Value, ctx, bindings, base)
 		if err != nil || !ok {
 			return nil, ok, err
 		}
-		out[pairs[i].Key] = value
+		key, ok, err := evalFastHashPairKey(&pairs[i], ctx, bindings, base)
+		if err != nil || !ok {
+			return nil, ok, err
+		}
+		hashKey, ok := key.(object.Hashable)
+		if !ok {
+			return nil, true, fastLineError(pairs[i].Line, fmt.Errorf("unusable as hash key: %s", key.Type()))
+		}
+		out[hashKey.HashKey()] = object.HashPair{
+			Key:   key,
+			Value: object.Wrap(value),
+		}
 	}
-	return out, true, nil
+	return &object.Hash{Pairs: out}, true, nil
 }
 
 func evalFastLoopValue(value *compiler.FastValuePlan, ctx hctx.Context, bindings fastRenderBindings, loopKey, loopValue interface{}) (interface{}, bool, error) {
@@ -121,11 +128,23 @@ func evalFastLoopValue(value *compiler.FastValuePlan, ctx hctx.Context, bindings
 	case compiler.FastValueConcat:
 		return evalFastConcatValue(value, ctx, bindings, loopKey, loopValue, nil, true)
 	case compiler.FastValueCall:
-		return evalFastLoopCallValuePlan(value.Call, ctx, bindings, loopKey, loopValue)
+		result, ok, err := evalFastLoopCallValuePlan(value.Call, ctx, bindings, loopKey, loopValue)
+		if err != nil || !ok || len(value.Path) == 0 {
+			return result, ok, err
+		}
+		result, err = evalFastPathSteps(result, value.Path, ctx, bindings, loopKey, loopValue, true)
+		if err != nil {
+			return nil, true, err
+		}
+		return result, true, nil
 	case compiler.FastValueArray:
 		return evalFastLoopArrayValue(value.Elements, ctx, bindings, loopKey, loopValue)
 	case compiler.FastValueHash:
 		return evalFastLoopHashValue(value.Pairs, ctx, bindings, loopKey, loopValue)
+	case compiler.FastValuePath:
+		return evalFastPathValue(value, ctx, bindings, loopValue, loopKey, loopValue, true)
+	case compiler.FastValueIndex:
+		return evalFastIndexPlanValue(value, ctx, bindings, loopKey, loopValue, nil, true)
 	default:
 		return evalFastValue(value, ctx, bindings, loopValue)
 	}
@@ -143,16 +162,140 @@ func evalFastLoopArrayValue(elements []compiler.FastValuePlan, ctx hctx.Context,
 	return out, true, nil
 }
 
-func evalFastLoopHashValue(pairs []compiler.FastValuePair, ctx hctx.Context, bindings fastRenderBindings, loopKey, loopValue interface{}) (map[string]interface{}, bool, error) {
-	out := make(map[string]interface{}, len(pairs))
+func evalFastLoopHashValue(pairs []compiler.FastValuePair, ctx hctx.Context, bindings fastRenderBindings, loopKey, loopValue interface{}) (interface{}, bool, error) {
+	if fastValuePairsUseStaticStringKeys(pairs) {
+		out := make(map[string]interface{}, len(pairs))
+		for i := range pairs {
+			value, ok, err := evalFastLoopValue(&pairs[i].Value, ctx, bindings, loopKey, loopValue)
+			if err != nil || !ok {
+				return nil, ok, err
+			}
+			out[pairs[i].Key] = value
+		}
+		return out, true, nil
+	}
+	out := make(map[object.HashKey]object.HashPair, len(pairs))
 	for i := range pairs {
 		value, ok, err := evalFastLoopValue(&pairs[i].Value, ctx, bindings, loopKey, loopValue)
 		if err != nil || !ok {
 			return nil, ok, err
 		}
-		out[pairs[i].Key] = value
+		key, ok, err := evalFastLoopHashPairKey(&pairs[i], ctx, bindings, loopKey, loopValue)
+		if err != nil || !ok {
+			return nil, ok, err
+		}
+		hashKey, ok := key.(object.Hashable)
+		if !ok {
+			return nil, true, fastLineError(pairs[i].Line, fmt.Errorf("unusable as hash key: %s", key.Type()))
+		}
+		out[hashKey.HashKey()] = object.HashPair{
+			Key:   key,
+			Value: object.Wrap(value),
+		}
 	}
-	return out, true, nil
+	return &object.Hash{Pairs: out}, true, nil
+}
+
+func fastValuePairsUseStaticStringKeys(pairs []compiler.FastValuePair) bool {
+	for i := range pairs {
+		if pairs[i].KeyPlan != nil {
+			return false
+		}
+	}
+	return true
+}
+
+func evalFastHashPairKey(pair *compiler.FastValuePair, ctx hctx.Context, bindings fastRenderBindings, base interface{}) (object.Object, bool, error) {
+	if pair == nil {
+		return object.NullObject, true, nil
+	}
+	if pair.KeyPlan == nil {
+		return &object.String{Value: pair.Key}, true, nil
+	}
+	key, ok, err := evalFastValue(pair.KeyPlan, ctx, bindings, base)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+	return object.Wrap(key), true, nil
+}
+
+func evalFastLoopHashPairKey(pair *compiler.FastValuePair, ctx hctx.Context, bindings fastRenderBindings, loopKey, loopValue interface{}) (object.Object, bool, error) {
+	if pair == nil {
+		return object.NullObject, true, nil
+	}
+	if pair.KeyPlan == nil {
+		return &object.String{Value: pair.Key}, true, nil
+	}
+	key, ok, err := evalFastLoopValue(pair.KeyPlan, ctx, bindings, loopKey, loopValue)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+	return object.Wrap(key), true, nil
+}
+
+func evalFastPathValue(value *compiler.FastValuePlan, ctx hctx.Context, bindings fastRenderBindings, base interface{}, loopKey, loopValue interface{}, loopAware bool) (interface{}, bool, error) {
+	if value == nil || value.Kind != compiler.FastValuePath {
+		return nil, false, nil
+	}
+	raw := base
+	if value.NameIndex >= 0 {
+		var ok bool
+		raw, ok = bindings.value(value.NameIndex)
+		if !ok {
+			if value.NullOnMissing {
+				return nil, true, nil
+			}
+			return nil, false, nil
+		}
+	}
+	if !fastPathStepsNeedRuntimeBindings(value.Path) {
+		if result, handled, err := evalFastFieldChainValue(value, raw, ctx); handled || err != nil {
+			return result, true, err
+		}
+		if result, handled, err := evalFastAccessChainValue(value, raw, ctx); handled || err != nil {
+			return result, true, err
+		}
+	}
+	result, err := evalFastPathSteps(raw, value.Path, ctx, bindings, loopKey, loopValue, loopAware)
+	if err != nil {
+		return nil, true, err
+	}
+	return result, true, nil
+}
+
+func evalFastIndexPlanValue(value *compiler.FastValuePlan, ctx hctx.Context, bindings fastRenderBindings, loopKey, loopValue interface{}, base interface{}, loopAware bool) (interface{}, bool, error) {
+	if value == nil || value.Kind != compiler.FastValueIndex || value.Left == nil || value.Right == nil {
+		return nil, false, nil
+	}
+	left, ok, err := evalFastCompoundOperand(value.Left, ctx, bindings, loopKey, loopValue, base, loopAware)
+	if err != nil {
+		return nil, true, err
+	}
+	if !ok {
+		if value.NullOnMissing {
+			return nil, true, nil
+		}
+		return nil, false, nil
+	}
+	index, ok, err := evalFastCompoundOperand(value.Right, ctx, bindings, loopKey, loopValue, base, loopAware)
+	if err != nil {
+		return nil, true, err
+	}
+	if !ok {
+		return nil, false, nil
+	}
+	result, err := fastIndexGoValue(left, index)
+	if err != nil {
+		return nil, true, fastLineError(value.Line, err)
+	}
+	if len(value.Path) == 0 {
+		return result, true, nil
+	}
+	result, err = evalFastPathSteps(result, value.Path, ctx, bindings, loopKey, loopValue, loopAware)
+	if err != nil {
+		return nil, true, err
+	}
+	return result, true, nil
 }
 
 func evalFastLoopCallValuePlan(call *compiler.FastCallPlan, ctx hctx.Context, bindings fastRenderBindings, loopKey, loopValue interface{}) (interface{}, bool, error) {
@@ -182,14 +325,25 @@ func evalFastPrefixValue(value *compiler.FastValuePlan, ctx hctx.Context, bindin
 	if value == nil || value.Kind != compiler.FastValuePrefix || value.Right == nil {
 		return nil, false, nil
 	}
-	if value.Operator != "!" {
-		return nil, true, fastLineError(value.Line, fmt.Errorf("unknown fast prefix operator: %s", value.Operator))
-	}
 	right, ok, err := evalFastCompoundOperand(value.Right, ctx, bindings, loopKey, loopValue, base, loopAware)
 	if err != nil {
 		return nil, true, err
 	}
-	return !(ok && isTruthyFastValue(right)), true, nil
+	switch value.Operator {
+	case "!":
+		return !(ok && isTruthyFastValue(right)), true, nil
+	case "-":
+		if !ok {
+			right = nil
+		}
+		result, err := evalFastMinusOperator(right)
+		if err != nil {
+			return nil, true, fastLineError(value.Line, err)
+		}
+		return result, true, nil
+	default:
+		return nil, true, fastLineError(value.Line, fmt.Errorf("unknown fast prefix operator: %s", value.Operator))
+	}
 }
 
 func evalFastConcatValue(value *compiler.FastValuePlan, ctx hctx.Context, bindings fastRenderBindings, loopKey, loopValue, base interface{}, loopAware bool) (interface{}, bool, error) {
@@ -227,6 +381,9 @@ func evalFastCompoundOperand(value *compiler.FastValuePlan, ctx hctx.Context, bi
 func evalFastAddOperator(left, right interface{}) (interface{}, error) {
 	left = fastAddGoValue(left)
 	right = fastAddGoValue(right)
+	if appended, handled, err := fastNativeSliceAppend(left, right); handled || err != nil {
+		return appended, err
+	}
 	if _, ok := left.(string); ok {
 		return fmt.Sprint(left) + fmt.Sprint(right), nil
 	}
@@ -249,6 +406,31 @@ func evalFastAddOperator(left, right interface{}) (interface{}, error) {
 		}
 	}
 	return nil, fmt.Errorf("unable to operate (+) on %T and %T", left, right)
+}
+
+func fastNativeSliceAppend(left, right interface{}) (interface{}, bool, error) {
+	if left == nil {
+		return nil, false, nil
+	}
+	rv := reflect.ValueOf(left)
+	if rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			return nil, false, nil
+		}
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Slice {
+		return nil, false, nil
+	}
+	elem := rv.Type().Elem()
+	val := reflect.ValueOf(right)
+	if !val.IsValid() {
+		val = reflect.Zero(elem)
+	} else if elem.Kind() != reflect.Interface && !val.Type().AssignableTo(elem) {
+		return nil, true, fmt.Errorf("cannot append '%v' (untyped %s constant) as %s value in assignment", right, val.Type(), elem)
+	}
+	appended := reflect.Append(rv, val)
+	return appended.Interface(), true, nil
 }
 
 func fastAddGoValue(value interface{}) interface{} {
@@ -277,7 +459,8 @@ func evalFastInfixValue(value *compiler.FastValuePlan, ctx hctx.Context, binding
 	if err != nil {
 		return nil, true, err
 	}
-	if !ok {
+	leftOK := ok
+	if !leftOK {
 		left = nil
 	}
 	if loopAware {
@@ -288,14 +471,131 @@ func evalFastInfixValue(value *compiler.FastValuePlan, ctx hctx.Context, binding
 	if err != nil {
 		return nil, true, err
 	}
-	if !ok {
+	rightOK := ok
+	if !rightOK {
 		right = nil
 	}
 	result, err := evalFastInfixOperator(value.Operator, left, right)
 	if err != nil {
-		return nil, true, fastLineError(value.Line, err)
+		return nil, true, fastLineError(value.Line, annotateFastInfixError(value, leftOK, rightOK, left, right, err))
 	}
 	return result, true, nil
+}
+
+func annotateFastInfixError(value *compiler.FastValuePlan, leftOK, rightOK bool, left, right interface{}, err error) error {
+	if err == nil || value == nil {
+		return err
+	}
+	expression := fastValuePlanExpression(value)
+	if expression == "" {
+		return err
+	}
+	notes := make([]string, 0, 2)
+	if note := fastInfixNilOperandNote(value.Left, leftOK, left); note != "" {
+		notes = append(notes, note)
+	}
+	if note := fastInfixNilOperandNote(value.Right, rightOK, right); note != "" {
+		notes = append(notes, note)
+	}
+	if len(notes) == 0 {
+		return err
+	}
+	message := strings.TrimSpace(err.Error()) + " while evaluating " + expression + "; " + strings.Join(notes, "; ")
+	return fmt.Errorf("%s", message)
+}
+
+func fastInfixNilOperandNote(value *compiler.FastValuePlan, ok bool, raw interface{}) string {
+	if ok && !(fastConditionOperandValue{raw: raw}).isNil() {
+		return ""
+	}
+	name := fastValuePlanExpression(value)
+	if name == "" {
+		return ""
+	}
+	return name + " is nil or missing"
+}
+
+func fastValuePlanExpression(value *compiler.FastValuePlan) string {
+	if value == nil {
+		return ""
+	}
+	switch value.Kind {
+	case compiler.FastValueName, compiler.FastValueLoopKey:
+		return value.Value
+	case compiler.FastValueString:
+		return strconv.Quote(value.Value)
+	case compiler.FastValueInteger:
+		return strconv.FormatInt(value.IntValue, 10)
+	case compiler.FastValueFloat:
+		return strconv.FormatFloat(value.FloatValue, 'f', -1, 64)
+	case compiler.FastValueBool:
+		return strconv.FormatBool(value.BoolValue)
+	case compiler.FastValuePath:
+		return fastPathValueExpression(value)
+	case compiler.FastValueIndex:
+		return fastIndexValueExpression(value)
+	case compiler.FastValueInfix, compiler.FastValueConcat:
+		left := fastValuePlanExpression(value.Left)
+		right := fastValuePlanExpression(value.Right)
+		if left == "" || right == "" || value.Operator == "" {
+			return ""
+		}
+		return left + " " + value.Operator + " " + right
+	case compiler.FastValuePrefix:
+		right := fastValuePlanExpression(value.Right)
+		if right == "" {
+			return ""
+		}
+		return value.Operator + right
+	case compiler.FastValueCall:
+		if value.Call != nil && value.Call.Name != "" {
+			return value.Call.Name + "(...)"
+		}
+	}
+	return ""
+}
+
+func fastPathValueExpression(value *compiler.FastValuePlan) string {
+	if value == nil {
+		return ""
+	}
+	expression := value.Value
+	for i := range value.Path {
+		step := value.Path[i]
+		switch step.Kind {
+		case compiler.FastPathStepProperty:
+			if step.Full != "" {
+				expression = step.Full
+			} else if expression == "" {
+				expression = step.Value
+			} else {
+				expression += "." + step.Value
+			}
+		case compiler.FastPathStepIndexInteger:
+			expression += "[" + strconv.Itoa(step.Index) + "]"
+		case compiler.FastPathStepIndexString:
+			expression += "[" + strconv.Quote(step.Value) + "]"
+		case compiler.FastPathStepCall:
+			if expression == "" {
+				expression = step.Value + "()"
+			} else {
+				expression += "()"
+			}
+		}
+	}
+	return expression
+}
+
+func fastIndexValueExpression(value *compiler.FastValuePlan) string {
+	if value == nil {
+		return ""
+	}
+	left := fastValuePlanExpression(value.Left)
+	right := fastValuePlanExpression(value.Right)
+	if left == "" || right == "" {
+		return ""
+	}
+	return left + "[" + right + "]"
 }
 
 func evalFastLogicalInfixValue(value *compiler.FastValuePlan, ctx hctx.Context, bindings fastRenderBindings, loopKey, loopValue, base interface{}, loopAware bool) (interface{}, bool, error) {
@@ -356,11 +656,37 @@ func evalFastInfixOperator(operator string, left, right interface{}) (interface{
 		return evalFastConditionInfixOperator(operator, leftValue, rightValue)
 	case "<=":
 		return evalFastConditionInfixOperator(operator, leftValue, rightValue)
+	case "~=":
+		pattern := fmt.Sprint(fastAddGoValue(right))
+		re, err := cachedRegex(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't compile regex %s", fastAddGoValue(right))
+		}
+		return re.MatchString(fmt.Sprint(fastAddGoValue(left))), nil
 	case "-", "*", "/":
 		return evalFastNumericArithmeticOperator(operator, left, right)
 	default:
 		return nil, fmt.Errorf("unknown fast infix operator: %s", operator)
 	}
+}
+
+func evalFastMinusOperator(value interface{}) (interface{}, error) {
+	value = fastAddGoValue(value)
+	if f, ok := value.(float32); ok {
+		return -float64(f), nil
+	}
+	if f, ok := value.(float64); ok {
+		return -f, nil
+	}
+	n, ok := numericValueFromGo(value)
+	if !ok {
+		return nil, fmt.Errorf("unsupported type for negation: %T", value)
+	}
+	i, ok := n.int64()
+	if !ok {
+		return nil, fmt.Errorf("unsupported type for negation: %T", value)
+	}
+	return -i, nil
 }
 
 func evalFastNumericArithmeticOperator(operator string, left, right interface{}) (interface{}, error) {
@@ -451,12 +777,14 @@ func canUseFastTopLevelAccessChain(value *compiler.FastValuePlan) bool {
 		case compiler.FastPathStepProperty:
 			if step.Method {
 				return i == len(value.Path)-2 &&
-					value.Path[len(value.Path)-1].Kind == compiler.FastPathStepCall
+					value.Path[len(value.Path)-1].Kind == compiler.FastPathStepCall &&
+					len(value.Path[len(value.Path)-1].Args) == 0
 			}
 		case compiler.FastPathStepIndexInteger, compiler.FastPathStepIndexString:
 			continue
 		case compiler.FastPathStepCall:
 			return i == len(value.Path)-1 &&
+				len(step.Args) == 0 &&
 				i > 0 &&
 				value.Path[i-1].Kind == compiler.FastPathStepProperty &&
 				value.Path[i-1].Method
@@ -1337,7 +1665,34 @@ func fieldAccessError(receiver, full, name string) error {
 	return fmt.Errorf("cannot return value obtained from unexported field or method '%s'", name)
 }
 
+func fastPathStepsNeedRuntimeBindings(steps []compiler.FastPathStep) bool {
+	for i := range steps {
+		step := &steps[i]
+		if len(step.Args) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func evalFastPathSteps(base interface{}, steps []compiler.FastPathStep, ctx hctx.Context, bindings fastRenderBindings, loopKey, loopValue interface{}, loopAware bool) (interface{}, error) {
+	raw := base
+	for i := range steps {
+		step := &steps[i]
+		var err error
+		raw, err = evalFastPathStepWithBindings(raw, step, ctx, bindings, loopKey, loopValue, loopAware)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return raw, nil
+}
+
 func evalFastPathStep(base interface{}, step *compiler.FastPathStep, ctx hctx.Context) (interface{}, error) {
+	return evalFastPathStepWithBindings(base, step, ctx, fastRenderBindings{}, nil, nil, false)
+}
+
+func evalFastPathStepWithBindings(base interface{}, step *compiler.FastPathStep, ctx hctx.Context, bindings fastRenderBindings, loopKey, loopValue interface{}, loopAware bool) (interface{}, error) {
 	switch step.Kind {
 	case compiler.FastPathStepProperty:
 		if err := spendFastTraversal(ctx, step.Line); err != nil {
@@ -1368,7 +1723,22 @@ func evalFastPathStep(base interface{}, step *compiler.FastPathStep, ctx hctx.Co
 		if err := spendFastFunctionCall(ctx, step.Value, step.Line); err != nil {
 			return nil, err
 		}
-		value, err := fastCallValue(step.Value, base, nil, ctx, &step.CallCache)
+		var args *fastCallArgs
+		var argStore fastCallArgs
+		if len(step.Args) > 0 {
+			for i := range step.Args {
+				arg, ok, err := evalFastCompoundOperand(&step.Args[i], ctx, bindings, loopKey, loopValue, nil, loopAware)
+				if err != nil {
+					return nil, err
+				}
+				if !ok {
+					return nil, fastLineError(step.Args[i].Line, fmt.Errorf("%q: unknown identifier", fastValueMissingName(&step.Args[i])))
+				}
+				argStore.Append(arg)
+			}
+			args = &argStore
+		}
+		value, err := fastCallValue(step.Value, base, args, ctx, &step.CallCache)
 		if err != nil {
 			return nil, fastLineError(step.Line, err)
 		}
@@ -1474,4 +1844,209 @@ func fastStringIndexValue(left interface{}, index string) (interface{}, error) {
 	default:
 		return nil, fmt.Errorf("could not index %T with %T", left, index)
 	}
+}
+
+func fastIndexGoValue(left, index interface{}) (interface{}, error) {
+	switch index := index.(type) {
+	case int:
+		return fastIndexValue(left, index)
+	case int8:
+		return fastIndexValue(left, int(index))
+	case int16:
+		return fastIndexValue(left, int(index))
+	case int32:
+		return fastIndexValue(left, int(index))
+	case int64:
+		return fastIndexValue(left, int(index))
+	case uint:
+		return fastIndexValue(left, int(index))
+	case uint8:
+		return fastIndexValue(left, int(index))
+	case uint16:
+		return fastIndexValue(left, int(index))
+	case uint32:
+		return fastIndexValue(left, int(index))
+	case uint64:
+		return fastIndexValue(left, int(index))
+	case string:
+		return fastStringIndexValue(left, index)
+	}
+	if obj, ok := left.(object.Object); ok {
+		switch obj := obj.(type) {
+		case *object.Hash:
+			key := object.Wrap(index)
+			hashKey, ok := key.(object.Hashable)
+			if !ok {
+				return nil, fmt.Errorf("unusable as hash key: %s", key.Type())
+			}
+			if pair, ok := obj.Pairs[hashKey.HashKey()]; ok {
+				return object.ToGo(pair.Value), nil
+			}
+			return nil, nil
+		default:
+			left = object.ToGo(obj)
+		}
+	}
+	rv, nilValue, ok := fastIndexRootValue(left)
+	if nilValue {
+		return nil, nil
+	}
+	if !ok {
+		return nil, fmt.Errorf("could not index %T with %T", left, index)
+	}
+	if rv.Kind() != reflect.Map {
+		return nil, fmt.Errorf("can't access Slice/Array with a non int Index (%v)", index)
+	}
+	key, err := fastReflectMapKey(rv.Type().Key(), index)
+	if err != nil {
+		return nil, err
+	}
+	val := rv.MapIndex(key)
+	if !val.IsValid() {
+		return nil, nil
+	}
+	return fastReflectInterface(val), nil
+}
+
+func setFastIndexGoValue(left, index, value interface{}) error {
+	raw := left
+	switch left := raw.(type) {
+	case *object.Array:
+		i, ok := toInt(object.Wrap(index))
+		if !ok {
+			return fmt.Errorf("can't access Slice/Array with a non int Index (%v)", index)
+		}
+		if i < 0 || int(i) >= len(left.Elements) {
+			return fmt.Errorf("array index out of bounds, got index %d, while array size is %d", i, len(left.Elements))
+		}
+		left.Elements[int(i)] = object.Wrap(value)
+		return nil
+	case *object.Hash:
+		key := object.Wrap(index)
+		hashKey, ok := key.(object.Hashable)
+		if !ok {
+			return fmt.Errorf("unusable as hash key: %s", key.Type())
+		}
+		left.Pairs[hashKey.HashKey()] = object.HashPair{Key: key, Value: object.Wrap(value)}
+		return nil
+	case object.Object:
+		raw = object.ToGo(left)
+	}
+	rv, nilValue, ok := fastIndexRootValue(raw)
+	if nilValue || !ok {
+		return fmt.Errorf("could not index %T with %T", raw, index)
+	}
+	switch rv.Kind() {
+	case reflect.Map:
+		key, err := fastReflectMapKey(rv.Type().Key(), index)
+		if err != nil {
+			return err
+		}
+		val, err := fastReflectAssignableValue(value, rv.Type().Elem())
+		if err != nil {
+			return err
+		}
+		rv.SetMapIndex(key, val)
+		return nil
+	case reflect.Array, reflect.Slice:
+		i, ok := fastReflectIndexInt(index)
+		if !ok {
+			return fmt.Errorf("can't access Slice/Array with a non int Index (%v)", index)
+		}
+		if i < 0 || rv.Len()-1 < i {
+			return fmt.Errorf("array index out of bounds, got index %d, while array size is %d", i, rv.Len())
+		}
+		slot := rv.Index(i)
+		if !slot.CanSet() {
+			return fmt.Errorf("cannot assign to index %d of %T", i, raw)
+		}
+		val, err := fastReflectAssignableValue(value, slot.Type())
+		if err != nil {
+			return err
+		}
+		slot.Set(val)
+		return nil
+	default:
+		return fmt.Errorf("could not index %T with %T", raw, index)
+	}
+}
+
+func fastIndexRootValue(raw interface{}) (reflect.Value, bool, bool) {
+	if raw == nil {
+		return reflect.Value{}, true, true
+	}
+	rv := reflect.ValueOf(raw)
+	rv = unwrapFastFieldChainValue(rv)
+	if !rv.IsValid() {
+		return reflect.Value{}, true, true
+	}
+	switch rv.Kind() {
+	case reflect.Array, reflect.Slice, reflect.Map:
+		return rv, false, true
+	default:
+		return reflect.Value{}, false, false
+	}
+}
+
+func fastReflectMapKey(keyType reflect.Type, index interface{}) (reflect.Value, error) {
+	key := reflect.ValueOf(index)
+	if !key.IsValid() {
+		return reflect.Value{}, fmt.Errorf("cannot use <nil> as %s value in map index", keyType)
+	}
+	if key.Type().AssignableTo(keyType) {
+		return key, nil
+	}
+	if key.Type().ConvertibleTo(keyType) {
+		return key.Convert(keyType), nil
+	}
+	if keyType.Kind() != reflect.Interface && key.Kind() != keyType.Kind() {
+		return reflect.Value{}, fmt.Errorf("cannot use %v (%s constant) as %s value in map index", index, key.Kind().String(), keyType.String())
+	}
+	return reflect.Value{}, fmt.Errorf("cannot use %v (%s constant) as %s value in map index", index, key.Type().String(), keyType.String())
+}
+
+func fastReflectIndexInt(index interface{}) (int, bool) {
+	switch index := index.(type) {
+	case int:
+		return index, true
+	case int8:
+		return int(index), true
+	case int16:
+		return int(index), true
+	case int32:
+		return int(index), true
+	case int64:
+		return int(index), true
+	case uint:
+		return int(index), true
+	case uint8:
+		return int(index), true
+	case uint16:
+		return int(index), true
+	case uint32:
+		return int(index), true
+	case uint64:
+		return int(index), true
+	default:
+		return 0, false
+	}
+}
+
+func fastReflectAssignableValue(value interface{}, target reflect.Type) (reflect.Value, error) {
+	if value == nil {
+		switch target.Kind() {
+		case reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice, reflect.Func:
+			return reflect.Zero(target), nil
+		default:
+			return reflect.Value{}, fmt.Errorf("cannot use '<nil>' as %s value in assignment", target)
+		}
+	}
+	val := reflect.ValueOf(value)
+	if val.Type().AssignableTo(target) {
+		return val, nil
+	}
+	if val.Type().ConvertibleTo(target) {
+		return val.Convert(target), nil
+	}
+	return reflect.Value{}, fmt.Errorf("cannot use '%v' (untyped %s constant) as %s value in assignment", value, val.Type(), target)
 }

--- a/vm/vm/loop_size.go
+++ b/vm/vm/loop_size.go
@@ -1,0 +1,107 @@
+package vm
+
+import (
+	"strings"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+	"github.com/gobuffalo/plush/v5/vm/compiler"
+)
+
+const fastLoopMaxGrow = 256 << 10
+
+type fastLoopSizeObservation struct {
+	available           bool
+	itemCountKnown      bool
+	learnedBytesPerItem int
+	samplesBefore       uint64
+	growHint            int
+	limited             bool
+	growCalled          bool
+	growAllocated       int
+}
+
+func fastLoopGrowHint(loop *compiler.FastLoopPlan, itemCount int) int {
+	if !plush.OutputSizeEstimatorEnabled() || loop == nil || loop.Silent || loop.SizeStats == nil || loop.SizeStats.Samples() == 0 || itemCount <= 0 {
+		return 0
+	}
+	bytesPerItem := loop.SizeStats.BytesPerItem()
+	if bytesPerItem <= 0 {
+		return 0
+	}
+	if itemCount > fastLoopMaxGrow/bytesPerItem {
+		return fastLoopMaxGrow
+	}
+	hint := itemCount * bytesPerItem
+	if hint > fastLoopMaxGrow {
+		return fastLoopMaxGrow
+	}
+	return hint
+}
+
+func growFastLoopOutput(out *strings.Builder, loop *compiler.FastLoopPlan, itemCount int) int {
+	if out == nil {
+		return 0
+	}
+	hint := fastLoopGrowHint(loop, itemCount)
+	if hint <= 0 || out.Cap()-out.Len() >= hint {
+		return 0
+	}
+	out.Grow(hint)
+	return hint
+}
+
+func beginFastLoopSizeObservation(out *strings.Builder, loop *compiler.FastLoopPlan, itemCount int, itemCountKnown bool) fastLoopSizeObservation {
+	if !plush.OutputSizeEstimatorEnabled() || loop == nil || loop.Silent || loop.SizeStats == nil {
+		return fastLoopSizeObservation{}
+	}
+	observation := fastLoopSizeObservation{
+		available:           true,
+		itemCountKnown:      itemCountKnown,
+		learnedBytesPerItem: loop.SizeStats.BytesPerItem(),
+		samplesBefore:       loop.SizeStats.Samples(),
+	}
+	if !itemCountKnown || itemCount <= 0 {
+		return observation
+	}
+	observation.growHint = fastLoopGrowHint(loop, itemCount)
+	observation.limited = fastLoopGrowLimited(observation.learnedBytesPerItem, itemCount)
+	if out == nil || observation.growHint <= 0 {
+		return observation
+	}
+	capacityBefore := out.Cap()
+	growFastLoopOutput(out, loop, itemCount)
+	observation.growAllocated = out.Cap() - capacityBefore
+	observation.growCalled = observation.growAllocated > 0
+	return observation
+}
+
+func fastLoopGrowLimited(bytesPerItem, itemCount int) bool {
+	if bytesPerItem <= 0 || itemCount <= 0 {
+		return false
+	}
+	return itemCount > fastLoopMaxGrow/bytesPerItem
+}
+
+func observeFastLoopOutput(ctx hctx.Context, loop *compiler.FastLoopPlan, producedBytes, renderedItems int, observation fastLoopSizeObservation) {
+	if !observation.available || !plush.OutputSizeEstimatorEnabled() || loop == nil || loop.Silent || loop.SizeStats == nil || producedBytes < 0 || renderedItems <= 0 {
+		return
+	}
+	loop.SizeStats.Observe(producedBytes / renderedItems)
+	plush.AddRenderDiagnosticLoopOutput(
+		ctx,
+		loop.IterableName,
+		loop.Line,
+		renderedItems,
+		observation.learnedBytesPerItem,
+		observation.growHint,
+		producedBytes,
+		loop.SizeStats.BytesPerItem(),
+		observation.samplesBefore,
+		loop.SizeStats.Samples(),
+		observation.itemCountKnown,
+		observation.limited,
+		observation.growCalled,
+		observation.growAllocated,
+	)
+}

--- a/vm/vm/loop_size_test.go
+++ b/vm/vm/loop_size_test.go
@@ -1,0 +1,191 @@
+package vm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/vm/compiler"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_VM_Fast_Loop_Size_Learns_And_Predicts(t *testing.T) {
+	tmpl, err := Compile(`<%= for (_, item) in items { %><li><%= item %></li><% } %>`)
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
+	require.Len(t, tmpl.bytecode.FastRenderPlan.Segments, 1)
+
+	loop := tmpl.bytecode.FastRenderPlan.Segments[0].Loop
+	require.NotNil(t, loop)
+	require.NotNil(t, loop.SizeStats)
+
+	items := []string{"aaaa", "bbbb"}
+	firstCtx := plush.NewContextWith(map[string]interface{}{"items": items})
+	rendered, err := tmpl.Render(firstCtx)
+	require.NoError(t, err)
+	require.Equal(t, "<li>aaaa</li><li>bbbb</li>", rendered)
+	require.Equal(t, uint64(1), loop.SizeStats.Samples())
+	require.Equal(t, len(rendered)/len(items), loop.SizeStats.BytesPerItem())
+	require.Equal(t, 100*loop.SizeStats.BytesPerItem(), fastLoopGrowHint(loop, 100))
+	firstDiagnostics, ok := plush.RenderDiagnosticsFromContext(firstCtx)
+	require.True(t, ok)
+	require.Equal(t, 1, firstDiagnostics.LoopOutput.Calls)
+	require.Equal(t, len(items), firstDiagnostics.LoopOutput.Items)
+	require.Equal(t, 1, firstDiagnostics.LoopOutput.KnownCount)
+	require.Zero(t, firstDiagnostics.LoopOutput.Learned)
+	require.Equal(t, len(rendered), firstDiagnostics.LoopOutput.Actual)
+	require.Len(t, firstDiagnostics.LoopOutput.Details, 1)
+	require.Equal(t, "items", firstDiagnostics.LoopOutput.Details[0].Name)
+	require.Zero(t, firstDiagnostics.LoopOutput.Details[0].SamplesBefore)
+	require.Equal(t, uint64(1), firstDiagnostics.LoopOutput.Details[0].SamplesAfter)
+	require.Equal(t, len(rendered)/len(items), firstDiagnostics.LoopOutput.Details[0].EstimateBytesPerItem)
+
+	manyItems := make([]string, 100)
+	for i := range manyItems {
+		manyItems[i] = "cccc"
+	}
+	secondCtx := plush.NewContextWith(map[string]interface{}{"items": manyItems})
+	rendered, err = tmpl.Render(secondCtx)
+	require.NoError(t, err)
+	require.Len(t, rendered, len(manyItems)*len("<li>cccc</li>"))
+	require.Equal(t, uint64(2), loop.SizeStats.Samples())
+	require.Equal(t, len("<li>cccc</li>"), loop.SizeStats.BytesPerItem())
+	secondDiagnostics, ok := plush.RenderDiagnosticsFromContext(secondCtx)
+	require.True(t, ok)
+	require.Equal(t, 1, secondDiagnostics.LoopOutput.Calls)
+	require.Equal(t, len(manyItems), secondDiagnostics.LoopOutput.Items)
+	require.Equal(t, len(rendered), secondDiagnostics.LoopOutput.Learned)
+	require.Equal(t, len(rendered), secondDiagnostics.LoopOutput.Actual)
+	require.Equal(t, 1, secondDiagnostics.LoopOutput.WithinTen)
+	require.Equal(t, len(rendered), secondDiagnostics.LoopOutput.GrowHint)
+	require.Len(t, secondDiagnostics.LoopOutput.Details, 1)
+	require.Equal(t, uint64(1), secondDiagnostics.LoopOutput.Details[0].SamplesBefore)
+	require.Equal(t, uint64(2), secondDiagnostics.LoopOutput.Details[0].SamplesAfter)
+}
+
+func Test_VM_Fast_Loop_Size_Grow_Uses_Remaining_Capacity_And_Cap(t *testing.T) {
+	stats := &compiler.LoopSizeStats{}
+	stats.Observe(1024)
+	loop := &compiler.FastLoopPlan{SizeStats: stats}
+
+	var out strings.Builder
+	out.WriteString("prefix")
+	require.Equal(t, fastLoopMaxGrow, fastLoopGrowHint(loop, 1000))
+	require.Equal(t, fastLoopMaxGrow, growFastLoopOutput(&out, loop, 1000))
+	require.GreaterOrEqual(t, out.Cap()-out.Len(), fastLoopMaxGrow)
+	require.Zero(t, growFastLoopOutput(&out, loop, 1000))
+}
+
+func Test_VM_Fast_Loop_Size_Counts_Break_And_Continue_Iterations(t *testing.T) {
+	type item struct {
+		Name string
+		Skip bool
+		Stop bool
+	}
+	tmpl, err := Compile(`<%= for (_, item) in items { %>xx<%= if item.Stop { %><%= break %><% } %><%= if item.Skip { %><%= continue %><% } %><%= item.Name %><% } %>`)
+	require.NoError(t, err)
+	loop := tmpl.bytecode.FastRenderPlan.Segments[0].Loop
+	require.NotNil(t, loop)
+
+	rendered, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"items": []item{
+			{Name: "A"},
+			{Name: "B", Skip: true},
+			{Name: "C", Stop: true},
+			{Name: "D"},
+		},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "xxAxxxx", rendered)
+	require.Equal(t, uint64(1), loop.SizeStats.Samples())
+	require.Equal(t, len(rendered)/3, loop.SizeStats.BytesPerItem())
+}
+
+func Test_VM_Fast_Loop_Size_Nested_Loops_Learn_Independently(t *testing.T) {
+	type group struct {
+		Values []string
+	}
+	tmpl, err := Compile(`<%= for (_, group) in groups { %>[<%= for (_, value) in group.Values { %><%= value %>,<% } %>]<% } %>`)
+	require.NoError(t, err)
+	outer := tmpl.bytecode.FastRenderPlan.Segments[0].Loop
+	require.NotNil(t, outer)
+
+	var inner *compiler.FastLoopPlan
+	for i := range outer.Parts {
+		if outer.Parts[i].Kind == compiler.FastLoopPartLoop {
+			inner = outer.Parts[i].Loop
+			break
+		}
+	}
+	require.NotNil(t, inner)
+
+	rendered, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"groups": []group{{Values: []string{"a", "b"}}, {Values: []string{"c"}}},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "[a,b,][c,]", rendered)
+	require.Equal(t, uint64(1), outer.SizeStats.Samples())
+	require.Equal(t, uint64(2), inner.SizeStats.Samples())
+}
+
+func Test_VM_Fast_Loop_Size_Does_Not_Learn_From_Failed_Render(t *testing.T) {
+	type item struct {
+		Name string
+	}
+	tmpl, err := Compile(`<%= for (_, item) in items { %><%= item.Missing %><% } %>`)
+	require.NoError(t, err)
+	loop := tmpl.bytecode.FastRenderPlan.Segments[0].Loop
+	require.NotNil(t, loop)
+
+	_, err = tmpl.Render(plush.NewContextWith(map[string]interface{}{
+		"items": []item{{Name: "A"}},
+	}))
+	require.Error(t, err)
+	require.Zero(t, loop.SizeStats.Samples())
+}
+
+func Benchmark_VM_Fast_Loop_Size_Grow(b *testing.B) {
+	items := make([]string, 1000)
+	for i := range items {
+		items[i] = strings.Repeat("x", 64)
+	}
+	ctx := plush.NewContextWith(map[string]interface{}{"items": items})
+	plan := &compiler.FastRenderPlan{Bindings: []string{"items"}}
+	bindings := newFastRenderBindings(plan, ctx)
+	bytesPerItem := len("<li></li>") + len(items[0])
+
+	for _, test := range []struct {
+		name     string
+		adaptive bool
+	}{
+		{name: "natural_growth"},
+		{name: "adaptive", adaptive: true},
+	} {
+		b.Run(test.name, func(b *testing.B) {
+			loop := &compiler.FastLoopPlan{
+				IterableName:      "items",
+				IterableNameIndex: 0,
+				Parts: []compiler.FastLoopPart{
+					{Kind: compiler.FastLoopPartStatic, Value: "<li>"},
+					{Kind: compiler.FastLoopPartValue},
+					{Kind: compiler.FastLoopPartStatic, Value: "</li>"},
+				},
+			}
+			if test.adaptive {
+				loop.SizeStats = &compiler.LoopSizeStats{}
+				loop.SizeStats.Observe(bytesPerItem)
+			}
+			b.ReportAllocs()
+			b.SetBytes(int64(bytesPerItem * len(items)))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				var out strings.Builder
+				handled, err := renderFastLoop(&out, ctx, bindings, loop)
+				if err != nil || !handled {
+					b.Fatalf("render fast loop: handled=%t err=%v", handled, err)
+				}
+				benchmarkSink = out.String()
+			}
+		})
+	}
+}

--- a/vm/vm/loops_context.go
+++ b/vm/vm/loops_context.go
@@ -17,9 +17,15 @@ func (vm *VM) executeFor(iterable object.Object, block *object.Closure, keyName,
 	oldCtx := vm.ctx
 	loopCtx := vm.ctx
 	if writeLoopContext && vm.ctx != nil {
-		loopCtx = vm.ctx.New()
+		loopCtx = vm.contextWithFrameLocals()
+		if loopCtx == nil || loopCtx == oldCtx {
+			loopCtx = vm.ctx.New()
+		}
 		vm.ctx = loopCtx
-		defer func() { vm.ctx = oldCtx }()
+		defer func() {
+			vm.syncFrameBindingsFromContext(loopCtx)
+			vm.ctx = oldCtx
+		}()
 	}
 
 	ret := []object.Object{}
@@ -500,10 +506,47 @@ func (vm *VM) syncContextBindingsFromContext(target hctx.Context, source hctx.Co
 
 	frame := vm.currentFrame()
 	if frame == nil || frame.cl == nil || frame.cl.Fn == nil || len(frame.cl.Fn.LocalNames) == 0 {
+		vm.syncDynamicContextBindingsFromContext(target, source, frame)
 		return
 	}
 	for _, name := range frame.cl.Fn.LocalNames {
 		syncContextBinding(target, source, name)
+	}
+	vm.syncDynamicContextBindingsFromContext(target, source, frame)
+}
+
+func (vm *VM) syncDynamicContextBindingsFromContext(target hctx.Context, source hctx.Context, frame *Frame) {
+	if vm == nil || target == nil || source == nil || frame == nil {
+		return
+	}
+	seen := map[string]struct{}{}
+	ins := frame.Instructions()
+	for i := 0; i < len(ins); {
+		op := code.Opcode(ins[i])
+		def, err := code.Lookup(byte(op))
+		if err != nil {
+			i++
+			continue
+		}
+		operands, read := code.ReadOperands(def, ins[i+1:])
+		if len(operands) > 0 && dynamicContextNameOpcode(op) {
+			name := vm.stringConstant(operands[0])
+			if _, ok := seen[name]; !ok {
+				syncContextBinding(target, source, name)
+				seen[name] = struct{}{}
+			}
+		}
+		i += 1 + read
+	}
+}
+
+func dynamicContextNameOpcode(op code.Opcode) bool {
+	switch op {
+	case code.OpGetName, code.OpGetNameOrNull, code.OpSetName, code.OpAssignName,
+		code.OpWriteName, code.OpWriteNameOrNull, code.OpWriteNameProperty, code.OpWriteNameCall:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/vm/vm/loops_context.go
+++ b/vm/vm/loops_context.go
@@ -220,7 +220,7 @@ func loopNeedsContextWrites(block *object.Closure) bool {
 	for i := 0; i < len(ins); {
 		op := code.Opcode(ins[i])
 		switch op {
-		case code.OpGetName, code.OpGetNameOrNull, code.OpSetName, code.OpAssignName,
+		case code.OpGetName, code.OpGetNameOrNull, code.OpGetNameOrJumpMissing, code.OpSetName, code.OpAssignName,
 			code.OpWriteName, code.OpWriteNameOrNull, code.OpWriteNameProperty,
 			code.OpWriteGlobalProperty,
 			code.OpCall, code.OpWriteCall, code.OpWriteNameCall, code.OpCallBlock, code.OpRenderTemplate, code.OpHole:
@@ -542,7 +542,7 @@ func (vm *VM) syncDynamicContextBindingsFromContext(target hctx.Context, source 
 
 func dynamicContextNameOpcode(op code.Opcode) bool {
 	switch op {
-	case code.OpGetName, code.OpGetNameOrNull, code.OpSetName, code.OpAssignName,
+	case code.OpGetName, code.OpGetNameOrNull, code.OpGetNameOrJumpMissing, code.OpSetName, code.OpAssignName,
 		code.OpWriteName, code.OpWriteNameOrNull, code.OpWriteNameProperty, code.OpWriteNameCall:
 		return true
 	default:

--- a/vm/vm/native_calls.go
+++ b/vm/vm/native_calls.go
@@ -567,7 +567,7 @@ func (vm *VM) helperContext(block *object.Closure) plush.HelperContext {
 			return vm.runBlock(block, ctx)
 		}
 	}
-	return plush.NewHelperContext(vm.contextWithFrameLocals(), runner)
+	return plush.NewHelperContextWithLine(vm.contextWithFrameLocals(), runner, vm.currentLineNumber())
 }
 
 func (vm *VM) contextWithFrameLocals() hctx.Context {

--- a/vm/vm/output_size.go
+++ b/vm/vm/output_size.go
@@ -1,0 +1,494 @@
+package vm
+
+import (
+	"html/template"
+	"strings"
+	"sync/atomic"
+
+	"github.com/gobuffalo/plush/v5"
+	"github.com/gobuffalo/plush/v5/helpers/hctx"
+	"github.com/gobuffalo/plush/v5/vm/compiler"
+)
+
+type outputSizeOptions struct {
+	topLevel    bool
+	partialName string
+}
+
+type outputSizeObservation struct {
+	available      bool
+	scope          string
+	staticSize     int
+	stats          *compiler.OutputSizeStats
+	fallbackHint   int
+	growHint       int
+	estimateBefore int
+	samplesBefore  uint64
+	contextual     bool
+	yieldSize      int
+	overheadBefore int
+	profileBand    string
+	unstable       bool
+	limited        bool
+	minimum        int
+	maximum        int
+	growCalled     bool
+	capacityBefore int
+	capacityGrow   int
+	capacityFinal  int
+}
+
+type fileOutputSizeScope struct {
+	filename     string
+	renderPass   uint64
+	rootBytecode *compiler.Bytecode
+	layoutPass   atomic.Uint64
+}
+
+const outputSizeScopeTemplate = "template"
+const outputSizeScopeFile = "file"
+const outputSizeScopePartial = "partial"
+const contextualOutputOverheadGrowLimit = 4 << 20
+const unstablePartialGrowLimit = 64 << 10
+const inlinePartialParentGrowLimit = 64 << 10
+
+var fileOutputSizeScopeKey = "__plush_vm_file_output_size_scope__"
+
+func outputSizeStatsEnabled(ctx hctx.Context, options outputSizeOptions) bool {
+	return plush.OutputSizeEstimatorEnabled() &&
+		(options.topLevel || options.partialName != "") &&
+		(ctx == nil || !plush.IsHoleRender(ctx))
+}
+
+func outputGrowHint(bytecode *compiler.Bytecode, fallback int, ctx hctx.Context, options outputSizeOptions) int {
+	return beginOutputSizeObservation(bytecode, fallback, ctx, options).growHint
+}
+
+func beginOutputSizeObservation(bytecode *compiler.Bytecode, fallback int, ctx hctx.Context, options outputSizeOptions) outputSizeObservation {
+	if fallback < 0 {
+		fallback = 0
+	}
+	observation := outputSizeObservation{
+		scope:        outputSizeScopeTemplate,
+		fallbackHint: fallback,
+		growHint:     fallback,
+	}
+	if !outputSizeStatsEnabled(ctx, options) || bytecode == nil {
+		return observation
+	}
+	if options.partialName != "" {
+		observation.scope = outputSizeScopePartial
+		observation.stats = bytecode.PartialSizeStats
+	} else {
+		observation.stats = bytecode.OutputSizeStats
+	}
+	observation.staticSize = bytecode.StaticSize
+	if options.partialName == "" {
+		if scope := fileOutputScope(bytecode, ctx, options); scope != nil {
+			filename := plush.PunchHoleTemplateFilename(ctx)
+			if yieldSize, ok := fileOutputScopeLayoutYield(scope, filename, ctx); ok && scope.rootBytecode != nil {
+				observation.scope = outputSizeScopeFile
+				observation.stats, observation.profileBand = scope.rootBytecode.LayoutSizeProfile.Stats(yieldSize)
+				if observation.stats == nil {
+					observation.stats = scope.rootBytecode.LayoutSizeStats
+				}
+				observation.contextual = true
+				observation.yieldSize = yieldSize
+			}
+		}
+	}
+	if observation.stats == nil {
+		return observation
+	}
+	observation.available = true
+	observation.estimateBefore, observation.samplesBefore = outputSizeEstimateAndSamples(observation.stats)
+	observation.minimum, observation.maximum = observation.stats.Range()
+	observation.unstable = observation.stats.Unstable()
+	if observation.contextual {
+		overheadHint := observation.stats.GrowHint(observation.staticSize)
+		if observation.samplesBefore == 0 && fallback > overheadHint {
+			overheadHint = fallback
+		}
+		observation.overheadBefore = observation.estimateBefore
+		if observation.samplesBefore == 0 {
+			observation.overheadBefore = overheadHint
+		}
+		if observation.unstable {
+			capped := capUnstableTemplateGrow(overheadHint, observation.staticSize, observation.minimum)
+			observation.limited = capped < overheadHint
+			overheadHint = capped
+		}
+		observation.estimateBefore = addOutputSizes(observation.yieldSize, observation.overheadBefore)
+		observation.fallbackHint = addOutputSizes(observation.yieldSize, fallback)
+		observation.growHint = contextualOutputGrowHint(observation.yieldSize, overheadHint)
+		recordOutputGrowHint(bytecode, observation, ctx, options)
+		return observation
+	}
+	if observation.stats.Samples() > 0 {
+		observation.growHint = observation.stats.GrowHint(observation.staticSize)
+	} else if hint := observation.stats.GrowHint(observation.staticSize); hint > fallback {
+		observation.growHint = hint
+	}
+	if options.partialName == "" && observation.unstable {
+		capped := capUnstableTemplateGrow(observation.growHint, observation.staticSize, observation.minimum)
+		observation.limited = capped < observation.growHint
+		observation.growHint = capped
+	}
+	if options.partialName != "" && observation.unstable {
+		capped := capUnstablePartialGrow(observation.growHint, observation.staticSize)
+		observation.limited = capped < observation.growHint
+		observation.growHint = capped
+	}
+	recordOutputGrowHint(bytecode, observation, ctx, options)
+	return observation
+}
+
+func capUnstableTemplateGrow(hint, staticSize, minimum int) int {
+	limit := minimum
+	if staticSize > limit {
+		limit = staticSize
+	}
+	if limit < 0 {
+		limit = 0
+	}
+	if hint > limit {
+		return limit
+	}
+	return hint
+}
+func fileOutputScope(bytecode *compiler.Bytecode, ctx hctx.Context, options outputSizeOptions) *fileOutputSizeScope {
+	if !options.topLevel || bytecode == nil || ctx == nil || plush.IsHoleRender(ctx) {
+		return nil
+	}
+	if scope, ok := ctx.Value(fileOutputSizeScopeKey).(*fileOutputSizeScope); ok && scope != nil {
+		return scope
+	}
+	filename := plush.PunchHoleTemplateFilename(ctx)
+	if filename == "" {
+		return nil
+	}
+	pass, ok := plush.BuffaloRenderPassFromContext(ctx)
+	if !ok || pass.TemplateFilename != filename {
+		return nil
+	}
+	scope := &fileOutputSizeScope{
+		filename:     filename,
+		renderPass:   pass.ID,
+		rootBytecode: bytecode,
+	}
+	ctx.Set(fileOutputSizeScopeKey, scope)
+	return scope
+}
+
+func fileOutputScopeLayoutYield(scope *fileOutputSizeScope, filename string, ctx hctx.Context) (int, bool) {
+	if scope == nil || filename == "" || filename == scope.filename {
+		return 0, false
+	}
+	pass, ok := plush.BuffaloRenderPassFromContext(ctx)
+	if !ok {
+		return 0, false
+	}
+	if pass.ID == scope.renderPass || pass.TemplateFilename != filename {
+		return 0, false
+	}
+	yieldSize, ok := buffaloYieldOutputSize(ctx.Value("yield"))
+	if !ok {
+		return 0, false
+	}
+	layoutPass := scope.layoutPass.Load()
+	if layoutPass == 0 && scope.layoutPass.CompareAndSwap(0, pass.ID) {
+		layoutPass = pass.ID
+	} else if layoutPass == 0 {
+		layoutPass = scope.layoutPass.Load()
+	}
+	return yieldSize, layoutPass == pass.ID
+}
+
+func buffaloYieldOutputSize(value interface{}) (int, bool) {
+	switch value := value.(type) {
+	case template.HTML:
+		return len(value), true
+	default:
+		return 0, false
+	}
+}
+
+func addOutputSizes(left, right int) int {
+	if left < 0 {
+		left = 0
+	}
+	if right < 0 {
+		right = 0
+	}
+	maxInt := int(^uint(0) >> 1)
+	if right > maxInt-left {
+		return maxInt
+	}
+	return left + right
+}
+
+func contextualOutputGrowHint(yieldSize, overheadHint int) int {
+	if overheadHint > contextualOutputOverheadGrowLimit {
+		overheadHint = contextualOutputOverheadGrowLimit
+	}
+	return addOutputSizes(yieldSize, overheadHint)
+}
+
+func capUnstablePartialGrow(hint, staticSize int) int {
+	limit := unstablePartialGrowLimit
+	if staticSize > limit {
+		limit = staticSize
+	}
+	if hint > limit {
+		return limit
+	}
+	return hint
+}
+
+func growEmptyOutputBuilder(out *strings.Builder, hint int, observation *outputSizeObservation) {
+	recordOutputBuilderBeforeGrow(out, observation)
+	if out == nil || hint <= 0 || out.Len() != 0 {
+		return
+	}
+	if observation != nil {
+		observation.growCalled = true
+	}
+	out.Grow(hint)
+	recordOutputBuilderAfterGrow(out, observation)
+}
+
+func growInlineOutputBuilder(out *strings.Builder, hint int, observation *outputSizeObservation) {
+	recordOutputBuilderBeforeGrow(out, observation)
+	if out == nil || hint <= 0 || out.Cap()-out.Len() >= hint {
+		return
+	}
+	if out.Cap() >= inlinePartialParentGrowLimit {
+		if observation != nil {
+			observation.limited = true
+		}
+		return
+	}
+	if observation != nil {
+		observation.growCalled = true
+	}
+	out.Grow(hint)
+	recordOutputBuilderAfterGrow(out, observation)
+}
+
+func recordOutputBuilderBeforeGrow(out *strings.Builder, observation *outputSizeObservation) {
+	if out == nil || observation == nil {
+		return
+	}
+	observation.capacityBefore = out.Cap()
+	observation.capacityGrow = out.Cap()
+}
+
+func recordOutputBuilderAfterGrow(out *strings.Builder, observation *outputSizeObservation) {
+	if out == nil || observation == nil {
+		return
+	}
+	observation.capacityGrow = out.Cap()
+}
+
+func recordOutputBuilderFinal(out *strings.Builder, observation *outputSizeObservation) {
+	if out == nil || observation == nil {
+		return
+	}
+	observation.capacityFinal = out.Cap()
+}
+
+func beginPartialOutputObservation(bytecode *compiler.Bytecode, name string, ctx hctx.Context) outputSizeObservation {
+	return beginOutputSizeObservation(bytecode, 0, ctx, outputSizeOptions{partialName: name})
+}
+
+func observePartialOutput(bytecode *compiler.Bytecode, name string, ctx hctx.Context, size int, observation outputSizeObservation) {
+	observeOutputSize(bytecode, ctx, outputSizeOptions{partialName: name}, size, observation)
+}
+
+func renderStaticOutput(bytecode *compiler.Bytecode, ctx hctx.Context, options outputSizeOptions) string {
+	if bytecode == nil {
+		return ""
+	}
+	observation := beginOutputSizeObservation(bytecode, len(bytecode.StaticOutput), ctx, options)
+	observeOutputSize(bytecode, ctx, options, len(bytecode.StaticOutput), observation)
+	return bytecode.StaticOutput
+}
+
+func growVMRootOutput(machine *VM, bytecode *compiler.Bytecode, ctx hctx.Context, options outputSizeOptions) outputSizeObservation {
+	if machine == nil || len(machine.frames) == 0 || machine.frames[0] == nil {
+		return outputSizeObservation{}
+	}
+	observation := beginOutputSizeObservation(bytecode, 0, ctx, options)
+	growEmptyOutputBuilder(&machine.frames[0].output, observation.growHint, &observation)
+	return observation
+}
+
+func recordVMRootOutputFinal(machine *VM, observation *outputSizeObservation) {
+	if machine == nil || len(machine.frames) == 0 || machine.frames[0] == nil {
+		return
+	}
+	recordOutputBuilderFinal(&machine.frames[0].output, observation)
+}
+
+func vmRootOutputLen(machine *VM) int {
+	if machine == nil || len(machine.frames) == 0 || machine.frames[0] == nil {
+		return 0
+	}
+	return machine.frames[0].output.Len()
+}
+
+func observeOutputBuilderSize(bytecode *compiler.Bytecode, ctx hctx.Context, options outputSizeOptions, out *strings.Builder, observation outputSizeObservation) {
+	if out == nil {
+		return
+	}
+	recordOutputBuilderFinal(out, &observation)
+	observeOutputSize(bytecode, ctx, options, out.Len(), observation)
+}
+
+func observeOutputSize(bytecode *compiler.Bytecode, ctx hctx.Context, options outputSizeOptions, size int, observation outputSizeObservation) {
+	if !observation.available || !outputSizeStatsEnabled(ctx, options) || bytecode == nil {
+		return
+	}
+	observedSize := size
+	if observation.contextual {
+		observedSize -= observation.yieldSize
+		if observedSize < 0 {
+			observedSize = 0
+		}
+	}
+	observation.stats.Observe(observedSize)
+	recordOutputActual(bytecode, size, observation, ctx, options)
+}
+
+func recordOutputGrowHint(bytecode *compiler.Bytecode, observation outputSizeObservation, ctx hctx.Context, options outputSizeOptions) {
+	if !options.topLevel || !outputSizeStatsEnabled(ctx, options) || bytecode == nil || ctx == nil {
+		return
+	}
+	updateOutputSizeDiagnostics(ctx, observation, func(d *plush.RenderDiagnostics) {
+		d.OutputSize = plush.RenderOutputSizeDiagnostics{
+			Available:      true,
+			Scope:          observation.scope,
+			Contextual:     observation.contextual,
+			ProfileBand:    observation.profileBand,
+			YieldSize:      observation.yieldSize,
+			OverheadBefore: observation.overheadBefore,
+			StaticSize:     observation.staticSize,
+			FallbackHint:   observation.fallbackHint,
+			GrowHint:       observation.growHint,
+			EstimateBefore: observation.estimateBefore,
+			EstimateAfter:  observation.estimateBefore,
+			SamplesBefore:  observation.samplesBefore,
+			SamplesAfter:   observation.samplesBefore,
+			Minimum:        observation.minimum,
+			Maximum:        observation.maximum,
+			Unstable:       observation.unstable,
+			Limited:        observation.limited,
+			GrowCalled:     observation.growCalled,
+			CapacityBefore: observation.capacityBefore,
+			CapacityGrow:   observation.capacityGrow,
+			CapacityFinal:  observation.capacityFinal,
+			GrowAllocated:  outputSpeculativeAllocated(observation),
+		}
+	})
+}
+
+func recordOutputActual(bytecode *compiler.Bytecode, actual int, observation outputSizeObservation, ctx hctx.Context, options outputSizeOptions) {
+	if !outputSizeStatsEnabled(ctx, options) || bytecode == nil || ctx == nil {
+		return
+	}
+	estimate, samples := outputSizeEstimateAndSamples(observation.stats)
+	minimum, maximum := observation.stats.Range()
+	unstable := observation.stats.Unstable()
+	overheadActual := 0
+	overheadAfter := 0
+	if observation.contextual {
+		overheadActual = actual - observation.yieldSize
+		if overheadActual < 0 {
+			overheadActual = 0
+		}
+		overheadAfter = estimate
+		estimate = addOutputSizes(observation.yieldSize, estimate)
+	}
+	if options.partialName != "" {
+		plush.AddRenderDiagnosticPartialOutputAllocation(
+			ctx,
+			options.partialName,
+			observation.estimateBefore,
+			observation.growHint,
+			actual,
+			estimate,
+			samples,
+			plush.RenderPartialOutputAllocation{
+				GrowCalled:           observation.growCalled,
+				SpeculativeAllocated: outputSpeculativeAllocated(observation),
+				Unstable:             observation.stats.Unstable(),
+				Limited:              observation.limited,
+				Minimum:              minimum,
+				Maximum:              maximum,
+			},
+		)
+		return
+	}
+	updateOutputSizeDiagnostics(ctx, observation, func(d *plush.RenderDiagnostics) {
+		d.OutputSize = plush.RenderOutputSizeDiagnostics{
+			Available:      true,
+			Scope:          observation.scope,
+			Contextual:     observation.contextual,
+			ProfileBand:    observation.profileBand,
+			YieldSize:      observation.yieldSize,
+			OverheadBefore: observation.overheadBefore,
+			OverheadActual: overheadActual,
+			OverheadAfter:  overheadAfter,
+			StaticSize:     observation.staticSize,
+			FallbackHint:   observation.fallbackHint,
+			GrowHint:       observation.growHint,
+			EstimateBefore: observation.estimateBefore,
+			Actual:         actual,
+			EstimateAfter:  estimate,
+			SamplesBefore:  observation.samplesBefore,
+			SamplesAfter:   samples,
+			Observed:       true,
+			Minimum:        minimum,
+			Maximum:        maximum,
+			Unstable:       unstable,
+			Limited:        observation.limited,
+			GrowCalled:     observation.growCalled,
+			CapacityBefore: observation.capacityBefore,
+			CapacityGrow:   observation.capacityGrow,
+			CapacityFinal:  observation.capacityFinal,
+			UnusedCapacity: outputUnusedCapacity(observation, actual),
+			GrowAllocated:  outputSpeculativeAllocated(observation),
+		}
+	})
+}
+
+func outputSpeculativeAllocated(observation outputSizeObservation) int {
+	allocated := observation.capacityGrow - observation.capacityBefore
+	if allocated < 0 {
+		return 0
+	}
+	return allocated
+}
+
+func outputUnusedCapacity(observation outputSizeObservation, actual int) int {
+	unused := observation.capacityFinal - actual
+	if unused < 0 {
+		return 0
+	}
+	return unused
+}
+
+func updateOutputSizeDiagnostics(ctx hctx.Context, observation outputSizeObservation, update func(*plush.RenderDiagnostics)) {
+	if observation.scope == outputSizeScopeFile {
+		plush.UpdateRenderDiagnostics(ctx, update)
+		return
+	}
+	plush.UpdateRenderDiagnosticsForTemplate(ctx, plush.PunchHoleTemplateFilename(ctx), update)
+}
+
+func outputSizeEstimateAndSamples(stats *compiler.OutputSizeStats) (int, uint64) {
+	if stats == nil {
+		return 0, 0
+	}
+	return stats.Estimate(), stats.Samples()
+}

--- a/vm/vm/output_size_benchmark_test.go
+++ b/vm/vm/output_size_benchmark_test.go
@@ -1,0 +1,96 @@
+package vm
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gobuffalo/plush/v5"
+)
+
+type outputSizeBenchmarkRecord struct {
+	ID      int
+	Name    string
+	Content string
+}
+
+func Benchmark_VM_Output_Size_Estimator(b *testing.B) {
+	const source = `<main><%= for (_, entry) in entries { %><article data-id="<%= entry.ID %>"><h2><%= entry.Name %></h2><p><%= entry.Content %></p></article><% } %></main>`
+
+	workloads := []struct {
+		name     string
+		contexts []*plush.Context
+	}{
+		{
+			name: "stable",
+			contexts: []*plush.Context{
+				outputSizeBenchmarkContext(1024, 128),
+			},
+		},
+		{
+			name: "alternating",
+			contexts: []*plush.Context{
+				outputSizeBenchmarkContext(64, 32),
+				outputSizeBenchmarkContext(1024, 128),
+			},
+		},
+	}
+
+	for _, workload := range workloads {
+		workload := workload
+		b.Run(workload.name, func(b *testing.B) {
+			for _, mode := range []struct {
+				name    string
+				enabled bool
+			}{
+				{name: "disabled"},
+				{name: "enabled", enabled: true},
+			} {
+				mode := mode
+				b.Run(mode.name, func(b *testing.B) {
+					previous := plush.SetOutputSizeEstimatorEnabled(mode.enabled)
+					defer plush.SetOutputSizeEstimatorEnabled(previous)
+
+					tmpl, err := Compile(source)
+					if err != nil {
+						b.Fatal(err)
+					}
+					warmOutput, err := tmpl.Render(workload.contexts[0])
+					if err != nil {
+						b.Fatal(err)
+					}
+					if mode.enabled {
+						for _, ctx := range workload.contexts {
+							if _, err := tmpl.Render(ctx); err != nil {
+								b.Fatal(err)
+							}
+						}
+					}
+
+					b.ReportAllocs()
+					b.SetBytes(int64(len(warmOutput)))
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						out, err := tmpl.Render(workload.contexts[i%len(workload.contexts)])
+						if err != nil {
+							b.Fatal(err)
+						}
+						benchmarkSink = out
+					}
+				})
+			}
+		})
+	}
+}
+
+func outputSizeBenchmarkContext(count, contentSize int) *plush.Context {
+	records := make([]outputSizeBenchmarkRecord, count)
+	for i := range records {
+		records[i] = outputSizeBenchmarkRecord{
+			ID:      i,
+			Name:    fmt.Sprintf("entry-%d", i),
+			Content: strings.Repeat("x", contentSize),
+		}
+	}
+	return plush.NewContextWith(map[string]interface{}{"entries": records})
+}

--- a/vm/vm/partial_direct_edges_test.go
+++ b/vm/vm/partial_direct_edges_test.go
@@ -688,7 +688,7 @@ func Test_VM_Fast_No_Data_Partial_Fallback_Edge_Branches(t *testing.T) {
 	})
 	handled, err = renderFastNoDataPartialInto(&out, "edge_fallback_error.html", feederErrCtx, 12)
 	require.True(t, handled)
-	require.ErrorContains(t, err, "line 12: fallback missing")
+	require.ErrorContains(t, err, "line 12:edge_fallback_error.html: fallback missing")
 
 	metadataCtx := plush.NewContextWith(map[string]interface{}{
 		"partialFeeder": func(string) (string, error) {

--- a/vm/vm/partials.go
+++ b/vm/vm/partials.go
@@ -294,7 +294,7 @@ func (c *partialOverlayContext) SetID(id int, value interface{}) {
 }
 
 func (c *partialOverlayContext) UpdateID(id int, value interface{}) bool {
-	if c == nil || value == nil {
+	if c == nil {
 		return false
 	}
 	if c.setLocalIDExisting(id, value) {
@@ -310,7 +310,7 @@ func (c *partialOverlayContext) UpdateID(id int, value interface{}) bool {
 }
 
 func (c *partialOverlayContext) Update(key string, value interface{}) bool {
-	if c == nil || value == nil {
+	if c == nil {
 		return false
 	}
 	if c.setLocalExisting(key, value) {

--- a/vm/vm/partials.go
+++ b/vm/vm/partials.go
@@ -1598,7 +1598,7 @@ func renderLinkedPartialBytecode(link *partialBytecodeLink, ctx hctx.Context, fi
 	if link.source != "" && shouldFallbackPartialBytecode(bytecode) {
 		return renderInterpreterFallback(link.source, ctx, filename)
 	}
-	if bytecode.FastRenderPlan != nil {
+	if !bytecode.HasHoles && bytecode.FastRenderPlan != nil {
 		if rendered, ok, err := renderFastPlanWithBindingPlan(bytecode, bytecode.FastRenderPlan, ctx, link.fastBindingPlan(ctx)); ok || err != nil {
 			return rendered, err
 		}

--- a/vm/vm/partials.go
+++ b/vm/vm/partials.go
@@ -495,6 +495,7 @@ func renderFastDataPartialInto(out *strings.Builder, partial *compiler.FastParti
 			return true, fastLineError(partial.Line, err)
 		}
 	}
+	childFile := plush.TemplateFilenameForError(partialCtx)
 
 	if useMetaIDs {
 		setupFastPartialNesting(partialCtx, partial.Name, metaIDs)
@@ -507,25 +508,25 @@ func renderFastDataPartialInto(out *strings.Builder, partial *compiler.FastParti
 	}
 	if renderedCached, err := renderCachedPartialBytecodeInto(out, partialCtx, partial.Name, needsJSEscape); renderedCached || err != nil {
 		if err != nil {
-			return true, fastLineError(partial.Line, err)
+			return true, wrapVMPartialRenderError(ctx, partial.Line, partialCtx, childFile, err)
 		}
 		return true, nil
 	}
 
 	pf, ok := links.partialFeeder(partialCtx)
 	if !ok {
-		return true, fastLineError(partial.Line, fmt.Errorf("could not find partial feeder from helpers"))
+		return true, wrapVMPartialRenderError(ctx, partial.Line, partialCtx, childFile, fmt.Errorf("could not find partial feeder from helpers"))
 	}
 
 	part, err := pf(partial.Name)
 	if err != nil {
-		return true, fastLineError(partial.Line, err)
+		return true, wrapVMPartialRenderError(ctx, partial.Line, partialCtx, childFile, err)
 	}
 
 	if !needsJSEscape {
 		if renderedInline, err := renderLinkedPartialInline(out, part, partialCtx); renderedInline || err != nil {
 			if err != nil {
-				return true, fastLineError(partial.Line, err)
+				return true, wrapVMPartialRenderError(ctx, partial.Line, partialCtx, childFile, err)
 			}
 			return true, nil
 		}
@@ -533,7 +534,7 @@ func renderFastDataPartialInto(out *strings.Builder, partial *compiler.FastParti
 
 	part, err = renderLinkedPartial(part, partialCtx)
 	if err != nil {
-		return true, fastLineError(partial.Line, err)
+		return true, wrapVMPartialRenderError(ctx, partial.Line, partialCtx, childFile, err)
 	}
 	if needsJSEscape {
 		part = template.JSEscapeString(part)
@@ -574,7 +575,11 @@ func renderFastDataPartialDirectInto(out *strings.Builder, partial *compiler.Fas
 	if err := attachFastPartialDataLocalsFromPlan(&bindings, dataPlan, ctx, parentBindings, &localStorage); err != nil {
 		return true, err
 	}
-	return renderFastPlanInlineWithBindings(out, bytecode.FastRenderPlan, ctx, bindings)
+	ok, err = renderFastPlanInlineWithBindings(out, bytecode.FastRenderPlan, ctx, bindings)
+	if err != nil {
+		return ok, wrapVMPartialRenderError(ctx, partial.Line, nil, filename, err)
+	}
+	return ok, nil
 }
 
 func fastPartialDataCanDirect(plan *fastPartialDataBindingPlan) bool {
@@ -805,6 +810,7 @@ func renderFastNoDataPartialInto(out *strings.Builder, name string, ctx hctx.Con
 			return true, fastLineError(line, err)
 		}
 	}
+	childFile := plush.TemplateFilenameForError(partialCtx)
 
 	if useMetaIDs {
 		setupFastPartialNesting(partialCtx, name, metaIDs)
@@ -817,25 +823,25 @@ func renderFastNoDataPartialInto(out *strings.Builder, name string, ctx hctx.Con
 	}
 	if renderedCached, err := renderCachedPartialBytecodeInto(out, partialCtx, name, needsJSEscape); renderedCached || err != nil {
 		if err != nil {
-			return true, fastLineError(line, err)
+			return true, wrapVMPartialRenderError(ctx, line, partialCtx, childFile, err)
 		}
 		return true, nil
 	}
 
 	pf, ok := links.partialFeeder(partialCtx)
 	if !ok {
-		return true, fastLineError(line, fmt.Errorf("could not find partial feeder from helpers"))
+		return true, wrapVMPartialRenderError(ctx, line, partialCtx, childFile, fmt.Errorf("could not find partial feeder from helpers"))
 	}
 
 	part, err := pf(name)
 	if err != nil {
-		return true, fastLineError(line, err)
+		return true, wrapVMPartialRenderError(ctx, line, partialCtx, childFile, err)
 	}
 
 	if !needsJSEscape {
 		if renderedInline, err := renderLinkedPartialInline(out, part, partialCtx); renderedInline || err != nil {
 			if err != nil {
-				return true, fastLineError(line, err)
+				return true, wrapVMPartialRenderError(ctx, line, partialCtx, childFile, err)
 			}
 			return true, nil
 		}
@@ -843,7 +849,7 @@ func renderFastNoDataPartialInto(out *strings.Builder, name string, ctx hctx.Con
 
 	part, err = renderLinkedPartial(part, partialCtx)
 	if err != nil {
-		return true, fastLineError(line, err)
+		return true, wrapVMPartialRenderError(ctx, line, partialCtx, childFile, err)
 	}
 	if needsJSEscape {
 		part = template.JSEscapeString(part)
@@ -967,6 +973,8 @@ func fastRenderSegmentsCanRunWithoutPartialContext(segments []compiler.FastRende
 			if fastValuePlanNeedsPartialContext(&segment.ValuePlan) {
 				return false
 			}
+		case compiler.FastRenderSegmentCall:
+			return false
 		case compiler.FastRenderSegmentConditional:
 			if !fastConditionalCanRunWithoutPartialContext(segment.Conditional) {
 				return false
@@ -980,6 +988,10 @@ func fastRenderSegmentsCanRunWithoutPartialContext(segments []compiler.FastRende
 				return false
 			}
 		case compiler.FastRenderSegmentAssign:
+			if fastValuePlanNeedsPartialContext(&segment.ValuePlan) {
+				return false
+			}
+		case compiler.FastRenderSegmentReturn:
 			if fastValuePlanNeedsPartialContext(&segment.ValuePlan) {
 				return false
 			}
@@ -1028,10 +1040,21 @@ func fastLoopPartsCanRunWithoutPartialContext(parts []compiler.FastLoopPart) boo
 			compiler.FastLoopPartBreak,
 			compiler.FastLoopPartContinue:
 			continue
-		case compiler.FastLoopPartLet:
+		case compiler.FastLoopPartLet, compiler.FastLoopPartAssign:
 			if fastValuePlanNeedsPartialContext(&part.ValuePlan) {
 				return false
 			}
+			if part.AssignTarget != nil && part.AssignTarget.Kind == compiler.FastAssignTargetIndex {
+				if fastValuePlanNeedsPartialContext(&part.AssignTarget.Container) || fastValuePlanNeedsPartialContext(&part.AssignTarget.Index) {
+					return false
+				}
+			}
+		case compiler.FastLoopPartReturn:
+			if fastValuePlanNeedsPartialContext(&part.ValuePlan) {
+				return false
+			}
+		case compiler.FastLoopPartCall:
+			return false
 		case compiler.FastLoopPartPartial:
 			return false
 		case compiler.FastLoopPartConditional:
@@ -1072,6 +1095,14 @@ func fastValuePlanNeedsPartialContext(value *compiler.FastValuePlan) bool {
 	switch value.Kind {
 	case compiler.FastValueCall:
 		return true
+	case compiler.FastValuePath:
+		for i := range value.Path {
+			for argIndex := range value.Path[i].Args {
+				if fastValuePlanNeedsPartialContext(&value.Path[i].Args[argIndex]) {
+					return true
+				}
+			}
+		}
 	case compiler.FastValueInfix, compiler.FastValueConcat:
 		return fastValuePlanNeedsPartialContext(value.Left) || fastValuePlanNeedsPartialContext(value.Right)
 	case compiler.FastValuePrefix:
@@ -1086,6 +1117,17 @@ func fastValuePlanNeedsPartialContext(value *compiler.FastValuePlan) bool {
 		for i := range value.Pairs {
 			if fastValuePlanNeedsPartialContext(&value.Pairs[i].Value) {
 				return true
+			}
+		}
+	case compiler.FastValueIndex:
+		if fastValuePlanNeedsPartialContext(value.Left) || fastValuePlanNeedsPartialContext(value.Right) {
+			return true
+		}
+		for i := range value.Path {
+			for argIndex := range value.Path[i].Args {
+				if fastValuePlanNeedsPartialContext(&value.Path[i].Args[argIndex]) {
+					return true
+				}
 			}
 		}
 	}
@@ -1115,7 +1157,11 @@ func renderFastNoDataPartialDirectInto(out *strings.Builder, name string, ctx hc
 		out.WriteString(bytecode.StaticOutput)
 		return true, nil
 	}
-	return renderFastPlanInlineSafe(out, bytecode.FastRenderPlan, ctx, link.fastBindingPlan(ctx))
+	ok, err = renderFastPlanInlineSafe(out, bytecode.FastRenderPlan, ctx, link.fastBindingPlan(ctx))
+	if err != nil {
+		return ok, wrapVMPartialRenderError(ctx, line, nil, filename, err)
+	}
+	return ok, nil
 }
 
 func partialNeedsJSEscape(ctx hctx.Context, name string) bool {
@@ -1128,6 +1174,16 @@ func partialNeedsJSEscape(ctx hctx.Context, name string) bool {
 	}
 	ext := filepath.Ext(name)
 	return strings.Contains(ct, "javascript") && ext != ".js" && ext != ""
+}
+
+func wrapVMPartialRenderError(parentCtx hctx.Context, parentLine int, childCtx hctx.Context, childFile string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if childFile == "" {
+		childFile = plush.TemplateFilenameForError(childCtx)
+	}
+	return plush.WrapPartialRenderError(plush.TemplateFilenameForError(parentCtx), parentLine, childFile, err)
 }
 
 func partialNeedsJSEscapeFast(ctx *partialOverlayContext, name string, ids partialMetaIDs) bool {
@@ -1238,6 +1294,8 @@ func vmPartialHelper(name string, data map[string]interface{}, help plush.Helper
 		}
 	}
 
+	parentFile := plush.TemplateFilenameForError(help.Context)
+	parentLine := help.CallLine()
 	links := partialBytecodeLinks(help.Context)
 	child, releaseChild := partialHelperChildContext(help.Context)
 	help.Context = child
@@ -1270,15 +1328,16 @@ func vmPartialHelper(name string, data map[string]interface{}, help plush.Helper
 	} else {
 		help.Set(meta.TemplateFileKey, name)
 	}
+	childFile := plush.TemplateFilenameForError(help.Context)
 
 	pf, ok := links.partialFeeder(help.Context)
 	if !ok {
-		return "", fmt.Errorf("could not find partial feeder from helpers")
+		return "", plush.WrapPartialRenderError(parentFile, parentLine, childFile, fmt.Errorf("could not find partial feeder from helpers"))
 	}
 
 	part, err := pf(name)
 	if err != nil {
-		return "", err
+		return "", plush.WrapPartialRenderError(parentFile, parentLine, childFile, err)
 	}
 
 	if help.Value(vmAlreadyInPartial) == nil {
@@ -1298,7 +1357,7 @@ func vmPartialHelper(name string, data map[string]interface{}, help plush.Helper
 
 	part, err = renderLinkedPartial(part, help.Context)
 	if err != nil {
-		return "", err
+		return "", plush.WrapPartialRenderError(parentFile, parentLine, childFile, err)
 	}
 	if ct, ok := help.Value("contentType").(string); ok {
 		ext := filepath.Ext(name)
@@ -1540,7 +1599,7 @@ func renderLinkedPartialBytecode(link *partialBytecodeLink, ctx hctx.Context, fi
 		return renderInterpreterFallback(link.source, ctx, filename)
 	}
 	if bytecode.FastRenderPlan != nil {
-		if rendered, ok, err := renderFastPlanWithBindingPlan(bytecode.FastRenderPlan, ctx, link.fastBindingPlan(ctx)); ok || err != nil {
+		if rendered, ok, err := renderFastPlanWithBindingPlan(bytecode, bytecode.FastRenderPlan, ctx, link.fastBindingPlan(ctx)); ok || err != nil {
 			return rendered, err
 		}
 	}

--- a/vm/vm/partials.go
+++ b/vm/vm/partials.go
@@ -568,16 +568,26 @@ func renderFastDataPartialDirectInto(out *strings.Builder, partial *compiler.Fas
 		if err := evalFastPartialDataLocalValues(dataPlan, ctx, parentBindings); err != nil {
 			return true, err
 		}
+		observation := beginPartialOutputObservation(bytecode, filename, ctx)
+		growInlineOutputBuilder(out, observation.growHint, &observation)
+		start := out.Len()
 		out.WriteString(bytecode.StaticOutput)
+		observePartialOutput(bytecode, filename, ctx, out.Len()-start, observation)
 		return true, nil
 	}
 	bindings := newFastRenderBindingsWithPlan(bytecode.FastRenderPlan, ctx, link.fastBindingPlan(ctx))
 	if err := attachFastPartialDataLocalsFromPlan(&bindings, dataPlan, ctx, parentBindings, &localStorage); err != nil {
 		return true, err
 	}
+	observation := beginPartialOutputObservation(bytecode, filename, ctx)
+	growInlineOutputBuilder(out, observation.growHint, &observation)
+	start := out.Len()
 	ok, err = renderFastPlanInlineWithBindings(out, bytecode.FastRenderPlan, ctx, bindings)
 	if err != nil {
 		return ok, wrapVMPartialRenderError(ctx, partial.Line, nil, filename, err)
+	}
+	if ok {
+		observePartialOutput(bytecode, filename, ctx, out.Len()-start, observation)
 	}
 	return ok, nil
 }
@@ -1154,12 +1164,22 @@ func renderFastNoDataPartialDirectInto(out *strings.Builder, name string, ctx hc
 	}
 	bytecode := link.bytecode
 	if bytecode.Static {
+		observation := beginPartialOutputObservation(bytecode, filename, ctx)
+		growInlineOutputBuilder(out, observation.growHint, &observation)
+		start := out.Len()
 		out.WriteString(bytecode.StaticOutput)
+		observePartialOutput(bytecode, filename, ctx, out.Len()-start, observation)
 		return true, nil
 	}
+	observation := beginPartialOutputObservation(bytecode, filename, ctx)
+	growInlineOutputBuilder(out, observation.growHint, &observation)
+	start := out.Len()
 	ok, err = renderFastPlanInlineSafe(out, bytecode.FastRenderPlan, ctx, link.fastBindingPlan(ctx))
 	if err != nil {
 		return ok, wrapVMPartialRenderError(ctx, line, nil, filename, err)
+	}
+	if ok {
+		observePartialOutput(bytecode, filename, ctx, out.Len()-start, observation)
 	}
 	return ok, nil
 }
@@ -1382,6 +1402,7 @@ func renderLinkedPartial(input string, ctx hctx.Context) (string, error) {
 	filename := plush.PunchHoleTemplateFilename(ctx)
 	filename, forceCacheClear, cached, ok := punchHoleCacheStateForFilename(filename, ctx, input)
 	if ok {
+		observeCachedPartialOutput(filename, cached, ctx)
 		return cached, nil
 	}
 
@@ -1390,7 +1411,7 @@ func renderLinkedPartial(input string, ctx hctx.Context) (string, error) {
 	links := partialBytecodeLinks(ctx)
 	if link, ok := links.GetLink(linkKey, sourceHash); ok {
 		if shouldFallbackPartialBytecode(link.bytecode) {
-			return renderInterpreterFallback(input, ctx, filename)
+			return renderInterpreterPartial(input, ctx, filename, link.bytecode)
 		}
 		return renderLinkedPartialBytecode(link, ctx, filename, forceCacheClear)
 	}
@@ -1399,7 +1420,7 @@ func renderLinkedPartial(input string, ctx hctx.Context) (string, error) {
 		if bytecode, ok := cached.(*compiler.Bytecode); ok {
 			link := links.SetWithSource(linkKey, sourceHash, input, bytecode)
 			if shouldFallbackPartialBytecode(bytecode) {
-				return renderInterpreterFallback(input, ctx, filename)
+				return renderInterpreterPartial(input, ctx, filename, bytecode)
 			}
 			return renderLinkedPartialBytecode(link, ctx, filename, forceCacheClear)
 		}
@@ -1419,7 +1440,7 @@ func renderLinkedPartial(input string, ctx hctx.Context) (string, error) {
 	plush.CacheVMBytecodeForCleanFilenameWithSource(filename, cachedProgram, bytecode, input)
 	link := links.SetWithSource(linkKey, sourceHash, input, bytecode)
 	if shouldFallbackPartialBytecode(bytecode) {
-		return renderInterpreterFallback(input, ctx, filename)
+		return renderInterpreterPartial(input, ctx, filename, bytecode)
 	}
 	return renderLinkedPartialBytecode(link, ctx, filename, forceCacheClear)
 }
@@ -1513,6 +1534,13 @@ func renderLinkedPartialInline(out *strings.Builder, input string, ctx hctx.Cont
 	filename := plush.PunchHoleTemplateFilename(ctx)
 	filename, _, cached, ok := punchHoleCacheStateForFilename(filename, ctx, input)
 	if ok {
+		if link, linked := cachedPartialBytecodeLinkForFilename(filename, ctx); linked && link != nil && link.bytecode != nil {
+			observation := beginPartialOutputObservation(link.bytecode, filename, ctx)
+			growInlineOutputBuilder(out, observation.growHint, &observation)
+			out.WriteString(cached)
+			observePartialOutput(link.bytecode, filename, ctx, len(cached), observation)
+			return true, nil
+		}
 		out.WriteString(cached)
 		return true, nil
 	}
@@ -1556,6 +1584,15 @@ func renderLinkedPartialInline(out *strings.Builder, input string, ctx hctx.Cont
 	return renderLinkedPartialBytecodeInline(out, link, ctx)
 }
 
+func observeCachedPartialOutput(filename, rendered string, ctx hctx.Context) {
+	link, ok := cachedPartialBytecodeLinkForFilename(filename, ctx)
+	if !ok || link == nil || link.bytecode == nil {
+		return
+	}
+	observation := beginPartialOutputObservation(link.bytecode, filename, ctx)
+	observePartialOutput(link.bytecode, filename, ctx, len(rendered), observation)
+}
+
 func cachedPartialBytecodeCanDirectInline(filename string) (bool, bool) {
 	if filename == "" {
 		return false, false
@@ -1583,7 +1620,10 @@ func renderGenericPartialInline(out *strings.Builder, input string, ctx hctx.Con
 	if err != nil {
 		return true, err
 	}
+	observation := beginPartialOutputObservation(bytecode, filename, ctx)
+	growInlineOutputBuilder(out, observation.growHint, &observation)
 	out.WriteString(rendered)
+	observePartialOutput(bytecode, filename, ctx, len(rendered), observation)
 	return true, nil
 }
 
@@ -1593,17 +1633,30 @@ func renderLinkedPartialBytecode(link *partialBytecodeLink, ctx hctx.Context, fi
 	}
 	bytecode := link.bytecode
 	if bytecode.Static {
+		observation := beginPartialOutputObservation(bytecode, filename, ctx)
+		observePartialOutput(bytecode, filename, ctx, len(bytecode.StaticOutput), observation)
 		return bytecode.StaticOutput, nil
 	}
 	if link.source != "" && shouldFallbackPartialBytecode(bytecode) {
-		return renderInterpreterFallback(link.source, ctx, filename)
+		return renderInterpreterPartial(link.source, ctx, filename, bytecode)
 	}
 	if !bytecode.HasHoles && bytecode.FastRenderPlan != nil {
-		if rendered, ok, err := renderFastPlanWithBindingPlan(bytecode, bytecode.FastRenderPlan, ctx, link.fastBindingPlan(ctx)); ok || err != nil {
+		options := outputSizeOptions{partialName: filename}
+		if rendered, ok, err := renderFastPlanWithBindingPlanOptions(bytecode, bytecode.FastRenderPlan, ctx, link.fastBindingPlan(ctx), options); ok || err != nil {
 			return rendered, err
 		}
 	}
-	return renderBytecodeVMWithState(bytecode, ctx, filename, forceCacheClear, link.source)
+	return renderBytecodeVMWithStateOptions(bytecode, ctx, filename, forceCacheClear, link.source, outputSizeOptions{partialName: filename})
+}
+
+func renderInterpreterPartial(input string, ctx hctx.Context, filename string, bytecode *compiler.Bytecode) (string, error) {
+	rendered, err := renderInterpreterFallback(input, ctx, filename)
+	if err != nil {
+		return "", err
+	}
+	observation := beginPartialOutputObservation(bytecode, filename, ctx)
+	observePartialOutput(bytecode, filename, ctx, len(rendered), observation)
+	return rendered, nil
 }
 
 func renderLinkedPartialBytecodeInline(out *strings.Builder, link *partialBytecodeLink, ctx hctx.Context) (bool, error) {
@@ -1612,14 +1665,27 @@ func renderLinkedPartialBytecodeInline(out *strings.Builder, link *partialByteco
 	}
 	bytecode := link.bytecode
 	if bytecode.Static {
+		name := plush.PunchHoleTemplateFilename(ctx)
+		observation := beginPartialOutputObservation(bytecode, name, ctx)
+		growInlineOutputBuilder(out, observation.growHint, &observation)
+		start := out.Len()
 		out.WriteString(bytecode.StaticOutput)
+		observePartialOutput(bytecode, name, ctx, out.Len()-start, observation)
 		return true, nil
 	}
 	if bytecode.HasHoles {
 		return false, nil
 	}
 	if bytecode.FastRenderPlan != nil {
-		return renderFastPlanInlineSafe(out, bytecode.FastRenderPlan, ctx, link.fastBindingPlan(ctx))
+		name := plush.PunchHoleTemplateFilename(ctx)
+		observation := beginPartialOutputObservation(bytecode, name, ctx)
+		growInlineOutputBuilder(out, observation.growHint, &observation)
+		start := out.Len()
+		ok, err := renderFastPlanInlineSafe(out, bytecode.FastRenderPlan, ctx, link.fastBindingPlan(ctx))
+		if ok && err == nil {
+			observePartialOutput(bytecode, name, ctx, out.Len()-start, observation)
+		}
+		return ok, err
 	}
 	return false, nil
 }

--- a/vm/vm/render_diagnostics.go
+++ b/vm/vm/render_diagnostics.go
@@ -10,6 +10,7 @@ func updateBytecodeDiagnostics(ctx hctx.Context, bytecode *compiler.Bytecode) {
 	if ctx == nil || bytecode == nil {
 		return
 	}
+	fileOutputScope(bytecode, ctx, outputSizeOptions{topLevel: true})
 	stats := cachedFastRenderPlanDiagnostics(bytecode)
 	filename := plush.PunchHoleTemplateFilename(ctx)
 	plush.UpdateRenderDiagnosticsForTemplate(ctx, filename, func(d *plush.RenderDiagnostics) {

--- a/vm/vm/render_diagnostics.go
+++ b/vm/vm/render_diagnostics.go
@@ -118,6 +118,12 @@ func (b *fastPlanDiagnosticBuilder) segment(segment *compiler.FastRenderSegment,
 		b.value(segment.ValuePlan, depth+1)
 	case compiler.FastRenderSegmentAssign:
 		b.value(segment.ValuePlan, depth+1)
+		b.assignTarget(segment.AssignTarget, depth+1)
+	case compiler.FastRenderSegmentReturn:
+		b.stats.ValueWrites++
+		b.value(segment.ValuePlan, depth+1)
+	case compiler.FastRenderSegmentGeneric:
+		b.stats.ValueWrites++
 	}
 }
 
@@ -178,11 +184,25 @@ func (b *fastPlanDiagnosticBuilder) loopPart(part *compiler.FastLoopPart, depth 
 		b.partialPlan(part.Partial, depth+1)
 	case compiler.FastLoopPartLet:
 		b.value(part.ValuePlan, depth+1)
+	case compiler.FastLoopPartAssign:
+		b.value(part.ValuePlan, depth+1)
+		b.assignTarget(part.AssignTarget, depth+1)
+	case compiler.FastLoopPartReturn:
+		b.stats.ValueWrites++
+		b.value(part.ValuePlan, depth+1)
 	case compiler.FastLoopPartConditional:
 		b.loopConditional(part.Conditional, depth+1)
 	case compiler.FastLoopPartLoop:
 		b.loop(part.Loop, depth+1)
 	}
+}
+
+func (b *fastPlanDiagnosticBuilder) assignTarget(target *compiler.FastAssignTarget, depth int) {
+	if target == nil || target.Kind != compiler.FastAssignTargetIndex {
+		return
+	}
+	b.value(target.Container, depth+1)
+	b.value(target.Index, depth+1)
 }
 
 func (b *fastPlanDiagnosticBuilder) loopConditional(plan *compiler.FastLoopConditionalPlan, depth int) {
@@ -239,6 +259,16 @@ func (b *fastPlanDiagnosticBuilder) value(plan compiler.FastValuePlan, depth int
 		b.stats.NameSegments++
 	case compiler.FastValuePath:
 		b.stats.PropertyReads += len(plan.Path)
+		for i := range plan.Path {
+			step := &plan.Path[i]
+			if step.Kind == compiler.FastPathStepCall && len(step.Args) > 0 {
+				b.stats.HelperCalls++
+				b.helper(step.Value)
+			}
+			for argIndex := range step.Args {
+				b.value(step.Args[argIndex], depth+1)
+			}
+		}
 	case compiler.FastValueInfix, compiler.FastValueConcat:
 		if plan.Left != nil {
 			b.value(*plan.Left, depth+1)
@@ -259,6 +289,18 @@ func (b *fastPlanDiagnosticBuilder) value(plan compiler.FastValuePlan, depth int
 	case compiler.FastValueHash:
 		for i := range plan.Pairs {
 			b.value(plan.Pairs[i].Value, depth+1)
+		}
+	case compiler.FastValueIndex:
+		if plan.Left != nil {
+			b.value(*plan.Left, depth+1)
+		}
+		if plan.Right != nil {
+			b.value(*plan.Right, depth+1)
+		}
+		for i := range plan.Path {
+			for argIndex := range plan.Path[i].Args {
+				b.value(plan.Path[i].Args[argIndex], depth+1)
+			}
 		}
 	}
 }

--- a/vm/vm/render_diagnostics_test.go
+++ b/vm/vm/render_diagnostics_test.go
@@ -27,10 +27,10 @@ func Test_Render_Diagnostics_Fast_Render_Plan_Stats(t *testing.T) {
 					Condition: compiler.FastValuePlan{
 						Kind:     compiler.FastValueInfix,
 						Operator: "==",
-						Left:     &compiler.FastValuePlan{Kind: compiler.FastValuePath, Value: "product", Path: []compiler.FastPathStep{{Kind: compiler.FastPathStepProperty, Value: "Name"}}},
-						Right:    &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "Pizza"},
+						Left:     &compiler.FastValuePlan{Kind: compiler.FastValuePath, Value: "record", Path: []compiler.FastPathStep{{Kind: compiler.FastPathStepProperty, Value: "Name"}}},
+						Right:    &compiler.FastValuePlan{Kind: compiler.FastValueString, Value: "Active"},
 					},
-					Segments: []compiler.FastRenderSegment{{Kind: compiler.FastRenderSegmentStatic, Value: "pizza"}},
+					Segments: []compiler.FastRenderSegment{{Kind: compiler.FastRenderSegmentStatic, Value: "active"}},
 				}},
 			}},
 			{Kind: compiler.FastRenderSegmentLoop, Loop: &compiler.FastLoopPlan{
@@ -45,7 +45,7 @@ func Test_Render_Diagnostics_Fast_Render_Plan_Stats(t *testing.T) {
 			{Kind: compiler.FastRenderSegmentPartial, Partial: &compiler.FastPartialPlan{
 				Name: "row.plush",
 				Data: []compiler.FastPartialDataPair{
-					{Key: "title", Value: compiler.FastValuePlan{Kind: compiler.FastValuePath, Value: "product", Path: []compiler.FastPathStep{{Kind: compiler.FastPathStepProperty, Value: "Title"}}}},
+					{Key: "title", Value: compiler.FastValuePlan{Kind: compiler.FastValuePath, Value: "record", Path: []compiler.FastPathStep{{Kind: compiler.FastPathStepProperty, Value: "Title"}}}},
 				},
 			}},
 		},
@@ -92,6 +92,47 @@ func Test_Render_Diagnostics_Context_Expose_Fast_Render_Plan_Stats(t *testing.T)
 	require.Greater(t, diagnostics.FastPlan.Segments, 0)
 	require.Greater(t, diagnostics.FastPlan.NameSegments, 0)
 	require.NotZero(t, diagnostics.EngineDuration)
+}
+
+func Test_Render_Diagnostics_Context_Expose_Output_Size_Stats(t *testing.T) {
+	tmpl, err := Compile(`<h1><%= name %></h1>`)
+	require.NoError(t, err)
+
+	firstCtx := plush.NewContextWith(map[string]interface{}{"name": "Mido"})
+	firstOut, err := tmpl.Render(firstCtx)
+	require.NoError(t, err)
+	require.Equal(t, "<h1>Mido</h1>", firstOut)
+
+	firstDiagnostics, ok := plush.RenderDiagnosticsFromContext(firstCtx)
+	require.True(t, ok)
+	require.True(t, firstDiagnostics.OutputSize.Available)
+	require.Equal(t, len("<h1></h1>"), firstDiagnostics.OutputSize.StaticSize)
+	require.Equal(t, len("<h1></h1>")+16, firstDiagnostics.OutputSize.FallbackHint)
+	require.Equal(t, len("<h1></h1>")+16, firstDiagnostics.OutputSize.GrowHint)
+	require.Zero(t, firstDiagnostics.OutputSize.EstimateBefore)
+	require.Equal(t, len(firstOut), firstDiagnostics.OutputSize.Actual)
+	require.Equal(t, len(firstOut), firstDiagnostics.OutputSize.EstimateAfter)
+	require.Equal(t, uint64(0), firstDiagnostics.OutputSize.SamplesBefore)
+	require.Equal(t, uint64(1), firstDiagnostics.OutputSize.SamplesAfter)
+	require.True(t, firstDiagnostics.OutputSize.Observed)
+	require.True(t, firstDiagnostics.OutputSize.GrowCalled)
+	require.Positive(t, firstDiagnostics.OutputSize.GrowAllocated)
+	require.GreaterOrEqual(t, firstDiagnostics.OutputSize.CapacityFinal, firstDiagnostics.OutputSize.Actual)
+	require.Equal(t, firstDiagnostics.OutputSize.CapacityFinal-firstDiagnostics.OutputSize.Actual, firstDiagnostics.OutputSize.UnusedCapacity)
+
+	secondCtx := plush.NewContextWith(map[string]interface{}{"name": "Leela"})
+	secondOut, err := tmpl.Render(secondCtx)
+	require.NoError(t, err)
+	require.Equal(t, "<h1>Leela</h1>", secondOut)
+
+	secondDiagnostics, ok := plush.RenderDiagnosticsFromContext(secondCtx)
+	require.True(t, ok)
+	require.Equal(t, len(firstOut), secondDiagnostics.OutputSize.EstimateBefore)
+	require.Equal(t, len(firstOut), secondDiagnostics.OutputSize.GrowHint)
+	require.Equal(t, len(secondOut), secondDiagnostics.OutputSize.Actual)
+	require.Equal(t, uint64(1), secondDiagnostics.OutputSize.SamplesBefore)
+	require.Equal(t, uint64(2), secondDiagnostics.OutputSize.SamplesAfter)
+	require.NotEmpty(t, secondDiagnostics.OutputSizeHeader())
 }
 
 func Test_Render_Diagnostics_Caches_Fast_Render_Plan_Stats_On_Bytecode(t *testing.T) {

--- a/vm/vm/runtime.go
+++ b/vm/vm/runtime.go
@@ -331,7 +331,7 @@ func Render(input string, ctx hctx.Context) (string, error) {
 	if rendered, ok, err := tryRenderFastBytecode(cachedBytecode, ctx); ok || err != nil {
 		if ok {
 			plush.UpdateRenderDiagnosticsForTemplate(ctx, filename, func(d *plush.RenderDiagnostics) {
-				d.FastPath = plush.RenderFastPathFast
+				d.FastPath = renderFastPathForPlan(cachedBytecode.FastRenderPlan)
 			})
 		}
 		return rendered, err
@@ -387,7 +387,7 @@ func Render(input string, ctx hctx.Context) (string, error) {
 				if ok {
 					plush.UpdateRenderDiagnosticsForTemplate(ctx, filename, func(d *plush.RenderDiagnostics) {
 						d.VMBytecodeCache = plush.VMBytecodeCacheHit
-						d.FastPath = plush.RenderFastPathFast
+						d.FastPath = renderFastPathForPlan(bytecode.FastRenderPlan)
 					})
 				}
 				return rendered, err
@@ -456,7 +456,7 @@ func renderSourceCachedBytecode(source string, ctx hctx.Context, bytecode *compi
 	if rendered, ok, err := tryRenderFastBytecode(bytecode, ctx); ok || err != nil {
 		if ok {
 			plush.UpdateRenderDiagnosticsForTemplate(ctx, "", func(d *plush.RenderDiagnostics) {
-				d.FastPath = plush.RenderFastPathFast
+				d.FastPath = renderFastPathForPlan(bytecode.FastRenderPlan)
 			})
 		}
 		return rendered, err
@@ -509,7 +509,7 @@ func renderBytecode(bytecode *compiler.Bytecode, ctx hctx.Context) (string, erro
 	if rendered, ok, err := tryRenderFastBytecode(bytecode, ctx); ok || err != nil {
 		if ok {
 			plush.UpdateRenderDiagnosticsForTemplate(ctx, filename, func(d *plush.RenderDiagnostics) {
-				d.FastPath = plush.RenderFastPathFast
+				d.FastPath = renderFastPathForPlan(bytecode.FastRenderPlan)
 			})
 		}
 		return rendered, err
@@ -528,6 +528,13 @@ func renderBytecode(bytecode *compiler.Bytecode, ctx hctx.Context) (string, erro
 		}
 	}
 	return renderBytecodeVMWithState(bytecode, ctx, filename, forceCacheClear, "")
+}
+
+func renderFastPathForPlan(plan *compiler.FastRenderPlan) string {
+	if fastRenderPlanUsesGenericVM(plan) {
+		return plush.RenderFastPathGeneric
+	}
+	return plush.RenderFastPathFast
 }
 
 func punchHoleCacheState(ctx hctx.Context) (string, bool, string, bool) {

--- a/vm/vm/runtime.go
+++ b/vm/vm/runtime.go
@@ -317,7 +317,7 @@ func Render(input string, ctx hctx.Context) (string, error) {
 					d.VMBytecodeCache = plush.VMBytecodeCacheHitStatic
 					d.FastPath = plush.RenderFastPathStatic
 				})
-				return bytecode.StaticOutput, nil
+				return renderStaticOutput(bytecode, ctx, outputSizeOptions{topLevel: true}), nil
 			}
 			plush.UpdateRenderDiagnosticsForTemplate(ctx, filename, func(d *plush.RenderDiagnostics) {
 				d.VMBytecodeCache = plush.VMBytecodeCacheHit
@@ -328,7 +328,7 @@ func Render(input string, ctx hctx.Context) (string, error) {
 	if shouldFallbackGenericBytecode(cachedBytecode) {
 		return renderInterpreterFallback(input, ctx, filename)
 	}
-	if rendered, ok, err := tryRenderFastBytecode(cachedBytecode, ctx); ok || err != nil {
+	if rendered, ok, err := tryRenderFastBytecodeTopLevel(cachedBytecode, ctx); ok || err != nil {
 		if ok {
 			plush.UpdateRenderDiagnosticsForTemplate(ctx, filename, func(d *plush.RenderDiagnostics) {
 				d.FastPath = renderFastPathForPlan(cachedBytecode.FastRenderPlan)
@@ -360,7 +360,7 @@ func Render(input string, ctx hctx.Context) (string, error) {
 			})
 		}
 
-		return renderBytecodeVMWithState(cachedBytecode, ctx, filename, forceCacheClear, cacheSource)
+		return renderBytecodeVMWithStateTopLevel(cachedBytecode, ctx, filename, forceCacheClear, cacheSource)
 	}
 
 	filename, forceCacheClear, cached, ok := punchHoleCacheStateForFilename(filename, ctx, cacheSource)
@@ -381,9 +381,9 @@ func Render(input string, ctx hctx.Context) (string, error) {
 					d.VMBytecodeCache = plush.VMBytecodeCacheHitStatic
 					d.FastPath = plush.RenderFastPathStatic
 				})
-				return bytecode.StaticOutput, nil
+				return renderStaticOutput(bytecode, ctx, outputSizeOptions{topLevel: true}), nil
 			}
-			if rendered, ok, err := tryRenderFastBytecode(bytecode, ctx); ok || err != nil {
+			if rendered, ok, err := tryRenderFastBytecodeTopLevel(bytecode, ctx); ok || err != nil {
 				if ok {
 					plush.UpdateRenderDiagnosticsForTemplate(ctx, filename, func(d *plush.RenderDiagnostics) {
 						d.VMBytecodeCache = plush.VMBytecodeCacheHit
@@ -401,7 +401,7 @@ func Render(input string, ctx hctx.Context) (string, error) {
 			if restorePartial := installVMPartialHelperForBytecode(bytecode, ctx); restorePartial != nil {
 				defer restorePartial()
 			}
-			return renderBytecodeVMWithState(bytecode, ctx, filename, forceCacheClear, cacheSource)
+			return renderBytecodeVMWithStateTopLevel(bytecode, ctx, filename, forceCacheClear, cacheSource)
 		}
 	}
 
@@ -445,7 +445,7 @@ func renderSourceCachedBytecode(source string, ctx hctx.Context, bytecode *compi
 			d.VMBytecodeCache = plush.VMBytecodeCacheHitSource
 			d.FastPath = plush.RenderFastPathStatic
 		})
-		return bytecode.StaticOutput, nil
+		return renderStaticOutput(bytecode, ctx, outputSizeOptions{topLevel: true}), nil
 	}
 	plush.UpdateRenderDiagnosticsForTemplate(ctx, "", func(d *plush.RenderDiagnostics) {
 		d.VMBytecodeCache = plush.VMBytecodeCacheHitSource
@@ -453,7 +453,7 @@ func renderSourceCachedBytecode(source string, ctx hctx.Context, bytecode *compi
 	if shouldFallbackGenericBytecode(bytecode) {
 		return renderInterpreterFallback(source, ctx, "")
 	}
-	if rendered, ok, err := tryRenderFastBytecode(bytecode, ctx); ok || err != nil {
+	if rendered, ok, err := tryRenderFastBytecodeTopLevel(bytecode, ctx); ok || err != nil {
 		if ok {
 			plush.UpdateRenderDiagnosticsForTemplate(ctx, "", func(d *plush.RenderDiagnostics) {
 				d.FastPath = renderFastPathForPlan(bytecode.FastRenderPlan)
@@ -464,7 +464,7 @@ func renderSourceCachedBytecode(source string, ctx hctx.Context, bytecode *compi
 	if restorePartial := installVMPartialHelperForBytecode(bytecode, ctx); restorePartial != nil {
 		defer restorePartial()
 	}
-	return renderBytecodeVMWithState(bytecode, ctx, "", false, source)
+	return renderBytecodeVMWithStateTopLevel(bytecode, ctx, "", false, source)
 }
 
 func shouldFallbackGenericBytecode(bytecode *compiler.Bytecode) bool {
@@ -504,9 +504,9 @@ func renderBytecode(bytecode *compiler.Bytecode, ctx hctx.Context) (string, erro
 		plush.UpdateRenderDiagnosticsForTemplate(ctx, filename, func(d *plush.RenderDiagnostics) {
 			d.FastPath = plush.RenderFastPathStatic
 		})
-		return bytecode.StaticOutput, nil
+		return renderStaticOutput(bytecode, ctx, outputSizeOptions{topLevel: true}), nil
 	}
-	if rendered, ok, err := tryRenderFastBytecode(bytecode, ctx); ok || err != nil {
+	if rendered, ok, err := tryRenderFastBytecodeTopLevel(bytecode, ctx); ok || err != nil {
 		if ok {
 			plush.UpdateRenderDiagnosticsForTemplate(ctx, filename, func(d *plush.RenderDiagnostics) {
 				d.FastPath = renderFastPathForPlan(bytecode.FastRenderPlan)
@@ -527,7 +527,7 @@ func renderBytecode(bytecode *compiler.Bytecode, ctx hctx.Context) (string, erro
 			return cached, nil
 		}
 	}
-	return renderBytecodeVMWithState(bytecode, ctx, filename, forceCacheClear, "")
+	return renderBytecodeVMWithStateTopLevel(bytecode, ctx, filename, forceCacheClear, "")
 }
 
 func renderFastPathForPlan(plan *compiler.FastRenderPlan) string {
@@ -556,29 +556,42 @@ func punchHoleCacheStateForFilename(filename string, ctx hctx.Context, source st
 
 func renderBytecodeWithState(bytecode *compiler.Bytecode, ctx hctx.Context, filename string, forceCacheClear bool, source string) (string, error) {
 	if bytecode != nil && bytecode.Static {
-		return bytecode.StaticOutput, nil
+		return renderStaticOutput(bytecode, ctx, outputSizeOptions{topLevel: true}), nil
 	}
-	if rendered, ok, err := tryRenderFastBytecode(bytecode, ctx); ok || err != nil {
+	if rendered, ok, err := tryRenderFastBytecodeTopLevel(bytecode, ctx); ok || err != nil {
 		return rendered, err
 	}
-	return renderBytecodeVMWithState(bytecode, ctx, filename, forceCacheClear, source)
+	return renderBytecodeVMWithStateTopLevel(bytecode, ctx, filename, forceCacheClear, source)
 }
 
 func renderBytecodeVMWithState(bytecode *compiler.Bytecode, ctx hctx.Context, filename string, forceCacheClear bool, source string) (string, error) {
+	return renderBytecodeVMWithStateOptions(bytecode, ctx, filename, forceCacheClear, source, outputSizeOptions{})
+}
+
+func renderBytecodeVMWithStateTopLevel(bytecode *compiler.Bytecode, ctx hctx.Context, filename string, forceCacheClear bool, source string) (string, error) {
+	return renderBytecodeVMWithStateOptions(bytecode, ctx, filename, forceCacheClear, source, outputSizeOptions{topLevel: true})
+}
+
+func renderBytecodeVMWithStateOptions(bytecode *compiler.Bytecode, ctx hctx.Context, filename string, forceCacheClear bool, source string, options outputSizeOptions) (string, error) {
 	machine := newPooledWithContext(bytecode, ctx)
+	observation := growVMRootOutput(machine, bytecode, ctx, options)
 	if err := machine.Run(); err != nil {
 		defer machine.Release()
 		return "", machine.wrapRuntimeError(err)
 	}
 
+	recordVMRootOutputFinal(machine, &observation)
+	rootSize := vmRootOutputLen(machine)
 	rendered := machine.Rendered()
 	if bytecode == nil || !bytecode.HasHoles {
 		machine.Release()
+		observeOutputSize(bytecode, ctx, options, rootSize, observation)
 		return rendered, nil
 	}
 	holes := machine.PunchHoles()
 	machine.Release()
 	if !plush.IsPlushTemplateFile(filename) || len(holes) == 0 {
+		observeOutputSize(bytecode, ctx, options, rootSize, observation)
 		return rendered, nil
 	}
 
@@ -587,11 +600,17 @@ func renderBytecodeVMWithState(bytecode *compiler.Bytecode, ctx hctx.Context, fi
 		plush.CachePunchHoleSkeletonWithSource(filename, ctx, rendered, holes, forceCacheClear, source)
 	}
 	if plush.IsHoleRender(ctx) {
+		observeOutputSize(bytecode, ctx, options, rootSize, observation)
 		return rendered, nil
 	}
 
 	holes = plush.RenderPunchHolesConcurrentlyWith(holes, ctx, Render)
-	return plush.FillPunchHoles(rendered, holes)
+	filled, err := plush.FillPunchHoles(rendered, holes)
+	if err != nil {
+		return "", err
+	}
+	observeOutputSize(bytecode, ctx, options, rootSize, observation)
+	return filled, nil
 }
 
 func bytecodeCanUsePunchHoleCache(bytecode *compiler.Bytecode) bool {

--- a/vm/vm/runtime_helpers_test.go
+++ b/vm/vm/runtime_helpers_test.go
@@ -747,9 +747,9 @@ func Test_VM_Fast_Loop_Conditional_And_Call_Helpers(t *testing.T) {
 	require.Equal(t, "pre:", evaluated.Raw(1))
 
 	var out strings.Builder
-	require.NoError(t, writeFastLoopCallPart(&out, ctx, bindings, call, 1, "item"))
+	require.NoError(t, writeFastLoopCallPart(&out, ctx, bindings, nil, call, 1, "item"))
 	require.Equal(t, "pre:item", out.String())
-	require.NoError(t, writeFastLoopCallPart(&out, ctx, bindings, nil, 1, "item"))
+	require.NoError(t, writeFastLoopCallPart(&out, ctx, bindings, nil, nil, 1, "item"))
 
 	out.Reset()
 	conditional := &compiler.FastLoopConditionalPlan{

--- a/vm/vm/runtime_helpers_test.go
+++ b/vm/vm/runtime_helpers_test.go
@@ -1117,6 +1117,238 @@ func Test_VM_Runtime_Render_No_Filename_Uses_Source_Bytecode_Cache(t *testing.T)
 	require.Equal(t, plush.RenderFastPathFast, secondDiagnostics.FastPath)
 }
 
+func Test_VM_Output_Size_Stats_Fast_Render_Top_Level_Only(t *testing.T) {
+	tmpl, err := Compile(`<h1><%= name %></h1>`)
+	require.NoError(t, err)
+	bytecode := tmpl.bytecode
+	require.NotNil(t, bytecode.OutputSizeStats)
+	require.Equal(t, len("<h1></h1>"), bytecode.StaticSize)
+
+	rendered, err := tmpl.Render(plush.NewContextWith(map[string]interface{}{"name": "Mido"}))
+	require.NoError(t, err)
+	require.Equal(t, "<h1>Mido</h1>", rendered)
+	require.Equal(t, uint64(1), bytecode.OutputSizeStats.Samples())
+	require.Equal(t, len(rendered), bytecode.OutputSizeStats.Estimate())
+
+	rendered, handled, err := tryRenderFastBytecode(bytecode, plush.NewContextWith(map[string]interface{}{"name": "Leela"}))
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "<h1>Leela</h1>", rendered)
+	require.Equal(t, uint64(1), bytecode.OutputSizeStats.Samples())
+}
+
+func Test_VM_Output_Size_Stats_Normal_VM_Learns_Only_On_Success(t *testing.T) {
+	tmpl, err := Compile(`Hello <%= name %>`)
+	require.NoError(t, err)
+	bytecode := tmpl.bytecode
+	bytecode.FastRenderPlan = nil
+
+	rendered, err := renderBytecode(bytecode, plush.NewContextWith(map[string]interface{}{"name": "Amy"}))
+	require.NoError(t, err)
+	require.Equal(t, "Hello Amy", rendered)
+	require.Equal(t, uint64(1), bytecode.OutputSizeStats.Samples())
+	require.Equal(t, len(rendered), bytecode.OutputSizeStats.Estimate())
+
+	_, err = renderBytecode(bytecode, plush.NewContext())
+	require.Error(t, err)
+	require.Equal(t, uint64(1), bytecode.OutputSizeStats.Samples())
+	require.Equal(t, len(rendered), bytecode.OutputSizeStats.Estimate())
+}
+
+func Test_VM_Output_Size_Stats_Source_Cache_Is_Per_Bytecode(t *testing.T) {
+	clearSourceBytecodeCacheForTest()
+	defer clearSourceBytecodeCacheForTest()
+
+	firstSource := `<%= name %>`
+	firstRendered, err := Render(firstSource, plush.NewContextWith(map[string]interface{}{"name": "first"}))
+	require.NoError(t, err)
+	require.Equal(t, "first", firstRendered)
+	firstBytecode, ok := cachedSourceBytecode(preprocessTrimTags(firstSource))
+	require.True(t, ok)
+	require.Equal(t, uint64(1), firstBytecode.OutputSizeStats.Samples())
+
+	secondRendered, err := Render(firstSource, plush.NewContextWith(map[string]interface{}{"name": "second"}))
+	require.NoError(t, err)
+	require.Equal(t, "second", secondRendered)
+	require.Equal(t, uint64(2), firstBytecode.OutputSizeStats.Samples())
+
+	otherSource := `Hi <%= name %>`
+	otherRendered, err := Render(otherSource, plush.NewContextWith(map[string]interface{}{"name": "third"}))
+	require.NoError(t, err)
+	require.Equal(t, "Hi third", otherRendered)
+	otherBytecode, ok := cachedSourceBytecode(preprocessTrimTags(otherSource))
+	require.True(t, ok)
+	require.NotSame(t, firstBytecode, otherBytecode)
+	require.Equal(t, uint64(2), firstBytecode.OutputSizeStats.Samples())
+	require.Equal(t, uint64(1), otherBytecode.OutputSizeStats.Samples())
+}
+
+func Test_VM_Output_Size_Stats_Nested_Partial_Learns_Without_Changing_Template_Stats(t *testing.T) {
+	partial, err := Compile(`<span><%= name %></span>`)
+	require.NoError(t, err)
+	ctx := plush.NewContextWith(map[string]interface{}{"name": "Fry"})
+
+	rendered, err := renderLinkedPartialBytecode(&partialBytecodeLink{bytecode: partial.bytecode}, ctx, "partial.plush", false)
+	require.NoError(t, err)
+	require.Equal(t, "<span>Fry</span>", rendered)
+	require.Zero(t, partial.bytecode.OutputSizeStats.Samples())
+	require.Equal(t, uint64(1), partial.bytecode.PartialSizeStats.Samples())
+	require.Equal(t, len(rendered), partial.bytecode.PartialSizeStats.Estimate())
+
+	rendered, err = renderLinkedPartialBytecode(&partialBytecodeLink{bytecode: partial.bytecode}, ctx, "partial.plush", false)
+	require.NoError(t, err)
+	require.Equal(t, "<span>Fry</span>", rendered)
+	require.Equal(t, uint64(2), partial.bytecode.PartialSizeStats.Samples())
+
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, 2, diagnostics.PartialOutput.Calls)
+	require.Equal(t, len(rendered), diagnostics.PartialOutput.Learned)
+	require.Equal(t, len(rendered)*2, diagnostics.PartialOutput.Actual)
+	require.Equal(t, 1, diagnostics.PartialOutput.WithinTen)
+}
+
+func Test_VM_Output_Size_GrowHint_Uses_Fallback_Only_Until_Learned(t *testing.T) {
+	bytecode := &compiler.Bytecode{
+		StaticSize:      4,
+		OutputSizeStats: &compiler.OutputSizeStats{},
+	}
+	ctx := plush.NewContext()
+	options := outputSizeOptions{topLevel: true}
+
+	require.Equal(t, 64, outputGrowHint(bytecode, 64, ctx, options))
+
+	bytecode.ObserveOutputSize(10)
+	require.Equal(t, 10, outputGrowHint(bytecode, 64, ctx, options))
+}
+
+func Test_VM_Output_Size_Estimator_Disabled_Skips_All_Adaptive_Learning(t *testing.T) {
+	previous := plush.SetOutputSizeEstimatorEnabled(false)
+	defer plush.SetOutputSizeEstimatorEnabled(previous)
+
+	tmpl, err := Compile(`<%= for (_, item) in items { %><span><%= item %></span><% } %>`)
+	require.NoError(t, err)
+	loop := tmpl.bytecode.FastRenderPlan.Segments[0].Loop
+	require.NotNil(t, loop)
+
+	ctx := plush.NewContextWith(map[string]interface{}{"items": []string{"one", "two"}})
+	rendered, err := tmpl.Render(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "<span>one</span><span>two</span>", rendered)
+	require.Zero(t, tmpl.bytecode.OutputSizeStats.Samples())
+	require.Zero(t, loop.SizeStats.Samples())
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.False(t, diagnostics.OutputSize.Available)
+	require.Zero(t, diagnostics.PartialOutput.Calls)
+
+	plush.SetOutputSizeEstimatorEnabled(true)
+	_, err = tmpl.Render(plush.NewContextWith(map[string]interface{}{"items": []string{"three"}}))
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), tmpl.bytecode.OutputSizeStats.Samples())
+	require.Equal(t, uint64(1), loop.SizeStats.Samples())
+}
+
+func Test_VM_Contextual_Output_Grow_Uses_Exact_Yield_And_Caps_Only_Overhead(t *testing.T) {
+	const yieldSize = 22 << 20
+
+	require.Equal(t, yieldSize+(64<<10), contextualOutputGrowHint(yieldSize, 64<<10))
+	require.Equal(t, yieldSize+contextualOutputOverheadGrowLimit, contextualOutputGrowHint(yieldSize, 8<<20))
+}
+
+func Test_VM_Partial_Output_Size_Caps_Unstable_Speculative_Grow(t *testing.T) {
+	bytecode := &compiler.Bytecode{
+		StaticSize:       32,
+		PartialSizeStats: &compiler.OutputSizeStats{},
+	}
+	bytecode.PartialSizeStats.Observe(4 << 20)
+	bytecode.PartialSizeStats.Observe(32 << 10)
+
+	ctx := plush.NewContext()
+	observation := beginPartialOutputObservation(bytecode, "fragments/variable.plush", ctx)
+	require.True(t, observation.unstable)
+	require.True(t, observation.limited)
+	require.Greater(t, observation.estimateBefore, unstablePartialGrowLimit)
+	require.Equal(t, unstablePartialGrowLimit, observation.growHint)
+
+	var out strings.Builder
+	growInlineOutputBuilder(&out, observation.growHint, &observation)
+	out.WriteString("rendered")
+	observePartialOutput(bytecode, "fragments/variable.plush", ctx, out.Len(), observation)
+
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, 1, diagnostics.PartialOutput.Calls)
+	require.Equal(t, 1, diagnostics.PartialOutput.Unstable)
+	require.Equal(t, 1, diagnostics.PartialOutput.Limited)
+	require.Equal(t, 1, diagnostics.PartialOutput.GrowCalls)
+	require.GreaterOrEqual(t, diagnostics.PartialOutput.GrowAllocated, unstablePartialGrowLimit)
+	require.Len(t, diagnostics.PartialOutput.Details, 1)
+	require.True(t, diagnostics.PartialOutput.Details[0].Unstable)
+	require.Equal(t, 8, diagnostics.PartialOutput.Details[0].Minimum)
+	require.Equal(t, 4<<20, diagnostics.PartialOutput.Details[0].Maximum)
+}
+
+func Test_VM_Template_Output_Size_Uses_Observed_Minimum_When_Unstable(t *testing.T) {
+	bytecode := &compiler.Bytecode{
+		StaticSize:      32,
+		OutputSizeStats: &compiler.OutputSizeStats{},
+	}
+	bytecode.OutputSizeStats.Observe(4 << 10)
+	bytecode.OutputSizeStats.Observe(1 << 20)
+
+	observation := beginOutputSizeObservation(bytecode, 0, plush.NewContext(), outputSizeOptions{topLevel: true})
+	require.True(t, observation.unstable)
+	require.True(t, observation.limited)
+	require.Greater(t, observation.estimateBefore, 4<<10)
+	require.Equal(t, 4<<10, observation.growHint)
+}
+
+func Test_VM_Partial_Output_Size_Does_Not_Double_Large_Parent_Builder(t *testing.T) {
+	var out strings.Builder
+	out.Grow(inlinePartialParentGrowLimit)
+	out.WriteString(strings.Repeat("x", out.Cap()-1024))
+	capacityBefore := out.Cap()
+
+	observation := outputSizeObservation{growHint: 32 << 10}
+	growInlineOutputBuilder(&out, observation.growHint, &observation)
+
+	require.Equal(t, capacityBefore, out.Cap())
+	require.False(t, observation.growCalled)
+	require.True(t, observation.limited)
+	require.Zero(t, outputSpeculativeAllocated(observation))
+}
+
+func Test_VM_Output_Size_Diagnostics_Do_Not_Mix_Nested_Render_Snapshots(t *testing.T) {
+	outer := &compiler.Bytecode{
+		StaticSize:      4,
+		OutputSizeStats: &compiler.OutputSizeStats{},
+	}
+	inner := &compiler.Bytecode{
+		StaticSize:      2,
+		OutputSizeStats: &compiler.OutputSizeStats{},
+	}
+	ctx := plush.NewContext()
+	options := outputSizeOptions{topLevel: true}
+
+	outerObservation := beginOutputSizeObservation(outer, 64, ctx, options)
+	innerObservation := beginOutputSizeObservation(inner, 8, ctx, options)
+	observeOutputSize(inner, ctx, options, 12, innerObservation)
+	observeOutputSize(outer, ctx, options, 100, outerObservation)
+
+	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, 4, diagnostics.OutputSize.StaticSize)
+	require.Equal(t, 64, diagnostics.OutputSize.FallbackHint)
+	require.Equal(t, 64, diagnostics.OutputSize.GrowHint)
+	require.Zero(t, diagnostics.OutputSize.EstimateBefore)
+	require.Equal(t, 100, diagnostics.OutputSize.Actual)
+	require.Equal(t, 100, diagnostics.OutputSize.EstimateAfter)
+	require.Zero(t, diagnostics.OutputSize.SamplesBefore)
+	require.Equal(t, uint64(1), diagnostics.OutputSize.SamplesAfter)
+	require.True(t, diagnostics.OutputSize.Observed)
+}
+
 func Test_VM_Runtime_Source_Render_Ignores_Source_Blind_Stale_Bytecode(t *testing.T) {
 	cache := inmemory.NewMemoryCache()
 	plush.PlushCacheSetup(cache)

--- a/vm/vm/vm_package_coverage_edges_test.go
+++ b/vm/vm/vm_package_coverage_edges_test.go
@@ -456,7 +456,7 @@ func Test_VM_Fast_Mixed_Render_Remaining_Error_Branches(t *testing.T) {
 			}},
 			Line: 81,
 		},
-	}}})
+	}}}, nil)
 	require.True(t, handled)
 	require.ErrorContains(t, err, "line 81")
 
@@ -470,7 +470,7 @@ func Test_VM_Fast_Mixed_Render_Remaining_Error_Branches(t *testing.T) {
 			Right:    &compiler.FastValuePlan{Kind: compiler.FastValueInteger, IntValue: 2},
 			Line:     82,
 		},
-	}}})
+	}}}, nil)
 	require.True(t, handled)
 	require.ErrorContains(t, err, "line 82")
 
@@ -481,7 +481,7 @@ func Test_VM_Fast_Mixed_Render_Remaining_Error_Branches(t *testing.T) {
 			Segments:  []compiler.FastRenderSegment{{Kind: compiler.FastRenderSegmentStatic, Value: "never"}},
 			Line:      83,
 		}}},
-	}}})
+	}}}, nil)
 	require.True(t, handled)
 	require.ErrorContains(t, err, "line 83")
 }
@@ -515,7 +515,7 @@ func Test_VM_Fast_Call_And_Loop_Call_Remaining_Error_Branches(t *testing.T) {
 
 	badCtx := plush.NewContextWith(map[string]interface{}{"label": 12})
 	badBindings := newFastRenderBindings(&compiler.FastRenderPlan{Bindings: []string{"label"}}, badCtx)
-	err = writeFastLoopCallPart(&strings.Builder{}, badCtx, badBindings, &compiler.FastCallPlan{
+	err = writeFastLoopCallPart(&strings.Builder{}, badCtx, badBindings, nil, &compiler.FastCallPlan{
 		Name:      "label",
 		NameIndex: 0,
 		Line:      85,

--- a/vm/vm/vm_test.go
+++ b/vm/vm/vm_test.go
@@ -3651,6 +3651,30 @@ func Test_VM_Form_Helper_Context_Set_Is_Visible_After_Block_In_Caller_With_Local
 	require.Contains(t, out, "input:Fields[0].Second:second:field_input")
 }
 
+func Test_VM_Missing_Helper_In_Block_Condition_Uses_Else(t *testing.T) {
+	tmpl, err := Compile(`<%= wrapper({label: "example"}) { %><%= if(optional(record.Limit)) { %>set<% } else { %>fallback<% } %><% } %>`)
+	require.NoError(t, err)
+
+	bytecode := *tmpl.bytecode
+	bytecode.FastRenderPlan = nil
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"record": struct {
+			Limit int
+		}{Limit: 5},
+		"wrapper": func(data map[string]interface{}, help plush.HelperContext) (template.HTML, error) {
+			body, err := help.Block()
+			if err != nil {
+				return "", err
+			}
+			return template.HTML(`<section data-label="example">` + body + `</section>`), nil
+		},
+	})
+
+	out, err := renderBytecodeVMWithState(&bytecode, ctx, "", false, "")
+	require.NoError(t, err)
+	require.Equal(t, `<section data-label="example">fallback</section>`, out)
+}
+
 func Test_VM_Form_Helper_Context_Set_Is_Visible_After_Multiple_Caller_Loops(t *testing.T) {
 	tmpl, err := Compile(`<%= layout({}) { %>
 <% let selected = record.Entries[0] %>

--- a/vm/vm/vm_test.go
+++ b/vm/vm/vm_test.go
@@ -1634,13 +1634,13 @@ func Test_VM_Partial_Error_Includes_Parent_And_Partial_Filenames(t *testing.T) {
 			return "first\n<%= missing %>", nil
 		},
 	})
-	ctx.Set(meta.TemplateBaseFileNameKey, "application")
-	ctx.Set(meta.TemplateFileKey, "application.plush")
+	ctx.Set(meta.TemplateBaseFileNameKey, "layout")
+	ctx.Set(meta.TemplateFileKey, "layout.plush")
 	ctx.Set(meta.TemplateExtensionKey, "plush")
 
 	_, err := Render("<p>top</p>\n<%= partial(\"partials/row.plush\") %>", ctx)
 	require.Error(t, err)
-	require.EqualError(t, err, `application.plush:2:partials/row.plush:2: "missing": unknown identifier`)
+	require.EqualError(t, err, `layout.plush:2:partials/row.plush:2: "missing": unknown identifier`)
 }
 
 func Test_VM_Partial_Sees_Top_Level_Let_Alias_From_Pointer_Config(t *testing.T) {
@@ -2819,11 +2819,11 @@ func Test_VM_Fast_Top_Level_Infix_Output_Preserves_Missing_Ordered_Error(t *test
 }
 
 func Test_VM_Fast_Conditional_Missing_Ordered_Error_Names_Operand(t *testing.T) {
-	_, err := Render(`<%= if (productNumberOfReviews > 0) { %>yes<% } %>`, plush.NewContext())
+	_, err := Render(`<%= if (missingCount > 0) { %>yes<% } %>`, plush.NewContext())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), `unable to operate (>)`)
-	require.Contains(t, err.Error(), `while evaluating productNumberOfReviews > 0`)
-	require.Contains(t, err.Error(), `productNumberOfReviews is nil or missing`)
+	require.Contains(t, err.Error(), `while evaluating missingCount > 0`)
+	require.Contains(t, err.Error(), `missingCount is nil or missing`)
 }
 
 func Test_VM_Fast_Struct_Loop_Specializes_Conditional_Part_Automatically(t *testing.T) {
@@ -3462,6 +3462,420 @@ func Test_VM_Direct_Property_Write_Fusion_And_Raw_Loop_Values(t *testing.T) {
 	}))
 	require.NoError(t, err)
 	require.Equal(t, "&lt;Ada&gt;|Bender;&lt;Fry&gt;;", out)
+}
+
+func Test_VM_Block_Helper_Context_Set_Is_Visible_After_Inline_Loop_Assignment(t *testing.T) {
+	tmpl, err := Compile(`<%= if(record.Enabled) { %><%= wrap({}) { %><%= f.InputTag({name:"Fields[0].First", value: 1, class:"field_input"}) %><% } %><% let selected = record.Entries[0] %><%= for (i, entry) in record.Entries { %><%= if(entry.ID == input["target_id"]) { %><% selected = entry %><% } %><%= if(i == 2) { break } %><% } %><%= wrap({}) { %><%= f.InputTag({name:"Fields[0].Second", value: selected.ID, class:"field_input"}) %><%= if(record.Enabled) { %><%= f.InputTag({name:"Fields[0].Third", value: 3, class:"field_input"}) %><% } %><% } %><% } %>`)
+	require.NoError(t, err)
+
+	bytecode := *tmpl.bytecode
+	bytecode.FastRenderPlan = nil
+
+	type entry struct {
+		ID string
+	}
+	parent := plush.NewContextWith(map[string]interface{}{
+		"record": struct {
+			Enabled bool
+			Entries []entry
+		}{
+			Enabled: true,
+			Entries: []entry{
+				{ID: "first"},
+				{ID: "second"},
+			},
+		},
+		"input": map[string]string{"target_id": "second"},
+		"wrap": func(data map[string]interface{}, help plush.HelperContext) (template.HTML, error) {
+			help.Set("f", fastScriptPlanFormBuilder{})
+			body, err := help.Block()
+			if err != nil {
+				return "", err
+			}
+			return template.HTML(body), nil
+		},
+	})
+	ctx := borrowPartialOverlayContext(parent)
+	defer releasePartialOverlayContext(ctx)
+
+	out, err := renderBytecodeVMWithState(&bytecode, ctx, "", false, "")
+	require.NoError(t, err)
+	require.Contains(t, out, "input:Fields[0].First:1:field_input")
+	require.Contains(t, out, "input:Fields[0].Second:second:field_input")
+	require.Contains(t, out, "input:Fields[0].Third:3:field_input")
+}
+
+func Test_VM_Block_Helper_Context_Set_Is_Visible_After_Loop_Inside_Same_Block(t *testing.T) {
+	tmpl, err := Compile(`<%= wrap({}) { %><%= f.InputTag({name:"Fields[0].First", value: 1, class:"field_input"}) %><% let selected = record.Entries[0] %><%= for (i, entry) in record.Entries { %><%= if(entry.ID == input["target_id"]) { %><% selected = entry %><% } %><%= if(i == 2) { break } %><% } %><%= f.InputTag({name:"Fields[0].Second", value: selected.ID, class:"field_input"}) %><% } %>`)
+	require.NoError(t, err)
+
+	bytecode := *tmpl.bytecode
+	bytecode.FastRenderPlan = nil
+
+	type entry struct {
+		ID string
+	}
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"record": struct {
+			Entries []entry
+		}{
+			Entries: []entry{
+				{ID: "first"},
+				{ID: "second"},
+			},
+		},
+		"input": map[string]string{"target_id": "second"},
+		"wrap": func(data map[string]interface{}, help plush.HelperContext) (template.HTML, error) {
+			help.Set("f", fastScriptPlanFormBuilder{})
+			body, err := help.Block()
+			if err != nil {
+				return "", err
+			}
+			return template.HTML(body), nil
+		},
+	})
+
+	out, err := renderBytecodeVMWithState(&bytecode, ctx, "", false, "")
+	require.NoError(t, err)
+	require.Contains(t, out, "input:Fields[0].First:1:field_input")
+	require.Contains(t, out, "input:Fields[0].Second:second:field_input")
+}
+
+func Test_VM_Block_Helper_Context_Set_Is_Visible_After_Block_When_Frame_Has_Locals(t *testing.T) {
+	tmpl, err := Compile(`<%= outer({}) { %><% let selected = record.Entries[0] %><%= wrap({}) { %><%= f.InputTag({name:"Fields[0].First", value: 1, class:"field_input"}) %><% } %><%= for (i, entry) in record.Entries { %><%= if(entry.ID == input["target_id"]) { %><% selected = entry %><% } %><%= if(i == 2) { break } %><% } %><%= if(record.Enabled) { %><%= f.InputTag({name:"Fields[0].Second", value: selected.ID, class:"field_input"}) %><% } %><% } %>`)
+	require.NoError(t, err)
+
+	bytecode := *tmpl.bytecode
+	bytecode.FastRenderPlan = nil
+
+	type entry struct {
+		ID string
+	}
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"record": struct {
+			Enabled bool
+			Entries []entry
+		}{
+			Enabled: true,
+			Entries: []entry{
+				{ID: "first"},
+				{ID: "second"},
+			},
+		},
+		"input": map[string]string{"target_id": "second"},
+		"outer": func(data map[string]interface{}, help plush.HelperContext) (template.HTML, error) {
+			body, err := help.Block()
+			if err != nil {
+				return "", err
+			}
+			return template.HTML(body), nil
+		},
+		"wrap": func(data map[string]interface{}, help plush.HelperContext) (template.HTML, error) {
+			help.Set("f", fastScriptPlanFormBuilder{})
+			body, err := help.Block()
+			if err != nil {
+				return "", err
+			}
+			return template.HTML(body), nil
+		},
+	})
+
+	out, err := renderBytecodeVMWithState(&bytecode, ctx, "", false, "")
+	require.NoError(t, err)
+	require.Contains(t, out, "input:Fields[0].First:1:field_input")
+	require.Contains(t, out, "input:Fields[0].Second:second:field_input")
+}
+
+func Test_VM_Form_Helper_Context_Set_Is_Visible_After_Block_In_Caller_With_Locals(t *testing.T) {
+	tmpl, err := Compile(`<%= layout({}) { %>
+<% let selected = record.Entries[0] %>
+<%= form({action: submitPath(), method: "POST"}) { %>
+	<%= f.InputTag({name:"Fields[0].First", value: record.ID, class:"field_input"}) %>
+<% } %>
+<%= for (i, entry) in record.Entries { %>
+	<%= if(entry.ID == input["target_id"]) { %>
+		<% selected = entry %>
+	<% } %>
+	<%= if(i == 2) { break } %>
+<% } %>
+<%= if(record.Enabled) { %>
+	<%= f.InputTag({name:"Fields[0].Second", value: selected.ID, class:"field_input"}) %>
+<% } %>
+<% } %>`)
+	require.NoError(t, err)
+
+	bytecode := *tmpl.bytecode
+	bytecode.FastRenderPlan = nil
+
+	type entry struct {
+		ID string
+	}
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"record": struct {
+			ID      int
+			Enabled bool
+			Entries []entry
+		}{
+			ID:      7,
+			Enabled: true,
+			Entries: []entry{
+				{ID: "first"},
+				{ID: "second"},
+			},
+		},
+		"input": map[string]string{"target_id": "second"},
+		"submitPath": func() string {
+			return "/records"
+		},
+		"layout": func(data map[string]interface{}, help plush.HelperContext) (template.HTML, error) {
+			body, err := help.Block()
+			if err != nil {
+				return "", err
+			}
+			return template.HTML(body), nil
+		},
+		"form": func(data map[string]interface{}, help plush.HelperContext) (template.HTML, error) {
+			help.Set("f", fastScriptPlanFormBuilder{})
+			body, err := help.Block()
+			if err != nil {
+				return "", err
+			}
+			return template.HTML(fmt.Sprintf(`<form action="%s" method="%s">%s</form>`, data["action"], data["method"], body)), nil
+		},
+	})
+
+	out, err := renderBytecodeVMWithState(&bytecode, ctx, "", false, "")
+	require.NoError(t, err)
+	require.Contains(t, out, `<form action="/records" method="POST">`)
+	require.Contains(t, out, "input:Fields[0].First:7:field_input")
+	require.Contains(t, out, "input:Fields[0].Second:second:field_input")
+}
+
+func Test_VM_Form_Helper_Context_Set_Is_Visible_After_Multiple_Caller_Loops(t *testing.T) {
+	tmpl, err := Compile(`<%= layout({}) { %>
+<% let selected = record.Entries[0] %>
+<% let selectedValue = "" %>
+<% let selectedAsset = "" %>
+<%= form({action: submitPath(), method: "POST"}) { %>
+	<%= f.InputTag({name:"Fields[0].First", value: record.ID, class:"field_input"}) %>
+<% } %>
+<%= for (i, entry) in record.Entries { %>
+	<%= if(entry.ID == input["target_id"]) { %>
+		<% selected = entry %>
+	<% } %>
+	<%= if(i == 4) { break } %>
+<% } %>
+<%= for (fieldIndex, fieldName) in record.Fields { %>
+	<%= if(fieldName == "secondary") { %>
+		<%= for (_, entry) in record.Entries { %>
+			<% let active = "" %>
+			<%= if(entry.ID == selected.ID) { %>
+				<% active = "active" %>
+				<% selectedValue = entry.FieldValues[fieldIndex] %>
+			<% } %>
+			<span class="<%= active %>"><%= entry.FieldValues[fieldIndex] %></span>
+		<% } %>
+	<% } %>
+<% } %>
+<%= for (_, asset) in record.Assets { %>
+	<%= if(asset.Selected) { %>
+		<% selectedAsset = asset.Path %>
+	<% } %>
+<% } %>
+<%= if(record.Enabled) { %>
+	<%= f.InputTag({name:"Fields[0].Second", value: selected.ID, class:"field_input"}) %>
+	<%= f.InputTag({name:"Fields[0].Asset", value: selectedAsset, class:"field_input"}) %>
+	<%= f.InputTag({name:"Fields[0].Value", value: selectedValue, class:"field_input"}) %>
+<% } %>
+<% } %>`)
+	require.NoError(t, err)
+
+	bytecode := *tmpl.bytecode
+	bytecode.FastRenderPlan = nil
+
+	type entry struct {
+		ID          string
+		FieldValues []string
+	}
+	type asset struct {
+		Path     string
+		Selected bool
+	}
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"record": struct {
+			ID      int
+			Enabled bool
+			Entries []entry
+			Fields  []string
+			Assets  []asset
+		}{
+			ID:      7,
+			Enabled: true,
+			Entries: []entry{
+				{ID: "first", FieldValues: []string{"primary-a", "secondary-a"}},
+				{ID: "second", FieldValues: []string{"primary-b", "secondary-b"}},
+				{ID: "third", FieldValues: []string{"primary-c", "secondary-c"}},
+			},
+			Fields: []string{"primary", "secondary"},
+			Assets: []asset{
+				{Path: "fallback.txt"},
+				{Path: "selected.txt", Selected: true},
+			},
+		},
+		"input": map[string]string{"target_id": "second"},
+		"submitPath": func() string {
+			return "/records"
+		},
+		"layout": func(data map[string]interface{}, help plush.HelperContext) (template.HTML, error) {
+			body, err := help.Block()
+			if err != nil {
+				return "", err
+			}
+			return template.HTML(body), nil
+		},
+		"form": func(data map[string]interface{}, help plush.HelperContext) (template.HTML, error) {
+			help.Set("f", fastScriptPlanFormBuilder{})
+			body, err := help.Block()
+			if err != nil {
+				return "", err
+			}
+			return template.HTML(fmt.Sprintf(`<form action="%s" method="%s">%s</form>`, data["action"], data["method"], body)), nil
+		},
+	})
+
+	out, err := renderBytecodeVMWithState(&bytecode, ctx, "", false, "")
+	require.NoError(t, err)
+	require.Contains(t, out, `<form action="/records" method="POST">`)
+	require.Contains(t, out, "input:Fields[0].First:7:field_input")
+	require.Contains(t, out, `<span class="active">secondary-b</span>`)
+	require.Contains(t, out, "input:Fields[0].Second:second:field_input")
+	require.Contains(t, out, "input:Fields[0].Asset:selected.txt:field_input")
+	require.Contains(t, out, "input:Fields[0].Value:secondary-b:field_input")
+}
+
+func Test_VM_Helper_Context_Set_From_Silent_Call_Is_Visible_To_Later_Dynamic_Reads(t *testing.T) {
+	tmpl, err := Compile(`<% seed() %><%= label %>|<%= widget.Label %>`)
+	require.NoError(t, err)
+
+	bytecode := *tmpl.bytecode
+	bytecode.FastRenderPlan = nil
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"seed": func(help plush.HelperContext) {
+			help.Set("label", "ready")
+			help.Set("widget", struct {
+				Label string
+			}{Label: "visible"})
+		},
+	})
+
+	out, err := renderBytecodeVMWithState(&bytecode, ctx, "", false, "")
+	require.NoError(t, err)
+	require.Equal(t, "ready|visible", out)
+}
+
+func Test_VM_Helper_Context_Set_From_Block_Call_Is_Visible_After_Helper_Return(t *testing.T) {
+	tmpl, err := Compile(`<%= seed() { %><%= label %>|<%= widget.Label %><% } %>-><%= label %>|<%= widget.Label %>`)
+	require.NoError(t, err)
+
+	bytecode := *tmpl.bytecode
+	bytecode.FastRenderPlan = nil
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"seed": func(help plush.HelperContext) (template.HTML, error) {
+			help.Set("label", "before")
+			help.Set("widget", struct {
+				Label string
+			}{Label: "before"})
+			body, err := help.Block()
+			if err != nil {
+				return "", err
+			}
+			help.Set("label", "after")
+			help.Set("widget", struct {
+				Label string
+			}{Label: "after"})
+			return template.HTML(body), nil
+		},
+	})
+
+	out, err := renderBytecodeVMWithState(&bytecode, ctx, "", false, "")
+	require.NoError(t, err)
+	require.Equal(t, "before|before->after|after", out)
+}
+
+func Test_VM_BlockWith_Child_Context_Assignments_Sync_Back_To_Helper_Child(t *testing.T) {
+	tmpl, err := Compile(`<%= scope() { %><%= label %><% label = "updated" %>|<%= label %><% } %>`)
+	require.NoError(t, err)
+
+	bytecode := *tmpl.bytecode
+	bytecode.FastRenderPlan = nil
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"scope": func(help plush.HelperContext) (template.HTML, error) {
+			child := help.New()
+			child.Set("label", "initial")
+			body, err := help.BlockWith(child)
+			if err != nil {
+				return "", err
+			}
+			return template.HTML(body + "|child:" + child.Value("label").(string)), nil
+		},
+	})
+
+	out, err := renderBytecodeVMWithState(&bytecode, ctx, "", false, "")
+	require.NoError(t, err)
+	require.Equal(t, "initial|updated|child:updated", out)
+}
+
+func Test_VM_Helper_Context_Set_Is_Visible_To_Partial_Rendered_From_Block(t *testing.T) {
+	tmpl, err := Compile(`<%= wrap() { %><%= partial("piece") %><% } %>`)
+	require.NoError(t, err)
+
+	bytecode := *tmpl.bytecode
+	bytecode.FastRenderPlan = nil
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"partialFeeder": func(name string) (string, error) {
+			require.Equal(t, "piece", name)
+			return `<%= label %>|<%= widget.Label %>`, nil
+		},
+		"wrap": func(help plush.HelperContext) (template.HTML, error) {
+			help.Set("label", "partial-ready")
+			help.Set("widget", struct {
+				Label string
+			}{Label: "partial-visible"})
+			body, err := help.Block()
+			if err != nil {
+				return "", err
+			}
+			return template.HTML(body), nil
+		},
+	})
+
+	out, err := renderBytecodeVMWithState(&bytecode, ctx, "", false, "")
+	require.NoError(t, err)
+	require.Equal(t, "partial-ready|partial-visible", out)
+}
+
+func Test_VM_Partial_Helper_Does_Not_Sync_Recursive_Local_Bindings_To_Caller(t *testing.T) {
+	tmpl, err := Compile(`<%= partial("counter") %>|<%= number %>`)
+	require.NoError(t, err)
+
+	bytecode := *tmpl.bytecode
+	bytecode.FastRenderPlan = nil
+
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"number": 3,
+		"partialFeeder": func(name string) (string, error) {
+			require.Equal(t, "counter", name)
+			return `<%= if (number > 0) { %><% let number = number - 1 %><%= partial("counter") %><%= number %>,<% } %>`, nil
+		},
+	})
+
+	out, err := renderBytecodeVMWithState(&bytecode, ctx, "", false, "")
+	require.NoError(t, err)
+	require.Equal(t, "0,1,2,|3", out)
 }
 
 func Test_VM_Loop_Raw_Value_Detection_Rejects_Computed_Locals(t *testing.T) {

--- a/vm/vm/vm_test.go
+++ b/vm/vm/vm_test.go
@@ -1166,33 +1166,33 @@ func Test_VM_Fast_Render_Script_Loop_Control(t *testing.T) {
 }
 
 func Test_VM_Fast_Render_Loop_Block_Helper_Sees_Current_Value(t *testing.T) {
-	type product struct {
+	type item struct {
 		ID   int
 		Name string
 	}
 
-	tmpl, err := Compile(`<%= for (_, product) in products { %><%= form({id: product.ID, path: cartPath()}) { %><span><%= product.Name %></span><% } %><% } %>`)
+	tmpl, err := Compile(`<%= for (_, item) in items { %><%= wrap({id: item.ID, path: itemPath()}) { %><span><%= item.Name %></span><% } %><% } %>`)
 	require.NoError(t, err)
 	require.NotNil(t, tmpl.bytecode.FastRenderPlan)
 	require.Empty(t, tmpl.bytecode.FastReject)
 
 	ctx := plush.NewContextWith(map[string]interface{}{
-		"products": []product{{ID: 1, Name: "<A>"}, {ID: 2, Name: "B"}},
-		"cartPath": func() string {
-			return "/cart"
+		"items": []item{{ID: 1, Name: "<A>"}, {ID: 2, Name: "B"}},
+		"itemPath": func() string {
+			return "/items"
 		},
-		"form": func(data map[string]interface{}, help plush.HelperContext) (template.HTML, error) {
+		"wrap": func(data map[string]interface{}, help plush.HelperContext) (template.HTML, error) {
 			body, err := help.Block()
 			if err != nil {
 				return "", err
 			}
-			return template.HTML(fmt.Sprintf(`<form action="%s" id="%v">%s</form>`, data["path"], data["id"], body)), nil
+			return template.HTML(fmt.Sprintf(`<section data-path="%s" id="%v">%s</section>`, data["path"], data["id"], body)), nil
 		},
 	})
 
 	out, err := tmpl.Render(ctx)
 	require.NoError(t, err)
-	require.Equal(t, `<form action="/cart" id="1"><span>&lt;A&gt;</span></form><form action="/cart" id="2"><span>B</span></form>`, out)
+	require.Equal(t, `<section data-path="/items" id="1"><span>&lt;A&gt;</span></section><section data-path="/items" id="2"><span>B</span></section>`, out)
 
 	diagnostics, ok := plush.RenderDiagnosticsFromContext(ctx)
 	require.True(t, ok)
@@ -1625,6 +1625,22 @@ func Test_VM_Partial_Sees_Top_Level_Let_From_Parent_Template(t *testing.T) {
 	out, err := Render(`<% let activeRecord = viewData.Current %><%= partial("partials/color-token.plush.html") %>`, ctx)
 	require.NoError(t, err)
 	require.Contains(t, out, "<span class=\"token\">#123456</span>")
+}
+
+func Test_VM_Partial_Error_Includes_Parent_And_Partial_Filenames(t *testing.T) {
+	ctx := plush.NewContextWith(map[string]interface{}{
+		"partialFeeder": func(name string) (string, error) {
+			require.Equal(t, "partials/row.plush", name)
+			return "first\n<%= missing %>", nil
+		},
+	})
+	ctx.Set(meta.TemplateBaseFileNameKey, "application")
+	ctx.Set(meta.TemplateFileKey, "application.plush")
+	ctx.Set(meta.TemplateExtensionKey, "plush")
+
+	_, err := Render("<p>top</p>\n<%= partial(\"partials/row.plush\") %>", ctx)
+	require.Error(t, err)
+	require.EqualError(t, err, `application.plush:2:partials/row.plush:2: "missing": unknown identifier`)
 }
 
 func Test_VM_Partial_Sees_Top_Level_Let_Alias_From_Pointer_Config(t *testing.T) {
@@ -2798,6 +2814,16 @@ func Test_VM_Fast_Top_Level_Infix_Output_Preserves_Missing_Ordered_Error(t *test
 	_, err := Render(`<%= undefined > 3 %>`, plush.NewContext())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), `unable to operate (>)`)
+	require.Contains(t, err.Error(), `while evaluating undefined > 3`)
+	require.Contains(t, err.Error(), `undefined is nil or missing`)
+}
+
+func Test_VM_Fast_Conditional_Missing_Ordered_Error_Names_Operand(t *testing.T) {
+	_, err := Render(`<%= if (productNumberOfReviews > 0) { %>yes<% } %>`, plush.NewContext())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `unable to operate (>)`)
+	require.Contains(t, err.Error(), `while evaluating productNumberOfReviews > 0`)
+	require.Contains(t, err.Error(), `productNumberOfReviews is nil or missing`)
 }
 
 func Test_VM_Fast_Struct_Loop_Specializes_Conditional_Part_Automatically(t *testing.T) {
@@ -3296,7 +3322,9 @@ func Test_VM_Cached_Bytecode_Entry_Renders_VM_Only_Bytecode(t *testing.T) {
 	bytecode, ok := entry.VMBytecode.(*compiler.Bytecode)
 	require.True(t, ok)
 	require.False(t, bytecode.Static)
-	require.Nil(t, bytecode.FastRenderPlan)
+	require.NotNil(t, bytecode.FastRenderPlan)
+	require.Len(t, bytecode.FastRenderPlan.Segments, 1)
+	require.Equal(t, compiler.FastRenderSegmentGeneric, bytecode.FastRenderPlan.Segments[0].Kind)
 
 	ctx = plush.NewContext()
 	ctx.Set(meta.TemplateFileKey, filename)


### PR DESCRIPTION
This expands Plush VM fast-render coverage so more real templates stay inside the VM instead of falling back to the interpreter. It also improves diagnostics and error reporting around fast/generic VM paths and nested partial failures.

## Changes

- Added fast-plan support for assignments, index writes, returns, silent script helpers, silent loops, block helpers, receiver calls, dynamic callees, arrays, hashes, dynamic indexes, regex matches, and prefix numeric negation.
- Added generic VM whole-template segments for bytecode-safe syntax that is not specialized, keeping those renders in VM as `FastPath=generic`.
- Improved loop handling for nil loops, iterator reassignment, loop-local lets, nested assignment flows, loop returns, and helper/block context bindings inside loops.
- Improved VM partial rendering for parent binding visibility, dynamic partial names, layout data, and partial overlay behavior.
- Added nested template error traces with parent and partial filename/line context.
- Expanded diagnostics for fast/generic paths, reject reasons, assignment targets, helpers, partials, and hotspot reporting.
- Added documentation in `README.md` and `vm/FAST_PATHS.md`.
- Allow VM partial/render overlay contexts to update existing bindings to nil, matching interpreter behavior when an assigned expression resolves to a missing map value. 
- Sync outer assignments through loops, conditionals, helper blocks, and recursive partials
- Expand fast-plan coverage and keep unsupported syntax on the generic VM path
- Add no-fallback parity, cache-isolation, concurrency, and recursive-partial tests
- Improved memory allocation for the string builder when rendering the template files by using an adaptive learner 